### PR TITLE
Pre/Post draw hooks for items whoAmI fix

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -303,12 +303,12 @@ namespace Terraria.ModLoader
 			return null;
 		}
 
-		public virtual bool PreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale)
+		public virtual bool PreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale, int whoAmI)
 		{
 			return true;
 		}
 
-		public virtual void PostDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale)
+		public virtual void PostDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
 		{
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -86,9 +86,9 @@ namespace Terraria.ModLoader
 		private static Func<Item, Player, bool>[] HookGrabStyle;
 		private static Func<Item, Player, bool>[] HookOnPickup;
 		private static Func<Item, Color, Color?>[] HookGetAlpha;
-		private delegate bool DelegatePreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale);
+		private delegate bool DelegatePreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale, int whoAmI);
 		private static DelegatePreDrawInWorld[] HookPreDrawInWorld;
-		private static Action<Item, SpriteBatch, Color, Color, float, float>[] HookPostDrawInWorld;
+		private static Action<Item, SpriteBatch, Color, Color, float, float, int>[] HookPostDrawInWorld;
 		private static Func<Item, SpriteBatch, Vector2, Rectangle, Color, Color, Vector2, float, bool>[] HookPreDrawInInventory;
 		private static Action<Item, SpriteBatch, Vector2, Rectangle, Color, Color, Vector2, float>[] HookPostDrawInInventory;
 		private static Func<int, Vector2?>[] HookHoldoutOffset;
@@ -1202,16 +1202,16 @@ namespace Terraria.ModLoader
 		}
 		//in Terraria.Main.DrawItem after ItemSlot.GetItemLight call
 		//  if(!ItemLoader.PreDrawInWorld(item, Main.spriteBatch, color, alpha, ref rotation, ref scale)) { return; }
-		public static bool PreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale)
+		public static bool PreDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale, int whoAmI)
 		{
 			bool flag = true;
-			if (item.modItem != null && !item.modItem.PreDrawInWorld(spriteBatch, lightColor, alphaColor, ref rotation, ref scale))
+			if (item.modItem != null && !item.modItem.PreDrawInWorld(spriteBatch, lightColor, alphaColor, ref rotation, ref scale, whoAmI))
 			{
 				flag = false;
 			}
 			foreach (var hook in HookPreDrawInWorld)
 			{
-				if (!hook(item, spriteBatch, lightColor, alphaColor, ref rotation, ref scale))
+				if (!hook(item, spriteBatch, lightColor, alphaColor, ref rotation, ref scale, whoAmI))
 				{
 					flag = false;
 				}
@@ -1220,13 +1220,13 @@ namespace Terraria.ModLoader
 		}
 		//in Terraria.Main.DrawItem before every return (including for PreDrawInWorld) and at end of method call
 		//  ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, rotation, scale)
-		public static void PostDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale)
+		public static void PostDrawInWorld(Item item, SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
 		{
-			item.modItem?.PostDrawInWorld(spriteBatch, lightColor, alphaColor, rotation, scale);
+			item.modItem?.PostDrawInWorld(spriteBatch, lightColor, alphaColor, rotation, scale, whoAmI);
 
 			foreach (var hook in HookPostDrawInWorld)
 			{
-				hook(item, spriteBatch, lightColor, alphaColor, rotation, scale);
+				hook(item, spriteBatch, lightColor, alphaColor, rotation, scale, whoAmI);
 			}
 		}
 		//in Terraria.UI.ItemSlot.Draw place item-drawing code inside if statement

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -329,12 +329,12 @@ namespace Terraria.ModLoader
 			return null;
 		}
 
-		public virtual bool PreDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale)
+		public virtual bool PreDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, ref float rotation, ref float scale, int whoAmI)
 		{
 			return true;
 		}
 
-		public virtual void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale)
+		public virtual void PostDrawInWorld(SpriteBatch spriteBatch, Color lightColor, Color alphaColor, float rotation, float scale, int whoAmI)
 		{
 		}
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2751,9 +2751,9 @@
  			float scale = 1f;
  			Microsoft.Xna.Framework.Color alpha = item.GetAlpha(color);
  			ItemSlot.GetItemLight(ref alpha, ref scale, item, false);
-+			if (!ItemLoader.PreDrawInWorld(item, Main.spriteBatch, color, alpha, ref num4, ref scale))
++			if (!ItemLoader.PreDrawInWorld(item, Main.spriteBatch, color, alpha, ref num4, ref scale, whoami))
 +			{
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
 +				return;
 +			}
  			float num5 = (float)(item.height - Main.itemTexture[item.type].Height);
@@ -2763,7 +2763,7 @@
  				int num8 = Main.coinTexture[num7].Height / 8;
  				num6 = (float)(item.width / 2 - Main.coinTexture[num7].Width / 2);
  				Main.spriteBatch.Draw(Main.coinTexture[num7], new Vector2(item.position.X - Main.screenPosition.X + (float)(width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(num8 / 2) + num5), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, Main.itemFrame[whoami] * num8 + 1, Main.itemTexture[item.type].Width, num8)), alpha, num4, new Vector2((float)(width / 2), (float)(num8 / 2)), scale, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			if (ItemID.Sets.NebulaPickup[item.type])
@@ -2771,7 +2771,7 @@
  				num6 = (float)(item.width / 2 - rectangle.Width / 2);
  				num5 = (float)(item.height - rectangle.Height);
  				Main.spriteBatch.Draw(Main.itemTexture[item.type], new Vector2(item.position.X - Main.screenPosition.X + (float)(rectangle.Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(rectangle.Height / 2) + num5), new Microsoft.Xna.Framework.Rectangle?(rectangle), alpha, num4, rectangle.Size() / 2f, scale, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			if (ItemID.Sets.AnimatesAsSoul[item.type])
@@ -2779,7 +2779,7 @@
  				num6 = (float)(item.width / 2 - rectangle2.Width / 2);
  				num5 = (float)(item.height - rectangle2.Height);
  				Main.spriteBatch.Draw(Main.itemTexture[item.type], new Vector2(item.position.X - Main.screenPosition.X + (float)(rectangle2.Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(rectangle2.Height / 2) + num5), new Microsoft.Xna.Framework.Rectangle?(rectangle2), alpha, num4, rectangle2.Size() / 2f, scale, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			if (ItemID.Sets.TrapSigned[item.type])
@@ -2787,25 +2787,25 @@
  					Main.spriteBatch.Draw(Main.glowMaskTexture[(int)item.glowMask], new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, 0, Main.itemTexture[item.type].Width, Main.itemTexture[item.type].Height)), new Microsoft.Xna.Framework.Color(250, 250, 250, item.alpha), num4, new Vector2((float)(Main.itemTexture[item.type].Width / 2), (float)(Main.itemTexture[item.type].Height / 2)), scale, SpriteEffects.None, 0f);
  				}
  				Main.spriteBatch.Draw(Main.wireTexture, new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f) + Main.itemTexture[item.type].Size().RotatedBy((double)num4, default(Vector2)) * 0.45f * item.scale, new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(4, 58, 8, 8)), alpha, 0f, new Vector2(4f), 1f, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			if ((item.type >= 1522 && item.type <= 1527) || item.type == 3643)
  			{
  				Main.spriteBatch.Draw(Main.itemTexture[item.type], new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, 0, Main.itemTexture[item.type].Width, Main.itemTexture[item.type].Height)), new Microsoft.Xna.Framework.Color(250, 250, 250, (int)(Main.mouseTextColor / 2)), num4, new Vector2((float)(Main.itemTexture[item.type].Width / 2), (float)(Main.itemTexture[item.type].Height / 2)), (float)Main.mouseTextColor / 1000f + 0.8f, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			if (item.type == 3779)
  			{
  				Main.spriteBatch.Draw(Main.itemTexture[item.type], new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, 0, Main.itemTexture[item.type].Width, Main.itemTexture[item.type].Height)), alpha, num4, new Vector2((float)(Main.itemTexture[item.type].Width / 2), (float)(Main.itemTexture[item.type].Height / 2)), scale, SpriteEffects.None, 0f);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
 +				return;
 +			}
 +			if (ItemLoader.animations.Contains(item.type))
 +			{
 +				ItemLoader.DrawAnimatedItem(item, whoami, color, alpha, num4, scale);
-+				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++				ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  				return;
  			}
  			Main.spriteBatch.Draw(Main.itemTexture[item.type], new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, 0, Main.itemTexture[item.type].Width, Main.itemTexture[item.type].Height)), alpha, num4, new Vector2((float)(Main.itemTexture[item.type].Width / 2), (float)(Main.itemTexture[item.type].Height / 2)), scale, SpriteEffects.None, 0f);
@@ -2813,7 +2813,7 @@
  			{
  				Main.spriteBatch.Draw(Main.glowMaskTexture[(int)item.glowMask], new Vector2(item.position.X - Main.screenPosition.X + (float)(Main.itemTexture[item.type].Width / 2) + num6, item.position.Y - Main.screenPosition.Y + (float)(Main.itemTexture[item.type].Height / 2) + num5 + 2f), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(0, 0, Main.itemTexture[item.type].Width, Main.itemTexture[item.type].Height)), new Microsoft.Xna.Framework.Color(250, 250, 250, item.alpha), num4, new Vector2((float)(Main.itemTexture[item.type].Width / 2), (float)(Main.itemTexture[item.type].Height / 2)), scale, SpriteEffects.None, 0f);
  			}
-+			ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale);
++			ItemLoader.PostDrawInWorld(item, Main.spriteBatch, color, alpha, num4, scale, whoami);
  		}
  
  		protected void DrawRain()


### PR DESCRIPTION
item.whoAmI is not being set, thus animations sped up eachother when
done via draw hooks because they'd all use the same index (0). Fixed
with a whoAmI parameter.