### PR TITLE
[1.4] Adds ModContent.TryFind for boss bar and menu style recovery

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
@@ -100,7 +100,10 @@ namespace Terraria.ModLoader
 		/// Sets the saved style that should be switched to, handles possibly unloaded/invalid ones and defaults to the vanilla style
 		/// </summary>
 		internal static void GotoSavedStyle() {
-			switchToStyle = bossBarStyles.SingleOrDefault(m => m.FullName == lastSelectedStyle) ?? vanillaStyle;
+			switchToStyle = vanillaStyle;
+			if (ModContent.TryFind(lastSelectedStyle, out ModBossBarStyle value))
+				switchToStyle = value;
+
 			styleLoading = false;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -49,6 +49,7 @@ namespace Terraria.ModLoader
 		internal static void Add(ModMenu modMenu) {
 			lock (menus) {
 				menus.Add(modMenu);
+				ModTypeLookup<ModMenu>.Register(modMenu);
 			}
 		}
 
@@ -66,7 +67,10 @@ namespace Terraria.ModLoader
 				Main.instance.playOldTile = true; // If the previous menu was the 1.3.5.3 one, automatically reactivate it.
 			}
 
-			switchToMenu = menus.SingleOrDefault(m => m.FullName == LastSelectedModMenu && m.IsAvailable) ?? MenutML;
+			switchToMenu = MenutML;
+			if (ModContent.TryFind(LastSelectedModMenu, out ModMenu value) && value.IsAvailable)
+				switchToMenu = value;
+
 			loading = false;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBossBarStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBossBarStyle.cs
@@ -13,6 +13,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public bool IsSelected => BossBarLoader.CurrentStyle == this;
 
+		//TODO Localization
 		/// <summary>
 		/// Controls the name that shows up in the menu selection. If not overridden, it will use this mod's display name.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModMenu.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMenu.cs
@@ -51,6 +51,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual bool IsAvailable => true;
 
+		//TODO Localization
 		/// <summary>
 		/// Controls the name that shows up at the base of the screen when this ModMenu is active. If not overridden, it will use this mod's display name.
 		/// </summary>


### PR DESCRIPTION
### Description
Adds `ModContent.TryFind` for boss bar and menu style recovery, so it supports LegacyName.
In the process, also made ModMenu register into ModTypeLookup to make this actually work, aswell as added localization TODOs for future changes regarding that (implementation not yet decided)