### PR TITLE
Fixes to WingUpdate and WingSpeeds (Resolves #87)

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/EquipTexture.cs
+++ b/patches/tModLoader/Terraria.ModLoader/EquipTexture.cs
@@ -138,12 +138,26 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		[method: Obsolete("WingUpdate will return a bool value later. (Use NewWingUpdate in the meantime.) False will keep everything the same. True, you need to handle all animations in your own code.")]
 		public virtual void WingUpdate(Player player, bool inUse)
 		{
 			if (item != null)
 			{
 				item.WingUpdate(player, inUse);
 			}
+		}
+
+		public virtual bool NewWingUpdate(Player player, bool inUse)
+		{
+			if (item != null)
+			{
+				if (item.NewWingUpdate(player, inUse))
+				{
+					return true;
+				}
+				WingUpdate(player, inUse);
+			}
+			return false;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/EquipTexture.cs
+++ b/patches/tModLoader/Terraria.ModLoader/EquipTexture.cs
@@ -141,23 +141,13 @@ namespace Terraria.ModLoader
 		[method: Obsolete("WingUpdate will return a bool value later. (Use NewWingUpdate in the meantime.) False will keep everything the same. True, you need to handle all animations in your own code.")]
 		public virtual void WingUpdate(Player player, bool inUse)
 		{
-			if (item != null)
-			{
-				item.WingUpdate(player, inUse);
-			}
+			item?.WingUpdate(player, inUse);
 		}
 
 		public virtual bool NewWingUpdate(Player player, bool inUse)
 		{
-			if (item != null)
-			{
-				if (item.NewWingUpdate(player, inUse))
-				{
-					return true;
-				}
-				WingUpdate(player, inUse);
-			}
-			return false;
+			WingUpdate(player, inUse);
+			return item?.NewWingUpdate(player, inUse) ?? false;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -263,17 +263,37 @@ namespace Terraria.ModLoader
 		{
 		}
 
+		[method: Obsolete("Use the overloaded method with the player parameter.")]
 		public virtual void VerticalWingSpeeds(Item item, ref float ascentWhenFalling, ref float ascentWhenRising,
 			ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend)
 		{
 		}
 
+		public virtual void VerticalWingSpeeds(Item item, Player player, ref float ascentWhenFalling, ref float ascentWhenRising,
+	ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend)
+		{
+			VerticalWingSpeeds(item, ref ascentWhenFalling, ref ascentWhenRising, ref maxCanAscendMultiplier, ref maxAscentMultiplier, ref constantAscend);
+		}
+
+		[method: Obsolete("Use the overloaded method with the player parameter.")]
 		public virtual void HorizontalWingSpeeds(Item item, ref float speed, ref float acceleration)
 		{
 		}
 
+		public virtual void HorizontalWingSpeeds(Item item, Player player, ref float speed, ref float acceleration)
+		{
+			HorizontalWingSpeeds(item, ref speed, ref acceleration);
+		}
+
+		[method: Obsolete("WingUpdate will return a bool value later. (Use NewWingUpdate in the meantime.) False will keep everything the same. True, you need to handle all animations in your own code.")]
 		public virtual void WingUpdate(int wings, Player player, bool inUse)
 		{
+		}
+
+		public virtual bool NewWingUpdate(int wings, Player player, bool inUse)
+		{
+			WingUpdate(wings, player, inUse);
+			return false;
 		}
 
 		public virtual void Update(Item item, ref float gravity, ref float maxFallSpeed)

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -288,17 +288,36 @@ namespace Terraria.ModLoader
 		{
 		}
 
+		[method: Obsolete("Use the overloaded method with the player parameter.")]
 		public virtual void VerticalWingSpeeds(ref float ascentWhenFalling, ref float ascentWhenRising,
 			ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend)
 		{
 		}
 
+		public virtual void VerticalWingSpeeds(Player player, ref float ascentWhenFalling, ref float ascentWhenRising,
+	ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend)
+		{
+			VerticalWingSpeeds(ref ascentWhenFalling, ref ascentWhenRising, ref maxCanAscendMultiplier, ref maxAscentMultiplier, ref constantAscend);
+		}
+
+		[method: Obsolete("Use the overloaded method with the player parameter.")]
 		public virtual void HorizontalWingSpeeds(ref float speed, ref float acceleration)
 		{
 		}
 
+		public virtual void HorizontalWingSpeeds(Player player, ref float speed, ref float acceleration)
+		{
+			HorizontalWingSpeeds(ref speed, ref acceleration);
+		}
+
+		[method: Obsolete("WingUpdate will return a bool value later. (Use NewWingUpdate in the meantime.) False will keep everything the same. True, you need to handle all animations in your own code.")]
 		public virtual void WingUpdate(Player player, bool inUse)
 		{
+		}
+
+		public virtual bool NewWingUpdate(Player player, bool inUse)
+		{
+			return false;
 		}
 
 		public virtual void Update(ref float gravity, ref float maxFallSpeed)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3028,10 +3028,37 @@
  				}
  				else
  				{
-+					ItemLoader.WingUpdate(this, flag19);
++					bool isCustomWings = ItemLoader.WingUpdate(this, flag19);
  					if (flag19)
  					{
  						if (this.wings == 10 && Main.rand.Next(2) == 0)
+@@ -21476,7 +_,7 @@
+ 							}
+ 						}
+ 					}
+-					else
++					else if (!isCustomWings)
+ 					{
+ 						int num91 = 4;
+ 						if (this.wings == 32)
+@@ -21535,7 +_,7 @@
+ 						}
+ 						this.rocketTime = 0;
+ 					}
+-					if (flag19 && this.wings != 4 && this.wings != 22 && this.wings != 0 && this.wings != 24 && this.wings != 28 && this.wings != 30 && this.wings != 33)
++					if (flag19 && this.wings != 4 && this.wings != 22 && this.wings != 0 && this.wings != 24 && this.wings != 28 && this.wings != 30 && this.wings != 33 && !isCustomWings)
+ 					{
+ 						if (this.wingFrame == 3)
+ 						{
+@@ -21901,7 +_,7 @@
+ 										}
+ 									}
+ 								}
+-								else if (this.wings != 22 && this.wings != 28)
++								else if (this.wings != 22 && this.wings != 28 && !isCustomWings)
+ 								{
+ 									if (this.wings == 30)
+ 									{
 @@ -22831,6 +_,7 @@
  			this.grappling[0] = -1;
  			this.grapCount = 0;


### PR DESCRIPTION
ItemLoader.WingUpdate now returns a bool value.
Other classes that have WingUpdate now have a "NewWingUpdate" method that returns a bool value. (Calls the old WingUpdate and returns false by default for backward compatibility.)
Player.Update has a new local variable "isCustomWings" that gets the return value from ItemLoader.WingUpdate, and uses it to stay out of 3 if/else/else if blocks that play sounds or manipulate wing animations.

WingSpeeds methods (Vertical and Horizontal) have overloaded versions that also pass the player as a parameter. In stock code, the player parameter is used to get control status for jetpacks and hoverboards, as well as manipulate vertical velocity for hovering. (New overloaded version calls the old version by default for backward compatibility.)