### PR TITLE
[1.3] fix prechatbuttonclicked crashing on editing a grave

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3695,14 +3695,11 @@
  			if (!flag)
  				DrawNPCChatButtons(num, textColor, lineAmount, focusText, focusText2);
  
-@@ -28446,7 +_,14 @@
+@@ -28446,7 +_,11 @@
  					else
  						IngameFancyUI.OpenVirtualKeyboard(1);
  				}
-+				if (player[myPlayer].talkNPC < 0)
-+					return;
-+
-+				if (!NPCLoader.PreChatButtonClicked(true))
++				if (player[myPlayer].talkNPC < 0 || !NPCLoader.PreChatButtonClicked(true))
 +					return;
 +
 +				NPCLoader.OnChatButtonClicked(true);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3695,10 +3695,12 @@
  			if (!flag)
  				DrawNPCChatButtons(num, textColor, lineAmount, focusText, focusText2);
  
-@@ -28446,7 +_,12 @@
+@@ -28446,7 +_,14 @@
  					else
  						IngameFancyUI.OpenVirtualKeyboard(1);
  				}
++				if (player[myPlayer].talkNPC < 0)
++					return;
 +
 +				if (!NPCLoader.PreChatButtonClicked(true))
 +					return;


### PR DESCRIPTION
### What is the bug?
When the player clicks the edit button on a grave, tml silently crashes because it tries to access an NPC with whoami -1.

### How did you fix the bug?
tml breaks up the if/elseif chain by inserting two hooks, what it doesn't account for is talkNPC being possibly -1. Vanilla logic prevents that by not continuing the elseif chain when a sign (or grave) is edited. The fix is actually copied from the code that handles the second NPC UI button, where this problem doesn't occur.

### Are there alternatives to your fix?
NA
