### PR TITLE
[1.4] Allow Guns to shoot with no ammo

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
@@ -52,10 +52,10 @@ namespace ExampleMod.Content.Items.Weapons
 			return Main.rand.NextFloat() >= 0.38f;
 		}
 
-		// The following method allows this gun to shoot when having no ammo, as long as the player has either the ammo box or the ammo preservation buffs.
+		// The following method allows this gun to shoot when having no ammo, as long as the player has at least 10 example items in their inventory.
 		// The gun will then shoot as if the default ammo for it, in this case the musket ball, is being used.
 		public override bool NeedsAmmo(Player player) {
-			return !player.ammoBox && !player.ammoPotion;
+			return player.CountItem(ModContent.ItemType<ExampleItem>(), 10) < 10;
 		}
 
 		// The following method makes the gun slightly inaccurate

--- a/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
@@ -52,6 +52,12 @@ namespace ExampleMod.Content.Items.Weapons
 			return Main.rand.NextFloat() >= 0.38f;
 		}
 
+		// The following method allows this gun to shoot when having no ammo, as long as the player has either the ammo box or the ammo preservation buffs.
+		// The gun will then shoot as if the default ammo for it, in this case the musket ball, is being used.
+		public override bool NeedsAmmo(Player player) {
+			return !player.ammoBox && !player.ammoPotion;
+		}
+
 		// The following method makes the gun slightly inaccurate
 		public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback) {
 			velocity = velocity.RotatedByRandom(MathHelper.ToRadians(10));

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -255,6 +255,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Whether or not having no ammo prevents an item that uses ammo from shooting.
+		/// Return false to allow shooting with no ammo in the inventory, in which case the item will act as if the default ammo for it is being used.
+		/// Returns true by default.
+		/// </summary>
+		public virtual bool NeedsAmmo(Item item, Player player) {
+			return true;
+		}
+
+		/// <summary>
 		/// Allows you to modify various properties of the projectile created by a weapon based on the ammo it is using.
 		/// </summary>
 		/// <param name="weapon">The item that is using the given ammo.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -582,6 +582,22 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookNeedsAmmo = AddHook<Func<Item, Player, bool>>(g => g.NeedsAmmo);
+		/// <summary>
+		/// Calls ModItem.NeedsAmmo, then all GlobalItem.NeedsAmmo hooks, until any of them returns false.
+		/// </summary>
+		public static bool NeedsAmmo(Item weapon, Player player) {
+			if (!weapon.ModItem?.NeedsAmmo(player) ?? false)
+				return false;
+
+			foreach (var g in HookNeedsAmmo.Enumerate(weapon.globalItems)) {
+				if (!g.NeedsAmmo(weapon, player))
+					return false;
+			}
+
+			return true;
+		}
+
 		private delegate void DelegatePickAmmo(Item weapon, Item ammo, Player player, ref int type, ref float speed, ref StatModifier damage, ref float knockback);
 		private static HookList HookPickAmmo = AddHook<DelegatePickAmmo>(g => g.PickAmmo);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -324,6 +324,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Whether or not having no ammo prevents an item that uses ammo from shooting.
+		/// Return false to allow shooting with no ammo in the inventory, in which case this item will act as if the default ammo for it is being used.
+		/// Returns true by default.
+		/// </summary>
+		public virtual bool NeedsAmmo(Player player) {
+			return true;
+		}
+
+		/// <summary>
 		/// Allows you to modify various properties of the projectile created by a weapon based on the ammo it is using. This hook is called on the ammo.
 		/// </summary>
 		/// <param name="weapon">The item that is using this ammo.</param>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4931,8 +4931,9 @@
 +
 +			bool shootWithNoAmmo = false;
 +			if (!canShoot && !ItemLoader.NeedsAmmo(sItem, this)) {
-+				canShoot = shootWithNoAmmo = true;
-+				item.SetDefaults(sItem.useAmmo);
++				item = ContentSamples.ItemsByType[sItem.useAmmo];
++				if (item.ammo == sItem.useAmmo)
++					canShoot = shootWithNoAmmo = true;
 +			}
 +
  			if (!canShoot)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2207,6 +2207,16 @@
  							SmartSelect_SelectItem(i);
  							return;
  						}
+@@ -12560,6 +_,9 @@
+ 								}
+ 							}
+ 
++							if (!flag2 && !ItemLoader.NeedsAmmo(inventory[i], this))
++								flag2 = true;
++
+ 							if (flag2) {
+ 								SmartSelect_SelectItem(i);
+ 								return;
 @@ -12571,7 +_,7 @@
  							if (nonTorch == -1)
  								nonTorch = selectedItem;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2207,7 +2207,7 @@
  							SmartSelect_SelectItem(i);
  							return;
  						}
-@@ -12560,6 +_,9 @@
+@@ -12556,6 +_,9 @@
  								}
  							}
  
@@ -4917,7 +4917,7 @@
  						item = inventory[k];
  						canShoot = true;
  						break;
-@@ -37090,10 +_,31 @@
+@@ -37090,10 +_,39 @@
  				}
  			}
  
@@ -5092,16 +5092,12 @@
  
  			if (huntressAmmoCost90 && Main.rand.Next(10) == 0)
  				flag2 = true;
-@@ -37226,9 +_,10 @@
+@@ -37226,6 +_,7 @@
  			if (ammoCost75 && Main.rand.Next(4) == 0)
  				flag2 = true;
  
 +			/* Flamethrower + Elf Melter (handled by consumeAmmoOnFirstShotOnly) + Clentaminator (handled by consumeAmmoOnFirstShotOnly)
  			if (projToShoot == 85 && itemAnimation < itemAnimationMax - 2)
- 				flag2 = true;
--
-+			
- 			if ((projToShoot == 145 || projToShoot == 146 || projToShoot == 147 || projToShoot == 148 || projToShoot == 149) && itemAnimation < itemAnimationMax - 5)
  				flag2 = true;
  
 @@ -37239,6 +_,9 @@

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4919,10 +4919,10 @@
 +			Item item = ChooseAmmo(sItem);
 +			canShoot = item != null;
 +
++			bool shootWithNoAmmo = false;
 +			if (!canShoot && !ItemLoader.NeedsAmmo(sItem, this)) {
-+				canShoot = true;
++				canShoot = shootWithNoAmmo = true;
 +				item.SetDefaults(sItem.useAmmo);
-+				item.consumable = false;
 +			}
 +
  			if (!canShoot)
@@ -5006,7 +5006,7 @@
 +			ItemLoader.PickAmmo(sItem, item, this, ref projToShoot, ref speed, ref ammoDamage, ref KnockBack);
 +			totalDamage = (int)(ammoDamage.ApplyTo(item.damage) + 5E-06f);
 +
-+			if (!dontConsume && item.consumable && !IsAmmoFreeThisShot(sItem, item, projToShoot)) {
++			if (!dontConsume && !shootWithNoAmmo && item.consumable && !IsAmmoFreeThisShot(sItem, item, projToShoot)) {
 +				CombinedHooks.OnConsumeAmmo(this, sItem, item);
 +				item.stack--;
 +				if (item.stack <= 0) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4918,6 +4918,13 @@
 +			usedAmmoItemId = 0;
 +			Item item = ChooseAmmo(sItem);
 +			canShoot = item != null;
++
++			if (!canShoot && !ItemLoader.NeedsAmmo(sItem, this)) {
++				canShoot = true;
++				item.SetDefaults(sItem.useAmmo);
++				item.consumable = false;
++			}
++
  			if (!canShoot)
  				return;
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4819,7 +4819,7 @@
 +
 -		public bool HasAmmo(Item sItem, bool canUse) {
 +		internal bool HasAmmo(Item sItem, bool canUse) {
-+			return sItem.useAmmo == 0 || ChooseAmmo(sItem) != null;
++			return sItem.useAmmo == 0 || ChooseAmmo(sItem) != null || !ItemLoader.NeedsAmmo(sItem, this);
 +			/*
  			if (sItem.useAmmo > 0) {
  				canUse = false;


### PR DESCRIPTION
### What is the new feature?
Adds the `NeedsAmmo` hook to `ModItem` and `GlobalItem`, which allows any ammo consuming item to shoot when there's no valid ammo for the item left in the player's inventory, in which case the item will shoot as if the default ammo, the item with the type used as the ammo class's ID, is being used.
When shooting with no ammo, the code related to ammo consumption doesn't run, including the `ConsumeAmmo` and `OnConsumeAmmo` hooks.

### Why should this be part of tModLoader?
Some modders may want to allow shooting without ammo when using certain equipment, while under certain buffs, when using certain weapons, etc.

### Are there alternative designs?
Maybe also allowing to change which ammo type the item will use while having no ammo could be allowed, though it would require validation to make sure the ammo being selected also belongs to the ammo class in the item's `useAmmo` field, as the vanilla code doesn't expect certain items to use ammo outside their class.

### ExampleMod updates
Check the updated `ExampleMinigun` for an example of this hook's usage.

