### PR TITLE
fix DrawHair not passing head, added some docs to relevant methods

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria.ModLoader/GlobalItem.cs
@@ -589,7 +589,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to determine whether the skin/shirt on the player's arms and hands are drawn when a body armor is worn.
 		/// Note that if drawHands is false, the arms will not be drawn either.
-		/// 
+		/// "body" is the player's associated body equipment texture.
 		/// This method is not instanced.
 		/// </summary>
 		public virtual void DrawHands(int body, ref bool drawHands, ref bool drawArms) {
@@ -597,7 +597,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to determine whether the player's hair or alt (hat) hair will be drawn when a head armor is worn.
-		/// 
+		/// "head" is the player's associated head equipment texture.
 		/// This method is not instanced.
 		/// </summary>
 		public virtual void DrawHair(int head, ref bool drawHair, ref bool drawAltHair) {
@@ -605,7 +605,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Return false to hide the player's head when a head armor is worn. Returns true by default.
-		/// 
+		/// "head" is the player's associated head equipment texture.
 		/// This method is not instanced.
 		/// </summary>
 		public virtual bool DrawHead(int head) {
@@ -614,7 +614,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Return false to hide the player's body when a body armor is worn. Returns true by default.
-		/// 
+		/// "body" is the player's associated body equipment texture.
 		/// This method is not instanced.
 		/// </summary>
 		public virtual bool DrawBody(int body) {
@@ -623,7 +623,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Return false to hide the player's legs when a leg armor or shoe accessory is worn. Returns true by default.
-		/// 
+		/// "legs" and "shoes" are the player's associated legs and shoes equipment textures.
 		/// This method is not instanced.
 		/// </summary>
 		public virtual bool DrawLegs(int legs, int shoes) {

--- a/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ItemLoader.cs
@@ -1196,7 +1196,7 @@ namespace Terraria.ModLoader
 			texture?.DrawHair(ref drawHair, ref drawAltHair);
 
 			foreach (var g in HookDrawHair.arr)
-				g.DrawHair(player.body, ref drawHair, ref drawAltHair);
+				g.DrawHair(player.head, ref drawHair, ref drawAltHair);
 		}
 
 		private static HookList HookDrawHead = AddHook<Func<int, bool>>(g => g.DrawHead);


### PR DESCRIPTION
### What is the bug?
DrawHair hook being called with player.body instead of player.head

### How did you fix the bug?
change it to player.head

### Are there alternatives to your fix?
No

Also added some more docs explaining what the parameter means (modders could confuse it with checking `head` against an ItemID instead of its equipment texture ID

