### PR TITLE
[1.4] Basic support for the "boss health bars" feature

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/BlueJellyfishBigProgressBarGlobalNPC.cs
+++ b/ExampleMod/Common/GlobalNPCs/BlueJellyfishBigProgressBarGlobalNPC.cs
@@ -1,0 +1,17 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.GlobalNPCs
+{
+	//Showcases how to assign something to a vanilla NPC like you would do for a modded NPC using the SetStaticDefaults hook
+	//In this case, setting a big progress bar
+	public class BlueJellyfishBigProgressBarGlobalNPC : GlobalNPC
+	{
+		//SetupContent hook runs once per class, right after all content has loaded in and is functional
+		public override void SetupContent() {
+			//Custom "boss health bar", see the Content/BigProgressBars folder
+			Main.BigBossProgressBar.AddBar(NPCID.BlueJellyfish, new Content.BigProgressBars.BlueJellyfishBigProgressBar());
+		}
+	}
+}

--- a/ExampleMod/Content/BigProgressBars/BigProgressBarTemplate.cs
+++ b/ExampleMod/Content/BigProgressBars/BigProgressBarTemplate.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.GameContent.UI.BigProgressBar;
+
+namespace ExampleMod.Content.BigProgressBars
+{
+	class BigProgressBarTemplate : IBigProgressBar
+	{
+		//This class contains the same code vanilla CommonBossBigProgressBar uses. You are free to modify it as you see fit for your needs
+		//See PartyZombieBigProgressBar.cs + NPCs/PartyZombie.cs for usage example
+
+		private float _lifePercentToShow;
+		private int _headIndex;
+
+		public bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info) {
+			if (info.npcIndexToAimAt < 0 || info.npcIndexToAimAt > Main.maxNPCs)
+				return false;
+
+			NPC npc = Main.npc[info.npcIndexToAimAt];
+			if (!npc.active)
+				return false;
+			//These checks above are required to make sure that the game tracks a valid NPC
+
+			int bossHeadTextureIndex = npc.GetBossHeadTextureIndex();
+			if (bossHeadTextureIndex == -1)
+				return false;
+			//Only draws if this npc has a boss head texture
+
+			_lifePercentToShow = Utils.Clamp(npc.life / (float)npc.lifeMax, 0f, 1f);
+			_headIndex = bossHeadTextureIndex;
+			return true;
+		}
+
+		public void Draw(ref BigProgressBarInfo info, SpriteBatch spriteBatch) {
+			//Here you can do anything you want to draw your bar onto the screen. This example draws the boss head icon assigned previously
+			//You can also make use of the existing methods available: DrawBareBonesBar and DrawFancyBar. They are not very customizable, and if you need to, 
+			//it would be easier to find the code in the source (read the adaption guide on the tml wiki)
+			//and adapt it to your needs instead of making it from scratch
+
+			Texture2D value = TextureAssets.NpcHeadBoss[_headIndex].Value;
+			Rectangle barIconFrame = value.Frame();
+			BigProgressBarHelper.DrawFancyBar(spriteBatch, _lifePercentToShow, value, barIconFrame);
+		}
+	}
+}

--- a/ExampleMod/Content/BigProgressBars/BlueJellyfishBigProgressBar.cs
+++ b/ExampleMod/Content/BigProgressBars/BlueJellyfishBigProgressBar.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.GameContent.UI.BigProgressBar;
+using Terraria.ID;
+
+namespace ExampleMod.Content.BigProgressBars
+{
+	class BlueJellyfishBigProgressBar : IBigProgressBar
+	{
+		//Works for any NPC this is registered for, draws the jellyfish NPC textures' first frame as the icon
+
+		private float _lifePercentToShow;
+
+		public bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info) {
+			if (info.npcIndexToAimAt < 0 || info.npcIndexToAimAt > 200)
+				return false;
+
+			NPC npc = Main.npc[info.npcIndexToAimAt];
+			if (!npc.active)
+				return false;
+
+			_lifePercentToShow = Utils.Clamp(npc.life / (float)npc.lifeMax, 0f, 1f);
+			return true;
+		}
+
+		public void Draw(ref BigProgressBarInfo info, SpriteBatch spriteBatch) {
+			//Grab the blue jellyfish texture
+			Texture2D value = TextureAssets.Npc[NPCID.BlueJellyfish].Value;
+
+			//Take its first animation frame and offset the draw a bit (so it aligns with the space for the icon)
+			Rectangle barIconFrame = value.Frame(verticalFrames: Main.npcFrameCount[NPCID.BlueJellyfish], frameY: 0, sizeOffsetY: 14);
+
+			BigProgressBarHelper.DrawFancyBar(spriteBatch, _lifePercentToShow, value, barIconFrame);
+		}
+	}
+}

--- a/ExampleMod/Content/BigProgressBars/PartyZombieBigProgressBar.cs
+++ b/ExampleMod/Content/BigProgressBars/PartyZombieBigProgressBar.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameContent;
+using Terraria.GameContent.UI.BigProgressBar;
+using Terraria.ID;
+
+namespace ExampleMod.Content.BigProgressBars
+{
+	class PartyZombieBigProgressBar : IBigProgressBar
+	{
+		//Works for any NPC this is registered for, draws the Confetti item texture as the icon
+
+		private float _lifePercentToShow;
+
+		public bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info) {
+			if (info.npcIndexToAimAt < 0 || info.npcIndexToAimAt > 200)
+				return false;
+
+			NPC npc = Main.npc[info.npcIndexToAimAt];
+			if (!npc.active)
+				return false;
+
+			_lifePercentToShow = Utils.Clamp(npc.life / (float)npc.lifeMax, 0f, 1f);
+			return true;
+		}
+
+		public void Draw(ref BigProgressBarInfo info, SpriteBatch spriteBatch) {
+			Texture2D value = TextureAssets.Item[ItemID.Confetti].Value;
+			Rectangle barIconFrame = value.Frame();
+			BigProgressBarHelper.DrawFancyBar(spriteBatch, _lifePercentToShow, value, barIconFrame);
+		}
+	}
+}

--- a/ExampleMod/Content/NPCs/PartyZombie.cs
+++ b/ExampleMod/Content/NPCs/PartyZombie.cs
@@ -21,7 +21,6 @@ namespace ExampleMod.Content.NPCS
 			};
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(npc.type, value);
 
-			//TODO showcase changing vanilla NPC bars after ModSystem merge using PostSetupContent
 			//Custom "boss health bar", see the Content/BigProgressBars folder
 			Main.BigBossProgressBar.AddBar(npc.type, new Content.BigProgressBars.PartyZombieBigProgressBar());
 		}

--- a/ExampleMod/Content/NPCs/PartyZombie.cs
+++ b/ExampleMod/Content/NPCs/PartyZombie.cs
@@ -20,6 +20,10 @@ namespace ExampleMod.Content.NPCS
 				Velocity = 1f //Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 			};
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(npc.type, value);
+
+			//TODO showcase changing vanilla NPC bars after ModSystem merge using PostSetupContent
+			//Custom "boss health bar", see the Content/BigProgressBars folder
+			Main.BigBossProgressBar.AddBar(npc.type, new Content.BigProgressBars.PartyZombieBigProgressBar());
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
@@ -23,7 +23,7 @@ namespace Terraria.GameContent.UI.BigProgressBar
 		/// <param name="netID">The NPCs netID (most of the time the same as its type) to register to</param>
 		/// <param name="bar">The IBigProgressBar</param>
 		/// <returns>true if added, false if overridden</returns>
-		internal bool AddBar(int netID, IBigProgressBar bar) {
+		public bool AddBar(int netID, IBigProgressBar bar) {
 			//This is callable anywhere at any point in the game
 			if (!BarOverridden(netID) && !SpecialVanillaBarExists(netID)) {
 				overrideBossBarsByNpcNetId.Add(netID, bar);

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
@@ -1,11 +1,70 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 namespace Terraria.GameContent.UI.BigProgressBar
 {
 	public partial class BigProgressBarSystem
 	{
+		/// <summary>
+		/// Assign this bar to an NPC if you explicitely don't want to have one displayed. Alternatively, if you don't have a boss head assigned, the bar won't show up either
+		/// </summary>
 		public static NeverValidProgressBar NeverValid => _neverValid;
+
+		/// <summary>
+		/// Keeps track of added bars by mods. _bossBarsByNpcNetId only tracks special vanilla bars
+		/// </summary>
+		internal Dictionary<int, IBigProgressBar> overrideBossBarsByNpcNetId = new Dictionary<int, IBigProgressBar>();
+
+		//Main.BigBossProgressBar seems to never be re-initialized (neither does the static constructor get called again), so do custom unloading here
+		internal void Unload() => overrideBossBarsByNpcNetId.Clear();
+
+		/// <summary>
+		/// Overrides or adds a boss bar for an NPC
+		/// </summary>
+		/// <param name="netID">The NPCs netID (most of the time the same as its type) to register to</param>
+		/// <param name="bar">The IBigProgressBar</param>
+		/// <returns>true if added, false if overridden</returns>
+		internal bool AddBar(int netID, IBigProgressBar bar) {
+			//This is callable anywhere at any point in the game
+			if (!BarOverridden(netID) && !SpecialVanillaBarExists(netID)) {
+				overrideBossBarsByNpcNetId.Add(netID, bar);
+				return true;
+			}
+			else {
+				overrideBossBarsByNpcNetId[netID] = bar;
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Checks if an overridden bar exists for an NPCs netID
+		/// </summary>
+		/// <param name="netID">The netID to check for a bar with</param>
+		/// <returns>true if an overridden bar exists</returns>
+		public bool BarOverridden(int netID) => overrideBossBarsByNpcNetId.ContainsKey(netID);
+
+		/// <summary>
+		/// Checks if a special bar exists for a vanilla NPCs netID
+		/// </summary>
+		/// <param name="netID">The netID to check for a bar with</param>
+		/// <returns>true if a special vanilla bar exists</returns>
+		public bool SpecialVanillaBarExists(int netID) => _bossBarsByNpcNetId.ContainsKey(netID);
+
+		/// <summary>
+		/// Gets the bar associated with the NPCs netID. Prioritizes overridden/added bars
+		/// </summary>
+		/// <param name="netID">The netID associated with a bar to get</param>
+		/// <param name="bar">When this method returns, contains the bar associated with the specified netID; otherwise, null for the bar: The resulting bar would turn into one of type CommonBossBigProgressBar</param>
+		/// <returns>true if there is a bar associated with the netID; otherwise, false</returns>
+		public bool TryGetBar(int netID, out IBigProgressBar bar) {
+			bar = null;
+
+			//Prioritize overridden bars
+			if (overrideBossBarsByNpcNetId.TryGetValue(netID, out IBigProgressBar over))
+				bar = over;
+			else if (_bossBarsByNpcNetId.TryGetValue(netID, out IBigProgressBar value))
+				bar = value;
+
+			return bar != null;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.TML.cs
@@ -1,0 +1,11 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+
+namespace Terraria.GameContent.UI.BigProgressBar
+{
+	public partial class BigProgressBarSystem
+	{
+		public static NeverValidProgressBar NeverValid => _neverValid;
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
@@ -9,3 +9,13 @@
  	{
  		private IBigProgressBar _currentBar;
  		private CommonBossBigProgressBar _bossBar = new CommonBossBigProgressBar();
+@@ -86,7 +_,8 @@
+ 			bigProgressBarInfo.npcIndexToAimAt = npcIndex;
+ 			BigProgressBarInfo info = bigProgressBarInfo;
+ 			IBigProgressBar bigProgressBar = _bossBar;
++			//Moved if (_bossBarsByNpcNetId.TryGetValue(nPC.netID, out IBigProgressBar value)) into the partial .TML class
+-			if (_bossBarsByNpcNetId.TryGetValue(nPC.netID, out IBigProgressBar value))
++			if (TryGetBar(nPC.netID, out IBigProgressBar value))
+ 				bigProgressBar = value;
+ 
+ 			if (!bigProgressBar.ValidateAndCollectNecessaryInfo(ref info))

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs
++++ src/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs
+@@ -4,7 +_,7 @@
+ 
+ namespace Terraria.GameContent.UI.BigProgressBar
+ {
+-	public class BigProgressBarSystem
++	public partial class BigProgressBarSystem
+ 	{
+ 		private IBigProgressBar _currentBar;
+ 		private CommonBossBigProgressBar _bossBar = new CommonBossBigProgressBar();

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/IBigProgressBar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/IBigProgressBar.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/UI/BigProgressBar/IBigProgressBar.cs
++++ src/tModLoader/Terraria/GameContent/UI/BigProgressBar/IBigProgressBar.cs
+@@ -2,7 +_,7 @@
+ 
+ namespace Terraria.GameContent.UI.BigProgressBar
+ {
+-	internal interface IBigProgressBar
++	public interface IBigProgressBar
+ 	{
+ 		bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info);
+ 

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -515,6 +515,7 @@ namespace Terraria.ModLoader
 			ProjectileLoader.Unload();
 			NPCLoader.Unload();
 			NPCHeadLoader.Unload();
+			Main.BigBossProgressBar.Unload();
 			PlayerHooks.Unload();
 			BuffLoader.Unload();
 			MountLoader.Unload();


### PR DESCRIPTION
### What is the new feature?
Exposes a few things required for mods to make custom "boss health bars" (called `BigProgressBar`s in code).

### Explanation
This PR adds surface-level access to the "boss health bar" feature in 1.4. It makes the `IBigProgressBar` interface public, aswell as adding a way to register custom instances for npcs. 
Here are some notes on how this system works in vanilla:
* The game has a "boss health bar system" using an interface to track them
    * Each NPC has by default a `CommonBossBigProgressBar` that only works if the NPC also has a boss head texture
    * Only if the NPC has special behavior regarding displaying its bar (e.g. multisegment bosses), or it should not display a bar at all (e.g. Lunatic Cultist clone), the game assigns a custom bar
* It scans through all NPCs and picks the closest trackable one
* If one custom bar is found, do its logic and draw instead of the default one
* This means the common bar is opt-out for all bosses (usually have a boss head). There exists a custom `NeverValidProgressBar` bar
    * That can be assigned to an npc so that it never displays one, even if has a boss head. It has been made public for this purpose

### Why should this be part of tModLoader?
To interact with a vanilla feature.

### Are there alternative designs?
Yes, a custom ModType that implements `IBigProgressBar` for example, that takes care of loading and instantiating them as ModContent (so you don't have to create new objects for AddBar yourself) and can also add more hooks ontop.

Currently the `AddBar` method works with an entirely separate dictionary, not touching the vanilla one, only tracking additions. It supports vanilla NPC IDs aswell, making overrides possible. It prioritizes these in the `TryGetBar` method.

Overall this feature is very basic in its nature, and so is the PR. It doesn't "add" new capabilities to this system, such as controlling on/off status for each bar (ala `GlobalX`), but it does leave room for fully custom drawing (which mods like `YetAnotherBossHealthBar` could utilize). Sadly because there are no control options (vanilla or this PR) it would be hard to define a proper order/priority system for these bars (the last loaded mod could replace all bars with `NothingValid` leaving all other mods' additions/changes obsolete)

### Sample usage for the new feature
```cs
class PartyZombieBigProgressBar : IBigProgressBar {
//implement these
    void Draw(ref BigProgressBarInfo info, SpriteBatch spriteBatch);
    bool ValidateAndCollectNecessaryInfo(ref BigProgressBarInfo info);
}
```

In PartyZombie.SetStaticDefaults:
```cs
Main.BigBossProgressBar.AddBar(npc.type, new PartyZombieBigProgressBar());
```

### ExampleMod updates
`Content/NPCs/PartyZombie.cs` has an example of registering a health bar to a modded NPC. `ExampleMod/Common/GlobalNPCs/BlueJellyfishBigProgressBarGlobalNPC.cs` has one for a vanilla NPC. `Content/BigProgressBars` contains three bars, one for general use. A prime example for showcasing a custom health bar would be a multisegment boss (old ExampleMods Abomination boss).
