### PR TITLE
Added steam cloud quota check v2

### DIFF
--- a/patches/tModLoader/Terraria.GameContent.UI.Elements/UICharacterListItem.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.Elements/UICharacterListItem.cs.patch
@@ -4,28 +4,30 @@
  using Terraria.Localization;
  using Terraria.Social;
  using Terraria.UI;
-+using System.Reflection;
++using Terraria.Utilities;
 +using Terraria.ModLoader;
 +using System.Linq;
 +using Terraria.ModLoader.UI;
  
  namespace Terraria.GameContent.UI.Elements
  {
-@@ -23,6 +_,8 @@
+@@ -23,6 +_,9 @@
  		private Texture2D _buttonFavoriteInactiveTexture;
  		private Texture2D _buttonPlayTexture;
  		private Texture2D _buttonDeleteTexture;
 +		private Texture2D _errorTexture;
 +		private Texture2D _configTexture;
++		private ulong _fileSize;
  		private UIImageButton _deleteButton;
  
  		public bool IsFavorite => _data.IsFavorite;
-@@ -37,6 +_,8 @@
+@@ -37,6 +_,9 @@
  			_buttonFavoriteInactiveTexture = TextureManager.Load("Images/UI/ButtonFavoriteInactive");
  			_buttonPlayTexture = TextureManager.Load("Images/UI/ButtonPlay");
  			_buttonDeleteTexture = TextureManager.Load("Images/UI/ButtonDelete");
 +			_errorTexture = UICommon.ButtonErrorTexture;
 +			_configTexture = UICommon.ButtonConfigTexture;
++			_fileSize = (ulong)FileUtilities.GetFileSize(data.Path, data.IsCloudSave);
  			Height.Set(96f, 0f);
  			Width.Set(0f, 1f);
  			SetPadding(6f);
@@ -114,7 +116,20 @@
  			_deleteButtonLabel.Top.Set(-3f, 0f);
  			Append(_deleteButtonLabel);
  			uIImageButton.SetSnapPoint("Play", snapPointIndex);
-@@ -113,13 +_,22 @@
+@@ -107,19 +_,32 @@
+ 
+ 		private void CloudMouseOver(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
++					_buttonLabel.SetText(Language.GetTextValue("UI.MoveOffCloud"));
++			else {
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
+-				_buttonLabel.SetText(Language.GetTextValue("UI.MoveOffCloud"));
++					_buttonLabel.SetText(Language.GetTextValue("tModLoader.CloudWarning"));
+-			else
++				else
+-				_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++					_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++			}
  		}
  
  		private void PlayMouseOver(UIMouseEvent evt, UIElement listeningElement) {
@@ -138,6 +153,20 @@
  		private void DeleteMouseOut(UIMouseEvent evt, UIElement listeningElement) {
  			_deleteButtonLabel.SetText("");
  		}
+@@ -131,8 +_,12 @@
+ 		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
+ 				_data.MoveToLocal();
+-			else
++			else {
++				ModLoader.Engine.Steam.RecalculateAvailableSteamCloudStorage(); //Only recalculate when about to put the file to cloud
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
++					return; //Don't allow both the move to cloud, and the setting of the label
+ 				_data.MoveToCloud();
++			}
+ 
+ 			((UIImageButton)evt.Target).SetImage(_data.IsCloudSave ? _buttonCloudActiveTexture : _buttonCloudInactiveTexture);
+ 			if (_data.IsCloudSave)
 @@ -181,6 +_,13 @@
  			(Parent.Parent as UIList)?.UpdateOrder();
  		}

--- a/patches/tModLoader/Terraria.GameContent.UI.Elements/UIWorldListItem.cs.patch
+++ b/patches/tModLoader/Terraria.GameContent.UI.Elements/UIWorldListItem.cs.patch
@@ -8,19 +8,27 @@
  using Terraria.Graphics;
  using Terraria.IO;
  using Terraria.Localization;
-+using Terraria.ModLoader;
++using Terraria.Utilities;
 +using Terraria.ModLoader.Config;
  using Terraria.Social;
  using Terraria.UI;
  
-@@ -24,6 +_,7 @@
+@@ -24,12 +_,15 @@
  		private Texture2D _buttonPlayTexture;
  		private Texture2D _buttonSeedTexture;
  		private Texture2D _buttonDeleteTexture;
 +		private Texture2D _configTexture;
++		private ulong _fileSize;
  		private UIImageButton _deleteButton;
  
  		public bool IsFavorite => _data.IsFavorite;
+ 
+ 		public UIWorldListItem(WorldFileData data, int snapPointIndex) {
+ 			_data = data;
++			_fileSize = (ulong)FileUtilities.GetFileSize(data.Path, data.IsCloudSave);
+ 			LoadTextures();
+ 			InitializeAppearance();
+ 			_worldIcon = new UIImage(GetIcon());
 @@ -79,6 +_,17 @@
  				num += 24f;
  			}
@@ -47,7 +55,18 @@
  		}
  
  		private void InitializeAppearance() {
-@@ -142,13 +_,18 @@
+@@ -137,18 +_,27 @@
+ 		private void CloudMouseOver(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
+ 				_buttonLabel.SetText(Language.GetTextValue("UI.MoveOffCloud"));
+-			else
+-				_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++			else {
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
++					_buttonLabel.SetText(Language.GetTextValue("tModLoader.CloudWarning"));
++				else
++					_buttonLabel.SetText(Language.GetTextValue("UI.MoveToCloud"));
++			}
  		}
  
  		private void PlayMouseOver(UIMouseEvent evt, UIElement listeningElement) {
@@ -67,6 +86,20 @@
  		private void DeleteMouseOver(UIMouseEvent evt, UIElement listeningElement) {
  			_deleteButtonLabel.SetText(Language.GetTextValue("UI.Delete"));
  		}
+@@ -164,8 +_,12 @@
+ 		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
+ 			if (_data.IsCloudSave)
+ 				_data.MoveToLocal();
+-			else
++			else {
++				ModLoader.Engine.Steam.RecalculateAvailableSteamCloudStorage(); //Only recalculate when about to put the file to cloud
++				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
++					return; //Don't allow both the move to cloud, and the setting of the label
+ 				_data.MoveToCloud();
++			}
+ 
+ 			((UIImageButton)evt.Target).SetImage(_data.IsCloudSave ? _buttonCloudActiveTexture : _buttonCloudInactiveTexture);
+ 			if (_data.IsCloudSave)
 @@ -194,7 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
+++ b/patches/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
@@ -255,6 +255,7 @@
 		"NewModsListing": "New mods:\n{0}",
 		"PlayerCustomDataFail": "A problem was encountered when loading custom data for a player",
 		"PlayerLoadWorldFail": "A problem was encountered when trying to load a world",
+		"CloudWarning": "Cloud storage limit reached, unable to move to cloud",
 
 		// Mod Sources
 		"MSBuild": "Build",

--- a/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Engine/Steam.cs
@@ -18,6 +18,22 @@ namespace Terraria.ModLoader.Engine
 		public static AppId_t TerrariaAppId_t = new AppId_t(TerrariaAppID);
 		public static bool IsSteamApp => SocialAPI.Mode == SocialMode.Steam && SteamAPI.Init() && SteamApps.BIsAppInstalled(new AppId_t(TMLAppID));
 
+		public static ulong lastAvailableSteamCloudStorage = ulong.MaxValue;
+
+		public static bool CheckSteamCloudStorageSufficient(ulong input)
+		{
+			if (SocialAPI.Cloud != null)
+				return input < lastAvailableSteamCloudStorage;
+			return true;
+		}
+
+		// Called in PostSocialInitialize and just before files get sent to cloud
+		public static void RecalculateAvailableSteamCloudStorage()
+		{
+			if (SocialAPI.Cloud != null)
+				SteamRemoteStorage.GetQuota(out _, out lastAvailableSteamCloudStorage);
+		}
+
 		public static string GetSteamTerrariaInstallDir()
 		{
 			SteamApps.GetAppInstallDir(TerrariaAppId_t, out string terrariaInstallLocation, 1000);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -812,8 +812,8 @@
 +					if (!Directory.Exists(vanillaContentFolder))
 +						vanillaContentFolder = Path.Combine(steamInstallFolder, "Terraria.app/Contents/MacOS/Content");
 +				}
-+				Steamworks.SteamRemoteStorage.GetQuota(out ulong pnTotalBytes, out ulong puAvailableBytes);
-+				Logging.Terraria.Info($"Steam Cloud Quota: {UIMemoryBar.SizeSuffix((long)puAvailableBytes)} available");
++				ModLoader.Engine.Steam.RecalculateAvailableSteamCloudStorage();
++				Logging.Terraria.Info($"Steam Cloud Quota: {UIMemoryBar.SizeSuffix((long)ModLoader.Engine.Steam.lastAvailableSteamCloudStorage)} available");
 +			}
 +			if (!Directory.Exists(vanillaContentFolder)) {
 +				Interface.MessageBoxShow(Language.GetTextValue("tModLoader.ContentFolderNotFound"));


### PR DESCRIPTION
**This is an alternate version of #1028**

### What is the bug?
On Steam, because Terraria and tModLoader share the same cloud space, people (usually with a full Terraria steam cloud) want to move their tModLoader files to the cloud, which leads to them being deleted instead (usually after restarting the game)

### How did you fix the bug?
Added a static 'last available steam cloud space' variable that gets updated whenever data is about to be sent to the cloud, aswell as a field for both player and world data that tracks its filesize.


### Are there alternatives to your fix?
The previous PR: #1028
In the case where storage is almost full, you upload a file, and then its full, and you try to upload the next, it lets you click the button but then recalculates storage, and then shows you the tooltip that it's not possible. It would be possible to additionally recalculate after moving to cloud aswell (after `_data.MoveToCloud()`), to update tooltips without having to click the button
