### PR TITLE
[1.4] fix prechatbuttonclicked crashing on editing a grave

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2273,9 +2273,15 @@
  			if (!flag) {
  				DrawNPCChatButtons(num, textColor, amountOfLines, focusText, focusText2);
  				if (text2 != null) {
-@@ -29215,7 +_,13 @@
+@@ -29211,11 +_,19 @@
+ 						SubmitSignText();
+ 					else
+ 						IngameFancyUI.OpenVirtualKeyboard(1);
++					return;
+ 				}
  				else if (NPCID.Sets.IsTownPet[npc[player[myPlayer].talkNPC].type]) {
  					player[myPlayer].PetAnimal(player[myPlayer].talkNPC);
++					return;
  				}
 +
 +				if (!NPCLoader.PreChatButtonClicked(true))


### PR DESCRIPTION
Duplicate of the PR for 1.3: #1162 

Fixes it in a different way by just escaping the method instead