### PR TITLE
[1.4 Draft] ModEvent + ModInvasion

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
+using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria.DataStructures;
+using Terraria.GameContent;
+using Terraria.ModLoader;
 using Terraria.ModLoader.Engine;
 
 namespace Terraria
@@ -29,5 +28,74 @@ namespace Terraria
 		public static Color DiscoColor => new Color(DiscoR, DiscoG, DiscoB);
 		public static Color MouseTextColorReal => new Color(mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f);
 		public static bool PlayerLoaded => CurrentFrameFlags.ActivePlayersCount > 0;
+
+		internal static Dictionary<int, ModInvasion.ModInvasionProgressDisplay> invasionDisplays = new Dictionary<int, ModInvasion.ModInvasionProgressDisplay>();
+
+		public static void DrawModdedInvasionUI() {
+			int i = 0;
+
+			foreach (ModInvasion modInvasion in ModEventLoader.ModInvasions) {
+				invasionDisplays.TryGetValue(modInvasion.Type, out ModInvasion.ModInvasionProgressDisplay progressDisplay);
+
+				if (!modInvasion.Active && (progressDisplay == null || progressDisplay.DisplayLeft == 0))
+					continue;
+
+				if (!gamePaused && !modInvasion.Active)
+					progressDisplay.DisplayLeft--;
+
+				if (progressDisplay.DisplayLeft > 0)
+					progressDisplay.Alpha += 0.05f;
+				else
+					progressDisplay.Alpha -= 0.05f;
+
+				if (progressDisplay.Alpha <= 0f)
+					return;
+
+				if (progressDisplay.Alpha >= 1f)
+					progressDisplay.Alpha = 1f;
+
+				float scale = 0.5f + progressDisplay.Alpha * 0.5f;
+				Texture2D icon = modInvasion.Icon;
+				string title = modInvasion.Title;
+
+				int width = (int)(200f * scale);
+				int height = (int)(45f * scale);
+				Vector2 offset = (height + 50) * i * Vector2.UnitY;
+
+				if (invasionType != -1)
+					offset.Y += height + 50;
+
+				Vector2 uiPosition = new Vector2(screenWidth - 120, screenHeight - 40) - offset;
+
+				Utils.DrawInvBG(R: new Rectangle((int)uiPosition.X - width / 2, (int)uiPosition.Y - height / 2, width, height), sb: spriteBatch, c: modInvasion.ProgressUIColor);
+
+				string progressText = modInvasion.ProgressText;
+				Texture2D value2 = TextureAssets.ColorBar.Value;
+
+				float progress = modInvasion.Progress;
+				float progressBarWidth = 169f * scale;
+				float progressBarHeight = 8f * scale;
+				Vector2 progressBarPos = uiPosition + Vector2.UnitY * progressBarHeight + Vector2.UnitX * 1f;
+
+				Utils.DrawBorderString(spriteBatch, progressText, progressBarPos, Color.White * progressDisplay.Alpha, scale, 0.5f, 1f);
+				spriteBatch.Draw(value2, uiPosition, null, Color.White * progressDisplay.Alpha, 0f, new Vector2(value2.Width / 2, 0f), scale, SpriteEffects.None, 0f);
+				progressBarPos += Vector2.UnitX * (progress - 0.5f) * progressBarWidth;
+				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), modInvasion.ProgressBarColor * progressDisplay.Alpha, 0f, new Vector2(1f, 0.5f), new Vector2(progressBarWidth * progress, progressBarHeight), SpriteEffects.None, 0f);
+				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), new Color(255, 165, 0, 127) * progressDisplay.Alpha, 0f, new Vector2(1f, 0.5f), new Vector2(2f, progressBarHeight), SpriteEffects.None, 0f);
+				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), Color.Black * progressDisplay.Alpha, 0f, new Vector2(0f, 0.5f), new Vector2(progressBarWidth * (1f - progress), progressBarHeight), SpriteEffects.None, 0f);
+
+				Vector2 invasionTitleSize = FontAssets.MouseText.Value.MeasureString(title);
+				float num13 = 120f;
+				if (invasionTitleSize.X > 200f)
+					num13 += invasionTitleSize.X - 200f;
+
+				Rectangle r3 = Utils.CenteredRectangle(new Vector2(screenWidth - num13, screenHeight - 80) - offset, (invasionTitleSize + new Vector2(icon.Width + 12, 6f)) * scale);
+				Utils.DrawInvBG(spriteBatch, r3, modInvasion.TitleUIColor);
+				spriteBatch.Draw(icon, r3.Left() + Vector2.UnitX * scale * 8f, null, Color.White * progressDisplay.Alpha, 0f, new Vector2(0f, icon.Height / 2), scale * 0.8f, SpriteEffects.None, 0f);
+				Utils.DrawBorderString(spriteBatch, title, r3.Right() + Vector2.UnitX * scale * -22f, Color.White * progressDisplay.Alpha, scale * 0.9f, 1f, 0.4f);
+
+				i++;
+			}
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -35,7 +35,8 @@ namespace Terraria
 			int i = 0;
 
 			foreach (ModInvasion modInvasion in ModEventLoader.ModInvasions) {
-				invasionDisplays.TryGetValue(modInvasion.Type, out ModInvasion.ModInvasionProgressDisplay progressDisplay);
+				if (!invasionDisplays.TryGetValue(modInvasion.Type, out ModInvasion.ModInvasionProgressDisplay progressDisplay))
+					continue;
 
 				if (!modInvasion.Active && (progressDisplay == null || progressDisplay.Alpha == 0))
 					continue;

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -37,7 +37,7 @@ namespace Terraria
 			foreach (ModInvasion modInvasion in ModEventLoader.ModInvasions) {
 				invasionDisplays.TryGetValue(modInvasion.Type, out ModInvasion.ModInvasionProgressDisplay progressDisplay);
 
-				if (!modInvasion.Active && (progressDisplay == null || progressDisplay.DisplayLeft == 0))
+				if (!modInvasion.Active && (progressDisplay == null || progressDisplay.Alpha == 0))
 					continue;
 
 				if (!gamePaused && !modInvasion.Active)
@@ -49,7 +49,7 @@ namespace Terraria
 					progressDisplay.Alpha -= 0.05f;
 
 				if (progressDisplay.Alpha <= 0f)
-					return;
+					continue;
 
 				if (progressDisplay.Alpha >= 1f)
 					progressDisplay.Alpha = 1f;

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -54,45 +54,53 @@ namespace Terraria
 				if (progressDisplay.Alpha >= 1f)
 					progressDisplay.Alpha = 1f;
 
-				float scale = 0.5f + progressDisplay.Alpha * 0.5f;
 				Texture2D icon = modInvasion.Icon;
+
 				string title = modInvasion.Title;
+				float alpha = progressDisplay.Alpha;
+				float scale = 0.5f + alpha * 0.5f;
 
 				int width = (int)(200f * scale);
 				int height = (int)(45f * scale);
-				Vector2 offset = (height + 50) * i * Vector2.UnitY;
+				Vector2 uiOffset = (height + 50) * i * Vector2.UnitY;
 
 				if (invasionType != 0 && invasionProgressAlpha > 0f)
-					offset.Y += height + 50;
+					uiOffset.Y += height + 50;
 
-				Vector2 uiPosition = new Vector2(screenWidth - 120, screenHeight - 40) - offset;
+				Vector2 uiPosition = new Vector2(screenWidth - 120, screenHeight - 40) - uiOffset;
 
-				Utils.DrawInvBG(R: new Rectangle((int)uiPosition.X - width / 2, (int)uiPosition.Y - height / 2, width, height), sb: spriteBatch, c: modInvasion.ProgressUIColor);
+				Utils.DrawInvBG(spriteBatch, new Rectangle((int)uiPosition.X - width / 2, (int)uiPosition.Y - height / 2, width, height), modInvasion.ProgressUIColor);
 
+				Texture2D progressBarOutline = TextureAssets.ColorBar.Value;
 				string progressText = modInvasion.ProgressText;
-				Texture2D value2 = TextureAssets.ColorBar.Value;
-
 				float progress = modInvasion.Progress;
 				float progressBarWidth = 169f * scale;
 				float progressBarHeight = 8f * scale;
 				Vector2 progressBarPos = uiPosition + Vector2.UnitY * progressBarHeight + Vector2.UnitX * 1f;
 
-				Utils.DrawBorderString(spriteBatch, progressText, progressBarPos, Color.White * progressDisplay.Alpha, scale, 0.5f, 1f);
-				spriteBatch.Draw(value2, uiPosition, null, Color.White * progressDisplay.Alpha, 0f, new Vector2(value2.Width / 2, 0f), scale, SpriteEffects.None, 0f);
+				Utils.DrawBorderString(spriteBatch, progressText, progressBarPos, Color.White * alpha, scale, 0.5f, 1f);
+
+				spriteBatch.Draw(progressBarOutline, uiPosition, null, Color.White * alpha, 0f, new Vector2(progressBarOutline.Width / 2, 0f), scale, SpriteEffects.None, 0f);
+
 				progressBarPos += Vector2.UnitX * (progress - 0.5f) * progressBarWidth;
-				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), modInvasion.ProgressBarColor * progressDisplay.Alpha, 0f, new Vector2(1f, 0.5f), new Vector2(progressBarWidth * progress, progressBarHeight), SpriteEffects.None, 0f);
-				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), new Color(255, 165, 0, 127) * progressDisplay.Alpha, 0f, new Vector2(1f, 0.5f), new Vector2(2f, progressBarHeight), SpriteEffects.None, 0f);
-				spriteBatch.Draw(TextureAssets.MagicPixel.Value, progressBarPos, new Rectangle(0, 0, 1, 1), Color.Black * progressDisplay.Alpha, 0f, new Vector2(0f, 0.5f), new Vector2(progressBarWidth * (1f - progress), progressBarHeight), SpriteEffects.None, 0f);
+
+				Texture2D magicPixel = TextureAssets.MagicPixel.Value;
+				Rectangle sourceRect = new Rectangle(0, 0, 1, 1);
+
+				spriteBatch.Draw(magicPixel, progressBarPos, sourceRect, modInvasion.ProgressBarColor * alpha, 0f, new Vector2(1f, 0.5f), new Vector2(progressBarWidth * progress, progressBarHeight), SpriteEffects.None, 0f);
+				spriteBatch.Draw(magicPixel, progressBarPos, sourceRect, new Color(255, 165, 0, 127) * alpha, 0f, new Vector2(1f, 0.5f), new Vector2(2f, progressBarHeight), SpriteEffects.None, 0f);
+				spriteBatch.Draw(magicPixel, progressBarPos, sourceRect, Color.Black * alpha, 0f, new Vector2(0f, 0.5f), new Vector2(progressBarWidth * (1f - progress), progressBarHeight), SpriteEffects.None, 0f);
 
 				Vector2 invasionTitleSize = FontAssets.MouseText.Value.MeasureString(title);
-				float num13 = 120f;
-				if (invasionTitleSize.X > 200f)
-					num13 += invasionTitleSize.X - 200f;
+				float titleUIWidth = 120f;
 
-				Rectangle r3 = Utils.CenteredRectangle(new Vector2(screenWidth - num13, screenHeight - 80) - offset, (invasionTitleSize + new Vector2(icon.Width + 12, 6f)) * scale);
-				Utils.DrawInvBG(spriteBatch, r3, modInvasion.TitleUIColor);
-				spriteBatch.Draw(icon, r3.Left() + Vector2.UnitX * scale * 8f, null, Color.White * progressDisplay.Alpha, 0f, new Vector2(0f, icon.Height / 2), scale * 0.8f, SpriteEffects.None, 0f);
-				Utils.DrawBorderString(spriteBatch, title, r3.Right() + Vector2.UnitX * scale * -22f, Color.White * progressDisplay.Alpha, scale * 0.9f, 1f, 0.4f);
+				if (invasionTitleSize.X > 200f)
+					titleUIWidth += invasionTitleSize.X - 200f;
+
+				Rectangle titleUIRect = Utils.CenteredRectangle(new Vector2(screenWidth - titleUIWidth, screenHeight - 80) - uiOffset, (invasionTitleSize + new Vector2(icon.Width + 12, 6f)) * scale);
+				Utils.DrawInvBG(spriteBatch, titleUIRect, modInvasion.TitleUIColor);
+				spriteBatch.Draw(icon, titleUIRect.Left() + Vector2.UnitX * scale * 8f, null, Color.White * alpha, 0f, new Vector2(0f, icon.Height / 2), scale * 0.8f, SpriteEffects.None, 0f);
+				Utils.DrawBorderString(spriteBatch, title, titleUIRect.Right() + Vector2.UnitX * scale * -22f, Color.White * alpha, scale * 0.9f, 1f, 0.4f);
 
 				i++;
 			}

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -62,7 +62,7 @@ namespace Terraria
 				int height = (int)(45f * scale);
 				Vector2 offset = (height + 50) * i * Vector2.UnitY;
 
-				if (invasionType != -1)
+				if (invasionType != 0 && invasionProgressAlpha > 0f)
 					offset.Y += height + 50;
 
 				Vector2 uiPosition = new Vector2(screenWidth - 120, screenHeight - 40) - offset;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3425,6 +3425,14 @@
  		public static void NewText(string newText, byte R = byte.MaxValue, byte G = byte.MaxValue, byte B = byte.MaxValue) {
  			chatMonitor.NewText(newText, R, G, B);
  			SoundEngine.PlaySound(12);
+@@ -49417,6 +_,7 @@
+ 			CreditsRollEvent.UpdateTime();
+ 			WorldGen.mysticLogsEvent.UpdateTime();
+ 			PylonSystem.Update();
++			ModEventLoader.UpdateActiveEvents();
+ #if CLIENT
+ 			if (NPC.MoonLordCountdown > 0) {
+ 				float num4 = MathHelper.Clamp((float)Math.Sin((float)NPC.MoonLordCountdown / 60f * 0.5f) * 2f, 0f, 1f);
 @@ -49830,7 +_,7 @@
  					num++;
  			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2644,6 +2644,15 @@
  						if ((!expertMode || type != 266) && ((type != 439 && type != 440) || npc[num2].ai[0] != 5f)) {
  							if (type >= 134 && type <= 136) {
  								scale = 1.5f;
+@@ -35548,6 +_,8 @@
+ 		}
+ 
+ 		public static void DrawInvasionProgress() {
++			DrawModdedInvasionUI();
++
+ 			if (invasionProgress == -1)
+ 				return;
+ 
 @@ -35983,8 +_,10 @@
  			screenLastPosition = screenPosition;
  			screenPosition.Y = (float)(worldSurface * 16.0 - (double)screenHeight);

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedEvent.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+using Terraria.ModLoader.IO;
+
+namespace Terraria.ModLoader.Default
+{
+	public class UnloadedEvent : ModEvent
+	{
+		internal IList<TagCompound> data;
+
+		public override Texture2D Icon => null;
+
+		public override TagCompound Save() {
+			return new TagCompound() {
+				[nameof(data)] = data
+			};
+		}
+
+		public override void Load(TagCompound tag) {
+			WorldIO.LoadModEventData(tag.GetList<TagCompound>("data"));
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
@@ -25,7 +25,7 @@ namespace Terraria.ModLoader.Default
 		}
 
 		public override void LoadWorldData(TagCompound tag) {
-			WorldIO.LoadModData(tag.GetList<TagCompound>("list"));
+			WorldIO.LoadModSystemData(tag.GetList<TagCompound>("list"));
 			WorldIO.LoadNPCs(tag.GetList<TagCompound>("unloadedNPCs"));
 			WorldIO.LoadNPCKillCounts(tag.GetList<TagCompound>("unloadedKillCounts"));
 		}

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -329,6 +329,9 @@ namespace Terraria.ModLoader.IO
 							modInvasion.Active = tag.GetBool("active");
 							modInvasion.Progress = tag.GetFloat("progress");
 							modInvasion.Load(tag.GetCompound("data"));
+
+							if (modInvasion.Active)
+								Main.invasionDisplays[modInvasion.Type] = new ModInvasion.ModInvasionProgressDisplay(160, 0f);
 						}
 						catch (Exception e) {
 							throw new CustomModDataException(modInvasion.Mod,

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -551,6 +551,7 @@ namespace Terraria.ModLoader
 			Config.ConfigManager.Unload();
 			CustomCurrencyManager.Initialize();
 			EffectsTracker.RemoveModEffects();
+			ModEventLoader.Unload();
 			
 			// ItemID.Search = IdDictionary.Create<ItemID, short>();
 			// NPCID.Search = IdDictionary.Create<NPCID, short>();

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -1,6 +1,6 @@
 ﻿namespace Terraria.ModLoader
 {
-	public class ModEvent : ModType
+	public abstract class ModEvent : ModType
 	{
 		public int Type { get; internal set; }
 
@@ -8,12 +8,18 @@
 
 		protected virtual void StartEvent() { }
 
-		protected virtual void StopEvent() { }
+		protected virtual void EndEvent() { }
 
 		protected internal virtual void Update() { }
 
 		public void Start() {
 			Active = true;
+			StartEvent();
+		}
+
+		public void End() {
+			EndEvent();
+			Active = false;
 		}
 
 		protected override void Register() {

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -1,10 +1,14 @@
-﻿namespace Terraria.ModLoader
+﻿using Microsoft.Xna.Framework.Graphics;
+
+namespace Terraria.ModLoader
 {
 	public abstract class ModEvent : ModType
 	{
 		public int Type { get; internal set; }
 
 		public bool Active { get; internal set; }
+
+		public abstract Texture2D Icon { get; }
 
 		protected virtual void StartEvent() { }
 
@@ -14,6 +18,7 @@
 
 		public void Start() {
 			Active = true;
+			Main.invasionDisplays[Type] = new ModInvasion.ModInvasionProgressDisplay(160, 0f);
 			StartEvent();
 		}
 
@@ -24,6 +29,10 @@
 
 		protected override void Register() {
 			ModTypeLookup<ModEvent>.Register(this);
+
+			if (this is ModInvasion modInvasion)
+				ModTypeLookup<ModInvasion>.Register(modInvasion);
+
 			Type = ModEventLoader.Register(this);
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -3,13 +3,15 @@
 	public class ModEvent : ModType
 	{
 		public int Type { get; internal set; }
-
+		
 		public bool Active { get; internal set; }
-
+		
 		protected virtual void StartEvent() { }
 
 		protected virtual void StopEvent() { }
-
+		/// <summary>
+		/// An method that runs every tick while the event is activated.
+		/// </summary>
 		protected internal virtual void Update() { }
 
 		public void Start() {

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -3,15 +3,13 @@
 	public class ModEvent : ModType
 	{
 		public int Type { get; internal set; }
-		
+
 		public bool Active { get; internal set; }
-		
+
 		protected virtual void StartEvent() { }
 
 		protected virtual void StopEvent() { }
-		/// <summary>
-		/// An method that runs every tick while the event is activated.
-		/// </summary>
+
 		protected internal virtual void Update() { }
 
 		public void Start() {

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -1,0 +1,24 @@
+﻿namespace Terraria.ModLoader
+{
+	public class ModEvent : ModType
+	{
+		public int Type { get; internal set; }
+
+		public bool Active { get; internal set; }
+
+		protected virtual void StartEvent() { }
+
+		protected virtual void StopEvent() { }
+
+		protected internal virtual void Update() { }
+
+		public void Start() {
+			Active = true;
+		}
+
+		protected override void Register() {
+			ModTypeLookup<ModEvent>.Register(this);
+			Type = ModEventLoader.Register(this);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEvent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {
@@ -15,6 +16,10 @@ namespace Terraria.ModLoader
 		protected virtual void EndEvent() { }
 
 		protected internal virtual void Update() { }
+
+		public virtual TagCompound Save() => null;
+
+		public virtual void Load(TagCompound tag) { }
 
 		public void Start() {
 			Active = true;

--- a/patches/tModLoader/Terraria/ModLoader/ModEventLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEventLoader.cs
@@ -5,9 +5,14 @@ namespace Terraria.ModLoader
 	public static class ModEventLoader
 	{
 		internal static readonly IList<ModEvent> ModEvents = new List<ModEvent>();
+		internal static readonly IList<ModInvasion> ModInvasions = new List<ModInvasion>();
 
 		internal static int Register(ModEvent modEvent) {
 			ModEvents.Add(modEvent);
+
+			if (modEvent is ModInvasion modInvasion)
+				ModInvasions.Add(modInvasion);
+
 			return ModEvents.Count - 1;
 		}
 
@@ -20,6 +25,7 @@ namespace Terraria.ModLoader
 
 		internal static void Unload() {
 			ModEvents.Clear();
+			ModInvasions.Clear();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModEventLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModEventLoader.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public static class ModEventLoader
+	{
+		internal static readonly IList<ModEvent> ModEvents = new List<ModEvent>();
+
+		internal static int Register(ModEvent modEvent) {
+			ModEvents.Add(modEvent);
+			return ModEvents.Count - 1;
+		}
+
+		internal static void UpdateActiveEvents() {
+			foreach (ModEvent modEvent in ModEvents) {
+				if (modEvent.Active)
+					modEvent.Update();
+			}
+		}
+
+		internal static void Unload() {
+			ModEvents.Clear();
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader
+{
+	public class ModInvasion : ModEvent
+	{
+		public virtual Texture2D Icon { get; }
+
+		public float Progress { get; set; }
+
+		IDictionary<int, float> spawnPool = new Dictionary<int, float>();
+
+
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
@@ -1,17 +1,30 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System.Collections.Generic;
 
 namespace Terraria.ModLoader
 {
-	public class ModInvasion : ModEvent
+	public abstract class ModInvasion : ModEvent
 	{
-		public virtual Texture2D Icon { get; }
+		internal class ModInvasionProgressDisplay
+		{
+			public int DisplayLeft;
+			public float Alpha;
+
+			public ModInvasionProgressDisplay(int displayLeft, float alpha) {
+				DisplayLeft = displayLeft;
+				Alpha = alpha;
+			}
+		}
 
 		public float Progress { get; set; }
 
-		IDictionary<int, float> spawnPool = new Dictionary<int, float>();
+		public abstract string Title { get; }
 
+		public abstract string ProgressText { get; }
 
+		public virtual Color TitleUIColor => new Color(63, 65, 151, 255) * 0.785f;
+
+		public virtual Color ProgressUIColor => new Color(63, 65, 151, 255) * 0.785f;
+
+		public virtual Color ProgressBarColor => new Color(255, 241, 51);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModInvasion.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace Terraria.ModLoader
 {
@@ -21,10 +22,32 @@ namespace Terraria.ModLoader
 
 		public abstract string ProgressText { get; }
 
-		public virtual Color TitleUIColor => new Color(63, 65, 151, 255) * 0.785f;
+		public virtual bool PreDrawBottomPanel(SpriteBatch spriteBatch, ref Rectangle destination, ref Color color) => true;
 
-		public virtual Color ProgressUIColor => new Color(63, 65, 151, 255) * 0.785f;
+		public virtual void PostDrawBottomPanel(SpriteBatch spriteBatch, Rectangle destination, Color color) { }
 
-		public virtual Color ProgressBarColor => new Color(255, 241, 51);
+		public virtual bool PreDrawProgressText(SpriteBatch spriteBatch, ref Vector2 anchorPosition, ref Color color, ref float scale, ref float anchorX, ref float anchorY) => true;
+
+		public virtual void PostDrawProgressText(SpriteBatch spriteBatch, Vector2 anchorPosition, Color color, float scale, float anchorX, float anchorY) { }
+
+		public virtual bool PreDrawProgressBarOutline(SpriteBatch spriteBatch, ref Vector2 center, ref Color color, ref float rotation, ref Vector2 origin, ref float scale) => true;
+		
+		public virtual void PostDrawProgressBarOutline(SpriteBatch spriteBatch, Vector2 center, Color color, float rotation, Vector2 origin, float scale) { }
+
+		public virtual bool PreDrawProgressBar(SpriteBatch spriteBatch, ref Vector2 position, ref float width, ref float height, ref Color color) => true;
+
+		public virtual void PostDrawProgressBar(SpriteBatch spriteBatch, Vector2 position, float width, float height, Color color) { }
+
+		public virtual bool PreDrawTopPanel(SpriteBatch spriteBatch, ref Rectangle destination, ref Color color) => true;
+
+		public virtual void PostDrawTopPanel(SpriteBatch spriteBatch, Rectangle destination, Color color) { }
+
+		public virtual bool PreDrawIcon(SpriteBatch spriteBatch, ref Vector2 position, ref Color color, ref float rotation, ref Vector2 origin, ref float scale, ref SpriteEffects effects) => true;
+
+		public virtual void PostDrawIcon(SpriteBatch spriteBatch, Vector2 position, Color color, float rotation, Vector2 origin, float scale, SpriteEffects effects) { }
+
+		public virtual bool PreDrawTitle(SpriteBatch spriteBatch, ref Vector2 position, ref Color color, ref float scale, ref float anchorX, ref float anchorY) => true;
+
+		public virtual void PostDrawTitle(SpriteBatch spriteBatch, Vector2 position, Color color, float scale, float anchorX, float anchorY) { }
 	}
 }


### PR DESCRIPTION
**Last update: Feb 11, 2023**

### What is the new feature?
This PR adds two new types to tML: `ModEvent` and `ModInvasion`.
`ModEvent` represents any event that can happen in a world. On their own, they do not do anything, and instead serve as markers that indicate a certain event is happening. Every `ModEvent` can be started, cancelled and queried by any mod.

Implementations of the event logic are not carried out inside a `ModEvent` class. Rather, you must query whether the event is active from elsewhere, and execute logic there.

`ModInvasion` extends from `ModEvent`. They can be started and terminated in the exact same sense that `ModEvent` does, but the main difference is that `ModInvasion` offers support for displaying an invasion UI on the bottom right of the screen that can be customized by the modder. Ideally, `ModInvasion` should also offer functionality that allows modders to specify the "contents" of an invasion - what enemies it spawns, how much they count, etc.

Another important aspect that this PR accomplishes is making modded events and invasions capable of running alongside one another, with proper UIs displaying and stacking in regards to multiple invasions occurring.

### Why should this be part of tModLoader?
- Modders have been asking for this stuff for a very, very long time
- Cross-mod compatibility, as in mods can stop, start and affect the progress bar of other mods' invasions
- Integration with the bestiary

### Sample usage for the new feature
```cs
public class ExampleEvent : ModEvent
{
    public override Texture2D Icon => TextureAssets.MagicPixel.Value;

    protected override void StartEvent()
    {
        string startMessage = "My event has started!";
        Color color = Color.CadetBlue;

        if (Main.netMode == NetmodeID.SinglePlayer)
            Main.NewText(startMessage, color);
        else
            ChatHelper.BroadcastChatMessage(NetworkText.FromLiteral(startMessage), color);
    }

    protected override void EndEvent()
    {
        string endMessage = "My event is ending...";
        Color color = Color.CadetBlue;

        if (Main.netMode == NetmodeID.SinglePlayer)
            Main.NewText(endMessage, color);
        else
            ChatHelper.BroadcastChatMessage(NetworkText.FromLiteral(endMessage), color);
    }
}
```
And elsewhere, wherever appropriate...
```cs
if (ModContent.GetInstance<ExampleEvent>().Active)
    // Event logic
```
An example for `ModInvasion` will come later when it is more developed.

# Todo
- **Verify and update this draft to the latest tML version**
- Stop UIs from stacking too much if too many invasions are active
- Multiplayer sync for events starting and ending, as well as invasion progress
- Bestiary support
- Testing hooks that manipulate invasion UI drawing
- Perhaps a form of `GlobalEvent`, but I am unsure of this
- Flesh out `ModInvasion` and design the functionality described earlier

This PR is a draft and will be updated as it is developed.