### PR TITLE
Fishing hooks Pt 1

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/FishingAttempt.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/FishingAttempt.cs.patch
@@ -1,0 +1,10 @@
+--- src/Terraria/Terraria/DataStructures/FishingAttempt.cs
++++ src/tModLoader/Terraria/DataStructures/FishingAttempt.cs
+@@ -24,6 +_,7 @@
+ 		public int questFish;
+ 		public int heightLevel;
+ 		public int rolledItemDrop;
++		public int rolledItemStack;
+ 		public int rolledEnemySpawn;
+ 	}
+ }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -246,6 +246,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to change an item bait's rate of consumption, being able to force it to be consumed or stop it from being consumed or return null for unchanged vanilla behaviour.
+		/// Forcing to be consumed takes precedence over not being consumed, over vanilla usage.
 		/// </summary>
 		/// <param name="bait">The bait item being targeted</param>
 		/// <param name="player">The player using this bait</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -245,6 +245,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to change an item bait's rate of consumption, being able to force it to be consumed or stop it from being consumed or return null for unchanged vanilla behaviour.
+		/// </summary>
+		/// <param name="bait">The bait item being targeted</param>
+		/// <param name="player">The player using this bait</param>
+		public virtual bool? ConsumeBait(Item bait, Player player) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
 		/// <param name="weapon">The item that is using this ammo</param>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -517,15 +517,21 @@ namespace Terraria.ModLoader
 			if (bait.IsAir)
 				return null;
 
-			bool? ans = bait.modItem?.ConsumeBait(player);
-			if (ans != null)
-				return ans;
-			foreach (var g in HookConsumeBait.arr) {
-				ans = g.ConsumeBait(bait, player);
-				if (ans != null)
-					return ans;
+			bool? result = null;
+
+			foreach (GlobalItem g in HookConsumeBait.arr) {
+				bool? consumeBait = g.Instance(bait).ConsumeBait(bait, player);
+
+				if (consumeBait.HasValue) {
+					if (!consumeBait.Value) {
+						return false;
+					}
+
+					result = true;
+				}
 			}
-			return null;
+
+			return result ?? bait.modItem?.ConsumeBait(player);
 		}
 
 		private static HookList HookOnConsumeAmmo = AddHook<Action<Item, Player>>(g => g.OnConsumeAmmo);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -513,6 +513,10 @@ namespace Terraria.ModLoader
 
 		private delegate bool? DelegateConsumeBait(Item bait, Player player);
 		private static HookList HookConsumeBait = AddHook<DelegateConsumeBait>(p => p.ConsumeBait);
+
+		/// <summary>
+		/// Hook that decides if bait is consumed or not. True stops the code and immediately forces consumption. False is only valid if no True is found.
+		/// </summary>
 		public static bool? ConsumeBait(Player player, Item bait) {
 			if (bait.IsAir)
 				return null;
@@ -523,11 +527,11 @@ namespace Terraria.ModLoader
 				bool? consumeBait = g.Instance(bait).ConsumeBait(bait, player);
 
 				if (consumeBait.HasValue) {
-					if (!consumeBait.Value) {
-						return false;
+					if (consumeBait.Value) {
+						return true;
 					}
 
-					result = true;
+					result = false;
 				}
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -511,6 +511,23 @@ namespace Terraria.ModLoader
 			return true;
 		}
 
+		private delegate bool? DelegateConsumeBait(Player player);
+		private static HookList HookConsumeBait = AddHook<DelegateConsumeBait>(p => p.ConsumeBait);
+		public static bool? ConsumeBait(Player player, Item bait) {
+			if (bait.IsAir)
+				return null;
+
+			bool? ans = bait.modItem?.ConsumeBait(player);
+			if (ans != null)
+				return ans;
+			foreach (var g in HookConsumeBait.arr) {
+				ans = g.ConsumeBait(bait, player);
+				if (ans != null)
+					return ans;
+			}
+			return null;
+		}
+
 		private static HookList HookOnConsumeAmmo = AddHook<Action<Item, Player>>(g => g.OnConsumeAmmo);
 		/// <summary>
 		/// Calls ModItem.OnConsumeAmmo for the weapon, ModItem.OnConsumeAmmo for the ammo, then each GlobalItem.OnConsumeAmmo hook for the weapon and ammo.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -511,7 +511,7 @@ namespace Terraria.ModLoader
 			return true;
 		}
 
-		private delegate bool? DelegateConsumeBait(Player player);
+		private delegate bool? DelegateConsumeBait(Item bait, Player player);
 		private static HookList HookConsumeBait = AddHook<DelegateConsumeBait>(p => p.ConsumeBait);
 		public static bool? ConsumeBait(Player player, Item bait) {
 			if (bait.IsAir)

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -321,6 +321,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to change this bait's rate of consumption, being able to force it to be consumed or stop it from being consumed or return null for unchanged vanilla behaviour.
+		/// </summary>
+		/// <param name="player">The player using this bait</param>
+		public virtual bool? ConsumeBait(Player player) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the projectile created by a weapon based on the ammo it is using. This hook is called on the ammo.
 		/// </summary>
 		/// <param name="weapon">The item that is using this ammo</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -680,17 +680,12 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to change the item the player gains from catching a fish. The fishingRod and bait parameters refer to the said items in the player's inventory. The liquidType parameter is 0 if the player is fishing in water, 1 for lava, and 2 for honey. The poolSize parameter is the tile size of the pool the player is fishing in. The worldLayer parameter is 0 if the player is in the sky, 1 if the player is on the surface, 2 if the player is underground, 3 if the player is in the caverns, and 4 if the player is in the underworld. The questFish parameter is the item ID for the day's Angler quest. Modify the caughtType parameter to change the item the player catches. The junk parameter is whether the player catches junk; you can set this to true if you make the player catch a junk item, and is mostly used to pass information (has no effect on the game).
+		/// Allows you to modify the result of the fishing attempt.
 		/// </summary>
-		/// <param name="fishingRod"></param>
-		/// <param name="bait"></param>
-		/// <param name="power"></param>
-		/// <param name="liquidType"></param>
-		/// <param name="poolSize"></param>
-		/// <param name="worldLayer"></param>
-		/// <param name="questFish"></param>
-		/// <param name="caughtType"></param>
-		public virtual void CatchFish(Item fishingRod, Item bait, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType) {
+		/// <param name="fisher">The FishingAttempt structure for this fishing. Modify this parameter to change the caught item or NPC.</param>
+		/// <param name="sonarText">Change this to overwrite the default sonar text. If null (default), the item/monster name will show. If "", no name will be shown.<param>
+		/// <param name="color">Change this to overwrite the color of your new sonar text. Defaults to White.<param>
+		public virtual void CatchFish(FishingAttempt fisher, ref string sonarText, ref Color color) {
 		}
 
 		/// <summary>
@@ -708,6 +703,23 @@ namespace Terraria.ModLoader
 		/// <param name="rareMultiplier"></param>
 		/// <param name="rewardItems"></param>
 		public virtual void AnglerQuestReward(float rareMultiplier, List<Item> rewardItems) {
+		}
+
+		/// <summary>
+		/// Allows you to change or add effects when an NPC was summoned from fishing. Called after the summon, so cannot alter the result. Used primarily to add graphic and sound effects to a NPC Summon.
+		/// </summary>
+		/// <param name="NPCType">The type of the NPC that was summoned.</param>
+		/// <param name="bobber">The projectile bobber that summoned the NPC.<param>
+		/// <param name="baitUsed">The type of the bait item used in the summoning.<param>
+		public virtual void OnFishedNPCSummon(int NPCType, Projectile bobber, int baitUsed) {
+		}
+
+		/// <summary>
+		/// Allows you to change if bait is consumed, either stopping it from being consumed (return false), force it to be consumed (return true) or leave the vanilla behaviour (return null, default)
+		/// </summary>
+		/// <param name="bait">The bait item that was used. Changing its contents will affect the inventory item.</param>
+		public virtual bool? ConsumeBait(Item bait) {
+			return null;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
@@ -863,13 +863,20 @@ namespace Terraria.ModLoader
 
 		private delegate bool? DelegateConsumeBait(Item bait);
 		private static HookList HookConsumeBait = AddHook<DelegateConsumeBait>(p => p.ConsumeBait);
+		/// <summary>
+		/// Just like ItemLoader.ConsumeBait, true forces the bait to be consumed, false will stop bait consumption and null will return vanilla behaviour
+		/// </summary>
 		public static bool? ConsumeBait(Player player, Item bait) {
+			bool? result = null;
 			foreach (int index in HookConsumeBait.arr) {
 				bool? ans = player.modPlayers[index].ConsumeBait(bait);
-				if (ans != null)
-					return ans;
+				if (ans.HasValue)
+					if (ans.Value)
+						return ans;
+					else
+						result = false;
 			}
-			return null;
+			return result;
 		}
 
 		private static HookList HookGetDyeTraderReward = AddHook<Action<List<int>>>(p => p.GetDyeTraderReward);

--- a/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerHooks.cs
@@ -827,19 +827,12 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private delegate void DelegateCatchFish(Item fishingRod, Item bait, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType);
+		private delegate void DelegateCatchFish(FishingAttempt fisher, ref string sonarText, ref Color color);
 		private static HookList HookCatchFish = AddHook<DelegateCatchFish>(p => p.CatchFish);
 
-		public static void CatchFish(Player player, Item fishingRod, int power, int liquidType, int poolSize, int worldLayer, int questFish, ref int caughtType) {
-			int i = 0;
-			while (i < 58) {
-				if (player.inventory[i].stack > 0 && player.inventory[i].bait > 0) {
-					break;
-				}
-				i++;
-			}
+		public static void CatchFish(Player player, FishingAttempt fisher, ref string sonarText, ref Color color) {
 			foreach (int index in HookCatchFish.arr) {
-				player.modPlayers[index].CatchFish(fishingRod, player.inventory[i], power, liquidType, poolSize, worldLayer, questFish, ref caughtType);
+				player.modPlayers[index].CatchFish(fisher, ref sonarText, ref color);
 			}
 		}
 
@@ -858,6 +851,25 @@ namespace Terraria.ModLoader
 			foreach (int index in HookAnglerQuestReward.arr) {
 				player.modPlayers[index].AnglerQuestReward(rareMultiplier, rewardItems);
 			}
+		}
+
+		private delegate void DelegateOnFishedNPCSummon(int NPCType, Projectile bobber, int baitUsed);
+		private static HookList HookOnFishedNPCSummon = AddHook<DelegateOnFishedNPCSummon>(p => p.OnFishedNPCSummon);
+		public static void OnFishedNPCSummon(Player player, int NPCType, Projectile bobber, int baitUsed) {
+			foreach (int index in HookOnFishedNPCSummon.arr) {
+				player.modPlayers[index].OnFishedNPCSummon(NPCType, bobber, baitUsed);
+			}
+		}
+
+		private delegate bool? DelegateConsumeBait(Item bait);
+		private static HookList HookConsumeBait = AddHook<DelegateConsumeBait>(p => p.ConsumeBait);
+		public static bool? ConsumeBait(Player player, Item bait) {
+			foreach (int index in HookConsumeBait.arr) {
+				bool? ans = player.modPlayers[index].ConsumeBait(bait);
+				if (ans != null)
+					return ans;
+			}
+			return null;
 		}
 
 		private static HookList HookGetDyeTraderReward = AddHook<Action<List<int>>>(p => p.GetDyeTraderReward);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3111,11 +3111,10 @@
  			int whoAmI = base.whoAmI;
  			bool flag = true;
  			int num = (int)((float)Main.mouseX + Main.screenPosition.X) / 16;
-@@ -35712,10 +_,13 @@
- 					NPC.SpawnOnPlayer(whoAmI, 370);
+@@ -35713,9 +_,13 @@
  				else
  					NetMessage.SendData(61, -1, -1, null, whoAmI, 370f);
--
+ 
 +				PlayerHooks.OnFishedNPCSummon(this, 370, bobber, baitTypeUsed);
  				bobber.ai[0] = 2f;
 +				bobber.netUpdate = true;
@@ -3139,9 +3138,10 @@
  			baitTypeUsed = item.type;
  			if (baitTypeUsed == 2673)
  				flag = true;
-+			bool? baitOverride = PlayerHooks.ConsumeBait(this, item) ?? ItemLoader.ConsumeBait(this, item);
- 
+-
 -			if (flag) {
++			bool? baitOverride = PlayerHooks.ConsumeBait(this, item) ?? ItemLoader.ConsumeBait(this, item);
++			//bait vanilla behaviour is to be consumed, but using == null or true allows for mods to force bait to be consumed even if some other mods added bait-saving mechanics
 +			if (flag && (baitOverride == null || baitOverride.Value)) {
  				if (item.type == 4361 || item.type == 4362)
  					NPC.LadyBugKilled(base.Center, item.type == 4362);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3135,16 +3135,14 @@
  			}
  			else if (Main.rand.Next(7) == 0 && !accFishingLine) {
  				bobber.ai[0] = 2f;
-@@ -35787,8 +_,11 @@
+@@ -35787,8 +_,9 @@
  			baitTypeUsed = item.type;
  			if (baitTypeUsed == 2673)
  				flag = true;
-+			bool? baitOverride = PlayerHooks.ConsumeBait(this, item);
-+			if (baitOverride == null)
-+				baitOverride = ItemLoader.ConsumeBait(this, item);
++			bool? baitOverride = PlayerHooks.ConsumeBait(this, item) ?? ItemLoader.ConsumeBait(this, item);
  
 -			if (flag) {
-+			if (flag && baitOverride == null || baitOverride.Value) {
++			if (flag && (baitOverride == null || baitOverride.Value)) {
  				if (item.type == 4361 || item.type == 4362)
  					NPC.LadyBugKilled(base.Center, item.type == 4362);
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3111,6 +3111,43 @@
  			int whoAmI = base.whoAmI;
  			bool flag = true;
  			int num = (int)((float)Main.mouseX + Main.screenPosition.X) / 16;
+@@ -35712,10 +_,13 @@
+ 					NPC.SpawnOnPlayer(whoAmI, 370);
+ 				else
+ 					NetMessage.SendData(61, -1, -1, null, whoAmI, 370f);
+-
++				PlayerHooks.OnFishedNPCSummon(this, 370, bobber, baitTypeUsed);
+ 				bobber.ai[0] = 2f;
++				bobber.netUpdate = true;
++				return;
+ 			}
++			
+-			else if (bobber.localAI[1] < 0f) {
++			if (bobber.localAI[1] < 0f) {
+ 				Point point = new Point((int)bobber.position.X, (int)bobber.position.Y);
+ 				int num = (int)(0f - bobber.localAI[1]);
+ 				if (num == 618)
+@@ -35728,6 +_,7 @@
+ 					NPC.NewNPC(point.X, point.Y, num);
+ 					bobber.ai[0] = 2f;
+ 				}
++				PlayerHooks.OnFishedNPCSummon(this, num, bobber, baitTypeUsed);
+ 			}
+ 			else if (Main.rand.Next(7) == 0 && !accFishingLine) {
+ 				bobber.ai[0] = 2f;
+@@ -35787,8 +_,11 @@
+ 			baitTypeUsed = item.type;
+ 			if (baitTypeUsed == 2673)
+ 				flag = true;
++			bool? baitOverride = PlayerHooks.ConsumeBait(this, item);
++			if (baitOverride == null)
++				baitOverride = ItemLoader.ConsumeBait(this, item);
+ 
+-			if (flag) {
++			if (flag && baitOverride == null || baitOverride.Value) {
+ 				if (item.type == 4361 || item.type == 4362)
+ 					NPC.LadyBugKilled(base.Center, item.type == 4362);
+ 
 @@ -35830,6 +_,11 @@
  			if (sItem.type == 3006)
  				flag2 = true;

--- a/patches/tModLoader/Terraria/PopupText.TML.cs
+++ b/patches/tModLoader/Terraria/PopupText.TML.cs
@@ -11,38 +11,13 @@ namespace Terraria
 	public partial class PopupText
 	{
 		public static int NewText(PopupTextContext context, string text, Color color, Vector2 position, bool stay5TimesLonger) {
-		if (!Main.showItemText)
-			return -1;
-
-		if (Main.netMode == 2)
-			return -1;
-
-		int num = FindNextItemTextSlot();
-		if (num >= 0) {
-			Vector2 value = FontAssets.MouseText.Value.MeasureString(text);
-			PopupText popupText = Main.popupText[num];
-			Main.popupText[num].alpha = 1f;
-			popupText.alphaDir = -1;
-			popupText.active = true;
-			popupText.scale = 0f;
-			popupText.NoStack = true;
-			popupText.rotation = 0f;
-			popupText.position = position - value / 2f;
-			popupText.expert = false;
-			popupText.master = false;
-			popupText.name = text;
-			popupText.stack = 1;
-			popupText.velocity.Y = -7f;
-			popupText.lifeTime = 60;
-			popupText.context = context;
-			if (stay5TimesLonger)
-				popupText.lifeTime *= 5;
-			popupText.coinValue = 0;
-			popupText.coinText = false;
-			popupText.color = color;
+			int ans = NewText(context, 1, position, stay5TimesLonger);
+			if (ans == -1)
+				return -1;
+			Main.popupText[ans].color = color;
+			Main.popupText[ans].name = text;
+			Main.popupText[ans].npcNetID = 0;
+			return ans;
 		}
-
-		return num;
 	}
-}
 }

--- a/patches/tModLoader/Terraria/PopupText.TML.cs
+++ b/patches/tModLoader/Terraria/PopupText.TML.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.GameContent;
+
+namespace Terraria
+{
+	public partial class PopupText
+	{
+		public static int NewText(PopupTextContext context, string text, Color color, Vector2 position, bool stay5TimesLonger) {
+		if (!Main.showItemText)
+			return -1;
+
+		if (Main.netMode == 2)
+			return -1;
+
+		int num = FindNextItemTextSlot();
+		if (num >= 0) {
+			Vector2 value = FontAssets.MouseText.Value.MeasureString(text);
+			PopupText popupText = Main.popupText[num];
+			Main.popupText[num].alpha = 1f;
+			popupText.alphaDir = -1;
+			popupText.active = true;
+			popupText.scale = 0f;
+			popupText.NoStack = true;
+			popupText.rotation = 0f;
+			popupText.position = position - value / 2f;
+			popupText.expert = false;
+			popupText.master = false;
+			popupText.name = text;
+			popupText.stack = 1;
+			popupText.velocity.Y = -7f;
+			popupText.lifeTime = 60;
+			popupText.context = context;
+			if (stay5TimesLonger)
+				popupText.lifeTime *= 5;
+			popupText.coinValue = 0;
+			popupText.coinText = false;
+			popupText.color = color;
+		}
+
+		return num;
+	}
+}
+}

--- a/patches/tModLoader/Terraria/PopupText.cs.patch
+++ b/patches/tModLoader/Terraria/PopupText.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/PopupText.cs
 +++ src/tModLoader/Terraria/PopupText.cs
-@@ -1,6 +_,8 @@
+@@ -1,10 +_,12 @@
  using Microsoft.Xna.Framework;
  using Terraria.GameContent;
 +using Terraria.ID;
@@ -9,6 +9,11 @@
  
  namespace Terraria
  {
+-	public class PopupText
++	public partial class PopupText
+ 	{
+ 		public Vector2 position;
+ 		public Vector2 velocity;
 @@ -25,6 +_,7 @@
  		public static int sonarText = -1;
  		public bool expert;
@@ -17,48 +22,6 @@
  		public bool sonar;
  		public PopupTextContext context;
  		public int npcNetID;
-@@ -40,6 +_,41 @@
- 			}
- 		}
- 
-+		public static int NewText(PopupTextContext context, string text, Color color, Vector2 position, bool stay5TimesLonger) {
-+			if (!Main.showItemText)
-+				return -1;
-+
-+			if (Main.netMode == 2)
-+				return -1;
-+
-+			int num = FindNextItemTextSlot();
-+			if (num >= 0) {
-+				Vector2 value = FontAssets.MouseText.Value.MeasureString(text);
-+				PopupText popupText = Main.popupText[num];
-+				Main.popupText[num].alpha = 1f;
-+				popupText.alphaDir = -1;
-+				popupText.active = true;
-+				popupText.scale = 0f;
-+				popupText.NoStack = true;
-+				popupText.rotation = 0f;
-+				popupText.position = position - value / 2f;
-+				popupText.expert = false;
-+				popupText.master = false;
-+				popupText.name = text;
-+				popupText.stack = 1;
-+				popupText.velocity.Y = -7f;
-+				popupText.lifeTime = 60;
-+				popupText.context = context;
-+				if (stay5TimesLonger)
-+					popupText.lifeTime *= 5;
-+				popupText.coinValue = 0;
-+				popupText.coinText = false;
-+				popupText.color = color;
-+			}
-+
-+			return num;
-+		}
-+
- 		public static int NewText(PopupTextContext context, int npcNetID, Vector2 position, bool stay5TimesLonger) {
- 			if (!Main.showItemText)
- 				return -1;
 @@ -184,7 +_,6 @@
  				Main.popupText[num2].position.X = newItem.position.X + (float)newItem.width * 0.5f - vector2.X * 0.5f;
  				Main.popupText[num2].position.Y = newItem.position.Y + (float)newItem.height * 0.25f - vector2.Y * 0.5f;

--- a/patches/tModLoader/Terraria/PopupText.cs.patch
+++ b/patches/tModLoader/Terraria/PopupText.cs.patch
@@ -17,6 +17,48 @@
  		public bool sonar;
  		public PopupTextContext context;
  		public int npcNetID;
+@@ -40,6 +_,41 @@
+ 			}
+ 		}
+ 
++		public static int NewText(PopupTextContext context, string text, Color color, Vector2 position, bool stay5TimesLonger) {
++			if (!Main.showItemText)
++				return -1;
++
++			if (Main.netMode == 2)
++				return -1;
++
++			int num = FindNextItemTextSlot();
++			if (num >= 0) {
++				Vector2 value = FontAssets.MouseText.Value.MeasureString(text);
++				PopupText popupText = Main.popupText[num];
++				Main.popupText[num].alpha = 1f;
++				popupText.alphaDir = -1;
++				popupText.active = true;
++				popupText.scale = 0f;
++				popupText.NoStack = true;
++				popupText.rotation = 0f;
++				popupText.position = position - value / 2f;
++				popupText.expert = false;
++				popupText.master = false;
++				popupText.name = text;
++				popupText.stack = 1;
++				popupText.velocity.Y = -7f;
++				popupText.lifeTime = 60;
++				popupText.context = context;
++				if (stay5TimesLonger)
++					popupText.lifeTime *= 5;
++				popupText.coinValue = 0;
++				popupText.coinText = false;
++				popupText.color = color;
++			}
++
++			return num;
++		}
++
+ 		public static int NewText(PopupTextContext context, int npcNetID, Vector2 position, bool stay5TimesLonger) {
+ 			if (!Main.showItemText)
+ 				return -1;
 @@ -184,7 +_,6 @@
  				Main.popupText[num2].position.X = newItem.position.X + (float)newItem.width * 0.5f - vector2.X * 0.5f;
  				Main.popupText[num2].position.Y = newItem.position.Y + (float)newItem.height * 0.25f - vector2.Y * 0.5f;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -424,7 +424,7 @@
 +
  			if (fisher.rolledItemDrop > 0) {
 -				if (Main.player[owner].sonarPotion) {
-+				if (Main.player[owner].sonarPotion && (sonarText == null || sonarText.Trim().Length > 0)) {
++				if (Main.player[owner].sonarPotion && sonarText != "") {
  					Item item = new Item();
  					item.SetDefaults(fisher.rolledItemDrop);
  					item.position = position;
@@ -439,10 +439,12 @@
  					if (PopupText.sonarText > -1)
  						Main.popupText[PopupText.sonarText].sonar = true;
  				}
-@@ -13093,13 +_,20 @@
+@@ -13093,13 +_,22 @@
  				float num3 = fisher.fishingLevel;
  				ai[1] = (float)Main.rand.Next(-240, -90) - num3;
  				localAI[1] = fisher.rolledItemDrop;
++				//localAI[0] was written to (up to 100), but never read other than to check if it had reached 100 and stop writing to it.
++				//As we needed a place to store the Item stack size for this extra functionality, and there was no other place available, we overwrote localAI[0] and removed the useless code.
 +				localAI[0] = fisher.rolledItemStack;
  				netUpdate = true;
  				flag = true;
@@ -539,6 +541,15 @@
  						for (int l = 0; l < num4; l++) {
  							Dust obj = Main.dust[WorldGen.KillTile_MakeTileDust(j, k, tileSafely)];
  							obj.velocity.Y -= 3f + (float)num3 * 1.5f;
+@@ -32984,6 +_,8 @@
+ 					AI_061_FishingBobber_DoASplash();
+ 			}
+ 
++			//localAI[0] increase removed because it was not being read anywhere and we needed a space for allowing the modders to add an stack size to their items, if they want to
++
+ 			if (ai[0] >= 1f) {
+ 				if (ai[0] == 2f) {
+ 					ai[0] += 1f;
 @@ -32992,9 +_,6 @@
  						AI_061_FishingBobber_DoASplash();
  				}
@@ -549,18 +560,17 @@
  				if (frameCounter == 0) {
  					frameCounter = 1;
  					ReduceRemainingChumsInPool();
-@@ -33158,7 +_,10 @@
+@@ -33158,6 +_,10 @@
  		private void AI_061_FishingBobber_GiveItemToPlayer(Player thePlayer, int itemType) {
  			Item item = new Item();
  			item.SetDefaults(itemType);
 +			if (localAI[0] > 0) {
 +				item.stack = (int)localAI[0];
 +			}
--			if (itemType == 3196) {
-+			else if (itemType == 3196) {
++			else { 
+ 			if (itemType == 3196) {
  				int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
  				int minValue = (finalFishingLevel / 20 + 3) / 2;
- 				int num = (finalFishingLevel / 10 + 6) / 2;
 @@ -33177,7 +_,7 @@
  				int num2 = item.stack = Main.rand.Next(minValue, num + 1);
  			}
@@ -570,11 +580,12 @@
  				int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
  				int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
  				int num3 = (finalFishingLevel2 / 2 + 30) / 2;
-@@ -33195,7 +_,7 @@
+@@ -33195,7 +_,8 @@
  
  				int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
  			}
 -
++			}
 +			ItemLoader.CaughtFishStack(item);
  			item.newAndShiny = true;
  			Item item2 = thePlayer.GetItem(owner, item, default(GetItemSettings));

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -414,15 +414,7 @@
  			if (wet)
  				position += wetVelocity;
  			else
-@@ -13006,6 +_,7 @@
- 
- 			fisher.playerFishingConditions = Main.player[owner].GetFishingConditions();
- 			int baitItemType = fisher.playerFishingConditions.BaitItemType;
-+
- 			if (baitItemType == 2673) {
- 				Main.player[owner].displayedFishingInfo = Language.GetTextValue("GameUI.FishingWarning");
- 				if ((fisher.X < 380 || fisher.X > Main.maxTilesX - 380) && fisher.waterTilesCount > 1000 && !NPC.AnyNPCs(370)) {
-@@ -13080,12 +_,23 @@
+@@ -13080,12 +_,22 @@
  			FishingCheck_RollEnemySpawns(ref fisher);
  			FishingCheck_RollItemDrop(ref fisher);
  			bool flag = false;
@@ -431,16 +423,12 @@
 +			PlayerHooks.CatchFish(Main.player[owner], fisher, ref sonarText, ref color);
 +
  			if (fisher.rolledItemDrop > 0) {
-+				if (Main.player[owner].sonarPotion && (sonarText == null || sonarText.Trim().Length > 0)) {
-+
 -				if (Main.player[owner].sonarPotion) {
++				if (Main.player[owner].sonarPotion && (sonarText == null || sonarText.Trim().Length > 0)) {
+ 					Item item = new Item();
+ 					item.SetDefaults(fisher.rolledItemDrop);
+ 					item.position = position;
 +					if (sonarText == null) {
--					Item item = new Item();
-+						Item item = new Item();
--					item.SetDefaults(fisher.rolledItemDrop);
-+						item.SetDefaults(fisher.rolledItemDrop);
--					item.position = position;
-+						item.position = position;
 -					PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, item, 1, noStack: true);
 +						PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, item, 1, noStack: true);
 +					}
@@ -561,78 +549,30 @@
  				if (frameCounter == 0) {
  					frameCounter = 1;
  					ReduceRemainingChumsInPool();
-@@ -33158,44 +_,49 @@
+@@ -33158,7 +_,10 @@
  		private void AI_061_FishingBobber_GiveItemToPlayer(Player thePlayer, int itemType) {
  			Item item = new Item();
  			item.SetDefaults(itemType);
 +			if (localAI[0] > 0) {
 +				item.stack = (int)localAI[0];
 +			}
-+			else {
 -			if (itemType == 3196) {
-+				if (itemType == 3196) {
--				int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
-+					int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
--				int minValue = (finalFishingLevel / 20 + 3) / 2;
-+					int minValue = (finalFishingLevel / 20 + 3) / 2;
--				int num = (finalFishingLevel / 10 + 6) / 2;
-+					int num = (finalFishingLevel / 10 + 6) / 2;
--				if (Main.rand.Next(50) < finalFishingLevel)
-+					if (Main.rand.Next(50) < finalFishingLevel)
--					num++;
-+						num++;
- 
--				if (Main.rand.Next(100) < finalFishingLevel)
-+					if (Main.rand.Next(100) < finalFishingLevel)
--					num++;
-+						num++;
- 
--				if (Main.rand.Next(150) < finalFishingLevel)
-+					if (Main.rand.Next(150) < finalFishingLevel)
--					num++;
-+						num++;
- 
--				if (Main.rand.Next(200) < finalFishingLevel)
-+					if (Main.rand.Next(200) < finalFishingLevel)
--					num++;
-+						num++;
- 
--				int num2 = item.stack = Main.rand.Next(minValue, num + 1);
-+					int num2 = item.stack = Main.rand.Next(minValue, num + 1);
--			}
-+				}
++			else if (itemType == 3196) {
+ 				int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
+ 				int minValue = (finalFishingLevel / 20 + 3) / 2;
+ 				int num = (finalFishingLevel / 10 + 6) / 2;
+@@ -33177,7 +_,7 @@
+ 				int num2 = item.stack = Main.rand.Next(minValue, num + 1);
+ 			}
  
 -			if (itemType == 3197) {
-+				if (itemType == 3197) {
--				int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
-+					int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
--				int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
-+					int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
--				int num3 = (finalFishingLevel2 / 2 + 30) / 2;
-+					int num3 = (finalFishingLevel2 / 2 + 30) / 2;
--				if (Main.rand.Next(50) < finalFishingLevel2)
-+					if (Main.rand.Next(50) < finalFishingLevel2)
--					num3 += 4;
-+						num3 += 4;
++			else if (itemType == 3197) {
+ 				int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
+ 				int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
+ 				int num3 = (finalFishingLevel2 / 2 + 30) / 2;
+@@ -33195,7 +_,7 @@
  
--				if (Main.rand.Next(100) < finalFishingLevel2)
-+					if (Main.rand.Next(100) < finalFishingLevel2)
--					num3 += 4;
-+						num3 += 4;
- 
--				if (Main.rand.Next(150) < finalFishingLevel2)
-+					if (Main.rand.Next(150) < finalFishingLevel2)
--					num3 += 4;
-+						num3 += 4;
- 
--				if (Main.rand.Next(200) < finalFishingLevel2)
-+					if (Main.rand.Next(200) < finalFishingLevel2)
--					num3 += 4;
-+						num3 += 4;
- 
--				int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
-+					int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
-+				}
+ 				int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
  			}
 -
 +			ItemLoader.CaughtFishStack(item);

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -414,16 +414,66 @@
  			if (wet)
  				position += wetVelocity;
  			else
-@@ -13080,6 +_,9 @@
+@@ -13006,6 +_,7 @@
+ 
+ 			fisher.playerFishingConditions = Main.player[owner].GetFishingConditions();
+ 			int baitItemType = fisher.playerFishingConditions.BaitItemType;
++
+ 			if (baitItemType == 2673) {
+ 				Main.player[owner].displayedFishingInfo = Language.GetTextValue("GameUI.FishingWarning");
+ 				if ((fisher.X < 380 || fisher.X > Main.maxTilesX - 380) && fisher.waterTilesCount > 1000 && !NPC.AnyNPCs(370)) {
+@@ -13080,12 +_,23 @@
  			FishingCheck_RollEnemySpawns(ref fisher);
  			FishingCheck_RollItemDrop(ref fisher);
  			bool flag = false;
-+			PlayerHooks.CatchFish(Main.player[owner], Main.player[owner].inventory[Main.player[owner].selectedItem],
-+				fisher.waterNeededToFish, fisher.inLava ? 1 : fisher.inHoney ? 2 : 0, fisher.fishingLevel, fisher.heightLevel, fisher.questFish, ref fisher.rolledItemDrop);
++			string sonarText = null;
++			Color color = Color.White;
++			PlayerHooks.CatchFish(Main.player[owner], fisher, ref sonarText, ref color);
 +
  			if (fisher.rolledItemDrop > 0) {
- 				if (Main.player[owner].sonarPotion) {
- 					Item item = new Item();
++				if (Main.player[owner].sonarPotion && (sonarText == null || sonarText.Trim().Length > 0)) {
++
+-				if (Main.player[owner].sonarPotion) {
++					if (sonarText == null) {
+-					Item item = new Item();
++						Item item = new Item();
+-					item.SetDefaults(fisher.rolledItemDrop);
++						item.SetDefaults(fisher.rolledItemDrop);
+-					item.position = position;
++						item.position = position;
+-					PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, item, 1, noStack: true);
++						PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, item, 1, noStack: true);
++					}
++					else {
++						PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, sonarText, color, base.Center, stay5TimesLonger: false);
++					}
++
+ 					if (PopupText.sonarText > -1)
+ 						Main.popupText[PopupText.sonarText].sonar = true;
+ 				}
+@@ -13093,13 +_,20 @@
+ 				float num3 = fisher.fishingLevel;
+ 				ai[1] = (float)Main.rand.Next(-240, -90) - num3;
+ 				localAI[1] = fisher.rolledItemDrop;
++				localAI[0] = fisher.rolledItemStack;
+ 				netUpdate = true;
+ 				flag = true;
+ 			}
+ 
+ 			if (fisher.rolledEnemySpawn > 0) {
+-				if (Main.player[owner].sonarPotion) {
+-					PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, fisher.rolledEnemySpawn, base.Center, stay5TimesLonger: false);
++				if (Main.player[owner].sonarPotion && (sonarText == null || sonarText.Trim().Length > 0)) {
++
++					if (sonarText == null) {
++						PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, fisher.rolledEnemySpawn, base.Center, stay5TimesLonger: false);
++					}
++					else {
++						PopupText.sonarText = PopupText.NewText(PopupTextContext.SonarAlert, sonarText, color, base.Center, stay5TimesLonger: false);
++					}
+ 					if (PopupText.sonarText > -1)
+ 						Main.popupText[PopupText.sonarText].sonar = true;
+ 				}
 @@ -13575,9 +_,11 @@
  				while (Main.tile[i, num].liquid > 0 && !WorldGen.SolidTile(i, num) && num < Main.maxTilesY - 10) {
  					numWaters++;
@@ -501,10 +551,90 @@
  						for (int l = 0; l < num4; l++) {
  							Dust obj = Main.dust[WorldGen.KillTile_MakeTileDust(j, k, tileSafely)];
  							obj.velocity.Y -= 3f + (float)num3 * 1.5f;
-@@ -33196,6 +_,7 @@
- 				int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
- 			}
+@@ -32992,9 +_,6 @@
+ 						AI_061_FishingBobber_DoASplash();
+ 				}
  
+-				if (localAI[0] < 100f)
+-					localAI[0] += 1f;
+-
+ 				if (frameCounter == 0) {
+ 					frameCounter = 1;
+ 					ReduceRemainingChumsInPool();
+@@ -33158,44 +_,49 @@
+ 		private void AI_061_FishingBobber_GiveItemToPlayer(Player thePlayer, int itemType) {
+ 			Item item = new Item();
+ 			item.SetDefaults(itemType);
++			if (localAI[0] > 0) {
++				item.stack = (int)localAI[0];
++			}
++			else {
+-			if (itemType == 3196) {
++				if (itemType == 3196) {
+-				int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
++					int finalFishingLevel = thePlayer.GetFishingConditions().FinalFishingLevel;
+-				int minValue = (finalFishingLevel / 20 + 3) / 2;
++					int minValue = (finalFishingLevel / 20 + 3) / 2;
+-				int num = (finalFishingLevel / 10 + 6) / 2;
++					int num = (finalFishingLevel / 10 + 6) / 2;
+-				if (Main.rand.Next(50) < finalFishingLevel)
++					if (Main.rand.Next(50) < finalFishingLevel)
+-					num++;
++						num++;
+ 
+-				if (Main.rand.Next(100) < finalFishingLevel)
++					if (Main.rand.Next(100) < finalFishingLevel)
+-					num++;
++						num++;
+ 
+-				if (Main.rand.Next(150) < finalFishingLevel)
++					if (Main.rand.Next(150) < finalFishingLevel)
+-					num++;
++						num++;
+ 
+-				if (Main.rand.Next(200) < finalFishingLevel)
++					if (Main.rand.Next(200) < finalFishingLevel)
+-					num++;
++						num++;
+ 
+-				int num2 = item.stack = Main.rand.Next(minValue, num + 1);
++					int num2 = item.stack = Main.rand.Next(minValue, num + 1);
+-			}
++				}
+ 
+-			if (itemType == 3197) {
++				if (itemType == 3197) {
+-				int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
++					int finalFishingLevel2 = thePlayer.GetFishingConditions().FinalFishingLevel;
+-				int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
++					int minValue2 = (finalFishingLevel2 / 4 + 15) / 2;
+-				int num3 = (finalFishingLevel2 / 2 + 30) / 2;
++					int num3 = (finalFishingLevel2 / 2 + 30) / 2;
+-				if (Main.rand.Next(50) < finalFishingLevel2)
++					if (Main.rand.Next(50) < finalFishingLevel2)
+-					num3 += 4;
++						num3 += 4;
+ 
+-				if (Main.rand.Next(100) < finalFishingLevel2)
++					if (Main.rand.Next(100) < finalFishingLevel2)
+-					num3 += 4;
++						num3 += 4;
+ 
+-				if (Main.rand.Next(150) < finalFishingLevel2)
++					if (Main.rand.Next(150) < finalFishingLevel2)
+-					num3 += 4;
++						num3 += 4;
+ 
+-				if (Main.rand.Next(200) < finalFishingLevel2)
++					if (Main.rand.Next(200) < finalFishingLevel2)
+-					num3 += 4;
++						num3 += 4;
+ 
+-				int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
++					int num4 = item.stack = Main.rand.Next(minValue2, num3 + 1);
++				}
+ 			}
+-
 +			ItemLoader.CaughtFishStack(item);
  			item.newAndShiny = true;
  			Item item2 = thePlayer.GetItem(owner, item, default(GetItemSettings));


### PR DESCRIPTION
### What is the new feature?
This pull request adds a couple new Fishing Hooks, and fixes the main one (CatchFish) to use the new Terraria FishingAttempt.
- CatchFish now takes a FishingAttempt, an optional text and color parameters to allow overriding the Sonar text.
- OnFishingNPCSummon Hook that allows to run extra code after an npc is summoned through fishing (including Duke Fishron)
- A ConsumeBait hook that allows modders to control how their bait is spent.

### Why should this be part of tModLoader?
Fishing hooks are something tMod is sorely lacking.
The old system did not allow for players to access all information about their fishing conditions, and could not spawn npcs just like the blood moon fishing allows.
The hooks allow for new implementations, like more Duke-like bossses, or simply surprising the player with different items.

### Are there alternative designs?
The old method for using CatchFish was still usable, but lacked QoL features the new design presents. As for the new hooks, ConsumeBait could be divided in a canConsume/ modifyUse pair. Also, consumeBait could be accessed from both bait and Fishing Rod, but the current implementation only uses Bait.

### ExampleMod updates
Adding a new ExampleFishingPlayer could showcase the new features of the FishingAttempt implementation. Could also add a ExampleBait with reduced consumption chance.