### PR TITLE
[1.4] Mod/GlobalWall.CanPlace, and Mod/GlobalTile.CanPlace fixes regarding block swap

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -54,6 +54,17 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to stop a wall from being placed at the given coordinates. Return false to stop the wall from being placed. Returns true by default.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public virtual bool CanPlace(int i, int j, int type) {
+			return true;
+		}
+
+		/// <summary>
 		/// Whether or not the wall at the given coordinates can be killed by an explosion (ie. bombs). Returns true by default; return false to stop an explosion from destroying it.
 		/// </summary>
 		public virtual bool CanExplode(int i, int j, int type) {

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -80,6 +80,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to stop this block from being placed at the given coordinates. Return false to stop the block from being placed. Returns true by default.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		public virtual bool CanPlace(int i, int j) {
+			return true;
+		}
+
+		/// <summary>
 		/// Whether or not the tile/wall at the given coordinates can be killed by an explosion (ie. bombs). Returns true by default; return false to stop an explosion from destroying it.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -325,15 +325,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to stop this tile from being placed at the given coordinates. Return false to block the tile from being placed. Returns true by default.
-		/// </summary>
-		/// <param name="i">The x position in tile coordinates.</param>
-		/// <param name="j">The y position in tile coordinates.</param>
-		public virtual bool CanPlace(int i, int j) {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to make something happen when this tile is right-clicked by the player. Return true to indicate that a tile interaction has occurred, preventing other right click actions like minion targetting from happening. Returns false by default.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -678,8 +678,10 @@ namespace Terraria.ModLoader
 				damage = 0;
 			}
 		}
-		//in Terraria.Player.PlaceThing after tileObject is initalized add else to if statement and before add
+		//in Terraria.Player.PlaceThing_Tiles after tileObject is initalized add else to if statement and before add
 		//  if(!TileLoader.CanPlace(Player.tileTargetX, Player.tileTargetY)) { }
+		//and in Terraria.Player.PlaceThing_TryReplacingTiles after WorldGen.IsTileReplacable add
+		//  if (!TileLoader.CanPlace(tileTargetX, tileTargetY, HeldItem.createTile)) return false
 		public static bool CanPlace(int i, int j, int type) {
 			foreach (var hook in HookCanPlace) {
 				if (!hook(i, j, type)) {

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -29,6 +29,7 @@ namespace Terraria.ModLoader
 		private static DelegateDrop[] HookDrop;
 		private delegate void DelegateKillWall(int i, int j, int type, ref bool fail);
 		private static DelegateKillWall[] HookKillWall;
+		private static Func<int, int, int, bool>[] HookCanPlace;
 		private static Func<int, int, int, bool>[] HookCanExplode;
 		private delegate void DelegateModifyLight(int i, int j, int type, ref float r, ref float g, ref float b);
 		private static DelegateModifyLight[] HookModifyLight;
@@ -87,6 +88,7 @@ namespace Terraria.ModLoader
 			ModLoader.BuildGlobalHook(ref HookCreateDust, globalWalls, g => g.CreateDust);
 			ModLoader.BuildGlobalHook(ref HookDrop, globalWalls, g => g.Drop);
 			ModLoader.BuildGlobalHook(ref HookKillWall, globalWalls, g => g.KillWall);
+			ModLoader.BuildGlobalHook(ref HookCanPlace, globalWalls, g => g.CanPlace);
 			ModLoader.BuildGlobalHook(ref HookCanExplode, globalWalls, g => g.CanExplode);
 			ModLoader.BuildGlobalHook(ref HookModifyLight, globalWalls, g => g.ModifyLight);
 			ModLoader.BuildGlobalHook(ref HookRandomUpdate, globalWalls, g => g.RandomUpdate);
@@ -185,6 +187,17 @@ namespace Terraria.ModLoader
 			foreach (var hook in HookKillWall) {
 				hook(i, j, type, ref fail);
 			}
+		}
+
+		//in Terraria.Player.PlaceThing_Walls after bool flag = true;, before PlaceThing_TryReplacingWalls
+		//  flag &= WallLoader.CanPlace(tileTargetX, tileTargetY, inventory[selectedItem].createWall);
+		public static bool CanPlace(int i, int j, int type) {
+			foreach (var hook in HookCanPlace) {
+				if (!hook(i, j, type)) {
+					return false;
+				}
+			}
+			return GetWall(type)?.CanPlace(i, j) ?? true;
 		}
 
 		public static bool CanExplode(int i, int j, int type) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3236,8 +3236,13 @@
  					PlaceThing_Tiles_BlockPlacementIfOverPlayers(ref canPlace, ref objectData);
  					PlaceThing_Tiles_BlockPlacementForRepeatedPigronatas(ref canPlace, ref objectData);
  					PlaceThing_Tiles_BlockPlacementForRepeatedPumpkins(ref canPlace, ref objectData);
-@@ -27782,7 +_,7 @@
+@@ -27780,9 +_,12 @@
+ 				if (!WorldGen.IsTileReplacable(tileTargetX, tileTargetY))
+ 					return false;
  
++				if (!TileLoader.CanPlace(tileTargetX, tileTargetY, HeldItem.createTile))
++					return false;
++
  				if (0 == 0) {
  					if (hitReplace.AddDamage(num, pickaxeDamage) < 100) {
 -						int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3188,6 +3188,15 @@
  			int num = 50;
  			if (newItem.IsACoin)
  				num = 54;
+@@ -27628,6 +_,8 @@
+ 				return;
+ 
+ 			bool flag = true;
++			flag &= WallLoader.CanPlace(tileTargetX, tileTargetY, inventory[selectedItem].createWall);
++
+ 			if (TileReplacementEnabled)
+ 				flag = PlaceThing_TryReplacingWalls(flag);
+ 
 @@ -27636,6 +_,7 @@
  
  			WorldGen.PlaceWall(tileTargetX, tileTargetY, inventory[selectedItem].createWall);

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1382,6 +1382,15 @@
  			for (int i = 0; i < num; i++) {
  				KillTile_MakeTileDust(x, y, tileSafely);
  			}
+@@ -39233,7 +_,7 @@
+ 
+ 		public static bool WouldTileReplacementWork(ushort attemptingToReplaceWith, int x, int y) {
+ 			Tile tile = Main.tile[x, y];
+-			if (attemptingToReplaceWith >= 624)
++			if (attemptingToReplaceWith >= TileLoader.TileCount)
+ 				return false;
+ 
+ 			if (TileID.Sets.Conversion.Grass[attemptingToReplaceWith])
 @@ -39242,7 +_,7 @@
  			bool flag = !ReplaceTile_IsValidSolid(attemptingToReplaceWith) || !ReplaceTile_IsValidSolid(tile.type);
  			bool num = !ReplaceTile_IsValidPlatform(attemptingToReplaceWith) || !ReplaceTile_IsValidPlatform(tile.type);


### PR DESCRIPTION
### Description
This PR adds the hook requested in #872. It also fixes block swap not being possible to do for modded tiles due to a hardcoded `TileID.Count` check which has been changed to `TileLoader.TileCount` instead, and makes it call `TileLoader.CanPlace` in the block swap context.