### PR TITLE
Implemented Modded Torch Smart Select Along With Other QOL Improvements  

### DIFF
--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -37,12 +37,12 @@ namespace ExampleMod.Content.Items.Placeable
 			itemGroup = ContentSamples.CreativeHelper.ItemGroup.Torches; //Vanilla usually matches sorting methods with the right type of item, but sometimes, like with torches, it doesn't. Make sure to set whichever items manually if need be. 
 		}
 
-		public override void TorchVFX(out float R, out float G, out float B, out int DustType) {
+		public override void TorchVFX(out float r, out float g, out float b, out int dustId) {
 			//Set the color of the light
-			R = 1f;
-			G = 1f;
-			B = 1f;
-			DustType = ModContent.DustType<Sparkle>(); //Set the type of particles the torch should emit
+			r = 1f;
+			g = 1f;
+			b = 1f;
+			dustId = ModContent.DustType<Sparkle>(); //Set the type of particles the torch should emit
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -12,6 +12,8 @@ namespace ExampleMod.Content.Items.Placeable
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded torch.");
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 100;
+
+			ItemID.Sets.Torches[Type] = true;
 		}
 
 		public override void SetDefaults() {
@@ -35,27 +37,11 @@ namespace ExampleMod.Content.Items.Placeable
 			itemGroup = ContentSamples.CreativeHelper.ItemGroup.Torches; //Vanilla usually matches sorting methods with the right type of item, but sometimes, like with torches, it doesn't. Make sure to set whichever items manually if need be. 
 		}
 
-		public override void HoldItem(Player player) {
-			// Randomly spawn sparkles when the torch is held. Twice bigger chance to spawn them when swinging the torch.
-			if (Main.rand.Next(player.itemAnimation > 0 ? 40 : 80) == 0) {
-				Dust.NewDust(new Vector2(player.itemLocation.X + 16f * player.direction, player.itemLocation.Y - 14f * player.gravDir), 4, 4, ModContent.DustType<Sparkle>());
-			}
-
-			// Create a white (1.0, 1.0, 1.0) light at the torch's approximate position, when the item is held.
-			Vector2 position = player.RotatedRelativePoint(new Vector2(player.itemLocation.X + 12f * player.direction + player.velocity.X, player.itemLocation.Y - 14f + player.velocity.Y), true);
-
-			Lighting.AddLight(position, 1f, 1f, 1f);
-		}
-
-		public override void PostUpdate() {
-			// Create a white (1.0, 1.0, 1.0) light when the item is in world, and isn't underwater.
-			if (!Item.wet) {
-				Lighting.AddLight(Item.Center, 1f, 1f, 1f);
-			}
-		}
-
-		public override void AutoLightSelect(ref bool dryTorch, ref bool wetTorch, ref bool glowstick) {
-			dryTorch = true; // This makes our item eligible for being selected with smart select at a short distance when not underwater.
+		public override void TorchVFX(out float R, out float G, out float B, out int DustType) {
+			R = 1f;
+			G = 1f;
+			B = 1f;
+			DustType = ModContent.DustType<Sparkle>();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -37,11 +37,10 @@ namespace ExampleMod.Content.Items.Placeable
 			itemGroup = ContentSamples.CreativeHelper.ItemGroup.Torches; //Vanilla usually matches sorting methods with the right type of item, but sometimes, like with torches, it doesn't. Make sure to set whichever items manually if need be. 
 		}
 
-		public override void TorchVFX(out float r, out float g, out float b, out int dustId) {
-			//Set the color of the light
-			r = 1f;
-			g = 1f;
-			b = 1f;
+		public override void ModifyTorchEffects(out Vector3 lightColor, out int dustId) {
+			lightColor.X = 1.0f; //R
+			lightColor.Y = 1.0f; //G
+			lightColor.Z = 1.0f; //B
 			dustId = ModContent.DustType<Sparkle>(); //Set the type of particles the torch should emit
 		}
 

--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -38,10 +38,11 @@ namespace ExampleMod.Content.Items.Placeable
 		}
 
 		public override void TorchVFX(out float R, out float G, out float B, out int DustType) {
+			//Set the color of the light
 			R = 1f;
 			G = 1f;
 			B = 1f;
-			DustType = ModContent.DustType<Sparkle>();
+			DustType = ModContent.DustType<Sparkle>(); //Set the type of particles the torch should emit
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -700,8 +700,8 @@
 +						Lighting.AddLight(base.Center, torchID);
 +					}
 +					else {
-+						ModItem.TorchVFX(out float R, out float G, out float B, out int _);
-+						Lighting.AddLight(base.Center, R, G, B);
++						ModItem.ModifyTorchEffects(out Vector3 color, out int _);
++						Lighting.AddLight(base.Center, color);
 +					}
 +				}
  			}

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -686,6 +686,27 @@
  					position = (position + item.position) / 2f;
  					velocity = (velocity + item.velocity) / 2f;
  					int num3 = item.stack;
+@@ -45781,10 +_,17 @@
+ 			else if (type == 2701) {
+ 				Lighting.AddLight((int)((position.X + (float)(width / 2)) / 16f), (int)((position.Y + (float)(height / 2)) / 16f), 0.7f, 0.65f, 0.55f);
+ 			}
+-			else if (createTile == 4) {
++			else if (createTile >= 0 && TileID.Sets.Torch[createTile]) {
+ 				int torchID = placeStyle;
+-				if ((!wet && ItemID.Sets.Torches[type]) || ItemID.Sets.WaterTorches[type])
++				if ((!wet && ItemID.Sets.Torches[type]) || ItemID.Sets.WaterTorches[type]) {
++					if (ModItem == null) {
+-					Lighting.AddLight(base.Center, torchID);
++						Lighting.AddLight(base.Center, torchID);
++					}
++					else {
++						ModItem.TorchVFX(out float R, out float G, out float B, out int _);
++						Lighting.AddLight(base.Center, R, G, B);
++					}
++				}
+ 			}
+ 			else if (type == 3114) {
+ 				if (!wet)
 @@ -45979,6 +_,9 @@
  			if (Main.rand == null)
  				Main.rand = new UnifiedRandom();

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -871,12 +871,17 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to tell the game whether this item is a torch that cannot be placed in liquid, a torch that can be placed in liquid, or a glowstick. This information is used for when the player is holding down the auto-select hotkey.
+		/// Allows you to determine the color of light and dust that this torch emits when held or dropped on the ground
 		/// </summary>
-		/// <param name="dryTorch">if set to <c>true</c> [dry torch].</param>
-		/// <param name="wetTorch">if set to <c>true</c> [wet torch].</param>
-		/// <param name="glowstick">if set to <c>true</c> [glowstick].</param>
-		public virtual void AutoLightSelect(ref bool dryTorch, ref bool wetTorch, ref bool glowstick) {
+		/// <param name="R">The red component of the torch light (0-1)</param>
+		/// <param name="G">The green component of the torch light (0-1)</param>
+		/// <param name="B">The blue component of the torch light (0-1)</param>
+		/// <param name="dustId">The id of the dust that the torch emits</param>
+		public virtual void TorchVFX(out float R, out float G, out float B, out int dustId) {
+			R = 0;
+			G = 0;
+			B = 0;
+			dustId = DustID.Torch;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -873,14 +873,14 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to determine the color of light and dust that this torch emits when held or dropped on the ground
 		/// </summary>
-		/// <param name="R">The red component of the torch light (0-1)</param>
-		/// <param name="G">The green component of the torch light (0-1)</param>
-		/// <param name="B">The blue component of the torch light (0-1)</param>
+		/// <param name="r">The red component of the torch light (0-1)</param>
+		/// <param name="g">The green component of the torch light (0-1)</param>
+		/// <param name="b">The blue component of the torch light (0-1)</param>
 		/// <param name="dustId">The id of the dust that the torch emits</param>
-		public virtual void TorchVFX(out float R, out float G, out float B, out int dustId) {
-			R = 0;
-			G = 0;
-			B = 0;
+		public virtual void TorchVFX(out float r, out float g, out float b, out int dustId) {
+			r = 0;
+			g = 0;
+			b = 0;
 			dustId = DustID.Torch;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -873,14 +873,10 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to determine the color of light and dust that this torch emits when held or dropped on the ground
 		/// </summary>
-		/// <param name="r">The red component of the torch light (0-1)</param>
-		/// <param name="g">The green component of the torch light (0-1)</param>
-		/// <param name="b">The blue component of the torch light (0-1)</param>
+		/// <param name="lightColor">The color of the light that the torch emits (r, g, b)</param>
 		/// <param name="dustId">The id of the dust that the torch emits</param>
-		public virtual void TorchVFX(out float r, out float g, out float b, out int dustId) {
-			r = 0;
-			g = 0;
-			b = 0;
+		public virtual void ModifyTorchEffects(out Vector3 lightColor, out int dustId) {
+			lightColor = Vector3.Zero;
 			dustId = DustID.Torch;
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3765,13 +3765,16 @@
  					int num178 = Projectile.NewProjectile(projectileSource_Item_WithPotentialAmmo, pointPoisition.X, pointPoisition.Y, num2, num3, projToShoot, Damage, KnockBack, i);
  					if (sItem.type == 726)
  						Main.projectile[num178].magic = true;
-@@ -34203,8 +_,14 @@
+@@ -34203,8 +_,17 @@
  				else if (num2 >= 427)
  					num = num2 - 426;
  
 +				int num3 = 0;
 +				if (sItem.ModItem != null) {
-+					sItem.ModItem.TorchVFX(out R, out G, out B, out num3);
++					sItem.ModItem.ModifyTorchEffects(out Vector3 color, out num3);
++					R = color.X;
++					G = color.Y;
++					B = color.Z;
 +				}
 +				else {
 -				TorchID.TorchColor(num, out R, out G, out B);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3765,6 +3765,23 @@
  					int num178 = Projectile.NewProjectile(projectileSource_Item_WithPotentialAmmo, pointPoisition.X, pointPoisition.Y, num2, num3, projToShoot, Damage, KnockBack, i);
  					if (sItem.type == 726)
  						Main.projectile[num178].magic = true;
+@@ -34203,8 +_,14 @@
+ 				else if (num2 >= 427)
+ 					num = num2 - 426;
+ 
++				int num3 = 0;
++				if (num >= 22) {
++					sItem.ModItem.TorchVFX(out R, out G, out B, out num3);
++				}
++				else {
+-				TorchID.TorchColor(num, out R, out G, out B);
++					TorchID.TorchColor(num, out R, out G, out B);
+-				int num3 = TorchID.Dust[num];
++					num3 = TorchID.Dust[num];
++				}
+ 				int maxValue = 30;
+ 				if (itemAnimation > 0)
+ 					maxValue = 7;
 @@ -34460,6 +_,10 @@
  		}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3770,7 +3770,7 @@
  					num = num2 - 426;
  
 +				int num3 = 0;
-+				if (num >= 22) {
++				if (sItem.ModItem != null) {
 +					sItem.ModItem.TorchVFX(out R, out G, out B, out num3);
 +				}
 +				else {


### PR DESCRIPTION
### What is the new feature?
This allows modded torches to be selected by smart select while also reducing the general torch boilerplate code that is required for modded torches.
This should resolve the rest of #1383 for 1.4.
### Why should this be part of tModLoader?
Typically for modders to implement torches they have to override `HoldItem` and `PostUpdate` where they then have to do the standard check to ensure that the player isn't underwater before spawning particles and creating the light. The code almost always looks the same and is already handled by the game. This PR allows modders to just add the torch item to `ItemID.Sets.Torches` and possibly `ItemID.Sets.WaterTorches` and then override the new method `TorchVFX` where they can then return the color of light to create and the type of particles to spawn. This automatically handles torch smart select and removes the boilerplate code previously present.
### Are there alternative designs?
A new `TileID` set could be created just for smart select or it could be done the way it was in 1.3 where you need to override `AutoLightSelect` and then set the bools `dryTorch`, `wetTorch` and `glowstick` respectively.
### Sample usage for the new feature
```c#
public override void SetStaticDefaults() {
	ItemID.Sets.Torches[Type] = true; //Add the item to the torch set
	...
}

//Override the new method
public override void TorchVFX(out float R, out float G, out float B, out int DustType) {
	//Set the color of the light
	R = 1f;
	G = 1f;
	B = 1f;
	DustType = ModContent.DustType<Sparkle>(); //Set the type of particles the torch should emit
}
```
### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
Updated to use the new torch system.
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.

You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.
If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:

Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
