### PR TITLE
[1.4] Add IgnoredByGrowingSaplings

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -36,6 +36,9 @@
 
 			/// <summary> Whether or not this tile counts as a lava source for crafting purposes. </summary>
 			public static bool[] CountsAsLavaSource = Factory.CreateBoolSet();
+
+			/// <summary> Whether or not saplings count this tile as empty when trying to grow. </summary>
+			public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 201, 233, 352, 485, 529, 530);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -384,6 +384,25 @@
  				flag4 = true;
  
  			if (!flag3) {
+@@ -16281,6 +_,7 @@
+ 						if (TileID.Sets.CommonSapling[Main.tile[i, j].type])
+ 							break;
+ 
++						/*
+ 						switch (Main.tile[i, j].type) {
+ 							case 3:
+ 							case 24:
+@@ -16304,6 +_,10 @@
+ 							case 530:
+ 								continue;
+ 						}
++						*/
++
++						if (TileID.Sets.IgnoredByGrowingSaplings[Main.tile[i, j].type])
++							continue;
+ 
+ 						return false;
+ 					}
 @@ -16321,6 +_,7 @@
  		}
  


### PR DESCRIPTION
### What is the new feature?
* A new TileID Set, named `IgnoredByGrowingSaplings`, that is used to allow tiles to be treated as empty when growing saplings - specifically, in the `WorldGen.EmptyTileCheck()` method.

### Why should this be part of tModLoader?
* Currently, growing saplings into trees calls `WorldGen.EmptyTileCheck()` to ensure the tree can actually grow. In this method, in addition to inactive tiles, a hardcoded list of other tiles (like grass, thorns, etc.) are counted as "empty" when checking saplings. If any tile not in this hardcoded list is detected, then the sapling will not grow.
* An example of this being an issue is a modder adding in a new type of foliage, like a Hallowed version of the Corruption's thorns. In the current system, any sapling near these Hallowed thorns would be unable to grow, despite being able to grow near Corrupt thorns.

### Are there alternative designs?
* Adding a new method to `ModTile` and/or `GlobalTile` that allows the user to determine whether a tile is counted as empty for any parameters of `WorldGen.EmptyTileCheck()`.

### Sample usage for the new feature
```cs
public override SetDefaults() {
    TileID.Sets.IgnoredByGrowingSaplings[Type] = true;
    ...
}
```