### PR TITLE
Cleanup the Linux installer

### DIFF
--- a/installer2/LinuxInfo.java
+++ b/installer2/LinuxInfo.java
@@ -40,16 +40,30 @@ public class LinuxInfo
 
     private static File getInstallDir(String homeDir, boolean normalHome)
     {
-        File file = new File(homeDir);
+        File installDir = new File(homeDir);
+        File newSteamDir;
         if (normalHome)
         {
-            file = new File(file, ".local");
-            file = new File(file, "share");
+            newSteamDir = new File(installDir, ".steam");
+            if (newSteamDir.isDirectory())
+            {
+                installDir = newSteamDir;
+                installDir = new File(installDir, "steam");
+            }
+            else
+            {
+                installDir = new File(installDir, ".local");
+                installDir = new File(installDir, "share");
+                installDir = new File(installDir, "Steam");
+            }
         }
-        file = new File(file, "Steam");
-        file = new File(file, "steamapps");
-        file = new File(file, "common");
-        file = new File(file, "Terraria");
-        return file;
+        else
+        {
+            installDir = new File(installDir, "Steam");
+        }
+        installDir = new File(installDir, "steamapps");
+        installDir = new File(installDir, "common");
+        installDir = new File(installDir, "Terraria");
+        return installDir;
     }
 }

--- a/solutions/ReleaseExtras/README_Linux.txt
+++ b/solutions/ReleaseExtras/README_Linux.txt
@@ -1,3 +1,7 @@
 To install tModLoader, simply run the tModLoaderInstaller.jar file. Java 1.7 or higher is required for the installer to run. The installer will make a window pop up, informing you of either success or failure.
 
-If the installer for some reason does not work, or if you do not want to install/upgrade Java, you may also do a manual install. Go to your Terraria's Steam folder; for most people, from the home folder this will be ".local/share/Steam/steamapps/common/Terraria". Then, copy all these files into that folder. You may wish to back-up your vanilla Terraria.exe first.
+If the installer for some reason does not work, or if you do not want to install/upgrade Java, you may also do a manual install.  You may wish to back-up your vanilla Terraria.exe first.
+
+1.  Go to your Terraria's Steam folder (the one containing Terraria.exe).  For older installations of Steam, this will be "~/.local/share/Steam/steamapps/common/Terraria".  For newer installations of Steam, this will be "~/.steam/steam/steamapps/common/Terraria".
+
+2.  Copy all of these files into that folder.


### PR DESCRIPTION
Newer installations of Steam organize the installation
differently.  Now the Linux installer handles 3 scenarios:

1. XDG_DATA_HOME is set (unaffected by this patch)
2. HOME is set and Steam was installed with "old" paths
2. HOME is set and Steam was installed with "new" paths

<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change
The tModLoader Linux installer now handles 3 scenarios:

1. XDG_DATA_HOME is set (unaffected by this patch)
2. HOME is set and Steam was installed with "old" paths
2. HOME is set and Steam was installed with "new" paths

### Alternate designs
I considered more verbose code with comments, but felt that would not adhere to the style of this file.

### Why this should be merged into tModLoader
Without this patch, users with newer versions of Steam will be unable to easily install tModLoader.

### Benefits
Easier installation for novice Linux users.

### Possible drawbacks
None that I can see.

### Applicable Issues
The XDG_DATA_HOME code path was untested and unchanged.

### Sample Usage
N/A


