### PR TITLE
Fixed the bug when player is killed by mod projectile

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria.ModLoader/Mod.cs
@@ -2235,7 +2235,7 @@ namespace Terraria.ModLoader
 				Main.projFrames[projectile.projectile.type] = 1;
 				ProjectileLoader.SetupProjectileInfo(projectile.projectile);
 				projectile.SetDefaults();
-				Main.projName[modProjectile.projectile.type] = modProjectile.projectile.name;
+				Main.projName[projectile.projectile.type] = projectile.projectile.name;
 				if (projectile.projectile.hostile)
 				{
 					Main.projHostile[projectile.projectile.type] = true;

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -82,7 +82,7 @@ namespace Terraria.ModLoader
 			Array.Resize(ref Main.projHook, nextProjectile);
 			Array.Resize(ref Main.projFrames, nextProjectile);
 			Array.Resize(ref Main.projPet, nextProjectile);
-			Array.Resize(ref Main.projName, ProjectileLoader.nextProjectile);
+			Array.Resize(ref Main.projName, nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosLifeTimeMultiplier, nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosMaximumRange, nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosTopSpeed, nextProjectile);

--- a/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ProjectileLoader.cs
@@ -82,6 +82,7 @@ namespace Terraria.ModLoader
 			Array.Resize(ref Main.projHook, nextProjectile);
 			Array.Resize(ref Main.projFrames, nextProjectile);
 			Array.Resize(ref Main.projPet, nextProjectile);
+			Array.Resize(ref Main.projName, ProjectileLoader.nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosLifeTimeMultiplier, nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosMaximumRange, nextProjectile);
 			Array.Resize(ref ProjectileID.Sets.YoyosTopSpeed, nextProjectile);


### PR DESCRIPTION
I have noticed that when player is killed by mod projectile, it actually throw an IndexOutOfRange error which leads to no death text would be shown. I'd like to fix this bug by adding the hook for `Main.projName`.