### PR TITLE
[1.4] Fix NPCID.Sets.MPAllowedEnemies ignoring modded entries + ExampleMod adjustment

### DIFF
--- a/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
+++ b/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
@@ -6,37 +6,59 @@ using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items.Consumables
 {
+	//This is the Item used to summon a boss, in this case the vanilla Plantera boss.
 	public class PlanteraItem : ModItem
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Plantera");
 			Tooltip.SetDefault("The wrath of the jungle");
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;
-			ItemID.Sets.SortingPriorityBossSpawns[item.type] = 12; // This helps sort inventory know that this is a boss summoning item.
+			ItemID.Sets.SortingPriorityBossSpawns[Type] = 12; // This helps sort inventory know that this is a boss summoning Item.
+
+			//This is set to true for all NPCs that can be summoned via an Item (calling NPC.SpawnOnPlayer). If this is for a modded boss,
+			//write this in the bosses file instead
+			NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] = true;
+		}
+
+		public override void Unload() {
+			//If the mod is disabled, the flag should be reset again to retain the original state of the game
+			NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] = false;
 		}
 
 		public override void SetDefaults() {
-			item.width = 20;
-			item.height = 20;
-			item.maxStack = 20;
-			item.value = 100;
-			item.rare = ItemRarityID.Blue;
-			item.useAnimation = 30;
-			item.useTime = 30;
-			item.useStyle = ItemUseStyleID.HoldUp;
-			item.consumable = true;
+			Item.width = 20;
+			Item.height = 20;
+			Item.maxStack = 20;
+			Item.value = 100;
+			Item.rare = ItemRarityID.Blue;
+			Item.useAnimation = 30;
+			Item.useTime = 30;
+			Item.useStyle = ItemUseStyleID.HoldUp;
+			Item.consumable = true;
 		}
 
 		public override bool CanUseItem(Player player) {
+			//If you decide to use the below UseItem code, you have to include !NPC.AnyNPCs(id), as this is also the check the server does when receiving MessageID.SpawnBoss
 			return Main.hardMode && NPC.downedMechBoss1 && NPC.downedMechBoss2 && NPC.downedMechBoss3 && !NPC.AnyNPCs(NPCID.Plantera);
 		}
 
 		public override bool UseItem(Player player) {
-			NPC.SpawnOnPlayer(player.whoAmI, NPCID.Plantera);
-
-			// Avoid trying to call sounds on dedicated servers.
-			if (!Main.dedServ) {
+			if (player.whoAmI == Main.myPlayer) {
+				//If the player using the item is the client
+				//(explicitely excluded serverside here)
 				SoundEngine.PlaySound(SoundID.Roar, player.position, 0);
+
+				int type = NPCID.Plantera;
+
+				if (Main.netMode != NetmodeID.MultiplayerClient) {
+					//If the player is not in multiplayer, spawn directly
+					NPC.SpawnOnPlayer(player.whoAmI, type);
+				}
+				else {
+					//If the player is in multiplayer, request a spawn
+					//This will only work if NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] is true, which we set in this class above
+					NetMessage.SendData(MessageID.SpawnBoss, number: player.whoAmI, number2: type);
+				}
 			}
 
 			return true;

--- a/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
+++ b/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
@@ -20,11 +20,6 @@ namespace ExampleMod.Content.Items.Consumables
 			NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] = true;
 		}
 
-		public override void Unload() {
-			//If the mod is disabled, the flag should be reset again to retain the original state of the game
-			NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] = false;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 20;
 			Item.height = 20;
@@ -56,7 +51,7 @@ namespace ExampleMod.Content.Items.Consumables
 				}
 				else {
 					//If the player is in multiplayer, request a spawn
-					//This will only work if NPCID.Sets.MPAllowedEnemies[NPCID.Plantera] is true, which we set in this class above
+					//This will only work if NPCID.Sets.MPAllowedEnemies[type] is true, which we set in this class above
 					NetMessage.SendData(MessageID.SpawnBoss, number: player.whoAmI, number2: type);
 				}
 			}

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -335,6 +335,15 @@
  							player5.buffType[num50] = reader.ReadUInt16();
  							if (player5.buffType[num50] > 0)
  								player5.buffTime[num50] = 60;
+@@ -2178,7 +_,7 @@
+ 						if (Main.netMode != 2)
+ 							break;
+ 
+-						if (num180 >= 0 && num180 < 665 && NPCID.Sets.MPAllowedEnemies[num180]) {
++						if (num180 >= 0 && num180 < NPCID.Sets.MPAllowedEnemies.Length && NPCID.Sets.MPAllowedEnemies[num180]) {
+ 							if (!NPC.AnyNPCs(num180))
+ 								NPC.SpawnOnPlayer(plr, num180);
+ 						}
 @@ -2466,6 +_,7 @@
  					break;
  				case 74:


### PR DESCRIPTION
### Description
Fixes a hardcoded NPCID.Count value to use NPCID.Sets.MPAllowedEnemies.Length instead to make it see modded entries.

Also adds new 1.4 "boss summon" item code by adjusting current "Plantera Item" in ExampleMod.
