### PR TITLE
Add object overload for ErrorLogger.Log

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
@@ -222,31 +222,31 @@ namespace Terraria.ModLoader
 		{
 			Directory.CreateDirectory(LogPath);
 			using (StreamWriter writer = File.AppendText(LogPath + Path.DirectorySeparatorChar + "Logs.txt"))
-                        {
-                             writer.WriteLine("Object type: " + param.GetType());
-                             foreach (PropertyInfo property in param.GetType().GetProperties())
-                             {
-                                 writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
-                             }
+			{
+				writer.WriteLine("Object type: " + param.GetType());
+				foreach (PropertyInfo property in param.GetType().GetProperties())
+				{
+					writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
+				}
 
-          		     foreach (FieldInfo field in param.GetType().GetFields())
-          	             {
-                                 writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
-                             }
+				foreach (FieldInfo field in param.GetType().GetFields())
+				{
+					writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
+				}
 
-                             foreach (MethodInfo method in param.GetType().GetMethods())
-                             {
-                                 writer.Write("METHOD " + method.Name + "\n");
-                             }
+				foreach (MethodInfo method in param.GetType().GetMethods())
+				{
+					writer.Write("METHOD " + method.Name + "\n");
+				}
 
-                             int temp = 0;
+				int temp = 0;
 
-                             foreach(ConstructorInfo constructor in param.GetType().GetConstructors())
-                             {
-                                temp++;
-                                writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");
-                             }
-                        }
+				foreach (ConstructorInfo constructor in param.GetType().GetConstructors())
+				{
+					temp++;
+					writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");
+				}
+			}
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
@@ -215,36 +215,44 @@ namespace Terraria.ModLoader
 		}
 		
 		/// <summary>
-                /// Allows you to log an object, this get all the 
+                /// Allows you to log an object for your own testing purposes. The message will be added to the Logs.txt file in the Logs folder. 
                 /// </summary>
                 /// <param name="param">The object to be logged.</param>
-		public static void Log(object param)
+		/// <param name="alternateOutput">If true, the object's data will be manually retrieved and logged. If false, the object's ToString method is logged.</param>
+		public static void Log(object param, bool alternateOutput = false)
 		{
 			Directory.CreateDirectory(LogPath);
 			using (StreamWriter writer = File.AppendText(LogPath + Path.DirectorySeparatorChar + "Logs.txt"))
 			{
-				writer.WriteLine("Object type: " + param.GetType());
-				foreach (PropertyInfo property in param.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+				if (!alternateOutput)
 				{
-					writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
+					writer.WriteLine(param.ToString());
 				}
-
-				foreach (FieldInfo field in param.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+				else
 				{
-					writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
-				}
+					writer.WriteLine("Object type: " + param.GetType());
+					foreach (PropertyInfo property in param.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+					{
+						writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
+					}
 
-				foreach (MethodInfo method in param.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
-				{
-					writer.Write("METHOD " + method.Name + "\n");
-				}
+					foreach (FieldInfo field in param.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+					{
+						writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
+					}
 
-				int temp = 0;
+					foreach (MethodInfo method in param.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+					{
+						writer.Write("METHOD " + method.Name + "\n");
+					}
 
-				foreach (ConstructorInfo constructor in param.GetType().GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
-				{
-					temp++;
-					writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");
+					int temp = 0;
+
+					foreach (ConstructorInfo constructor in param.GetType().GetConstructors(BindingFlags.Public | BindingFlags.NonPublic))
+					{
+						temp++;
+						writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");
+					}
 				}
 			}
 		}

--- a/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
@@ -3,6 +3,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using Terraria.ModLoader.IO;
+using System.Reflection;
 
 namespace Terraria.ModLoader
 {
@@ -211,6 +212,41 @@ namespace Terraria.ModLoader
 			{
 				writer.WriteLine(message);
 			}
+		}
+		
+		/// <summary>
+                /// Allows you to log an object, this get all the 
+                /// </summary>
+                /// <param name="param">The object to be logged.</param>
+		public static void Log(object param)
+		{
+			Directory.CreateDirectory(LogPath);
+			using (StreamWriter writer = File.AppendText(LogPath + Path.DirectorySeparatorChar + "Logs.txt"))
+                        {
+                             writer.WriteLine("Object type: " + param.GetType());
+                             foreach (PropertyInfo property in param.GetType().GetProperties())
+                             {
+                                 writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
+                             }
+
+          		     foreach (FieldInfo field in param.GetType().GetFields())
+          	             {
+                                 writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
+                             }
+
+                             foreach (MethodInfo method in param.GetType().GetMethods())
+                             {
+                                 writer.Write("METHOD " + method.Name + "\n");
+                             }
+
+                             int temp = 0;
+
+                             foreach(ConstructorInfo constructor in param.GetType().GetConstructors())
+                             {
+                                temp++;
+                                writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");
+                             }
+                        }
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ErrorLogger.cs
@@ -224,24 +224,24 @@ namespace Terraria.ModLoader
 			using (StreamWriter writer = File.AppendText(LogPath + Path.DirectorySeparatorChar + "Logs.txt"))
 			{
 				writer.WriteLine("Object type: " + param.GetType());
-				foreach (PropertyInfo property in param.GetType().GetProperties())
+				foreach (PropertyInfo property in param.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
 				{
 					writer.Write("PROPERTY " + property.Name + " = " + property.GetValue(param, null) + "\n");
 				}
 
-				foreach (FieldInfo field in param.GetType().GetFields())
+				foreach (FieldInfo field in param.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
 				{
 					writer.Write("FIELD " + field.Name + " = " + (field.GetValue(param).ToString() != "" ? field.GetValue(param) : "(Field value not found)") + "\n");
 				}
 
-				foreach (MethodInfo method in param.GetType().GetMethods())
+				foreach (MethodInfo method in param.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
 				{
 					writer.Write("METHOD " + method.Name + "\n");
 				}
 
 				int temp = 0;
 
-				foreach (ConstructorInfo constructor in param.GetType().GetConstructors())
+				foreach (ConstructorInfo constructor in param.GetType().GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
 				{
 					temp++;
 					writer.Write("CONSTRUCTOR " + temp + " : " + constructor.Name + "\n");


### PR DESCRIPTION
This overload allows the user to log objects, it simply retrieves methods, constructors, fields and properties in them.
(Fields and properties have their name AND value get retrieved)

I tested this and it should work, tell me if you get any errors/exceptions