### PR TITLE
Added ModContainer

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Default/MysteryTileEntity.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Default/MysteryTileEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using Terraria.DataStructures;
 using Terraria.ModLoader.IO;
 
@@ -49,6 +50,13 @@ namespace Terraria.ModLoader.Default
 				newEntity.type = (byte)tileEntity.Type;
 				newEntity.Position = Position;
 				newEntity.Load(data);
+				if (newEntity is ModContainer)
+				{
+					ModContainer.ContainersByID[newEntity.ID] = (ModContainer)newEntity;
+					ModContainer.ContainersByPosition[newEntity.Position] = (ModContainer)newEntity;
+					((ModContainer)newEntity).Setup();
+					((ModContainer)newEntity).LoadStorage(data.GetList<TagCompound>("storage"));
+				}
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria.ModLoader.IO/TileIO.cs
+++ b/patches/tModLoader/Terraria.ModLoader.IO/TileIO.cs
@@ -52,7 +52,7 @@ namespace Terraria.ModLoader.IO
 					var modTile = TileLoader.GetTile(type);
 					tileList.Add(new TagCompound
 					{
-						["value"] = (short) type,
+						["value"] = (short)type,
 						["mod"] = modTile.mod.Name,
 						["name"] = modTile.Name,
 						["framed"] = Main.tileFrameImportant[type],
@@ -67,7 +67,7 @@ namespace Terraria.ModLoader.IO
 					var modWall = WallLoader.GetWall(wall);
 					wallList.Add(new TagCompound
 					{
-						["value"] = (short) wall,
+						["value"] = (short)wall,
 						["mod"] = modWall.mod.Name,
 						["name"] = modWall.Name,
 					});
@@ -544,7 +544,8 @@ namespace Terraria.ModLoader.IO
 			if (itemFrames.Count > 0)
 			{
 				tag.Set("itemFrames", itemFrames.Select(entry =>
-					new TagCompound {
+					new TagCompound
+					{
 						["id"] = entry.Value,
 						["item"] = ItemIO.Save(((TEItemFrame)TileEntity.ByID[entry.Key]).item)
 					}
@@ -650,8 +651,8 @@ namespace Terraria.ModLoader.IO
 				Tile left = Main.tile[i, j];
 				Tile right = Main.tile[i + 1, j];
 				if (left.active() && right.active() && (left.type == TileID.Mannequin || left.type == TileID.Womannequin)
-				    && left.type == right.type && (left.frameX == 0 || left.frameX == 36) && right.frameX == left.frameX + 18
-				    && left.frameY / 18 == position && left.frameY == right.frameY)
+					&& left.type == right.type && (left.frameX == 0 || left.frameX == 36) && right.frameX == left.frameX + 18
+					&& left.frameY / 18 == position && left.frameY == right.frameY)
 				{
 					if (position == 0)
 					{
@@ -696,13 +697,20 @@ namespace Terraria.ModLoader.IO
 				if (pair.Value.type >= ModTileEntity.numVanilla)
 				{
 					ModTileEntity tileEntity = (ModTileEntity)pair.Value;
+					TagCompound data = null;
+					if (tileEntity.Save() != null) data = tileEntity.Save();
+					if (tileEntity is ModContainer)
+					{
+						if (data == null) data = new TagCompound();
+						data.Set("storage", ((ModContainer)tileEntity).SaveStorage());
+					}
 					list.Add(new TagCompound
 					{
 						["mod"] = tileEntity.mod.Name,
 						["name"] = tileEntity.Name,
 						["X"] = tileEntity.Position.X,
 						["Y"] = tileEntity.Position.Y,
-						["data"] = tileEntity.Save()
+						["data"] = data
 					});
 				}
 			}
@@ -711,6 +719,9 @@ namespace Terraria.ModLoader.IO
 
 		internal static void LoadTileEntities(IList<TagCompound> list)
 		{
+			ModContainer.ContainersByID.Clear();
+			ModContainer.ContainersByPosition.Clear();
+
 			foreach (TagCompound tag in list)
 			{
 				Mod mod = ModLoader.GetMod(tag.GetString("mod"));
@@ -726,6 +737,7 @@ namespace Terraria.ModLoader.IO
 						try
 						{
 							newEntity.Load(tag.GetCompound("data"));
+							if (newEntity is ModContainer) ((ModContainer)newEntity).LoadStorage(tag.GetCompound("data").GetList<TagCompound>("storage"));
 							if (newEntity is MysteryTileEntity)
 							{
 								((MysteryTileEntity)newEntity).TryRestore(ref newEntity);
@@ -750,12 +762,19 @@ namespace Terraria.ModLoader.IO
 				{
 					newEntity.ID = TileEntity.AssignNewID();
 					TileEntity.ByID[newEntity.ID] = newEntity;
+					if (newEntity is ModContainer) ModContainer.ContainersByID[newEntity.ID] = (ModContainer)newEntity;
 					TileEntity other;
 					if (TileEntity.ByPosition.TryGetValue(newEntity.Position, out other))
 					{
 						TileEntity.ByID.Remove(other.ID);
+						ModContainer.ContainersByID.Remove(other.ID);
 					}
 					TileEntity.ByPosition[newEntity.Position] = newEntity;
+					if (newEntity is ModContainer)
+					{
+						ModContainer.ContainersByPosition[newEntity.Position] = (ModContainer)newEntity;
+						((ModContainer)newEntity).Setup();
+					}
 				}
 			}
 		}

--- a/patches/tModLoader/Terraria.ModLoader/ModContainer.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModContainer.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Terraria.DataStructures;
+using Terraria.ModLoader.IO;
+
+namespace Terraria.ModLoader
+{
+	// run send/receive automatically
+	public abstract class ModContainer : ModTileEntity
+	{
+		public static readonly Dictionary<Point16, ModContainer> ContainersByPosition = new Dictionary<Point16, ModContainer>();
+		public static readonly Dictionary<int, ModContainer> ContainersByID = new Dictionary<int, ModContainer>();
+
+		public Dictionary<int, Item> inventory = new Dictionary<int, Item>();
+
+		/// <summary>
+		/// Determines whether inventory should be dropped on kill (Defaults to True)
+		/// </summary>
+		public bool dropItemsOnKill = true;
+		
+		public List<TagCompound> SaveStorage()
+		{
+			List<TagCompound> storage = new List<TagCompound>();
+
+			if (inventory.Count > 0)
+			{
+				for (int i = 0; i < inventory.Count; i++)
+				{
+					storage.Add(new TagCompound
+					{
+						["slot"] = i,
+						["item"] = ItemIO.Save(inventory[i])
+					});
+				}
+			}
+			return storage;
+		}
+
+		public void LoadStorage(IList<TagCompound> tag)
+		{
+			inventory.Clear();
+			for (int i = 0; i < tag.Count; i++) inventory.Add(tag[i].GetInt("slot"), tag[i].Get<Item>("item"));
+		}
+
+		public void SendStorage(BinaryWriter writer)
+		{
+			if (inventory.Count > 0)
+			{
+				writer.Write(inventory.Count);
+				for (int i = 0; i < inventory.Count; i++) ItemIO.Send(inventory[i], writer, true, true);
+			}
+		}
+
+		public void ReceiveStorage(BinaryReader reader)
+		{
+			inventory.Clear();
+			int count = reader.ReadInt32();
+			for (int i = 0; i < count; i++) inventory[i] = ItemIO.Receive(reader, true, true);
+		}
+
+		/// <summary>
+		/// Adds a slot to the inventory
+		/// </summary>
+		/// <param name="id">ID of the slot</param>
+		public void AddSlot(int id)
+		{
+			if (!inventory.ContainsKey(id)) inventory.Add(id, new Item());
+		}
+
+		public virtual void Setup()
+		{
+		}
+	}
+}

--- a/patches/tModLoader/Terraria.ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModTileEntity.cs
@@ -1,13 +1,15 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Terraria.DataStructures;
+using Terraria.Localization;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {
 	/// <summary>
-	/// Tile Entities are Entities tightly coupled with tiles, allowing the possibility of tiles to exhibit cool behavior. TileEntitry.Update is called in SP and on Server, not on Clients.
+	/// Tile Entities are Entities tightly coupled with tiles, allowing the possibility of tiles to exhibit cool behavior. TileEntity.Update is called in SP and on Server, not on Clients.
 	/// </summary>
 	/// <seealso cref="Terraria.DataStructures.TileEntity" />
 	public abstract class ModTileEntity : TileEntity
@@ -169,6 +171,12 @@ namespace Terraria.ModLoader
 			newEntity.type = (byte)Type;
 			ByID[newEntity.ID] = newEntity;
 			ByPosition[newEntity.Position] = newEntity;
+			if (newEntity is ModContainer)
+			{
+				ModContainer.ContainersByID[newEntity.ID] = (ModContainer)newEntity;
+				ModContainer.ContainersByPosition[newEntity.Position] = (ModContainer)newEntity;
+				((ModContainer)newEntity).Setup();
+			}
 			return newEntity.ID;
 		}
 
@@ -184,6 +192,21 @@ namespace Terraria.ModLoader
 				if (tileEntity.type == Type)
 				{
 					((ModTileEntity)tileEntity).OnKill();
+					if (tileEntity is ModContainer)
+					{
+						if (((ModContainer)tileEntity).dropItemsOnKill)
+						{
+							ModContainer c = (ModContainer)tileEntity;
+
+							for (int x = 0; x < c.inventory.Count; x++)
+							{
+								if (!c.inventory[x].IsAir) Item.NewItem(new Rectangle(pos.X * 16, pos.Y * 16, 32, 32), c.inventory[x].type, c.inventory[x].stack);
+							}
+						}
+
+						ModContainer.ContainersByID.Remove(tileEntity.ID);
+						ModContainer.ContainersByPosition.Remove(pos);
+					}
 					ByID.Remove(tileEntity.ID);
 					ByPosition.Remove(pos);
 				}
@@ -212,6 +235,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public sealed override void WriteExtraData(BinaryWriter writer, bool networkSend)
 		{
+			if (this is ModContainer) ((ModContainer)this).SendStorage(writer);
 			NetSend(writer, networkSend);
 		}
 
@@ -220,6 +244,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public sealed override void ReadExtraData(BinaryReader reader, bool networkSend)
 		{
+			if (this is ModContainer) ((ModContainer)this).ReceiveStorage(reader);
 			NetReceive(reader, networkSend);
 		}
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3677,10 +3677,15 @@
  			if (Main.ignoreErrors)
  			{
  				try
-@@ -58909,6 +_,11 @@
+@@ -58909,6 +_,16 @@
  					RemoteClient.CheckSection(k, Main.player[k].position, 1);
  				}
  			}
++		}
++
++		public static void NewText(object o, Microsoft.Xna.Framework.Color color, bool force = false)
++		{
++			NewText(o.ToString(), color.R, color.G, color.B, force);
 +		}
 +
 +		public static void NewText(string newText, Microsoft.Xna.Framework.Color color, bool force = false)

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -356,7 +356,17 @@
  						int num142 = this.reader.ReadInt32();
  						if (Main.netMode == 2 && num140 != this.whoAmI && !Main.pvpBuff[num141])
  						{
-@@ -2889,7 +_,7 @@
+@@ -2886,13 +_,27 @@
+ 							tileEntity.ID = num180;
+ 							TileEntity.ByID[tileEntity.ID] = tileEntity;
+ 							TileEntity.ByPosition[tileEntity.Position] = tileEntity;
++
++							if(tileEntity is ModContainer)
++							{
++								ModContainer.ContainersByID[tileEntity.ID] = (ModContainer)tileEntity;
++								ModContainer.ContainersByPosition[tileEntity.Position] = (ModContainer)tileEntity;
++							}	
++							
  							return;
  						}
  						TileEntity tileEntity2;
@@ -365,6 +375,16 @@
  						{
  							TileEntity.ByID.Remove(num180);
  							TileEntity.ByPosition.Remove(tileEntity2.Position);
++
++							if (tileEntity2 is ModContainer)
++							{
++								ModContainer.ContainersByID.Remove(num180);
++								ModContainer.ContainersByPosition.Remove(tileEntity2.Position);
++							}
++
+ 							return;
+ 						}
+ 						return;
 @@ -3489,9 +_,34 @@
  						CombatText.NewText(new Rectangle(x13, y13, 0, 0), color4, networkText.ToString(), false, false);
  						return;

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -246,6 +246,19 @@
  							if ((b & 16) == 16)
  							{
  								tile.wallColor(reader.ReadByte());
+@@ -2037,6 +_,12 @@
+ 				TileEntity tileEntity = TileEntity.Read(reader, false);
+ 				TileEntity.ByID[tileEntity.ID] = tileEntity;
+ 				TileEntity.ByPosition[tileEntity.Position] = tileEntity;
++
++				if (tileEntity is ModContainer)
++				{
++					ModContainer.ContainersByID[tileEntity.ID] = (ModContainer)tileEntity;
++					ModContainer.ContainersByPosition[tileEntity.Position] = (ModContainer)tileEntity;
++				}
+ 			}
+ 		}
+ 
 @@ -2405,6 +_,7 @@
  				{
  					NetMessage.SendData(5, toWho, fromWho, null, plr, (float)(58 + Main.player[plr].armor.Length + Main.player[plr].dye.Length + Main.player[plr].miscEquips.Length + 1 + m), (float)Main.player[plr].miscDyes[m].prefix, 0f, 0, 0, 0);


### PR DESCRIPTION
### Description of the Change

Adds the ModContainer class (which inherits ModTileEntity) which allows the modder to create containers.

### Alternate designs

I considered making an interface for it, but those aren't commonly spread in Terraria/tML.

### Why this should be merged into tModLoader

The fact that this is an united system, allows for easy manipulation with the inventories (such as searching for items/making mods that function like Magic Storage but has IO)

### Benefits

Relatively easy way to add containers, saving/loading is supported without the need to do it yourself, containers automatically drop items upon being broken (optional), ModContainer class contains Send/Receive methods for syncing inventory.

### Possible drawbacks

I don't see any of this code breaking already existing systems, I had to redo some data saving for ModTileEntity, but I have tested it and it both keeps the data (Save method) and the storage data.

### Applicable Issues

Unsure if the networking works.

### Sample Usage

I plan on including an example container in the ExampleMod (sometimes soon when I have time)