### PR TITLE
Added steam cloud quota check

### DIFF
--- a/patches/tModLoader/Terraria.GameContent.UI.Elements/UICharacterListItem.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.Elements/UICharacterListItem.cs.patch
@@ -114,7 +114,15 @@
  			_deleteButtonLabel.Top.Set(-3f, 0f);
  			Append(_deleteButtonLabel);
  			uIImageButton.SetSnapPoint("Play", snapPointIndex);
-@@ -113,13 +_,22 @@
+@@ -109,17 +_,29 @@
+ 			if (_data.IsCloudSave)
+ 				_buttonLabel.SetText(Language.GetTextValue("UI.MoveOffCloud"));
+ 			else
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient())
++					_buttonLabel.SetText(Language.GetTextValue("tModLoader.CloudWarning"));
++				else
+-				_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++					_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
  		}
  
  		private void PlayMouseOver(UIMouseEvent evt, UIElement listeningElement) {
@@ -138,6 +146,19 @@
  		private void DeleteMouseOut(UIMouseEvent evt, UIElement listeningElement) {
  			_deleteButtonLabel.SetText("");
  		}
+@@ -131,8 +_,11 @@
+ 		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
+ 				_data.MoveToLocal();
+-			else
++			else {
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient())
++					return; //Don't allow both the move to cloud, and the setting of the label
+ 				_data.MoveToCloud();
++			}
+ 
+ 			((UIImageButton)evt.Target).SetImage(_data.IsCloudSave ? _buttonCloudActiveTexture : _buttonCloudInactiveTexture);
+ 			if (_data.IsCloudSave)
 @@ -181,6 +_,13 @@
  			(Parent.Parent as UIList)?.UpdateOrder();
  		}

--- a/patches/tModLoader/Terraria.GameContent.UI.Elements/UIWorldListItem.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.Elements/UIWorldListItem.cs.patch
@@ -47,7 +47,15 @@
  		}
  
  		private void InitializeAppearance() {
-@@ -142,13 +_,18 @@
+@@ -138,17 +_,25 @@
+ 			if (_data.IsCloudSave)
+ 				_buttonLabel.SetText(Language.GetTextValue("UI.MoveOffCloud"));
+ 			else
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient())
++					_buttonLabel.SetText(Language.GetTextValue("tModLoader.CloudWarning"));
++				else
+-				_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++					_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
  		}
  
  		private void PlayMouseOver(UIMouseEvent evt, UIElement listeningElement) {
@@ -67,6 +75,19 @@
  		private void DeleteMouseOver(UIMouseEvent evt, UIElement listeningElement) {
  			_deleteButtonLabel.SetText(Language.GetTextValue("UI.Delete"));
  		}
+@@ -164,8 +_,11 @@
+ 		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
+ 				_data.MoveToLocal();
+-			else
++			else {
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient())
++					return; //Don't allow both the move to cloud, and the setting of the label
+ 				_data.MoveToCloud();
++			}
+ 
+ 			((UIImageButton)evt.Target).SetImage(_data.IsCloudSave ? _buttonCloudActiveTexture : _buttonCloudInactiveTexture);
+ 			if (_data.IsCloudSave)
 @@ -194,7 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -255,6 +255,7 @@
 		"NewModsListing": "New mods:\n{0}",
 		"PlayerCustomDataFail": "A problem was encountered when loading custom data for a player",
 		"PlayerLoadWorldFail": "A problem was encountered when trying to load a world",
+		"CloudWarning": "Cloud storage limit reached, unable to move to cloud",
 
 		// Mod Sources
 		"MSBuild": "Build",

--- a/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
@@ -14,6 +14,8 @@ namespace Terraria.ModLoader.Engine
 		public const uint TMLAppID = 1281930;
 		public const uint TerrariaAppID = 105600;
 
+		public const float SteamCloudQuotaLimitRatio = 0.9f;
+
 		public static AppId_t TMLAppID_t = new AppId_t(TMLAppID);
 		public static AppId_t TerrariaAppId_t = new AppId_t(TerrariaAppID);
 		public static bool IsSteamApp => SocialAPI.Mode == SocialMode.Steam && SteamAPI.Init() && SteamApps.BIsAppInstalled(new AppId_t(TMLAppID));
@@ -48,6 +50,15 @@ namespace Terraria.ModLoader.Engine
 			bool exists = File.Exists("steam_appid.txt");
 			File.WriteAllText("steam_appid.txt", TerrariaAppID.ToString());
 			return exists;
+		}
+
+		public static bool CheckSteamCloudStorageSufficient()
+		{
+			if (IsSteamApp)
+				if (SteamRemoteStorage.GetQuota(out ulong pnTotalBytes, out ulong puAvailableBytes))
+					if (1f - puAvailableBytes / (float)pnTotalBytes > SteamCloudQuotaLimitRatio)
+						return false;
+			return true;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
@@ -54,7 +54,7 @@ namespace Terraria.ModLoader.Engine
 
 		public static bool CheckSteamCloudStorageSufficient()
 		{
-			if (IsSteamApp)
+			if (SocialAPI.Cloud != null)
 				if (SteamRemoteStorage.GetQuota(out ulong pnTotalBytes, out ulong puAvailableBytes))
 					if (1f - puAvailableBytes / (float)pnTotalBytes > SteamCloudQuotaLimitRatio)
 						return false;


### PR DESCRIPTION
**This is an alternate version of #1045**

### What is the bug?
On Steam, because Terraria and tModLoader share the same cloud space, people (usually with a full Terraria steam cloud) want to move their tModLoader files to the cloud, which leads to them being deleted instead (usually after restarting the game)

### How did you fix the bug?
Prevent pressing the "move to cloud" button when the quota exceeds 90%

### Are there alternatives to your fix?
Currently this recalculates the quota on mouseover, aka every tick. This could be solved by caching the last value that was calculated (once when the game starts, and then once every "move to/off cloud" press)

