### PR TITLE
[1.4] safety aiStyle >= 0 for NoMultiplayerSmoothingByAI

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -746,6 +746,15 @@
  					if (buffTime[i] < time)
  						buffTime[i] = time;
  
+@@ -71162,7 +_,7 @@
+ 				if (NPCID.Sets.NoMultiplayerSmoothingByType[type]) {
+ 					netOffset *= 0f;
+ 				}
+-				else if (NPCID.Sets.NoMultiplayerSmoothingByAI[aiStyle]) {
++				else if (aiStyle >= 0 && NPCID.Sets.NoMultiplayerSmoothingByAI[aiStyle]) {
+ 					netOffset *= 0f;
+ 				}
+ 				else {
 @@ -71231,6 +_,7 @@
  			}
  

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -751,7 +751,7 @@
  					netOffset *= 0f;
  				}
 -				else if (NPCID.Sets.NoMultiplayerSmoothingByAI[aiStyle]) {
-+				else if (aiStyle >= 0 && NPCID.Sets.NoMultiplayerSmoothingByAI[aiStyle]) {
++				else if (aiStyle >= 0 && aiStyle < NPCLoader.NPCCount && NPCID.Sets.NoMultiplayerSmoothingByAI[aiStyle]) {
  					netOffset *= 0f;
  				}
  				else {


### PR DESCRIPTION
Adds a safety check for a new 1.4 added array that is indexed by aiStyle. Modded NPCs that have a custom ai and don't wish to use default ai (0) (which does targeting, spriteDirection setting and horizontal movement reduction), will error on that line in multiplayer.