### PR TITLE
New OnCatchNPC hook

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -192,6 +192,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to make things happen when an NPC is catched. Ran Serverside.
+		/// </summary>
+		/// <param name="npc">The catched NPC</param>
+		/// <param name="player">The player catching the NPC</param>
+		public virtual void OnCatchNPC(NPC npc, Player player) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether an NPC can hit the given player. Return false to block the NPC from hitting the target. Returns true by default. CooldownSlot determines which of the player's cooldown counters to use (-1, 0, or 1), and defaults to -1.
 		/// </summary>
 		/// <param name="npc"></param>

--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -192,9 +192,9 @@ namespace Terraria.ModLoader
 		}
 
         /// <summary>
-        /// Allows you to make things happen when an NPC is catched. Ran Serverside.
+        /// Allows you to make things happen when an NPC is caught. Ran Serverside.
         /// </summary>
-        /// <param name="npc">The catched NPC</param>
+        /// <param name="npc">The caught NPC</param>
         /// <param name="player">The player catching the NPC</param>
         /// <param name="item">The item that will be spawned</param>
         public virtual void OnCatchNPC(NPC npc, Player player, Item item) {

--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -191,12 +191,13 @@ namespace Terraria.ModLoader
 		public virtual void NPCLoot(NPC npc) {
 		}
 
-		/// <summary>
-		/// Allows you to make things happen when an NPC is catched. Ran Serverside.
-		/// </summary>
-		/// <param name="npc">The catched NPC</param>
-		/// <param name="player">The player catching the NPC</param>
-		public virtual void OnCatchNPC(NPC npc, Player player) {
+        /// <summary>
+        /// Allows you to make things happen when an NPC is catched. Ran Serverside.
+        /// </summary>
+        /// <param name="npc">The catched NPC</param>
+        /// <param name="player">The player catching the NPC</param>
+        /// <param name="item">The item that will be spawned</param>
+        public virtual void OnCatchNPC(NPC npc, Player player, Item item) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -326,6 +326,13 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to make things happen when this NPC is catched. Ran Serverside
+		/// </summary>
+		/// <param name="player">The player catching this NPC</param>
+		public virtual void OnCatchNPC(Player player) {
+		}
+
+		/// <summary>
 		/// Allows you to customize what happens when this boss dies, such as which name is displayed in the defeat message and what type of potion it drops.
 		/// </summary>
 		/// <param name="name"></param>

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -325,11 +325,12 @@ namespace Terraria.ModLoader
 		public virtual void NPCLoot() {
 		}
 
-		/// <summary>
-		/// Allows you to make things happen when this NPC is catched. Ran Serverside
-		/// </summary>
-		/// <param name="player">The player catching this NPC</param>
-		public virtual void OnCatchNPC(Player player) {
+        /// <summary>
+        /// Allows you to make things happen when this NPC is catched. Ran Serverside
+        /// </summary>
+        /// <param name="player">The player catching this NPC</param>
+        /// <param name="item">The item that will be spawned</param>
+        public virtual void OnCatchNPC(Player player, Item item) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -326,7 +326,7 @@ namespace Terraria.ModLoader
 		}
 
         /// <summary>
-        /// Allows you to make things happen when this NPC is catched. Ran Serverside
+        /// Allows you to make things happen when this NPC is caught. Ran Serverside
         /// </summary>
         /// <param name="player">The player catching this NPC</param>
         /// <param name="item">The item that will be spawned</param>

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -433,6 +433,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookOnCatchNPC = AddHook<Action<NPC, Player>>(g => g.OnCatchNPC);
+
+		public static void OnCatchNPC(NPC npc, Player player) {
+			npc.modNPC?.OnCatchNPC(player);
+
+			foreach (GlobalNPC g in HookOnCatchNPC.arr) {
+				g.Instance(npc).OnCatchNPC(npc, player);
+			}
+		}
+
 		private delegate bool DelegateCanHitPlayer(NPC npc, Player target, ref int cooldownSlot);
 		private static HookList HookCanHitPlayer = AddHook<DelegateCanHitPlayer>(g => g.CanHitPlayer);
 

--- a/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/NPCLoader.cs
@@ -433,13 +433,13 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static HookList HookOnCatchNPC = AddHook<Action<NPC, Player>>(g => g.OnCatchNPC);
+		private static HookList HookOnCatchNPC = AddHook<Action<NPC, Player, Item>>(g => g.OnCatchNPC);
 
-		public static void OnCatchNPC(NPC npc, Player player) {
-			npc.modNPC?.OnCatchNPC(player);
+		public static void OnCatchNPC(NPC npc, Player player, Item item) {
+			npc.modNPC?.OnCatchNPC(player, item);
 
 			foreach (GlobalNPC g in HookOnCatchNPC.arr) {
-				g.Instance(npc).OnCatchNPC(npc, player);
+				g.Instance(npc).OnCatchNPC(npc, player, item);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -556,11 +556,13 @@
  			if (this.type != 16 && this.type != 81 && this.type != 121 && Main.rand.Next(6) == 0 && this.lifeMax > 1 && this.damage > 0)
  			{
  				int num77 = (int)Player.FindClosest(this.position, this.width, this.height);
-@@ -63308,6 +_,7 @@
+@@ -63307,7 +_,8 @@
+ 				}
  				Item item = new Item();
  				item.SetDefaults((int)Main.npc[i].catchItem, false);
- 				Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
-+				NPCLoader.OnCatchNPC(Main.npc[i], Main.player[who]);
+-				Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
++				int itemWhoAmI = Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
++				NPCLoader.OnCatchNPC(Main.npc[i], Main.player[who], Main.item[itemWhoAmI]);
  				Main.npc[i].active = false;
  				NetMessage.SendData(23, -1, -1, null, i, 0f, 0f, 0f, 0, 0, 0);
  			}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -556,14 +556,15 @@
  			if (this.type != 16 && this.type != 81 && this.type != 121 && Main.rand.Next(6) == 0 && this.lifeMax > 1 && this.damage > 0)
  			{
  				int num77 = (int)Player.FindClosest(this.position, this.width, this.height);
-@@ -63307,7 +_,8 @@
+@@ -63307,7 +_,9 @@
  				}
  				Item item = new Item();
  				item.SetDefaults((int)Main.npc[i].catchItem, false);
 -				Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
-+				int itemWhoAmI = Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
++				int itemWhoAmI = Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, true, 0, true, false);
 +				NPCLoader.OnCatchNPC(Main.npc[i], Main.player[who], Main.item[itemWhoAmI]);
- 				Main.npc[i].active = false;
++ 			NetMessage.SendData(MessageID.SyncItem, -1, -1, null, itemWhoAmI, 1f); // NewItem above changed to noBroadcast, number2 is 1 for noGrabDelay effect.
+     Main.npc[i].active = false;
  				NetMessage.SendData(23, -1, -1, null, i, 0f, 0f, 0f, 0, 0, 0);
  			}
 @@ -63380,6 +_,7 @@

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -556,6 +556,14 @@
  			if (this.type != 16 && this.type != 81 && this.type != 121 && Main.rand.Next(6) == 0 && this.lifeMax > 1 && this.damage > 0)
  			{
  				int num77 = (int)Player.FindClosest(this.position, this.width, this.height);
+@@ -63308,6 +_,7 @@
+ 				Item item = new Item();
+ 				item.SetDefaults((int)Main.npc[i].catchItem, false);
+ 				Item.NewItem((int)Main.player[who].Center.X, (int)Main.player[who].Center.Y, 0, 0, (int)Main.npc[i].catchItem, 1, false, 0, true, false);
++				NPCLoader.OnCatchNPC(Main.npc[i], Main.player[who]);
+ 				Main.npc[i].active = false;
+ 				NetMessage.SendData(23, -1, -1, null, i, 0f, 0f, 0f, 0, 0, 0);
+ 			}
 @@ -63380,6 +_,7 @@
  			{
  				itemType = 3860;


### PR DESCRIPTION
### Description of the Change
A new hook that runs after an NPC is successfully catched when `NPC.CatchNPC(int i, int who = -1)` is called. See: #664 

### Alternate designs
Using `On.` and replace the method, but a hook is more elegant.

### Why this should be merged into tModLoader
There was no hook before where you could make things happen when an NPC is catched.

### Benefits
Modders can now make things happen when an NPC is catched, such as:
* Create visuals
* Track "catch progress/count"
* Spawn items

### Possible drawbacks
Dunno

### Applicable Issues
It's inserted right after the `npc.catchItem` is spawned. Maybe make the hook allow the modder to decide if the item should be spawned in or not.

### Sample Usage
```cs
//public class MyNPC : ModNPC
public override void OnCatchNPC(Player player)
{
    Main.NewText(player.name + " just catched " + npc.GivenOrTypeName);
}

