### PR TITLE
Prefix hook fixes and use examples for ExampleMod

### DIFF
--- a/ExampleMod/Items/Accessories/ManaHeart.cs
+++ b/ExampleMod/Items/Accessories/ManaHeart.cs
@@ -1,6 +1,7 @@
 ﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.Utilities;
 
 namespace ExampleMod.Items.Accessories
 {
@@ -20,6 +21,11 @@ namespace ExampleMod.Items.Accessories
 
 		public override void UpdateAccessory(Player player, bool hideVisual) {
 			player.GetModPlayer<ExamplePlayer>().manaHeart = true;
+		}
+
+		public override int ChoosePrefix(UnifiedRandom rand) {
+			// When the item is given a prefix, only roll the best modifiers for accessories
+			return rand.Next(new int[] { PrefixID.Arcane, PrefixID.Lucky, PrefixID.Menacing, PrefixID.Quick, PrefixID.Violent, PrefixID.Warding });
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Items/PrefixChanceGlobalItem.cs
+++ b/ExampleMod/Items/PrefixChanceGlobalItem.cs
@@ -15,7 +15,7 @@ namespace ExampleMod.Items
 	{
 		public override bool? PrefixChance(Item item, int pre, UnifiedRandom rand) {
 			// pre: The prefix being applied to the item, or the roll mode
-			// -1 is when an item is bought from a shop, crafted or generated in a chest
+			// -1 is when an item is naturally generated in a chest, crafted, purchased from an NPC, looted from a grab bag (excluding presents), or dropped by a slain enemy
 			// -2 is when an item is rolled in the tinkerer
 			// -3 determines if an item can be placed in the tinkerer slot
 
@@ -35,7 +35,7 @@ namespace ExampleMod.Items
 
 			// To prevent rolling of a prefix on spawn, return false when pre is -1
 			if (pre == -1) {
-				if (item.melee && item.modItem != null && item.modItem.mod.Name == mod.Name) {
+				if (item.melee && item.modItem?.mod == mod) {
 					// All melee weapons from ExampleMod won't have a prefix when they are crafted, bought, taken from a generated chest, opened, or dropped by an enemy
 					return false;
 				}

--- a/ExampleMod/Items/PrefixChanceGlobalItem.cs
+++ b/ExampleMod/Items/PrefixChanceGlobalItem.cs
@@ -1,0 +1,66 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.Utilities;
+
+namespace ExampleMod.Items
+{
+	/// <summary>
+	/// This class demonstrates how to manipulate the chances of prefixes given to items.
+	/// For other prefix related hooks and their usage, see also:
+	/// <seealso cref="Accessories.ManaHeart"/>
+	/// <seealso cref="Weapons.ExampleYoyo"/>
+	/// </summary>
+	public class PrefixChanceGlobalItem : GlobalItem
+	{
+		public override bool? PrefixChance(Item item, int pre, UnifiedRandom rand) {
+			// pre: The prefix being applied to the item, or the roll mode
+			// -1 is when an item is bought from a shop, crafted or generated in a chest
+			// -2 is when an item is rolled in the tinkerer
+			// -3 determines if an item can be placed in the tinkerer slot
+
+			// To prevent putting an item in the tinkerer slot, return false when pre is -3
+			if (pre == -3 && item.type == ItemID.LaserRifle) {
+				// This will make the Laser Rifle not be reforgeable at all (useful if you want your item to preserve its custom name color)
+				return false;
+			}
+
+			// To make an item reset its prefix when reforging
+			if (pre == -2) {
+				if (Main.LocalPlayer.HasBuff(BuffID.Cursed)) {
+					// If the player is cursed, make it remove the prefix
+					return false;
+				}
+			}
+
+			// To prevent rolling of a prefix on spawn, return false when pre is -1
+			if (pre == -1) {
+				if (item.melee && item.modItem != null && item.modItem.mod.Name == mod.Name) {
+					// All melee weapons from ExampleMod won't have a prefix when they are crafted, bought, taken from a generated chest, opened, or dropped by an enemy
+					return false;
+				}
+			}
+
+			// For the following code, this is useful to know (from the terraria wiki):
+			// Nearly all weapons and accessories have a 75% chance of receiving a random modifier upon the item's creation
+			// (naturally generated in a chest, crafted, purchased from an NPC, looted from a grab bag (excluding presents), or dropped by a slain enemy).
+
+			// To change the chance of a prefix being rolled or not, return true or false depending on some condition
+			if (pre == -1 && item.type == ItemID.Shackle) {
+				// Force rolling
+				// return true;
+
+				// When using random numbers, make sure to use the rand object passed into this method, and not Main.rand.
+				// This will make it consistent with worldgen should this item be spawned in a chest
+				if (rand.NextFloat() < 0.5f) {
+					// Increase the chance of not receiving any prefix on spawn by 50%
+					return false;
+				}
+				// Keep in mind that if the code arrives here, there is still a 25% chance that it won't get a modifier.
+				// If you want a more controlled approach, return true in an else block
+			}
+
+			return null;
+		}
+	}
+}

--- a/ExampleMod/Items/Weapons/ExampleYoyo.cs
+++ b/ExampleMod/Items/Weapons/ExampleYoyo.cs
@@ -1,4 +1,5 @@
 ﻿using ExampleMod.Projectiles;
+using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -36,6 +37,25 @@ namespace ExampleMod.Items.Weapons
 			item.UseSound = SoundID.Item1;
 			item.value = Item.sellPrice(silver: 1);
 			item.shoot = ProjectileType<ExampleYoyoProjectile>();
+		}
+
+		// Make sure that your item can even receive these prefixes (check the vanilla wiki on prefixes)
+		// These are the ones that reduce damage of a melee weapon
+		private static readonly int[] unwantedPrefixes = new int[] { PrefixID.Terrible, PrefixID.Dull, PrefixID.Shameful, PrefixID.Annoying, PrefixID.Broken, PrefixID.Damaged, PrefixID.Shoddy};
+
+		public override bool AllowPrefix(int pre) {
+			// return false to make the game reroll the prefix
+
+			// DON'T DO THIS BY ITSELF:
+			// return false;
+			// This will get the game stuck because it will try to reroll every time. Instead, make it have a chance to return true
+
+			if (Array.IndexOf(unwantedPrefixes, pre) > -1) {
+				// Rolled a prefix we don't want, reroll
+				return false;
+			}
+			// Don't reroll
+			return true;
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Items/Weapons/ExampleYoyo.cs
+++ b/ExampleMod/Items/Weapons/ExampleYoyo.cs
@@ -51,6 +51,7 @@ namespace ExampleMod.Items.Weapons
 			// This will get the game stuck because it will try to reroll every time. Instead, make it have a chance to return true
 
 			if (Array.IndexOf(unwantedPrefixes, pre) > -1) {
+				// IndexOf returns a positive index of the element you search for. If not found, it's less than 0. Here check the opposite
 				// Rolled a prefix we don't want, reroll
 				return false;
 			}

--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -101,17 +101,17 @@ namespace Terraria.ModLoader
 		public virtual int ChoosePrefix(Item item, UnifiedRandom rand) => -1;
 
 		/// <summary>
-		/// To prevent putting the item in the tinkerer slot, return false when pre is -3
-		/// To prevent rolling of a prefix on spawn, return false when pre is -1
-		/// To force rolling of a prefix on spawn, return true when pre is -1
+		/// To prevent putting the item in the tinkerer slot, return false when pre is -3.
+		/// To prevent rolling of a prefix on spawn, return false when pre is -1.
+		/// To force rolling of a prefix on spawn, return true when pre is -1.
 		/// 
-		/// To reduce the probability of a prefix on spawn (pre == -1) to X%, return false 100-4X % of the time
-		/// To increase the probability of a prefix on spawn (pre == -1) to X%, return true (4X-100)/3 % of the time
+		/// To reduce the probability of a prefix on spawn (pre == -1) to X%, return false 100-4X % of the time.
+		/// To increase the probability of a prefix on spawn (pre == -1) to X%, return true (4X-100)/3 % of the time.
 		/// 
 		/// To delete a prefix from an item when the item is loaded, return false when pre is the prefix you want to delete.
-		/// Use AllowPrefix to prevent rolling of a certain prefix
+		/// Use AllowPrefix to prevent rolling of a certain prefix.
 		/// </summary>
-		/// <param name="pre">The prefix being applied to the item, or the roll mode. -1 is when an item is bought from a shop, crafted or generated in a chest. -2 is when the item is rolled in the tinkerer. -3 determines if the item can be placed in the tinkerer slot.</param>
+		/// <param name="pre">The prefix being applied to the item, or the roll mode. -1 is when the item is naturally generated in a chest, crafted, purchased from an NPC, looted from a grab bag (excluding presents), or dropped by a slain enemy (if it's spawned with prefixGiven: -1). -2 is when the item is rolled in the tinkerer. -3 determines if the item can be placed in the tinkerer slot.</param>
 		/// <returns></returns>
 		public virtual bool? PrefixChance(Item item, int pre, UnifiedRandom rand) => null;
 

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -249,12 +249,15 @@ namespace Terraria.ModLoader
 		public static int ChoosePrefix(Item item, UnifiedRandom rand) {
 			foreach (var g in HookChoosePrefix.arr) {
 				int pre = g.Instance(item).ChoosePrefix(item, rand);
-				if (pre >= 0) {
+				if (pre > 0) {
 					return pre;
 				}
 			}
 			if (item.modItem != null) {
-				return item.modItem.ChoosePrefix(rand);
+				int pre = item.modItem.ChoosePrefix(rand);
+				if (pre > 0) {
+					return pre;
+				}
 			}
 			return -1;
 		}
@@ -263,7 +266,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows for blocking, forcing and altering chance of prefix rolling.
-		/// False (block) takes precedence over True (force)
+		/// False (block) takes precedence over True (force).
 		/// Null gives vanilla behaviour
 		/// </summary>
 		public static bool? PrefixChance(Item item, int pre, UnifiedRandom rand) {

--- a/patches/tModLoader/Terraria.ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModItem.cs
@@ -192,17 +192,17 @@ namespace Terraria.ModLoader
 		public virtual int ChoosePrefix(UnifiedRandom rand) => -1;
 
 		/// <summary>
-		/// To prevent putting the item in the tinkerer slot, return false when pre is -3
-		/// To prevent rolling of a prefix on spawn, return false when pre is -1
-		/// To force rolling of a prefix on spawn, return true when pre is -1
+		/// To prevent putting the item in the tinkerer slot, return false when pre is -3.
+		/// To prevent rolling of a prefix on spawn, return false when pre is -1.
+		/// To force rolling of a prefix on spawn, return true when pre is -1.
 		/// 
-		/// To reduce the probability of a prefix on spawn (pre == -1) to X%, return false 100-4X % of the time
-		/// To increase the probability of a prefix on spawn (pre == -1) to X%, return true (4X-100)/3 % of the time
+		/// To reduce the probability of a prefix on spawn (pre == -1) to X%, return false 100-4X % of the time.
+		/// To increase the probability of a prefix on spawn (pre == -1) to X%, return true (4X-100)/3 % of the time.
 		/// 
 		/// To delete a prefix from an item when the item is loaded, return false when pre is the prefix you want to delete.
-		/// Use AllowPrefix to prevent rolling of a certain prefix
+		/// Use AllowPrefix to prevent rolling of a certain prefix.
 		/// </summary>
-		/// <param name="pre">The prefix being applied to the item, or the roll mode. -1 is when an item is bought from a shop, crafted or generated in a chest. -2 is when the item is rolled in the tinkerer. -3 determines if the item can be placed in the tinkerer slot.</param>
+		/// <param name="pre">The prefix being applied to the item, or the roll mode. -1 is when the item is naturally generated in a chest, crafted, purchased from an NPC, looted from a grab bag (excluding presents), or dropped by a slain enemy (if it's spawned with prefixGiven: -1). -2 is when the item is rolled in the tinkerer. -3 determines if the item can be placed in the tinkerer slot.</param>
 		/// <returns></returns>
 		public virtual bool? PrefixChance(int pre, UnifiedRandom rand) => null;
 

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -56,7 +56,7 @@
  				num8 = 0;
  				flag = false;
 -				if (num == -1 && unifiedRandom.Next(4) == 0)
-+				if (num == -1 && ((applyPrefixOverride ?? false) || unifiedRandom.Next(4) == 0))
++				if (pre == -1 && !(applyPrefixOverride ?? false) && unifiedRandom.NextBool(4))
  				{
  					num = 0;
  				}
@@ -146,7 +146,7 @@
  					}
  					else
  					{
-@@ -833,7 +_,9 @@
+@@ -833,14 +_,16 @@
  						{
  							return false;
  						}
@@ -156,6 +156,14 @@
  					}
  				}
  				if (pre == -3)
+ 				{
+ 					return true;
+ 				}
+-				if (pre == -1 && (num == 7 || num == 8 || num == 9 || num == 10 || num == 11 || num == 22 || num == 23 || num == 24 || num == 29 || num == 30 || num == 31 || num == 39 || num == 40 || num == 56 || num == 41 || num == 47 || num == 48 || num == 49) && unifiedRandom.Next(3) != 0)
++				if (pre == -1 && (num == 7 || num == 8 || num == 9 || num == 10 || num == 11 || num == 22 || num == 23 || num == 24 || num == 29 || num == 30 || num == 31 || num == 39 || num == 40 || num == 56 || num == 41 || num == 47 || num == 48 || num == 49) && (!(applyPrefixOverride ?? false) && !unifiedRandom.NextBool(3)))
+ 				{
+ 					num = 0;
+ 				}
 @@ -1175,6 +_,10 @@
  					num2 = 1.05f;
  					num8 = 2;


### PR DESCRIPTION
### Description of the Change
As requested by Chicken Bones, here are examples of usages for all three prefix related hooks `ChoosePrefix`, `AllowPrefix` and `PrefixChance`. With them come a few small fixes required for all the three hooks to work accordingly so their intended usage doesn't overlap. This is especially related to #388. ChoosePrefix hook now ignores 0 as an input (treats it as -1), since the previously planned function for allowing or not allowing is now handled by `AllowPrefix`, and chances by `PrefixChance`.

### Why this should be merged into tModLoader
* Control reforgability or prefixes an item receives dynamically
* Preserving the rarity color on an item
* Wiping all other modded prefixes on an item without any vanilla damage types

### Sample Usage
ExampleMod code provided


