### PR TITLE
(ExampleMod) Allow 1.3.4 minion targetting for HoverShooter.

### DIFF
--- a/ExampleMod/Items/Weapons/PurityTotem.cs
+++ b/ExampleMod/Items/Weapons/PurityTotem.cs
@@ -29,5 +29,24 @@ namespace ExampleMod.Items.Weapons
 			item.buffType = mod.BuffType("PurityWisp");	//The buff added to player after used the item
 			item.buffTime = 3600;				//The duration of the buff, here is 60 seconds
 		}
+		
+		public override bool AltFunctionUse(Player player)
+		{
+			return true;
+		}
+		
+		public override bool Shoot(Player player, ref Vector2 position, ref float speedX, ref float speedY, ref int type, ref int damage, ref float knockBack)
+		{
+			return player.altFunctionUse != 2;
+		}
+		
+		public override bool UseItem(Player player)
+		{
+			if(player.altFunctionUse == 2)
+			{
+				player.MinionNPCTargetAim();
+			}
+			return base.UseItem(player);
+		}
 	}
 }

--- a/ExampleMod/Projectiles/Minions/HoverShooter.cs
+++ b/ExampleMod/Projectiles/Minions/HoverShooter.cs
@@ -55,7 +55,17 @@ namespace ExampleMod.Projectiles.Minions
 			float targetDist = viewDist;
 			bool target = false;
 			projectile.tileCollide = true;
-			for (int k = 0; k < 200; k++)
+			if(player.HasMinionAttackTargetNPC)
+			{
+				NPC npc = Main.npc[player.MinionAttackTargetNPC];
+				if(Collision.CanHitLine(projectile.position, projectile.width, projectile.height, npc.position, npc.width, npc.height))
+				{
+					targetDist = Vector2.Distance(projectile.Center, targetPos);
+					targetPos = npc.Center;
+					target = true;
+				}
+			}
+			else for (int k = 0; k < 200; k++)
 			{
 				NPC npc = Main.npc[k];
 				if (npc.CanBeChasedBy(this, false))

--- a/ExampleMod/Projectiles/Minions/PurityWisp.cs
+++ b/ExampleMod/Projectiles/Minions/PurityWisp.cs
@@ -24,6 +24,7 @@ namespace ExampleMod.Projectiles.Minions
 			projectile.ignoreWater = true;
 			ProjectileID.Sets.MinionSacrificable[projectile.type] = true;
 			ProjectileID.Sets.Homing[projectile.type] = true;
+			ProjectileID.Sets.MinionTargettingFeature[projectile.type] = true; //This is necessary for right-click targetting
 			inertia = 20f;
 			shoot = mod.ProjectileType("PurityBolt");
 			shootSpeed = 12f;


### PR DESCRIPTION
In Terraria 1.3.4, there is a new feature which allows minions to target specific NPCs. You can right-click with any summon weapon and it locks on to the nearest enemy. However, the custom AI in Example Mod's HoverShooter class doesn't take advantage of that.

I wanted to fix that so that other modders can see how it works.