### PR TITLE
[1.4] GlobalBlockType to accompany ModBlockType, and a signature change for GlobalTile.PlaceInWorld

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -7,6 +7,8 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public abstract class GlobalBlockType : ModType
 	{
+		internal GlobalBlockType() { }
+
 		/// <summary>
 		/// Allows you to modify the properties of any tile/wall in the game. Most properties are stored as arrays throughout the Terraria code.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -1,0 +1,127 @@
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// This is the superclass for GlobalTile and GlobalWall, combining common code
+	/// </summary>
+	public abstract class GlobalBlockType : ModType
+	{
+		/// <summary>
+		/// Allows you to modify the properties of any tile/wall in the game. Most properties are stored as arrays throughout the Terraria code.
+		/// </summary>
+		public virtual void SetDefaults() {
+		}
+
+		/// <summary>
+		/// Allows you to customize which sound you want to play when the tile/wall at the given coordinates is hit. Return false to stop the game from playing its default sound for the tile/wall. Returns true by default.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public virtual bool KillSound(int i, int j, int type) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to change how many dust particles are created when the tile/wall at the given coordinates is hit.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <param name="fail"></param>
+		/// <param name="num"></param>
+		public virtual void NumDust(int i, int j, int type, bool fail, ref int num) {
+		}
+
+		/// <summary>
+		/// Allows you to modify the default type of dust created when the tile/wall at the given coordinates is hit. Return false to stop the default dust (the dustType parameter) from being created. Returns true by default.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <param name="dustType"></param>
+		/// <returns></returns>
+		public virtual bool CreateDust(int i, int j, int type, ref int dustType) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to stop a tile/wall from being placed at the given coordinates. Return false to block the tile/wall from being placed. Returns true by default.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public virtual bool CanPlace(int i, int j, int type) {
+			return true;
+		}
+
+		/// <summary>
+		/// Whether or not the tile/wall at the given coordinates can be killed by an explosion (ie. bombs). Returns true by default; return false to stop an explosion from destroying it.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public virtual bool CanExplode(int i, int j, int type) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to draw things behind the tile/wall at the given coordinates. Return false to stop the game from drawing the tile/wall normally. Returns true by default.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <param name="spriteBatch"></param>
+		/// <returns></returns>
+		public virtual bool PreDraw(int i, int j, int type, SpriteBatch spriteBatch) {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to draw things in front of the tile/wall at the given coordinates. This can also be used to do things such as creating dust. Called on active tiles. See also ModSystem.PostDrawTiles.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <param name="spriteBatch"></param>
+		public virtual void PostDraw(int i, int j, int type, SpriteBatch spriteBatch) {
+		}
+
+		/// <summary>
+		/// Called for every tile/wall the world randomly decides to update in a given tick. Useful for things such as growing or spreading.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		public virtual void RandomUpdate(int i, int j, int type) {
+		}
+
+		/// <summary>
+		/// Allows you to do something when this tile/wall is placed. Called on the local Client and Single Player.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates. Equal to Player.tileTargetX</param>
+		/// <param name="j">The y position in tile coordinates. Equal to Player.tileTargetY</param>
+		/// <param name="type"></param>
+		/// <param name="item">The item used to place this tile/wall.</param>
+		public virtual void PlaceInWorld(int i, int j, int type, Item item) {
+		}
+
+		/// <summary>
+		/// Allows you to determine how much light the block emits.
+		/// If it is a tile, make sure you set Main.tileLighted[Type] to true in SetDefaults for this to work.
+		/// If it is a wall, it can also let you light up the block in front of this wall.
+		/// </summary>
+		/// <param name="i"></param>
+		/// <param name="j"></param>
+		/// <param name="type"></param>
+		/// <param name="r"></param>
+		/// <param name="g"></param>
+		/// <param name="b"></param>
+		public virtual void ModifyLight(int i, int j, int type, ref float r, ref float g, ref float b) {
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -7,7 +7,7 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class allows you to modify the behavior of any tile in the game. Create an instance of an overriding class then call Mod.AddGlobalTile to use this.
 	/// </summary>
-	public abstract class GlobalTile : ModType
+	public abstract class GlobalTile : GlobalBlockType
 	{
 		/// <summary>
 		/// A convenient method for adding an integer to the end of an array. This can be used with the arrays in TileID.Sets.RoomNeeds.
@@ -54,46 +54,6 @@ namespace Terraria.ModLoader
 		public sealed override void SetupContent() => SetDefaults();
 
 		/// <summary>
-		/// Allows you to modify the properties of any tile in the game. Most properties are stored as arrays throughout the Terraria code.
-		/// </summary>
-		public virtual void SetDefaults() {
-		}
-
-		/// <summary>
-		/// Allows you to customize which sound you want to play when the tile at the given coordinates is hit. Return false to stop the game from playing its default sound for the tile. Returns true by default.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public virtual bool KillSound(int i, int j, int type) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to change how many dust particles are created when the tile at the given coordinates is hit.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="fail"></param>
-		/// <param name="num"></param>
-		public virtual void NumDust(int i, int j, int type, bool fail, ref int num) {
-		}
-
-		/// <summary>
-		/// Allows you to modify the default type of dust created when the tile at the given coordinates is hit. Return false to stop the default dust (the dustType parameter) from being created. Returns true by default.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="dustType"></param>
-		/// <returns></returns>
-		public virtual bool CreateDust(int i, int j, int type, ref int dustType) {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to modify the chance the tile at the given coordinates has of spawning a certain critter when the tile is killed.
 		/// </summary>
 		/// <param name="i"></param>
@@ -137,17 +97,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Whether or not the tile at the given coordinates can be killed by an explosion (ie. bombs). Returns true by default; return false to stop an explosion from destroying it.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public virtual bool CanExplode(int i, int j, int type) {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to make things happen when the tile is within a certain range of the player (around the same range water fountains and music boxes work). The closer parameter is whether or not the tile is within the range at which things like campfires and banners work.
 		/// </summary>
 		/// <param name="i"></param>
@@ -155,18 +104,6 @@ namespace Terraria.ModLoader
 		/// <param name="type"></param>
 		/// <param name="closer"></param>
 		public virtual void NearbyEffects(int i, int j, int type, bool closer) {
-		}
-
-		/// <summary>
-		/// Allows you to determine how much light the block emits. Make sure you set Main.tileLighted[type] to true in SetDefaults for this to work.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="r"></param>
-		/// <param name="g"></param>
-		/// <param name="b"></param>
-		public virtual void ModifyLight(int i, int j, int type, ref float r, ref float g, ref float b) {
 		}
 
 		/// <summary>
@@ -198,18 +135,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to draw things behind the tile at the given coordinates. Return false to stop the game from drawing the tile normally. Returns true by default.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="spriteBatch"></param>
-		/// <returns></returns>
-		public virtual bool PreDraw(int i, int j, int type, SpriteBatch spriteBatch) {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to make stuff happen whenever the tile at the given coordinates is drawn. For example, creating dust or changing the color the tile is drawn in.
 		/// </summary>
 		/// <param name="i"></param>
@@ -222,30 +147,11 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to draw things in front of the tile at the given coordinates. This can also be used to do things such as creating dust. Called on active tiles. See also ModSystem.PostDrawTiles.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="spriteBatch"></param>
-		public virtual void PostDraw(int i, int j, int type, SpriteBatch spriteBatch) {
-		}
-
-		/// <summary>
 		/// Special Draw. Only called if coordinates are placed in Main.specX/Y during DrawEffects. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
 		/// </summary>
 		/// <param name="i">The i.</param>
 		/// <param name="j">The j.</param>
 		public virtual void SpecialDraw(int i, int j, int type, SpriteBatch spriteBatch) {
-		}
-
-		/// <summary>
-		/// Called for every tile the world randomly decides to update in a given tick. Useful for things such as growing or spreading.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		public virtual void RandomUpdate(int i, int j, int type) {
 		}
 
 		/// <summary>
@@ -258,17 +164,6 @@ namespace Terraria.ModLoader
 		/// <param name="noBreak"></param>
 		/// <returns></returns>
 		public virtual bool TileFrame(int i, int j, int type, ref bool resetFrame, ref bool noBreak) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to stop a tile from being placed at the given coordinates. Return false to block the tile from being placed. Returns true by default.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public virtual bool CanPlace(int i, int j, int type) {
 			return true;
 		}
 
@@ -375,15 +270,6 @@ namespace Terraria.ModLoader
 		/// <returns></returns>
 		public virtual int SaplingGrowthType(int type, ref int style) {
 			return -1;
-		}
-
-		/// <summary>
-		/// Allows you to do something when this tile is placed. Called on the local Client and Single Player.
-		/// </summary>
-		/// <param name="i">The x position in tile coordinates. Equal to Player.tileTargetX</param>
-		/// <param name="j">The y position in tile coordinates. Equal to Player.tileTargetY</param>
-		/// <param name="item">The item used to place this tile.</param>
-		public virtual void PlaceInWorld(int i, int j, Item item) {
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalWall.cs
@@ -1,11 +1,9 @@
-using Microsoft.Xna.Framework.Graphics;
-
 namespace Terraria.ModLoader
 {
 	/// <summary>
 	/// This class allows you to modify the behavior of any wall in the game (although admittedly walls don't have much behavior). Create an instance of an overriding class then call Mod.AddGlobalWall to use this.
 	/// </summary>
-	public abstract class GlobalWall : ModType
+	public abstract class GlobalWall : GlobalBlockType
 	{
 		protected sealed override void Register() {
 			ModTypeLookup<GlobalWall>.Register(this);
@@ -13,32 +11,6 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() => SetDefaults();
-
-		/// <summary>
-		/// Allows you to modify the properties of any wall in the game. Most properties are stored as arrays throughout the Terraria code.
-		/// </summary>
-		public virtual void SetDefaults() {
-		}
-
-		/// <summary>
-		/// Allows you to customize which sound you want to play when the wall at the given coordinates is hit. Return false to stop the game from playing its default sound for the wall. Returns true by default.
-		/// </summary>
-		public virtual bool KillSound(int i, int j, int type) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to change how many dust particles are created when the wall at the given coordinates is hit.
-		/// </summary>
-		public virtual void NumDust(int i, int j, int type, bool fail, ref int num) {
-		}
-
-		/// <summary>
-		/// Allows you to modify the default type of dust created when the wall at the given coordinates is hit. Return false to stop the default dust (the dustType parameter) from being created. Returns true by default.
-		/// </summary>
-		public virtual bool CreateDust(int i, int j, int type, ref int dustType) {
-			return true;
-		}
 
 		/// <summary>
 		/// Allows you to customize which items the wall at the given coordinates drops. Return false to stop the game from dropping the wall's default item (the dropType parameter). Returns true by default.
@@ -51,55 +23,6 @@ namespace Terraria.ModLoader
 		/// Allows you to determine what happens when the wall at the given coordinates is killed or hit with a hammer. Fail determines whether the wall is mined (whether it is killed).
 		/// </summary>
 		public virtual void KillWall(int i, int j, int type, ref bool fail) {
-		}
-
-		/// <summary>
-		/// Allows you to stop a wall from being placed at the given coordinates. Return false to stop the wall from being placed. Returns true by default.
-		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
-		public virtual bool CanPlace(int i, int j, int type) {
-			return true;
-		}
-
-		/// <summary>
-		/// Whether or not the wall at the given coordinates can be killed by an explosion (ie. bombs). Returns true by default; return false to stop an explosion from destroying it.
-		/// </summary>
-		public virtual bool CanExplode(int i, int j, int type) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to determine how much light the wall emits. This can also let you light up the block in front of the wall.
-		/// </summary>
-		public virtual void ModifyLight(int i, int j, int type, ref float r, ref float g, ref float b) {
-		}
-
-		/// <summary>
-		/// Called for every wall the world randomly decides to update in a given tick. Useful for things such as growing or spreading.
-		/// </summary>
-		public virtual void RandomUpdate(int i, int j, int type) {
-		}
-
-		/// <summary>
-		/// Allows you to draw things behind the wall at the given coordinates. Return false to stop the game from drawing the wall normally. Returns true by default.
-		/// </summary>
-		public virtual bool PreDraw(int i, int j, int type, SpriteBatch spriteBatch) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to draw things in front of the wall at the given coordinates.
-		/// </summary>
-		public virtual void PostDraw(int i, int j, int type, SpriteBatch spriteBatch) {
-		}
-
-		/// <summary>
-		/// Called after this wall type was placed in the world by way of the item provided.
-		/// </summary>
-		public virtual void PlaceInWorld(int i, int j, int type, Item item) {
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -130,5 +130,15 @@ namespace Terraria.ModLoader
 		/// <param name="item">The item used to place this tile.</param>
 		public virtual void PlaceInWorld(int i, int j, Item item) {
 		}
+
+		/// <summary>
+		/// Allows you to determine how much light this block emits.
+		/// If it is a ModTile, make sure you set Main.tileLighted[Type] to true in SetDefaults for this to work.
+		/// If it is a ModWall, it can also let you light up the block in front of this wall.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		public virtual void ModifyLight(int i, int j, ref float r, ref float g, ref float b) {
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 namespace Terraria.ModLoader
 {
 	/// <summary>
-	/// This class represents a type of tile that can be added by a mod. Only one instance of this class will ever exist for each type of tile that is added. Any hooks that are called will be called by the instance corresponding to the tile type. This is to prevent the game from using a massive amount of memory storing tile instances.
+	/// This is the superclass for ModTile and ModWall, combining common code
 	/// </summary>
 	public abstract class ModBlockType : ModTexturedType
 	{
@@ -80,7 +80,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to stop this block from being placed at the given coordinates. Return false to stop the block from being placed. Returns true by default.
+		/// Allows you to stop this tile/wall from being placed at the given coordinates. Return false to stop the tile/wall from being placed. Returns true by default.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
@@ -127,14 +127,14 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates. Equal to Player.tileTargetX</param>
 		/// <param name="j">The y position in tile coordinates. Equal to Player.tileTargetY</param>
-		/// <param name="item">The item used to place this tile.</param>
+		/// <param name="item">The item used to place this tile/wall.</param>
 		public virtual void PlaceInWorld(int i, int j, Item item) {
 		}
 
 		/// <summary>
-		/// Allows you to determine how much light this block emits.
-		/// If it is a ModTile, make sure you set Main.tileLighted[Type] to true in SetDefaults for this to work.
-		/// If it is a ModWall, it can also let you light up the block in front of this wall.
+		/// Allows you to determine how much light this tile/wall emits.
+		/// If it is a tile, make sure you set Main.tileLighted[Type] to true in SetDefaults for this to work.
+		/// If it is a wall, it can also let you light up the block in front of this wall.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -238,14 +238,6 @@ namespace Terraria.ModLoader
 		public virtual float GetTorchLuck(Player player) => 0f;
 
 		/// <summary>
-		/// Allows you to determine how much light this block emits. Make sure you set Main.tileLighted[Type] to true in SetDefaults for this to work.
-		/// </summary>
-		/// <param name="i">The x position in tile coordinates.</param>
-		/// <param name="j">The y position in tile coordinates.</param>
-		public virtual void ModifyLight(int i, int j, ref float r, ref float g, ref float b) {
-		}
-
-		/// <summary>
 		/// Allows you to determine whether this block glows red when the given player has the Dangersense buff.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -92,12 +92,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine how much light this wall emits. This can also let you light up the block in front of this wall.
-		/// </summary>
-		public virtual void ModifyLight(int i, int j, ref float r, ref float g, ref float b) {
-		}
-
-		/// <summary>
 		/// Allows you to animate your wall. Use frameCounter to keep track of how long the current frame has been active, and use frame to change the current frame.
 		/// </summary>
 		public virtual void AnimateWall(ref byte frame, ref byte frameCounter) {

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -87,7 +87,7 @@ namespace Terraria.ModLoader
 		private static DelegateChangeWaterfallStyle[] HookChangeWaterfallStyle;
 		private delegate int DelegateSaplingGrowthType(int type, ref int style);
 		private static DelegateSaplingGrowthType[] HookSaplingGrowthType;
-		private static Action<int, int, Item>[] HookPlaceInWorld;
+		private static Action<int, int, int, Item>[] HookPlaceInWorld;
 
 		internal static int ReserveTileID() {
 			if (ModNet.AllowVanillaClients) throw new Exception("Adding tiles breaks vanilla client compatibility");
@@ -932,7 +932,7 @@ namespace Terraria.ModLoader
 				return;
 
 			foreach (var hook in HookPlaceInWorld) {
-				hook(i, j, item);
+				hook(i, j, type, item);
 			}
 
 			GetTile(type)?.PlaceInWorld(i, j, item);


### PR DESCRIPTION
### Description
In extension to PR #1266, which added `ModBlockType`, a superclass for `ModTile` and `ModWall` to unify some hooks (and IO backend code, which this PR doesn't touch on), it adds an additional method into `ModBlockType` that got missed (`ModifyLight`), aswell as creates an additional `GlobalBlockType` class for the `Global` variants respectively. 

For this to work, it had to change the signature of `GlobalTile.PlaceInWorld` from `PlaceInWorld(int i, int j, Item item)` to `PlaceInWorld(int i, int j, int type, Item item)` to keep it consistent with other hooks and `GlobalWall`.

The main goal is bringing the Mod/Global relation more in line and reduce code duplication.