### PR TITLE
Add ToFromStringConverter example to ExampleConfig

### DIFF
--- a/ExampleMod/ExampleConfig.cs
+++ b/ExampleMod/ExampleConfig.cs
@@ -155,8 +155,8 @@ namespace ExampleMod
 			[new PrefixDefinition("ExampleMod", "ReallyAwesome")] = 0.8f
 		};
 
-        // Using a custom class as a key in a Dictionary (see the ClassUsedAsKey definition by Ctrl+Leftclick on the class name)
-        public Dictionary<ClassUsedAsKey, Color> CustomKey = new Dictionary<ClassUsedAsKey, Color>();
+		// Using a custom class as a key in a Dictionary (see the ClassUsedAsKey definition by Ctrl+Leftclick on the class name)
+		public Dictionary<ClassUsedAsKey, Color> CustomKey = new Dictionary<ClassUsedAsKey, Color>();
 
 		public ModConfigShowcaseDataTypes() {
 			// Doing the initialization of defaults for reference types in a constructor is also acceptable.

--- a/ExampleMod/ExampleConfig.cs
+++ b/ExampleMod/ExampleConfig.cs
@@ -155,11 +155,21 @@ namespace ExampleMod
 			[new PrefixDefinition("ExampleMod", "ReallyAwesome")] = 0.8f
 		};
 
+        // Using a custom class as a key in a Dictionary (see the ClassUsedAsKey definition by Ctrl+Leftclick on the class name)
+        public Dictionary<ClassUsedAsKey, Color> CustomKey = new Dictionary<ClassUsedAsKey, Color>();
+
 		public ModConfigShowcaseDataTypes() {
 			// Doing the initialization of defaults for reference types in a constructor is also acceptable.
 			SomeClassA = new SimpleData() {
 				percent = .85f
 			};
+
+			CustomKey.Add(new ClassUsedAsKey() {
+				SomeBool = true,
+				SomeNumber = 42
+			},
+			new Color(1, 2, 3, 4));
+
 			itemDefinitionExample = new ItemDefinition("Terraria GoldOre"); // EntityDefinition uses ItemID field names rather than the numbers themselves for readability.
 		}
 	}
@@ -672,6 +682,50 @@ namespace ExampleMod
 
 		public override int GetHashCode() {
 			return new { ListOfInts, nestedSimple, IncrementalFloat }.GetHashCode();
+		}
+	}
+
+
+	[TypeConverter(typeof(ToFromStringConverter<ClassUsedAsKey>))]
+	public class ClassUsedAsKey
+	{
+		// When you save data from a dictionary into a file (json), you need to represent the key as a string
+		// But to get the object back, you need a TypeConverter, and this example shows how to implement one
+
+		// You start with the [TypeConverter(typeof(ToFromStringConverter<NameOfClassHere>))] attribute above the class
+		// For this to work, you need the usual Equals and GetHashCode overrides as explained in the other examples,
+		// plus ToString and FromString, which are used to transform your object into a string and back
+
+		public bool SomeBool { get; set; }
+		public int SomeNumber { get; set; }
+
+		public override bool Equals(object obj) {
+			if (obj is ClassUsedAsKey other)
+				return SomeBool == other.SomeBool && SomeNumber == other.SomeNumber;
+			return base.Equals(obj);
+		}
+
+		public override int GetHashCode() {
+			return new { SomeBool, SomeNumber }.GetHashCode();
+		}
+
+		// Here you need to write how the string representation of your object will look like so it is easy to reconstruct again
+		// Inside the json file, it will look something like this: "True, 5"
+		public override string ToString() {
+			return $"{SomeBool}, {SomeNumber}";
+		}
+
+		// Here you need to create an object from the given string (reverting ToString basically)
+		// This has to be static
+		public static ClassUsedAsKey FromString(string s)
+		{
+			// This following code depends on your implementation of ToString, here we just have two values separated by a ','
+			string[] vars = s.Split(new char[] { ',' }, 2, StringSplitOptions.RemoveEmptyEntries);
+			// The System.Convert class provides methods to transform data types between eachother, here using the string overload
+			return new ClassUsedAsKey {
+				SomeBool = Convert.ToBoolean(vars[0]),
+				SomeNumber = Convert.ToInt32(vars[1])
+			};
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change
If you work with ModConfigs you most likely will come across Dictionaries and want to use them with non-primitive data types aswell. An example of such are the `EntityDefinition` ones provided by tModLoader. Those use the `TypeConverter` attribute so they are able to be saved as a string representation inside the config file, and loaded back as an object. Since `ToFromStringConverter` is only used internally by tml, I want to provide an example that is easily understood and explain why it is needed if you plan to use your custom class as a key type in a Dictionary.

### Alternate designs
To be in line with ExampleConfigs examples, I used simple to understand variable names and comments where necessary. The way I did the `ToString` and `FromString` can be changed, and I will be happy for suggestions on how to improve those.

### Why this should be merged into tModLoader
Just an example showcasing something that is also internally used by tml.

### Benefits
Give modders more possibilities to use ModConfig.

### Possible drawbacks
not applicable.

### Applicable Issues
There is no try/catch inside the `FromString`, which causes illegal manipulations to the file to fail loading the key, and the mod will crash. Awaiting suggestions, see Alternate Designs.

### Sample Usage
See commit

