### PR TITLE
readd BossHeadSlot hook, add more docs to it

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalNPC.cs
@@ -346,10 +346,10 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to customize the boss head texture used by an NPC based on its state.
+		/// Allows you to customize the boss head texture used by an NPC based on its state. Set index to -1 to stop the texture from being displayed.
 		/// </summary>
 		/// <param name="npc"></param>
-		/// <param name="index"></param>
+		/// <param name="index">The index for NPCID.Sets.BossHeadTextures</param>
 		public virtual void BossHeadSlot(NPC npc, ref int index) {
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModNPC.cs
@@ -474,9 +474,9 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to customize the boss head texture used by this NPC based on its state.
+		/// Allows you to customize the boss head texture used by this NPC based on its state. Set index to -1 to stop the texture from being displayed.
 		/// </summary>
-		/// <param name="index"></param>
+		/// <param name="index">The index for NPCID.Sets.BossHeadTextures</param>
 		public virtual void BossHeadSlot(ref int index) {
 		}
 

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -83,6 +83,14 @@
  			}
  		}
  
+@@ -1754,6 +_,7 @@
+ 					break;
+ 			}
+ 
++			NPCLoader.BossHeadSlot(this, ref result);
+ 			return result;
+ 		}
+ 
 @@ -1775,6 +_,7 @@
  					break;
  			}


### PR DESCRIPTION
### What is the bug?
BossHeadSlot hook is not called after 0.11.7 happened, it existed in 0.11.6.2 tml. This PR adds it back how it was previously, and adds a bit more info on the docs to clarify how to use it

