### PR TITLE
Sound Support

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Mod.cs
@@ -44,6 +44,7 @@ namespace Terraria.ModLoader
 		internal readonly IDictionary<string, ModNPC> npcs = new Dictionary<string, ModNPC>();
 		internal readonly IDictionary<string, GlobalNPC> globalNPCs = new Dictionary<string, GlobalNPC>();
 		internal readonly IDictionary<string, ModGore> gores = new Dictionary<string, ModGore>();
+		internal readonly IDictionary<string, ModSound> sounds = new Dictionary<string, ModSound>();
 		/*
          * Initializes the mod's information, such as its name.
          */
@@ -143,6 +144,10 @@ namespace Terraria.ModLoader
 				if (type.IsSubclassOf(typeof(ModGore)))
 				{
 					AutoloadGore(type);
+				}
+				if (type.IsSubclassOf(typeof(ModSound)))
+				{
+					AutoloadSound(type);
 				}
 			}
 		}
@@ -662,6 +667,51 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		public void AddSound(string name, ModSound sound, string audioFilename)
+		{
+			int id = ModSound.ReserveSoundID();
+			sound.Name = name;
+			sound.Type = id;
+			sounds[name] = sound;
+			ModSound.sounds[id] = sound;
+			sound.audioFilename = audioFilename; 
+			sound.mod = this;
+		}
+
+		public ModSound GetSound(string name)
+		{
+			if (sounds.ContainsKey(name))
+			{
+				return sounds[name];
+			}
+			else
+			{
+				return null;
+			}
+		}
+
+		public int SoundType(string name)
+		{
+			ModSound sound = GetSound(name);
+			if (sound == null)
+			{
+				return 0;
+			}
+			return sound.Type;
+		}
+
+		private void AutoloadSound(Type type)
+		{
+			ModSound sound = (ModSound)Activator.CreateInstance(type);
+			sound.mod = this;
+			string name = type.Name;
+			string audioFilename = (type.Namespace + "." + type.Name).Replace('.', '/');
+			if (sound.Autoload(ref name, ref audioFilename))
+			{
+				AddSound(name, sound, audioFilename);
+			}
+		}
+
 		internal void SetupContent()
 		{
 			foreach (ModItem item in items.Values)
@@ -731,6 +781,11 @@ namespace Terraria.ModLoader
 			{
 				Main.goreTexture[gore.Type] = ModLoader.GetTexture(gore.texture);
 			}
+			foreach (ModSound sound in sounds.Values)
+			{
+				Main.soundItem[sound.Type] = ModLoader.GetSound(sound.audioFilename);
+				Main.soundInstanceItem[sound.Type] = Main.soundItem[sound.Type].CreateInstance();
+			}
 		}
 
 		internal void Unload() //I'm not sure why I have this
@@ -749,6 +804,7 @@ namespace Terraria.ModLoader
 			npcs.Clear();
 			globalNPCs.Clear();
 			gores.Clear();
+			sounds.Clear();
 		}
 
 		public virtual void ChatInput(string text)

--- a/patches/tModLoader/Terraria.ModLoader/ModSound.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModSound.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.ID;
+
+namespace Terraria.ModLoader
+{
+	public class ModSound
+	{
+		private static int nextSound = 126;
+		internal static readonly IDictionary<int, ModSound> sounds = new Dictionary<int, ModSound>();
+
+		internal static int ReserveSoundID()
+		{
+			int reserveID = nextSound;
+			nextSound++;
+			return reserveID;
+		}
+
+		public static ModSound GetSound(int type)
+		{
+			if (sounds.ContainsKey(type))
+			{
+				return sounds[type];
+			}
+			else
+			{
+				return null;
+			}
+		}
+
+		internal static void ResizeArrays(bool unloading = false)
+		{
+			Array.Resize(ref Main.soundItem, nextSound);
+			Array.Resize(ref Main.soundInstanceItem, nextSound);
+		}
+
+		internal static void Unload()
+		{
+			sounds.Clear();
+			nextSound = 126;
+		}
+
+		public string Name
+		{
+			get;
+			internal set;
+		}
+
+		public int Type
+		{
+			get;
+			internal set;
+		}
+
+		public Mod mod
+		{
+			get;
+			internal set;
+		}
+
+		internal string audioFilename;
+
+		public virtual bool Autoload(ref string name, ref string texture)
+		{
+			return mod.Properties.Autoload;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/Terraria\Terraria.csproj
 +++ src/tModLoader\Terraria.csproj
-@@ -28,9 +28,13 @@
+@@ -28,9 +28,14 @@
    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
      <DefineConstants>CLIENT</DefineConstants>
      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -8,13 +8,14 @@
    </PropertyGroup>
    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
      <DefineConstants>CLIENT</DefineConstants>
++    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 +  </PropertyGroup>
 +  <PropertyGroup>
 +    <ApplicationIcon>Icon.ico</ApplicationIcon>
    </PropertyGroup>
    <ItemGroup>
-     <Reference Include="Libraries.DotNetZip.Ionic.Zip.CF">
-@@ -238,6 +242,53 @@
+     <Reference Include="Ionic.Zip.CF">
+@@ -235,6 +240,54 @@
      <Compile Include="Terraria.Map\MapHelper.cs" />
      <Compile Include="Terraria.Map\MapTile.cs" />
      <Compile Include="Terraria.Map\WorldMap.cs" />
@@ -56,6 +57,7 @@
 +    <Compile Include="Terraria.ModLoader\ModProjectile.cs" />
 +    <Compile Include="Terraria.ModLoader\ModProperties.cs" />
 +    <Compile Include="Terraria.ModLoader\ModRecipe.cs" />
++    <Compile Include="Terraria.ModLoader\ModSound.cs" />
 +    <Compile Include="Terraria.ModLoader\ModTile.cs" />
 +    <Compile Include="Terraria.ModLoader\ModWall.cs" />
 +    <Compile Include="Terraria.ModLoader\NPCHeadLoader.cs" />
@@ -68,7 +70,7 @@
      <Compile Include="Terraria.Modules\AnchorDataModule.cs" />
      <Compile Include="Terraria.Modules\AnchorTypesModule.cs" />
      <Compile Include="Terraria.Modules\LiquidDeathModule.cs" />
-@@ -384,5 +435,8 @@
+@@ -381,6 +434,9 @@
      <EmbeddedResource Include="Terraria.Libraries\JSON.NET\Newtonsoft.Json.dll" />
      <EmbeddedResource Include="Terraria.Libraries\Steamworks.NET\Steamworks.NET.dll" />
    </ItemGroup>
@@ -76,4 +78,6 @@
 +    <Content Include="Icon.ico" />
 +  </ItemGroup>
    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
- </Project>
+   <PropertyGroup>
+     <PostBuildEvent>copy $(TargetPath) "C:\Program Files (x86)\Steam\steamapps\common\terraria"</PostBuildEvent>
+


### PR DESCRIPTION
Custom sounds for items support.  Changes to .tmod file format to
include .wav files. Load in a sound file by using and empty class
extending ModSound. Wav files should be stereo, 16 bit pcm, 44100 hz.

Also, auto copy built Terraria to Steam folder.