### PR TITLE
[1.4] Projectile Events

### DIFF
--- a/ExampleMod/Common/GlobalItems/ExampleGlobalEvents.cs
+++ b/ExampleMod/Common/GlobalItems/ExampleGlobalEvents.cs
@@ -24,10 +24,8 @@ namespace ExampleMod.Common.GlobalItems
 			}
 		}
 
-		private void SayHi_OnProjectileKill() {
-		 	Main.NewText("Hi!", Main.DiscoColor);
-		}
+		private void SayHi_OnProjectileKill(Projectile projectile) => Main.NewText("Hi!", Main.DiscoColor);
 		
-		private void AddADebuff_OnProjectileHitNPC(NPC npc) => npc.AddBuff(BuffID.OnFire, 50);
+		private void AddADebuff_OnProjectileHitNPC(Projectile projectile, NPC npc) => npc.AddBuff(BuffID.OnFire, 50);
 	}
 }

--- a/ExampleMod/Common/GlobalItems/ExampleGlobalEvents.cs
+++ b/ExampleMod/Common/GlobalItems/ExampleGlobalEvents.cs
@@ -1,0 +1,33 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.GlobalItems
+{
+	// This file shows you how to use AddToShotProjectile in a globalitem context. 
+	// AddToShotProjectile is a method that gets called once, only when Shoot returns true.
+	// It's applications include: Adding data to your item when it does something and you cannot directly modify a projectile,
+	// doing deterministic or clientsided things during an event (Events don't get synced!)
+	// and doing things when a projectile hits a tile in places that don't have it, such as here.
+	public class ExampleGlobalEvents : GlobalItem
+	{
+		public override void AddToShotProjectile(Projectile projectile, Item item) {
+			if (item.type == ItemID.Flamethrower) {
+				// Here we add a method to be called when the projectile's Kill method is called. It says hi!
+				projectile.OnProjectileKill += SayHi_OnProjectileKill;
+			}
+
+			// I want to set an NPC on fire always, but I don't want to pull over code to my GlobalProjectile, as the projectile this fires is vanilla.
+			// What do I do? 
+			if (item.type == ModContent.ItemType<Content.Items.Weapons.ExampleMagicWeapon>()) {
+				projectile.OnProjectileHitNPC += AddADebuff_OnProjectileHitNPC;
+			}
+		}
+
+		private void SayHi_OnProjectileKill() {
+		 	Main.NewText("Hi!", Main.DiscoColor);
+		}
+		
+		private void AddADebuff_OnProjectileHitNPC(NPC npc) => npc.AddBuff(BuffID.OnFire, 50);
+	}
+}

--- a/ExampleMod/Content/Items/Weapons/ExampleEventItem.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleEventItem.cs
@@ -1,0 +1,37 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+
+namespace ExampleMod.Content.Items.Weapons
+{
+	public class ExampleEventItem : ModItem
+	{
+		private int timesHit;
+		public override string Texture => "Examplemod/Content/Items/Weapons/ExampleShootingSword";
+		public override void SetDefaults() {
+			item.useTime = 20;
+			item.useAnimation = 20;
+			item.useStyle = ItemUseStyleID.Shoot;
+			item.autoReuse = true;
+			item.damage = 20;
+			item.DamageType = DamageClass.Ranged;
+			item.width = 32;
+			item.height = 32;
+			item.shoot = 10;
+			// This Ammo is nonspecific. I may not be able to control this, which is why I should use the events.
+			item.useAmmo = AmmoID.Bullet;
+		}
+		// Here I add something to every shot it fires. Notice that I'm not overriding shoot.
+		// The Shoot method returns 'True' by default. The method below will only be called if it returns true.
+		public override void AddToShotProjectile(Projectile projectile) {
+			projectile.OnProjectileHitNPC += Projectile_OnProjectileHitNPC;
+		}
+		// Here I launch the NPC up, give it the Cursed inferno debuff, and size it up by 1.2f when it is hit by this.
+		private void Projectile_OnProjectileHitNPC(NPC npc) {
+			DisplayName.SetDefault($"I have been used {timesHit} times!");
+			npc.velocity.Y -= 5;
+			npc.AddBuff(BuffID.CursedInferno, 60);
+			npc.scale *= 1.2f;
+		}
+	}
+}

--- a/ExampleMod/Content/Items/Weapons/ExampleEventItem.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleEventItem.cs
@@ -27,7 +27,7 @@ namespace ExampleMod.Content.Items.Weapons
 			projectile.OnProjectileHitNPC += Projectile_OnProjectileHitNPC;
 		}
 		// Here I launch the NPC up, give it the Cursed inferno debuff, and size it up by 1.2f when it is hit by this.
-		private void Projectile_OnProjectileHitNPC(NPC npc) {
+		private void Projectile_OnProjectileHitNPC(Projectile projectile, NPC npc) {
 			DisplayName.SetDefault($"I have been used {timesHit} times!");
 			npc.velocity.Y -= 5;
 			npc.AddBuff(BuffID.CursedInferno, 60);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -851,5 +851,10 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void NetReceive(Item item, BinaryReader reader) {
 		}
+		/// <summary>
+		/// This is where you would add to the events for a projectile created when Shoot returns true. Will not be called for other projectiles; manually add to their events.
+		/// </summary>
+		public virtual void AddToShotProjectile(Projectile projectile, Item item) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -385,5 +385,11 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void GrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY) {
 		}
+
+		/// <summary>
+		/// This is where you would add to the events for a projectile created when Shoot returns true. Will not be called for other projectiles; manually add to their events.
+		/// </summary>
+		public virtual void AddToShotProjectile(Projectile projectile) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1681,6 +1681,16 @@ namespace Terraria.ModLoader
 			return item.type != 0 && (item.modItem != null || item.prefix >= PrefixID.Count || HookNeedsSaving.arr.Count(g => g.Instance(item).NeedsSaving(item)) > 0);
 		}
 
+		private static HookList HookAddToShotProjectile = AddHook<Action<Projectile, Item>>(g => g.AddToShotProjectile);
+
+		internal static void AddToShotProjectile(Projectile projectile, Item item) {
+			item.modItem?.AddToShotProjectile(projectile);
+
+			foreach (GlobalItem g in HookAddToShotProjectile.arr) {
+				g.Instance(item).AddToShotProjectile(projectile, item);
+			}
+		}
+
 		internal static void WriteNetGlobalOrder(BinaryWriter w) {
 			w.Write((short)NetGlobals.Length);
 			foreach (var globalItem in NetGlobals) {

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -1019,6 +1019,12 @@ namespace Terraria.ModLoader
 		public virtual void ModifyTooltips(List<TooltipLine> tooltips) {
 		}
 
+		/// <summary>
+		/// This is where you would add to the events for a projectile created when Shoot returns true. Will not be called for other projectiles; manually add to their events.
+		/// </summary>
+		public virtual void AddToShotProjectile(Projectile projectile) {
+		}
+
 		public Recipe CreateRecipe(int amount = 1) => Recipe.Create(Mod, item.type, amount);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -431,5 +431,11 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void DrawBehind(int index, List<int> drawCacheProjsBehindNPCsAndTiles, List<int> drawCacheProjsBehindNPCs, List<int> drawCacheProjsBehindProjectiles, List<int> drawCacheProjsOverWiresUI) {
 		}
+
+		/// <summary>
+		/// This is where you would add to the events for a projectile created when Shoot returns true. Will not be called for other projectiles; manually add to their events.
+		/// </summary>
+		public virtual void AddToShotProjectile(Projectile projectile) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -628,6 +628,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookAddToShotProjectile = AddHook<Action<Projectile>>(g => g.AddToShotProjectile);
+
+		internal static void AddToShotProjectile(Projectile projectile) {
+			projectile.modProjectile?.AddToShotProjectile(projectile);
+
+			foreach (GlobalProjectile g in HookAddToShotProjectile.arr) {
+				g.Instance(projectile).AddToShotProjectile(projectile);
+			}
+		}
+
 		private static bool HasMethod(Type t, string method, params Type[] args) {
 			return t.GetMethod(method, args).DeclaringType != typeof(GlobalProjectile);
 		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3157,7 +3157,7 @@
  				if (sItem.stack <= 0)
  					sItem.SetDefaults();
  			}
-@@ -33870,7 +_,8 @@
+@@ -33870,8 +_,13 @@
  					Main.projectile[num177].originalDamage = damage;
  					UpdateMaxTurrets();
  				}
@@ -3165,8 +3165,13 @@
 +				else if (PlayerHooks.Shoot(this, sItem, ref pointPoisition, ref num2, ref num3, ref projToShoot, ref Damage, ref KnockBack)
 +					&& ItemLoader.Shoot(sItem, this, ref pointPoisition, ref num2, ref num3, ref projToShoot, ref Damage, ref KnockBack)) {
  					int num178 = Projectile.NewProjectile(pointPoisition.X, pointPoisition.Y, num2, num3, projToShoot, Damage, KnockBack, i);
++
++					ProjectileLoader.AddToShotProjectile(Main.projectile[num178]);
++					ItemLoader.AddToShotProjectile(Main.projectile[num178], sItem);
++
  					if (sItem.type == 726)
  						Main.projectile[num178].magic = true;
+ 
 @@ -34427,6 +_,8 @@
  		}
  

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -42,6 +42,13 @@ namespace Terraria
 		public event ProjectileDelegateKill OnProjectileKill;
 		public delegate void ProjectileDelegateKill();
 
+		internal void ClearEvents() {
+			OnProjectileHitNPC = null;
+			OnProjectileTileCollide = null;
+			OnProjectileHitPvp = null;
+			OnProjectileKill = null;
+		}
+
 		// Get
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -18,6 +18,30 @@ namespace Terraria
 		/// </summary>
 		public DamageClass DamageType { get; set; }
 
+		/// <summary>
+		/// An event to be called when a projectile hits an NPC. Will not sync; data here must be either deterministic or specific to the client.
+		/// </summary>
+		public event ProjectileDelegateOnHitNPC OnProjectileHitNPC;
+		public delegate void ProjectileDelegateOnHitNPC(NPC npc);
+
+		/// <summary>
+		/// An event to be called when a projectile hits a tile. Will not sync; data here must be either deterministic or specific to the client.
+		/// </summary>
+		public event ProjectileDelegateOnHitTile OnProjectileTileCollide;
+		public delegate void ProjectileDelegateOnHitTile(Microsoft.Xna.Framework.Vector2 coords);
+
+		/// <summary>
+		/// An event to be called when a projectile hits a player in PVP. Will not sync; data here must be either deterministic or specific to the client.
+		/// </summary>
+		public event ProjectileDelegateOnHitPvp OnProjectileHitPvp;
+		public delegate void ProjectileDelegateOnHitPvp(Player player);
+
+		/// <summary>
+		/// An event to be called when a projectile calls the Kill method. Will not sync; data here must be either deterministic or specific to the client.
+		/// </summary>
+		public event ProjectileDelegateKill OnProjectileKill;
+		public delegate void ProjectileDelegateKill();
+
 		// Get
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -295,11 +295,12 @@
  									}
  
  									if (type == 916)
-@@ -9856,6 +_,9 @@
+@@ -9856,6 +_,10 @@
  									if (type == 710)
  										BetsySharpnel(i);
  
 +									ProjectileLoader.OnHitNPC(this, Main.npc[i], num32, knockback, flag6);
++									OnProjectileHitNPC?.Invoke(Main.npc[i]);
 +									NPCLoader.OnHitByProjectile(Main.npc[i], this, num32, knockback, flag6);
 +									PlayerHooks.OnHitNPCWithProj(this, Main.npc[i], num32, knockback, flag6);
  									if (penetrate > 0 && type != 317 && type != 866) {
@@ -331,11 +332,12 @@
  						int num47 = (int)player2.Hurt(playerDeathReason, num46, base.direction, pvp: true, quiet: false, flag17);
  						if (num47 > 0 && Main.player[owner].ghostHeal && friendly && !hostile)
  							ghostHeal(num47, new Vector2(player2.Center.X, player2.Center.Y));
-@@ -10052,6 +_,8 @@
+@@ -10052,6 +_,9 @@
  						if ((melee || ProjectileID.Sets.IsAWhip[type]) && Main.player[owner].meleeEnchant == 7)
  							NewProjectile(player2.Center.X, player2.Center.Y, player2.velocity.X, player2.velocity.Y, 289, 0, 0f, owner);
  
 +						ProjectileLoader.OnHitPvp(this, player2, num47, flag17);
++						OnProjectileHitPvp?.Invoke(player2);
 +						PlayerHooks.OnHitPvpWithProj(this, player2, num47, flag17);
  						if (Main.netMode != 0)
  							NetMessage.SendPlayerHurt(num45, playerDeathReason, num46, base.direction, flag17, pvp: true, -1);
@@ -444,10 +446,12 @@
  						int num = (overrideWidth != -1) ? overrideWidth : base.width;
  						int num2 = (overrideHeight != -1) ? overrideHeight : base.height;
  						if (overrideHeight != -1 || overrideWidth != -1)
-@@ -12047,7 +_,9 @@
+@@ -12047,7 +_,11 @@
  						}
  					}
  
++					OnProjectileTileCollide?.Invoke(this.position);
++
 +					if (!ProjectileLoader.OnTileCollide(this, lastVelocity)) {
 +					}
 -					if (type == 663 || type == 665 || type == 667 || type == 677 || type == 678 || type == 679 || type == 691 || type == 692 || type == 693 || type == 688 || type == 689 || type == 690) {
@@ -647,11 +651,12 @@
  					AI_061_FishingBobber_GiveItemToPlayer(Main.player[owner], (int)ai[1]);
  
  				ai[1] = 0f;
-@@ -51207,6 +_,7 @@
+@@ -51207,6 +_,8 @@
  				}
  			}
  
 +			ProjectileLoader.Kill(this, num);
++			OnProjectileKill?.Invoke();
  			active = false;
  		}
  

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -651,15 +651,17 @@
  					AI_061_FishingBobber_GiveItemToPlayer(Main.player[owner], (int)ai[1]);
  
  				ai[1] = 0f;
-@@ -51207,6 +_,8 @@
+@@ -51207,7 +_,10 @@
  				}
  			}
  
 +			ProjectileLoader.Kill(this, num);
 +			OnProjectileKill?.Invoke();
  			active = false;
++			ClearEvents();
  		}
  
+ 		private void DoRainbowCrystalStaffExplosion() {
 @@ -51273,6 +_,9 @@
  			if (Main.tileDungeon[Main.tile[x, y].type] || TileID.Sets.BasicChest[Main.tile[x, y].type])
  				return false;


### PR DESCRIPTION
Hi, I'm extremely new to working with others and PRs and stuff. Don't be hard on me.
### What is the new feature?
I've added events for the purpose of reducing boilerplate code associated with projectile weapons and accessories.
### Why should this be part of tModLoader?
The current solution for similar stuff is to manually spawn and flag projectiles to do something as simple incrementing a value on an item or on hit effects in your GlobalItem. To avoid God Classing and headaches with organization, I've come up with the solution of using events in order to attach code to any projectile. 

### Are there alternative designs?
Mirsario had recommended hooks with basically identical features to this.

### Sample usage for the new feature
I have a gun. If I want every new ammo to increase the damage on this gun by one temporarily when it hits an enemy, I can simply subscribe to an event that increments a value on the gun's end by one when it hits an NPC. Previously this would require a lot of boilerplate - spawning a new projectile, getting it's ID, getting it's projectile instance from Main.projectile, and then flagging it. I'd then go to my general purpose GlobalProjectile to gather the player's helditem, which I can't reliably ensure is going to be the item I want it to when the projectile hits, cast it to the type I want, and then increment the value.

With this, I can simply make a method that increments said value and subscribe it to the event where I'd want it to go.
I also have an accessory. With this accessory, I want every projectile to explode on kill when I wear it. Same deal as the above one, less boilerplate needed. 

### ExampleMod updates
ExampleGlobalEvents - shows off subscribing in a globalitem context.
ExampleEventItem - shows off subscribing in a moditem context.

This commit is feature incomplete and will be updated as needed/requested.