### PR TITLE
Add setupRecipes bool to detect ModRecipe misuse

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModContent.cs
@@ -424,7 +424,9 @@ namespace Terraria.ModLoader
 
 			Recipe.numRecipes = 0;
 			RecipeGroupHelper.ResetRecipeGroups();
+			RecipeHooks.setupRecipes = true;
 			Recipe.SetupRecipes();
+			RecipeHooks.setupRecipes = false;
 		}
 
 		internal static void UnloadModContent() {

--- a/patches/tModLoader/Terraria.ModLoader/ModRecipe.cs
+++ b/patches/tModLoader/Terraria.ModLoader/ModRecipe.cs
@@ -26,6 +26,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="mod">The mod the recipe originates from.</param>
 		public ModRecipe(Mod mod) {
+			if (!RecipeHooks.setupRecipes)
+				throw new RecipeException("A ModRecipe can only be created inside recipe related methods");
 			this.mod = mod;
 		}
 

--- a/patches/tModLoader/Terraria.ModLoader/RecipeHooks.cs
+++ b/patches/tModLoader/Terraria.ModLoader/RecipeHooks.cs
@@ -10,12 +10,18 @@ namespace Terraria.ModLoader
 	{
 		internal static readonly IList<GlobalRecipe> globalRecipes = new List<GlobalRecipe>();
 
+		/// <summary>
+		/// Set when tML sets up modded recipes. Used to detect misuse of the ModRecipe ctor
+		/// </summary>
+		internal static bool setupRecipes = false;
+
 		internal static void Add(GlobalRecipe globalRecipe) {
 			globalRecipes.Add(globalRecipe);
 		}
 
 		internal static void Unload() {
 			globalRecipes.Clear();
+			setupRecipes = false;
 		}
 
 		internal static void AddRecipes() {


### PR DESCRIPTION
### What is the bug?
"fixes" #1125 

### How did you fix the bug?
By introducing an additional check inside the `ModRecipe` constructor

### Are there alternatives to your fix?
Do it in `ModRecipe.SetResult` instead, which is the origin of the stack overflow

