### PR TITLE
Fixed two TileLoader.Slope bugs

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5383,16 +5383,18 @@
  									}
  									if (item.axe > 0)
  									{
-@@ -32981,6 +_,9 @@
+@@ -32981,7 +_,10 @@
  										{
  											int num228 = Player.tileTargetX;
  											int num229 = Player.tileTargetY;
-+											if (TileLoader.Slope(num228, num228, Main.tile[num228, num229].type))
++											if (TileLoader.Slope(num228, num229, Main.tile[num228, num229].type))
 +											{
 +											}
- 											if (TileID.Sets.Platforms[(int)Main.tile[num228, num229].type])
+-											if (TileID.Sets.Platforms[(int)Main.tile[num228, num229].type])
++											else if (TileID.Sets.Platforms[(int)Main.tile[num228, num229].type])
  											{
  												if (Main.tile[num228, num229].halfBrick())
+ 												{
 @@ -33657,6 +_,7 @@
  				}
  				else if (item.useStyle == 3)


### PR DESCRIPTION
The return value of TileLoader.Slope was being ignored and the Y-coordinate passed to TileLoader.Slope was incorrect (it was the X-coordinate).
This should fix those two bugs.