### PR TITLE
ExamplePet and ExampleLightPet now disappear upon buff removal

### DIFF
--- a/ExampleMod/Projectiles/Pets/ExampleLightPet.cs
+++ b/ExampleMod/Projectiles/Pets/ExampleLightPet.cs
@@ -37,7 +37,7 @@ namespace ExampleMod.Projectiles.Pets
 		{
 			Player player = Main.player[projectile.owner];
 			ExamplePlayer modPlayer = (ExamplePlayer)player.GetModPlayer(mod, "ExamplePlayer");
-			if (!player.active)
+			if (!player.active || player.HasBuff(mod.BuffType("ExampleLightPet")) == -1)
 			{
 				projectile.active = false;
 				return;

--- a/ExampleMod/Projectiles/Pets/ExampleLightPet.cs
+++ b/ExampleMod/Projectiles/Pets/ExampleLightPet.cs
@@ -37,12 +37,12 @@ namespace ExampleMod.Projectiles.Pets
 		{
 			Player player = Main.player[projectile.owner];
 			ExamplePlayer modPlayer = (ExamplePlayer)player.GetModPlayer(mod, "ExamplePlayer");
-			if (!player.active || player.HasBuff(mod.BuffType("ExampleLightPet")) == -1)
+			if (!player.active)
 			{
 				projectile.active = false;
 				return;
 			}
-			if (player.dead)
+			if (player.dead || player.HasBuff(mod.BuffType("ExampleLightPet")) == -1)
 			{
 				modPlayer.exampleLightPet = false;
 			}

--- a/ExampleMod/Projectiles/Pets/ExamplePet.cs
+++ b/ExampleMod/Projectiles/Pets/ExamplePet.cs
@@ -28,7 +28,7 @@ namespace ExampleMod.Projectiles.Pets
 		{
 			Player player = Main.player[projectile.owner];
 			ExamplePlayer modPlayer = (ExamplePlayer)player.GetModPlayer(mod, "ExamplePlayer");
-			if (player.dead)
+			if (player.dead || player.HasBuff(mod.BuffType("ExamplePet")) == -1))
 			{
 				modPlayer.examplePet = false;
 			}


### PR DESCRIPTION
ExamplePet and ExampleLightPet now disappear upon buff removal, for example when right clicking the buff to remove it manually.