### PR TITLE
 Fix clientside lag when opening chests near crafting stations (don't incude the commits from this for 1.4)

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -207,14 +207,40 @@
  						float num163 = reader.ReadSingle();
  						int num164 = reader.ReadByte() - 1;
  						byte b14 = reader.ReadByte();
-@@ -1358,6 +_,7 @@
+@@ -1330,7 +_,7 @@
+ 						int num10 = Chest.FindChest(x2, y2);
+ 						if (num10 > -1 && Chest.UsingChest(num10) == -1) {
+ 							for (int l = 0; l < 40; l++) {
+-								NetMessage.SendData(32, whoAmI, -1, null, num10, l);
++								NetMessage.SendData(32, whoAmI, -1, null, num10, l, 1); //New, the 1 indicates the item is synced synced within RequestChestOpen
+ 							}
+ 
+ 							NetMessage.SendData(33, whoAmI, -1, null, num10);
+@@ -1346,6 +_,7 @@
+ 				case 32: {
+ 						int num215 = reader.ReadInt16();
+ 						int num216 = reader.ReadByte();
++						bool skipRecipes = reader.ReadBoolean(); // New, third parameter, sent as '(bool)(number3 == 1)', 1 meaning the item is synced within RequestChestOpen
+ 						int stack4 = reader.ReadInt16();
+ 						int pre2 = reader.ReadByte();
+ 						int type14 = reader.ReadInt16();
+@@ -1358,7 +_,15 @@
  						Main.chest[num215].item[num216].netDefaults(type14);
  						Main.chest[num215].item[num216].Prefix(pre2);
  						Main.chest[num215].item[num216].stack = stack4;
 +						ItemIO.ReceiveModData(Main.chest[num215].item[num216], reader);
- 						Recipe.FindRecipes();
++						//Previous
++						//Recipe.FindRecipes();
++						if (!skipRecipes)
+-						Recipe.FindRecipes();
++							Recipe.FindRecipes();
++						// New, skips FindRecipes if item is synced within RequestChestOpen.
++						// Note that in this case, SyncPlayerChestIndex (80), which is sent at the end of RequestChestOpen,
++						// calls FindRecipes for the current chest, so the client is still aware of new recipes.
++						// In 1.4, the commit adding this patch is redundant because it uses a param called canDelayCheck for FindRecipes, fixing the same problem as this commit
  						break;
  					}
+ 				case 33: {
 @@ -1413,6 +_,7 @@
  						break;
  					}

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -220,17 +220,15 @@
  				case 32: {
  						int num215 = reader.ReadInt16();
  						int num216 = reader.ReadByte();
-+						bool skipRecipes = reader.ReadBoolean(); // New, third parameter, sent as '(bool)(number3 == 1)', 1 meaning the item is synced within RequestChestOpen
++						bool skipRecipes = !ModNet.AllowVanillaClients && reader.ReadBoolean(); // New, third parameter, sent as '(bool)(number3 == 1)', 1 meaning the item is synced within RequestChestOpen
  						int stack4 = reader.ReadInt16();
  						int pre2 = reader.ReadByte();
  						int type14 = reader.ReadInt16();
-@@ -1358,7 +_,15 @@
+@@ -1358,7 +_,13 @@
  						Main.chest[num215].item[num216].netDefaults(type14);
  						Main.chest[num215].item[num216].Prefix(pre2);
  						Main.chest[num215].item[num216].stack = stack4;
 +						ItemIO.ReceiveModData(Main.chest[num215].item[num216], reader);
-+						//Previous
-+						//Recipe.FindRecipes();
 +						if (!skipRecipes)
 -						Recipe.FindRecipes();
 +							Recipe.FindRecipes();

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -137,6 +137,14 @@
  						writer.Write(number3);
  						writer.Write((byte)(number4 + 1f));
  						writer.Write((byte)number5);
+@@ -537,6 +_,7 @@
+ 							Item item3 = Main.chest[number].item[(byte)number2];
+ 							writer.Write((short)number);
+ 							writer.Write((byte)number2);
++							writer.Write((bool)(number3 == 1)); // New, passed as third parameter, default 0. 1 if sent from within a RequestChestOpen packet
+ 							short value2 = (short)item3.netID;
+ 							if (item3.Name == null)
+ 								value2 = 0;
 @@ -544,6 +_,7 @@
  							writer.Write((short)item3.stack);
  							writer.Write(item3.prefix);

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -137,11 +137,12 @@
  						writer.Write(number3);
  						writer.Write((byte)(number4 + 1f));
  						writer.Write((byte)number5);
-@@ -537,6 +_,7 @@
+@@ -537,6 +_,8 @@
  							Item item3 = Main.chest[number].item[(byte)number2];
  							writer.Write((short)number);
  							writer.Write((byte)number2);
-+							writer.Write((bool)(number3 == 1)); // New, passed as third parameter, default 0. 1 if sent from within a RequestChestOpen packet
++							if (!ModNet.AllowVanillaClients)
++								writer.Write((bool)(number3 == 1)); // New, passed as third parameter, default 0. 1 if sent from within a RequestChestOpen packet
  							short value2 = (short)item3.netID;
  							if (item3.Name == null)
  								value2 = 0;


### PR DESCRIPTION
### What is the bug?
In vanilla + tml especially, the `FindRecipes` call at the end of packet id `SyncChestItem` causes a lag spike when a client opens a chest, because for each single item, it's called.

### How did you fix the bug?
This PR modifies two packets, and one `SendData` call, introducing a third parameter denoting that `RequestChestOpen` has been sent previously from the client. It essentially skips the `FindRecipes` check. In this case, `SyncPlayerChestIndex`, which is sent at the end of `RequestChestOpen`, calls `FindRecipes` for the current chest, so the client is still aware of new recipes.

### Are there alternatives to your fix?
Backporting the 1.4 way of fixing the same bug by introducing a canDelayCheck parameter in `FindRecipes`, that is set to true in all netcode related calls, incuding all the logic and infrastructure needed to make this work (which would be a much bigger patch than this).
