### PR TITLE
Add call to "GlobalBgStyle.ChooseSurfaceBgStyle"

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3330,7 +3330,11 @@
  			try {
  				DrawSurfaceBG();
  				if (BackgroundEnabled)
-@@ -48903,6 +_,7 @@
+@@ -48900,9 +_,11 @@
+ 						num = 11;
+ 					else if (WorldGen.treeBG1 != WorldGen.treeBG4)
+ 						num = 12;
++					//Patch context.
  				}
  			}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3330,6 +3330,14 @@
  			try {
  				DrawSurfaceBG();
  				if (BackgroundEnabled)
+@@ -48903,6 +_,7 @@
+ 				}
+ 			}
+ 
++			SurfaceBgStyleLoader.ChooseStyle(ref num);
+ 			return num;
+ 		}
+ 
 @@ -49199,6 +_,15 @@
  			}
  		}


### PR DESCRIPTION
### What is the bug?
`GlobalBgStyle.ChooseSurfaceBgStyle` is never called so whatever mods do when overriding it doesn't happen.

### How did you fix the bug?
By adding a call to `SurfaceBgStyleLoader.ChooseStyle()`, which calls the `ChooseSurfaceBgStyle` hook of all mods.
In 1.3, this method is called in the `DrawBG` method of `Main`, after a bunch of nested ternary operators. In 1.4, that line was moved to a method called `GetPreferredBGStyleForPlayer`, so instead of calling `ChooseStyle` inside `DrawBG`, I'm calling it inside the new method right before the `return num;`.
1.3 code: 
![image](https://user-images.githubusercontent.com/31808958/103159157-a9911b80-47a4-11eb-8914-24423ce91f87.png)
1.4 code: DrawBG:
![image](https://user-images.githubusercontent.com/31808958/103159168-bb72be80-47a4-11eb-94bf-c4f0e6d3efa0.png)
GetPreferredBGStyleForPlayer:
![image](https://user-images.githubusercontent.com/31808958/103159174-d2b1ac00-47a4-11eb-8252-2f0fdc03aef7.png)

### Are there alternatives to your fix?
Another option would be to call `SurfaceBgStyleLoader.ChooseStyle()` after `GetPreferredBGStyleForPlayer` in `DrawBG` instead of inside `GetPreferredBGStyleForPlayer`.
