### PR TITLE
[1.4] Add worldGen to KillTile hooks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -127,7 +127,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. If <paramref name="fail"/> is true, the tile will not be mined; <paramref name="effectOnly"/> makes it so that only dust is created; <paramref name="noItem"/> stops items from dropping.
+		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. If <paramref name="fail"/> is true, the tile will not be mined; <paramref name="effectOnly"/> makes it so that only dust is created; <paramref name="noItem"/> stops items from dropping. <paramref name="worldGen"/> true if world generation is in progress.
 		/// </summary>
 		/// <param name="i"></param>
 		/// <param name="j"></param>
@@ -135,7 +135,8 @@ namespace Terraria.ModLoader
 		/// <param name="fail"></param>
 		/// <param name="effectOnly"></param>
 		/// <param name="noItem"></param>
-		public virtual void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem) {
+		/// <param name="worldGen"></param>
+		public virtual void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem, bool worldGen) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -282,11 +282,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe. Fail determines whether the tile is mined, effectOnly makes it so that only dust is created, and noItem stops items from dropping.
+		/// Allows you to determine what happens when the tile at the given coordinates is killed or hit with a pickaxe
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
-		public virtual void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem) {
+		/// <param name="fail">Determines whether the tile is mined</param>
+		/// <param name="effectOnly">Only dust / effects are created</param>
+		/// <param name="noItem">Stops items from dropping</param>
+		/// <param name="worldGen">Called from world generation</param>
+		public virtual void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem, bool worldGen) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader
 		private static Func<int, int, int, bool>[] HookDrop;
 		private delegate bool DelegateCanKillTile(int i, int j, int type, ref bool blockDamaged);
 		private static DelegateCanKillTile[] HookCanKillTile;
-		private delegate void DelegateKillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem);
+		private delegate void DelegateKillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem, bool worldGen);
 		private static DelegateKillTile[] HookKillTile;
 		private static Func<int, int, int, bool>[] HookCanExplode;
 		private static Action<int, int, int, bool>[] HookNearbyEffects;
@@ -466,11 +466,11 @@ namespace Terraria.ModLoader
 		}
 		//in Terraria.WorldGen.KillTile before if (!effectOnly && !WorldGen.stopDrops) add
 		//  TileLoader.KillTile(i, j, tile.type, ref fail, ref effectOnly, ref noItem);
-		public static void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem) {
-			GetTile(type)?.KillTile(i, j, ref fail, ref effectOnly, ref noItem);
+		public static void KillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem, bool worldGen) {
+			GetTile(type)?.KillTile(i, j, ref fail, ref effectOnly, ref noItem, worldGen);
 
 			foreach (var hook in HookKillTile) {
-				hook(i, j, type, ref fail, ref effectOnly, ref noItem);
+				hook(i, j, type, ref fail, ref effectOnly, ref noItem, worldGen);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1391,7 +1391,7 @@
  			if (num == 2)
  				return;
  
-+			TileLoader.KillTile(i, j, tile.type, ref fail, ref effectOnly, ref noItem); //Placed before gen check on purpose.
++			TileLoader.KillTile(i, j, tile.type, ref fail, ref effectOnly, ref noItem, gen); //Placed before gen check on purpose.
 +
  			if (gen)
  				noItem = true;


### PR DESCRIPTION
### What is the addition?
Add `worldGen` to KillTile hooks in reference to https://github.com/tModLoader/tModLoader/issues/1176

### Why should this be part of tModLoader?
Based on original issue, world generation is relevant context in this hook, and I doubt it will add any performance overhead.

### Are there alternative designs?
World gen state might be obtainable from some global interfaces or variables? It might still be relevant enough to be included as a param.

### Sample usage for the new feature
```C#
public class ExampleOre : ModTile
{
	public override void KillTile(int i, int j, ref bool fail, ref bool effectOnly, ref bool noItem, bool worldGen) {
		if (!worldGen) fail = true; // unbreakable, but doesn't get in the way of world generation passes
	}
}
```
