### PR TITLE
Add PlaceInWorld and PostDrawTiles hooks.

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalTile.cs
@@ -178,5 +178,9 @@ namespace Terraria.ModLoader
 		{
 			return -1;
 		}
+
+		public virtual void PlaceInWorld(int i, int j, Item item)
+		{
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalWall.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework.Graphics;
+using Terraria;
 
 namespace Terraria.ModLoader
 {
@@ -67,6 +68,10 @@ namespace Terraria.ModLoader
 		}
 
 		public virtual void PostDraw(int i, int j, int type, SpriteBatch spriteBatch)
+		{
+		}
+
+		public virtual void PlaceInWorld(int i, int j, Item item)
 		{
 		}
 	}

--- a/patches/tModLoader/Terraria.ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModTile.cs
@@ -249,5 +249,9 @@ namespace Terraria.ModLoader
 		{
 			return -1;
 		}
+
+		public virtual void PlaceInWorld(int i, int j, Item item)
+		{
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModWall.cs
@@ -122,5 +122,9 @@ namespace Terraria.ModLoader
 		public virtual void PostDraw(int i, int j, SpriteBatch spriteBatch)
 		{
 		}
+
+		public virtual void PlaceInWorld(int i, int j, Item item)
+		{
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/ModWorld.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModWorld.cs
@@ -86,5 +86,9 @@ namespace Terraria.ModLoader
 		//public virtual void WorldGenModifyHardmodeTaskList(List<GenPass> list)
 		//{
 		//}
+
+		public virtual void PostDrawTiles()
+		{
+		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/TileLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Terraria;
 using Terraria.ID;
 using Terraria.ObjectData;
 
@@ -76,6 +77,7 @@ namespace Terraria.ModLoader
 		private static DelegateChangeWaterfallStyle[] HookChangeWaterfallStyle;
 		private delegate int DelegateSaplingGrowthType(int type, ref int style);
 		private static DelegateSaplingGrowthType[] HookSaplingGrowthType;
+		private static Action<int, int, Item>[] HookPlaceInWorld;
 
 		internal static int ReserveTileID()
 		{
@@ -255,6 +257,7 @@ namespace Terraria.ModLoader
 			ModLoader.BuildGlobalHook(ref HookSlope, globalTiles, g => g.Slope);
 			ModLoader.BuildGlobalHook(ref HookChangeWaterfallStyle, globalTiles, g => g.ChangeWaterfallStyle);
 			ModLoader.BuildGlobalHook(ref HookSaplingGrowthType, globalTiles, g => g.SaplingGrowthType);
+			ModLoader.BuildGlobalHook(ref HookPlaceInWorld, globalTiles, g => g.PlaceInWorld);
 
 			if (!unloading)
 			{
@@ -1122,6 +1125,20 @@ namespace Terraria.ModLoader
 		public static Texture2D GetCactusTexture(int type)
 		{
 			return cacti.ContainsKey(type) ? cacti[type].GetTexture() : null;
+		}
+
+		public static void PlaceInWorld(int i, int j, Item item)
+		{
+			int type = item.createTile;
+			if(type < 0)
+				return;
+
+			foreach (var hook in HookPlaceInWorld)
+			{
+				hook(i, j, item);
+			}
+
+			GetTile(type)?.PlaceInWorld(i, j, item);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/WallLoader.cs
@@ -29,6 +29,7 @@ namespace Terraria.ModLoader
 		private static Action<int, int, int>[] HookRandomUpdate;
 		private static Func<int, int, int, SpriteBatch, bool>[] HookPreDraw;
 		private static Action<int, int, int, SpriteBatch>[] HookPostDraw;
+		private static Action<int, int, Item>[] HookPlaceInWorld;
 
 		internal static int ReserveWallID()
 		{
@@ -98,6 +99,7 @@ namespace Terraria.ModLoader
 			ModLoader.BuildGlobalHook(ref HookRandomUpdate, globalWalls, g => g.RandomUpdate);
 			ModLoader.BuildGlobalHook(ref HookPreDraw, globalWalls, g => g.PreDraw);
 			ModLoader.BuildGlobalHook(ref HookPostDraw, globalWalls, g => g.PostDraw);
+			ModLoader.BuildGlobalHook(ref HookPlaceInWorld, globalWalls, g => g.PlaceInWorld);
 
 			if (!unloading)
 			{
@@ -284,6 +286,20 @@ namespace Terraria.ModLoader
 			{
 				hook(i, j, type, spriteBatch);
 			}
+		}
+
+		public static void PlaceInWorld(int i, int j, Item item)
+		{
+			int type = item.createWall;
+			if(type < 0)
+				return;
+
+			foreach (var hook in HookPlaceInWorld)
+			{
+				hook(i, j, item);
+			}
+
+			GetWall(type)?.PlaceInWorld(i, j, item);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader/WorldHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/WorldHooks.cs
@@ -114,5 +114,13 @@ namespace Terraria.ModLoader
 				modWorld.ChooseWaterStyle(ref style);
 			}
 		}
+
+		public static void PostDrawTiles()
+		{
+			foreach (ModWorld modWorld in worlds)
+			{
+				modWorld.PostDrawTiles();
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -38201,7 +38201,7 @@
  				Overlays.Scene.Draw(Main.spriteBatch, RenderLayers.TilesAndNPCs);
  				if (!Main.mapFullscreen && Main.mapStyle == 2)
  				{
-@@ -56830,8 +_,10 @@
+@@ -56830,11 +_,16 @@
  							goto IL_4183;
  						}
  					}
@@ -38212,6 +38212,12 @@
  				IL_4183:
  				TimeLogger.DetailedDrawReset();
  				Main.spriteBatch.End();
++
++				WorldHooks.PostDrawTiles();
++
+ 				TimeLogger.DetailedDrawTime(35);
+ 				this.SortDrawCacheWorms();
+ 				this.DrawCachedProjs(this.DrawCacheProjsBehindProjectiles, true);
 @@ -56850,12 +_,14 @@
  						Main.essDir = -1;
  						Main.essScale = 1f;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3504,6 +3504,28 @@
  						{
  							if (Main.tile[Player.tileTargetX, Player.tileTargetY].wall > 0)
  							{
+@@ -30137,6 +_,8 @@
+ 							{
+ 								Main.blockMouse = true;
+ 							}
++
++							TileLoader.PlaceInWorld(Player.tileTargetX, Player.tileTargetY, this.inventory[this.selectedItem]);
+ 						}
+ 					}
+ 				}
+@@ -30160,9 +_,12 @@
+ 						this.itemTime = (int)((float)this.inventory[this.selectedItem].useTime * this.wallSpeed);
+ 						return;
+ 					}
++
+ 					WorldGen.PlaceWall(Player.tileTargetX, Player.tileTargetY, this.inventory[this.selectedItem].createWall, false);
++
+ 					if ((int)Main.tile[Player.tileTargetX, Player.tileTargetY].wall == this.inventory[this.selectedItem].createWall)
+ 					{
++						WallLoader.PlaceInWorld(Player.tileTargetX, Player.tileTargetY, this.inventory[this.selectedItem]);
+ 						this.itemTime = (int)((float)this.inventory[this.selectedItem].useTime * this.wallSpeed);
+ 						if (Main.netMode == 1)
+ 						{
 @@ -30348,7 +_,7 @@
  			int num2 = 25;
  			int num3 = 50;


### PR DESCRIPTION
I've added two new hooks:
`PlaceInWorld`, a hook/callback for placing tiles into the world which passes the tile coordinates and Item stack used.
Additionally, I've added a `PostDrawTiles` hook for `ModWorld` which would allow users to draw their own systems similar to Terraria's wiring system without drawing above of items, npcs, and UIs.