### PR TITLE
[1.4] Some 1.4 reimplementations from patching_todo.txt

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1097,6 +1097,15 @@
  				if (Main.player[myPlayer].buffType[num4] != player.buffType[num4])
  					flag3 = true;
  			}
+@@ -12983,6 +_,8 @@
+ 			if (flag)
+ 				NetMessage.SendData(138);
+ 
++			PlayerHooks.SendClientChanges(Main.player[myPlayer], clientPlayer);
++
+ 			clientPlayer = (Player)Main.player[myPlayer].clientClone();
+ 		}
+ 
 @@ -13025,6 +_,7 @@
  			}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2160,6 +2160,18 @@
  			int num2 = item.glowMask;
  			if (!gamePaused && base.IsActive && (item.IsACoin || item.type == 58 || item.type == 109) && color.R > 60 && (float)rand.Next(500) - (Math.Abs(item.velocity.X) + Math.Abs(item.velocity.Y)) * 10f < (float)((int)color.R / 50)) {
  				int type = 43;
+@@ -27897,6 +_,11 @@
+ 			if (item.type == 3779)
+ 				num2 = -1;
+ 
++			if (ItemLoader.animations.Contains(item.type)) {
++				ItemLoader.DrawAnimatedItem(item, whoami, color, currentColor, num, scale);
++				goto PostDraw;
++			}
++
+ 			spriteBatch.Draw(texture, vector2, frame, currentColor, num, vector, scale, SpriteEffects.None, 0f);
+ 			if (item.color != Microsoft.Xna.Framework.Color.Transparent)
+ 				spriteBatch.Draw(texture, vector2, frame, item.GetColor(color), num, vector, scale, SpriteEffects.None, 0f);
 @@ -27904,11 +_,15 @@
  			if (num2 != -1)
  				spriteBatch.Draw(TextureAssets.GlowMask[num2].Value, vector2, frame, new Microsoft.Xna.Framework.Color(250, 250, 250, item.alpha), num, vector, scale, SpriteEffects.None, 0f);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1130,6 +1130,14 @@
  			LockOnHelper.SetUP();
  			CurrentFrameFlags.HadAnActiveInteractibleProjectile = false;
  			PreUpdateAllProjectiles();
+@@ -13108,6 +_,7 @@
+ 			ProjectileUpdateLoopIndex = -1;
+ 			PostUpdateAllProjectiles();
+ 			LockOnHelper.SetDOWN();
++			ModHooks.MidUpdateProjectileItem();
+ 			Item.numberOfNewItems = 0;
+ 			for (int n = 0; n < 400; n++) {
+ 				if (ignoreErrors) {
 @@ -13138,11 +_,13 @@
  				Dust.UpdateDust();
  			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1052,6 +1052,15 @@
  					if (gameMenu)
  						UpdateMenu();
  
+@@ -12615,6 +_,8 @@
+ 
+ 			if (CanPauseGame()) {
+ 				DoUpdate_WhilePaused();
++				PlayerHooks.UpdateAutopause(player[myPlayer]);
++
+ 				gamePaused = true;
+ 				return;
+ 			}
 @@ -12661,6 +_,7 @@
  				Sandstorm.EmitDust();
  			}

--- a/patching_todo.txt
+++ b/patching_todo.txt
@@ -254,15 +254,15 @@
 			
 		//Reimplement the entire ModifyTooltips hook call with all the tooltipNames filling, based on diffs of 1.3.5.3. See MouseText_DrawItemTooltip.
 		
+		//Reimplement PreDrawExtras and PostDraw:
 		//In DrawProj, jump over drawing of all extras with a goto:
 			if (!ProjectileLoader.PreDrawExtras(projectile, spriteBatch)) {
 				goto DrawExtrasEnd;
 			}
-		
-		//Reimplement these calls (unrelated to each other):
-			ModHooks.MidUpdateProjectileItem();
 			
 			ProjectileLoader.PostDraw(projectile, spriteBatch, color25);
+			
+		//Projectile drawing hooks need more thought because of early returns
 			
 		//Reimplement broken patches:
 // {

--- a/patching_todo.txt
+++ b/patching_todo.txt
@@ -242,11 +242,6 @@
 		//Add this to the middle of DrawBG() after definition of the used variable.
 			SurfaceBgStyleLoader.ChooseStyle(ref preferredBGStyleForPlayer);
 			
-		//Add this near the end of Main.DrawItem, before the default drawing calls:
-			if(ItemLoader.animations.Contains(item.type))
-				ItemLoader.DrawAnimatedItem(item, whoAmI, color, alpha, rotation, scale);
-				goto PostDraw;
-			
 		//Add this to the end of DrawSurfaceBG_BackMountainsStep2:
 			SurfaceBgStyleLoader.DrawMiddleTexture();
 			

--- a/patching_todo.txt
+++ b/patching_todo.txt
@@ -262,8 +262,6 @@
 		//Reimplement these calls (unrelated to each other):
 			ModHooks.MidUpdateProjectileItem();
 			
-			PlayerHooks.SendClientChanges(player[myPlayer], clientPlayer);
-			
 			ProjectileLoader.PostDraw(projectile, spriteBatch, color25);
 			
 		//Reimplement broken patches:

--- a/patching_todo.txt
+++ b/patching_todo.txt
@@ -236,9 +236,6 @@
 		//In DrawWaters, replace '13' in for check with
 			WaterStyleLoader.WaterStyleCount'
 			
-		//Add this after DoUpdate_WhilePaused() call:
-			PlayerHooks.UpdateAutopause(player[myPlayer]);
-			
 		//Add this to the middle of DrawBG() after definition of the used variable.
 			SurfaceBgStyleLoader.ChooseStyle(ref preferredBGStyleForPlayer);
 			


### PR DESCRIPTION
### Description
Reimplemented a few calls (ItemLoader.DrawAnimatedItem, PlayerHooks.UpdateAutopause, PlayerHooks.SendClientChanges and ModHooks.MidUpdateProjectileItem) while staying true to its surrounding 1.3 logic

### Remarks
Projectile drawing got a new structure, with `if/return` instead of `if/else if`, making implementing PreDraw, PreDrawExtras and PostDraw more complicated.
