### PR TITLE
[1.4] Fix bad patch around AltFunctionUse

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2603,7 +2603,7 @@
  				controlUseItem = true;
  			}
  
-+			if (flag && altFunctionUse == 0 && ItemLoader.AltFunctionUse(inventory[selectedItem], this)) {
++			if (flag2 && altFunctionUse == 0 && ItemLoader.AltFunctionUse(inventory[selectedItem], this)) {
 +				altFunctionUse = 1;
 +				controlUseItem = true;
 +			}


### PR DESCRIPTION
### Description
In 1.3, the variable that vanilla used across the items valid for right-clicking "altFunctionUse = 1" was called `flag`. 1.4 introduced a check that makes it so right-clicking in UIs will not propagate into using the item anymore, by introducing a `flag2`, which then gets used inplace of `flag`. The patch was ported badly, meaning AltFunctionUse items skip this check. This PR fixes it.

```cs
bool flag2 = flag;
if (!ItemID.Sets.ItemsThatAllowRepeatedRightClick[inventory[selectedItem].type] && !Main.mouseRightRelease)
	flag2 = false;
```