### PR TITLE
Fix/Change location of ItemSlot.ShiftClicked to be in a more appropri…

### DIFF
--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -44,14 +44,61 @@
  						}
  
  						Recipe.FindRecipes();
-@@ -712,20 +_,24 @@
- 			if (inv[slot].type <= 0)
- 				return;
+@@ -683,28 +_,34 @@
+ 		}
  
+ 		private static bool LeftClick_SellOrTrash(Item[] inv, int context, int slot) {
+-			bool flag = false;
+-			bool result = false;
+-			if (NotUsingGamepad && Options.DisableLeftShiftTrashCan) {
+-				if ((uint)context <= 4u || context == 7)
+-					flag = true;
+-
+-				if (ControlInUse && flag) {
+-					SellOrTrash(inv, context, slot);
+-					result = true;
+-				}
++			Player player = Main.player[Main.myPlayer];
 +			if (PlayerHooks.ShiftClickSlot(player, inv, context, slot)) {
-+			}
--			if (Main.npcShop > 0 && !inv[slot].favorited) {
-+			else if (Main.npcShop > 0 && !inv[slot].favorited) {
++				return true;
+ 			}
+ 			else {
++				bool flag = false;
++				bool result = false;
++				if (NotUsingGamepad && Options.DisableLeftShiftTrashCan) {
++					if ((uint)context <= 4u || context == 7)
++						flag = true;
++
++					if (ControlInUse && flag) {
++						SellOrTrash(inv, context, slot);
++						result = true;
++					}
++				}
++				else {
+-				if ((uint)context <= 4u)
++					if ((uint)context <= 4u)
+-					flag = (Main.player[Main.myPlayer].chest == -1);
++						flag = (Main.player[Main.myPlayer].chest == -1);
+ 
+-				if (ShiftInUse && flag) {
++					if (ShiftInUse && flag) {
+-					SellOrTrash(inv, context, slot);
++						SellOrTrash(inv, context, slot);
+-					result = true;
++						result = true;
++					}
+ 				}
++
++				return result;
+ 			}
+-
+-			return result;
+ 		}
+ 
+ 		private static void SellOrTrash(Item[] inv, int context, int slot) {
+@@ -714,18 +_,20 @@
+ 
+ 			if (Main.npcShop > 0 && !inv[slot].favorited) {
  				Chest chest = Main.instance.shop[Main.npcShop];
 -				if (inv[slot].type < 71 || inv[slot].type > 74) {
 +				if (inv[slot].type < 71 || inv[slot].type > 74 && PlayerHooks.CanSellItem(player, Main.npc[player.talkNPC], chest.item, inv[slot])) {					


### PR DESCRIPTION
### What is the bug?
The hook for inventory shift seems to not be in the correct location, it does not fire when using basic shift operations when no sell window (or only fires when holding down control (trashkey) otherwise).

### How did you fix the bug?
I moved the hook to from what I can understand is a more suitable location, but was mostly a "hack"

### Are there alternatives to your fix?
Probably, seems to be a lot of shift functions

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
