### PR TITLE
Fix ModNet.DrawModDiagnoseNet() being called 121 times instead of once

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3967,15 +3967,15 @@
  				InReforgeMenu = false;
  			}
  
-@@ -33064,6 +_,8 @@
- 				num3 += 70;
+@@ -33065,6 +_,8 @@
  				text2 = $"{txDataType[j]:0,0}";
  				spriteBatch.DrawString(fontMouseText, text2, new Vector2(num3, num4), Microsoft.Xna.Framework.Color.White, 0f, default(Vector2), scale, SpriteEffects.None, 0f);
-+
-+				ModNet.DrawModDiagnoseNet();
  			}
++
++			ModNet.DrawModDiagnoseNet();
  		}
  
+ 		private void DrawInterface_16_MapOrMinimap() {
 @@ -33170,6 +_,11 @@
  						if (type == 439 || type == 370)
  							scale = 1.5f;


### PR DESCRIPTION
### What is the bug?
The text for modded packets that draws in the F8 menu is very thick, suggesting it is being drawn more than once.

### How did you fix the bug?
I suspect due to a bad patch for 1.3.5.3, the code for drawing it has been moved into the loop that draws each message separately, causing this overlap: [commit](https://github.com/tModLoader/tModLoader/commit/ce6f68082612770def90d41fa16e7aa43b98f731#diff-e3389e7ea64819b97386e48546a4c037936825946f9d14219333bf0404292724L4106)

I moved the call just after the loop.
