### PR TITLE
[1.4] ExampleMod: Fix ModTile properties

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Content/Tiles/ExampleBlock.cs
@@ -12,8 +12,8 @@ namespace ExampleMod.Content.Tiles
 			Main.tileMergeDirt[Type] = true;
 			Main.tileBlockLight[Type] = true;
 			Main.tileLighted[Type] = true;
-			dustType = ModContent.DustType<Sparkle>();
-			drop = ModContent.ItemType<Items.Placeable.ExampleBlock>();
+			DustType = ModContent.DustType<Sparkle>();
+			ItemDrop = ModContent.ItemType<Items.Placeable.ExampleBlock>();
 			AddMapEntry(new Color(200, 200, 200));
 
 			// todo: implement

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -24,10 +24,10 @@ namespace ExampleMod.Content.Tiles
 			name.SetDefault("ExampleOre");
 			AddMapEntry(new Color(152, 171, 198), name);
 
-			dustType = 84;
-			drop = ModContent.ItemType<Items.Placeable.ExampleOre>();
-			soundType = SoundID.Tink;
-			soundStyle = 1;
+			DustType = 84;
+			ItemDrop = ModContent.ItemType<Items.Placeable.ExampleOre>();
+			SoundType = SoundID.Tink;
+			SoundStyle = 1;
 			//mineResist = 4f;
 			//minPick = 200;
 		}

--- a/ExampleMod/Content/Tiles/ExampleSink.cs
+++ b/ExampleMod/Content/Tiles/ExampleSink.cs
@@ -29,8 +29,8 @@ namespace ExampleMod.Content.Tiles
 
 			AddMapEntry(new Color(100, 100, 100));
 
-			dustType = 84;
-			adjTiles = new int[] { Type };
+			DustType = 84;
+			AdjTiles = new int[] { Type };
 		}
 
 		public override void NumDust(int i, int j, bool fail, ref int num) {

--- a/ExampleMod/Content/Tiles/ExampleTorch.cs
+++ b/ExampleMod/Content/Tiles/ExampleTorch.cs
@@ -27,9 +27,9 @@ namespace ExampleMod.Content.Tiles
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			TileID.Sets.Torch[Type] = true;
 
-			drop = ModContent.ItemType<Items.Placeable.ExampleTorch>();
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.Torches };
+			ItemDrop = ModContent.ItemType<Items.Placeable.ExampleTorch>();
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.Torches };
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsTorch);
 

--- a/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
@@ -19,8 +19,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileID.Sets.IsValidSpawnPoint[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.Beds };
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.Beds };
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style4x2); //this style already takes care of direction for us

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
@@ -19,8 +19,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsChair);
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.Chairs };
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.Chairs };
 
 			// Names
 			ModTranslation name = CreateMapEntryName();

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -27,9 +27,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileID.Sets.BasicChest[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.Containers };
-			chestDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.Containers };
+			ChestDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 
 			// Names
 			ContainerName.SetDefault("Example Chest");
@@ -66,7 +66,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 				return false;
 			}
 
-			dustType = this.dustType;
+			DustType = dustType;
 			return true;
 		}
 
@@ -97,7 +97,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 		public override void NumDust(int i, int j, bool fail, ref int num) => num = 1;
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(i * 16, j * 16, 32, 32, chestDrop);
+			Item.NewItem(i * 16, j * 16, 32, 32, ChestDrop);
 			Chest.DestroyChest(i, j);
 		}
 

--- a/ExampleMod/Content/Tiles/Furniture/ExampleClock.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleClock.cs
@@ -16,8 +16,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileLavaDeath[Type] = true;
 			TileID.Sets.Clock[Type] = true;
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.GrandfatherClocks };
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.GrandfatherClocks };
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2xX);

--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
@@ -27,9 +27,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.ClosedDoor };
-			openDoorID = ModContent.TileType<ExampleDoorOpen>();
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.ClosedDoor };
+			OpenDoorID = ModContent.TileType<ExampleDoorOpen>();
 
 			// Names
 			ModTranslation name = CreateMapEntryName();

--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorOpen.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorOpen.cs
@@ -24,9 +24,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 
-			dustType = ModContent.DustType<Sparkle>();
-			adjTiles = new int[] { TileID.OpenDoor };
-			closeDoorID = ModContent.TileType<ExampleDoorClosed>();
+			DustType = ModContent.DustType<Sparkle>();
+			AdjTiles = new int[] { TileID.OpenDoor };
+			CloseDoorID = ModContent.TileType<ExampleDoorClosed>();
 
 			// Names
 			ModTranslation name = CreateMapEntryName();

--- a/ExampleMod/Content/Tiles/Furniture/ExamplePlatform.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExamplePlatform.cs
@@ -24,9 +24,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 			AddToArray(ref TileID.Sets.RoomNeeds.CountsAsDoor);
 			AddMapEntry(new Color(200, 200, 200));
 
-			dustType = ModContent.DustType<Sparkle>();
-			drop = ModContent.ItemType<Items.Placeable.Furniture.ExamplePlatform>();
-			adjTiles = new int[] { TileID.Platforms };
+			DustType = ModContent.DustType<Sparkle>();
+			ItemDrop = ModContent.ItemType<Items.Placeable.Furniture.ExamplePlatform>();
+			AdjTiles = new int[] { TileID.Platforms };
 
 			// Placement
 			TileObjectData.newTile.CoordinateHeights = new[] { 16 };

--- a/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
@@ -17,8 +17,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileFrameImportant[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 
-			dustType = ModContent.DustType<Dusts.Sparkle>();
-			adjTiles = new int[] { TileID.WorkBenches };
+			DustType = ModContent.DustType<Dusts.Sparkle>();
+			AdjTiles = new int[] { TileID.WorkBenches };
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x1);


### PR DESCRIPTION
Fixes ExampleMod to use new properties added in this commit: https://github.com/tModLoader/tModLoader/commit/1d52c3bbb995bd355646c3de121f5e9afda102b2