### PR TITLE
Fix NPCLoader calling PreDraw method in PostDraw

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -809,7 +809,7 @@ namespace Terraria.ModLoader
 
 			foreach (GlobalNPC g in HookPostDraw.arr)
 			{
-				g.Instance(npc).PreDraw(npc, spriteBatch, drawColor);
+				g.Instance(npc).PostDraw(npc, spriteBatch, drawColor);
 			}
 		}
 


### PR DESCRIPTION


### Description of the Change

PostDraw method is called PreDraw for GlobalNPCs, fixed to call PostDraw as expected.

