### PR TITLE
[1.4] Place NPCLoader.OnKill before DoDeathEvents instead of after

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -483,7 +483,7 @@
  				return;
  
  			Player closestPlayer = Main.player[Player.FindClosest(position, width, height)];
-@@ -58833,6 +_,9 @@
+@@ -58833,9 +_,13 @@
  			if ((type == 23 && Main.hardMode) || (SpawnedFromStatue && NPCID.Sets.NoEarlymodeLootWhenSpawnedFromStatue[type] && !Main.hardMode) || (SpawnedFromStatue && NPCID.Sets.StatueSpawnedDropRarity[type] != -1f && (Main.rand.NextFloat() >= NPCID.Sets.StatueSpawnedDropRarity[type] || !AnyInteractions())))
  				return;
  
@@ -493,14 +493,10 @@
  			bool num = downedMechBoss1 && downedMechBoss2 && downedMechBoss3;
  			DoDeathEvents_BeforeLoot(closestPlayer);
  			NPCLoot_DropItems(closestPlayer);
-@@ -58844,6 +_,7 @@
- 					ChatHelper.BroadcastChatMessage(NetworkText.FromKey(Lang.misc[32].Key), new Color(50, 255, 130));
- 			}
- 
 +			NPCLoader.OnKill(this);
- 			NPCLoot_DropMoney(closestPlayer);
- 			NPCLoot_DropHeals(closestPlayer);
- 		}
+ 			DoDeathEvents(closestPlayer);
+ 			if (!num && downedMechBoss1 && downedMechBoss2 && downedMechBoss3 && Main.hardMode) {
+ 				if (Main.netMode == 0)
 @@ -58881,7 +_,7 @@
  			WoFKilledToday = false;
  		}


### PR DESCRIPTION
### Description
Currently, `NPCLoader.OnKill` acts the same way as old 1.3 NPCLoader.NPCLoot. But in 1.4, regular drops are now fully handled in `NPCLoot_DropItems`. When looking into how vanilla sets and sync downed boss flags, I found out that there can be an improvement made that reduces unnecessary packet sending - syncing takes place whenever a boss dies in `DoDeathEvents`, previously it was before `NPCLoader.OnKill`, which meant that if you wanted to set your own modded downed boss flag, you would have to send a world update packet again (and that packet is huge btw). By moving the `NPCLoader.OnKill` method just before `DoDeathEvents` (instead of after how it is currently), syncing boss downed flags will not be required by the modder (if it's implemented correctly through a ModWorld with NetSend/NetReceive).

In short:
Before:
```cs
NPCLoot_DropItems
DoDeathEvents
Mechbosses_Chat
**NPCLoader.OnKill**
NPCLoot_DropMoney
```

After:
```cs
NPCLoot_DropItems
**NPCLoader.OnKill**
DoDeathEvents
Mechbosses_Chat
NPCLoot_DropMoney
```