### PR TITLE
[1.4] add setupRecipes bool to detect Recipe misuse

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -440,7 +440,9 @@ namespace Terraria.ModLoader
 
 			Recipe.numRecipes = 0;
 			RecipeGroupHelper.ResetRecipeGroups();
+			RecipeHooks.setupRecipes = true;
 			Recipe.SetupRecipes();
+			RecipeHooks.setupRecipes = false;
 		}
 
 		internal static void UnloadModContent() {

--- a/patches/tModLoader/Terraria/ModLoader/RecipeHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeHooks.cs
@@ -11,12 +11,18 @@ namespace Terraria.ModLoader
 	{
 		internal static readonly IList<GlobalRecipe> globalRecipes = new List<GlobalRecipe>();
 
+		/// <summary>
+		/// Set when tML sets up modded recipes. Used to detect misuse of the ModRecipe ctor
+		/// </summary>
+		internal static bool setupRecipes = false;
+
 		internal static void Add(GlobalRecipe globalRecipe) {
 			globalRecipes.Add(globalRecipe);
 		}
 
 		internal static void Unload() {
 			globalRecipes.Clear();
+			setupRecipes = false;
 		}
 
 		internal static void AddRecipes() {

--- a/patches/tModLoader/Terraria/ModLoader/RecipeHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeHooks.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader
 		internal static readonly IList<GlobalRecipe> globalRecipes = new List<GlobalRecipe>();
 
 		/// <summary>
-		/// Set when tML sets up modded recipes. Used to detect misuse of the ModRecipe ctor
+		/// Set when tML sets up modded recipes. Used to detect misuse of CreateRecipe
 		/// </summary>
 		internal static bool setupRecipes = false;
 

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -317,6 +317,9 @@ namespace Terraria
 		internal static Recipe Create(Mod mod, int result, int amount) {
 			var recipe = new Recipe(mod);
 
+			if (!RecipeHooks.setupRecipes)
+				throw new RecipeException("A Recipe can only be created inside recipe related methods");
+
 			recipe.createItem.SetDefaults(result, false);
 			recipe.createItem.stack = amount;
 


### PR DESCRIPTION
### What is the bug?
Duplicate of the 1.3 fix of : #1129 , "fixes" #1125 

### How did you fix the bug?
By introducing an additional check inside the `Recipe.Create` method

### Are there alternatives to your fix?
This is actually a better fix than the 1.3 version because it does it in a better place, since for modders, "creating a recipe" includes setting the result, and this PR adds the check directly before `createItem.SetDefaults`

