### PR TITLE
Account for newer Steam path in Linux installer

### DIFF
--- a/installer2/LinuxInfo.java
+++ b/installer2/LinuxInfo.java
@@ -4,20 +4,6 @@ public class LinuxInfo
 {
     public static void main(String[] args)
     {
-        String path = System.getenv("XDG_DATA_HOME");
-        File directory = null;
-        if (path != null)
-        {
-            directory = getInstallDir(path, false);
-        }
-        if (directory == null || !directory.exists())
-        {
-            path = System.getenv("HOME");
-            if (path != null)
-            {
-                directory = getInstallDir(path, true);
-            }
-        }
         String[] files = new String[]
         {
             "Terraria.exe",
@@ -35,21 +21,39 @@ public class LinuxInfo
             "ModCompile/Microsoft.Xna.Framework.Graphics.dll",
             "ModCompile/Microsoft.Xna.Framework.Xact.dll"
         };
-        Installer.tryInstall(files, directory);
+        Installer.tryInstall(files, getInstallDir());
     }
 
-    private static File getInstallDir(String homeDir, boolean normalHome)
+    private static File getInstallDir()
     {
-        File file = new File(homeDir);
-        if (normalHome)
+        File installDir;
+
+        String xdgHome = System.getenv("XDG_DATA_HOME");
+        if (xdgHome != null)
         {
-            file = new File(file, ".local");
-            file = new File(file, "share");
+            installDir = new File(xdgHome + "/Steam/steamapps/common/Terraria");
+            if (installDir.isDirectory())
+            {
+                return installDir;
+            }
         }
-        file = new File(file, "Steam");
-        file = new File(file, "steamapps");
-        file = new File(file, "common");
-        file = new File(file, "Terraria");
-        return file;
+
+        String home = System.getenv("HOME");
+        if (home != null)
+        {
+            installDir = new File(home + "/.local/share/Steam/steamapps/common/Terraria");
+            if (installDir.isDirectory())
+            {
+                return installDir;
+            }
+
+            installDir = new File(home + "/.steam/steam/steamapps/common/Terraria");
+            if (installDir.isDirectory())
+            {
+                return installDir;
+            }
+        }
+
+        return null;
     }
 }

--- a/solutions/ReleaseExtras/README_Linux.txt
+++ b/solutions/ReleaseExtras/README_Linux.txt
@@ -1,3 +1,7 @@
 To install tModLoader, simply run the tModLoaderInstaller.jar file. Java 1.7 or higher is required for the installer to run. The installer will make a window pop up, informing you of either success or failure.
 
-If the installer for some reason does not work, or if you do not want to install/upgrade Java, you may also do a manual install. Go to your Terraria's Steam folder; for most people, from the home folder this will be ".local/share/Steam/steamapps/common/Terraria". Then, copy all these files into that folder. You may wish to back-up your vanilla Terraria.exe first.
+If the installer for some reason does not work, or if you do not want to install/upgrade Java, you may also do a manual install.  You may wish to back-up your vanilla Terraria.exe first.
+
+1.  Go to your Terraria's Steam folder (the one containing Terraria.exe).  For older installations of Steam, this will be "~/.local/share/Steam/steamapps/common/Terraria".  For newer installations of Steam, this will be "~/.steam/steam/steamapps/common/Terraria".
+
+2.  Copy all of these files into that folder.


### PR DESCRIPTION
<!-- Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* Where applicable, provide Example Mod usage (example code), see the 'Sample usage' section
* If a header/description isn't applicable to your PR, leave it empty or remove it -->

### Description of the Change
Newer Steam installations under Linux change the installation path.  The tModLoader installer can now handle the new path (in addition to the two previous paths already handled).

### Alternate designs
At first, I made a patchset (now revoked) that mimic'd the file's format more closely.  I feel that adding support for the new path in the previous format made the code unwieldy.  I feel that this solution is superior.

### Why this should be merged into tModLoader
Users with newer Steam installations should be able to install tModLoader as easily as possible.

### Benefits
This patch makes tModLoader easier to use for more people.

### Possible drawbacks
None that I can see.

### Applicable Issues
I did not test the XDG_DATA_HOME variant as I am unfamiliar with that setup.  But I am confident that the code flow for that variant remains unchanged.

### Sample Usage
N/A