### PR TITLE
Adds a .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
### Description of the Change
Adds a `.editorconfig` file which will make some editors automatically follow the formatting rules outlined in `CONTRIBUTING.md`

### Benefits
Can't hurt and it saves headaches from having to reconfigure editors.

### Sample Usage
http://editorconfig.org/

