### PR TITLE
[1.4] Reimplement Mod/GlobalTile.SpecialDraw

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -40,10 +40,46 @@
  
  			Rectangle normalTileRect = new Rectangle(drawData.tileFrameX + drawData.addFrX, drawData.tileFrameY + drawData.addFrY, drawData.tileWidth, drawData.tileHeight - drawData.halfBrickHeight);
  			Vector2 vector = new Vector2((float)(tileX * 16 - (int)screenPosition.X) - ((float)drawData.tileWidth - 16f) / 2f, tileY * 16 - (int)screenPosition.Y + drawData.tileTop + drawData.halfBrickHeight) + screenOffset;
-+			TileLoader.DrawEffects(tileX, tileY, drawData.typeCache, Main.spriteBatch, ref drawData.tileLight, ref _specialTilesCount);
++			TileLoader.DrawEffects(tileX, tileY, drawData.typeCache, Main.spriteBatch, ref drawData);
  			if (drawData.tileLight.R < 1 && drawData.tileLight.G < 1 && drawData.tileLight.B < 1)
  				return;
  
+@@ -812,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private Texture2D GetTileDrawTexture(Tile tile, int tileX, int tileY) {
++		public Texture2D GetTileDrawTexture(Tile tile, int tileX, int tileY) {
+ 			Texture2D result = TextureAssets.Tile[tile.type].Value;
+ 			int tileStyle = 0;
+ 			int num = tile.type;
+@@ -837,7 +_,7 @@
+ 			return result;
+ 		}
+ 
+-		private Texture2D GetTileDrawTexture(Tile tile, int tileX, int tileY, int paintOverride) {
++		public Texture2D GetTileDrawTexture(Tile tile, int tileX, int tileY, int paintOverride) {
+ 			Texture2D result = TextureAssets.Tile[tile.type].Value;
+ 			int tileStyle = 0;
+ 			int num = tile.type;
+@@ -2820,7 +_,7 @@
+ 			return _tileSolid[typeCache];
+ 		}
+ 
+-		private void GetTileOutlineInfo(int x, int y, ushort typeCache, ref Color tileLight, ref Texture2D highlightTexture, ref Color highlightColor) {
++		public void GetTileOutlineInfo(int x, int y, ushort typeCache, ref Color tileLight, ref Texture2D highlightTexture, ref Color highlightColor) {
+ 			if (Main.InSmartCursorHighlightArea(x, y, out bool actuallySelected)) {
+ 				int num = (tileLight.R + tileLight.G + tileLight.B) / 3;
+ 				if (num > 10) {
+@@ -2850,7 +_,7 @@
+ 
+ 		private bool InAPlaceWithWind(int x, int y, int width, int height) => WorldGen.InAPlaceWithWind(x, y, width, height);
+ 
+-		private void GetTileDrawData(int x, int y, Tile tileCache, ushort typeCache, ref short tileFrameX, ref short tileFrameY, out int tileWidth, out int tileHeight, out int tileTop, out int halfBrickHeight, out int addFrX, out int addFrY, out SpriteEffects tileSpriteEffect, out Texture2D glowTexture, out Rectangle glowSourceRect, out Color glowColor) {
++		public void GetTileDrawData(int x, int y, Tile tileCache, ushort typeCache, ref short tileFrameX, ref short tileFrameY, out int tileWidth, out int tileHeight, out int tileTop, out int halfBrickHeight, out int addFrX, out int addFrY, out SpriteEffects tileSpriteEffect, out Texture2D glowTexture, out Rectangle glowSourceRect, out Color glowColor) {
+ 			tileTop = 0;
+ 			tileWidth = 16;
+ 			tileHeight = 16;
 @@ -4371,6 +_,9 @@
  						break;
  					}
@@ -54,3 +90,26 @@
  		}
  
  		private bool IsWindBlocked(int x, int y) {
+@@ -4438,11 +_,11 @@
+ 			}
+ 		}
+ 
+-		private void AddSpecialLegacyPoint(Point p) {
++		public void AddSpecialLegacyPoint(Point p) {
+ 			AddSpecialLegacyPoint(p.X, p.Y);
+ 		}
+ 
+-		private void AddSpecialLegacyPoint(int x, int y) {
++		public void AddSpecialLegacyPoint(int x, int y) {
+ 			_specialTileX[_specialTilesCount] = x;
+ 			_specialTileY[_specialTilesCount] = y;
+ 			_specialTilesCount++;
+@@ -5416,6 +_,8 @@
+ 
+ 					Main.spriteBatch.Draw(value9, vector, value10, new Color(255, 255, 255, 0) * 0.1f, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+ 				}
++
++				TileLoader.SpecialDraw(type, num, num2, Main.spriteBatch);
+ 			}
+ 		}
+ 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using Terraria.DataStructures;
 
 namespace Terraria.ModLoader
 {
@@ -136,21 +137,19 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to make stuff happen whenever the tile at the given coordinates is drawn. For example, creating dust or changing the color the tile is drawn in.
+		/// SpecialDraw will only be called if coordinates are added using Main.instance.TilesRenderer.AddSpecialLegacyPoint here.
 		/// </summary>
-		/// <param name="i"></param>
-		/// <param name="j"></param>
-		/// <param name="type"></param>
-		/// <param name="spriteBatch"></param>
-		/// <param name="drawColor"></param>
-		/// <param name="nextSpecialDrawIndex">The special draw count. Use with Main.specX and Main.specY and then increment to draw special things after the main tile drawing loop is complete via DrawSpecial.</param>
-		public virtual void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex) {
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		/// <param name="drawData">Various information about the tile that is being drawn, such as color, framing, glow textures, etc.</param>
+		public virtual void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {
 		}
 
 		/// <summary>
-		/// Special Draw. Only called if coordinates are placed in Main.specX/Y during DrawEffects. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
+		/// Special Draw. Only called if coordinates are added using Main.instance.TilesRenderer.AddSpecialLegacyPoint during DrawEffects. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
 		/// </summary>
-		/// <param name="i">The i.</param>
-		/// <param name="j">The j.</param>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
 		public virtual void SpecialDraw(int i, int j, int type, SpriteBatch spriteBatch) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
@@ -292,18 +293,19 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to make stuff happen whenever the tile at the given coordinates is drawn. For example, creating dust or changing the color the tile is drawn in.
+		/// SpecialDraw will only be called if coordinates are added using Main.instance.TilesRenderer.AddSpecialLegacyPoint here.
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
-		/// <param name="nextSpecialDrawIndex">The special draw count. Use with Main.specX and Main.specY and then increment to draw special things after the main tile drawing loop is complete via DrawSpecial.</param>
-		public virtual void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex) {
+		/// <param name="drawData">Various information about the tile that is being drawn, such as color, framing, glow textures, etc.</param>
+		public virtual void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {
 		}
 
 		/// <summary>
-		/// Special Draw. Only called if coordinates are placed in Main.specX/Y during DrawEffects. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
+		/// Special Draw. Only called if coordinates are added using Main.instance.TilesRenderer.AddSpecialLegacyPoint during DrawEffects. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
 		/// </summary>
-		/// <param name="i">The i.</param>
-		/// <param name="j">The j.</param>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
 		public virtual void SpecialDraw(int i, int j, SpriteBatch spriteBatch) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using Terraria.Audio;
+using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Biomes.CaveHouse;
 using Terraria.ID;
@@ -67,7 +68,7 @@ namespace Terraria.ModLoader
 		private static DelegateSetSpriteEffects[] HookSetSpriteEffects;
 		private static Action[] HookAnimateTile;
 		private static Func<int, int, int, SpriteBatch, bool>[] HookPreDraw;
-		private delegate void DelegateDrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex);
+		private delegate void DelegateDrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData);
 		private static DelegateDrawEffects[] HookDrawEffects;
 		private static Action<int, int, int, SpriteBatch>[] HookPostDraw;
 		private static Action<int, int, int, SpriteBatch>[] HookSpecialDraw;
@@ -606,12 +607,16 @@ namespace Terraria.ModLoader
 			return GetTile(type)?.PreDraw(i, j, spriteBatch) ?? true;
 		}
 
-		public static void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex) {
-			GetTile(type)?.DrawEffects(i, j, spriteBatch, ref drawColor, ref nextSpecialDrawIndex);
+		//in Terraria.GameContent.Drawing.TileDrawing after ShroomCap draw call, before color < check
+		//  TileLoader.DrawEffects(tileX, tileY, drawData.typeCache, Main.spriteBatch, ref drawData);
+		//1.3: drawColor corresponds to drawData.tileLight
+		public static void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {
+			GetTile(type)?.DrawEffects(i, j, spriteBatch, ref drawData);
 			foreach (var hook in HookDrawEffects) {
-				hook(i, j, type, spriteBatch, ref drawColor, ref nextSpecialDrawIndex);
+				hook(i, j, type, spriteBatch, ref drawData);
 			}
 		}
+
 		//in Terraria.GameContent.Drawing.TileDrawing.DrawSingleTile after if statement checking whether highlightTexture is null call
 		//  TileLoader.PostDraw(j, i, type, Main.spriteBatch);
 		public static void PostDraw(int i, int j, int type, SpriteBatch spriteBatch) {
@@ -622,14 +627,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		//in Terraria.GameContent.Drawing.TileDrawing at the end of the loop in DrawSpecialTilesLegacy call
+		//  TileLoader.SpecialDraw(type, num, num2, Main.spriteBatch);
 		/// <summary>
-		/// Special Draw calls ModTile and GlobalTile SpecialDraw methods. Special Draw is called from DrawTiles after the draw loop, allowing for basically another layer above tiles.  Main.specX and Main.specY are used to specify tiles to call SpecialDraw on. Use DrawEffects hook to queue for SpecialDraw. 
+		/// Special Draw calls ModTile and GlobalTile SpecialDraw methods. Special Draw is called at the end of the DrawSpecialTilesLegacy loop, allowing for basically another layer above tiles. Use DrawEffects hook to queue for SpecialDraw. 
 		/// </summary>
-		public static void SpecialDraw(int type, int specX, int specY, SpriteBatch spriteBatch) {
-			GetTile(type)?.SpecialDraw(specX, specY, spriteBatch);
+		public static void SpecialDraw(int type, int specialTileX, int specialTileY, SpriteBatch spriteBatch) {
+			GetTile(type)?.SpecialDraw(specialTileX, specialTileY, spriteBatch);
 
 			foreach (var hook in HookSpecialDraw) {
-				hook(specX, specY, type, spriteBatch);
+				hook(specialTileX, specialTileY, type, spriteBatch);
 			}
 		}
 


### PR DESCRIPTION
### What is the bug?
`TileLoader.SpecialDraw` is not called in 1.4.

### How did you fix the bug?
This PR adds the call back, together with adjustments to the new 1.4 code, which includes publicising a few methods to make code cleaner. I took the liberty to also publicise some general tile draw methods in case modders need to draw tiles semi-manually in some way (old 1.3 code for it was public before).
The PR also changes `TileLoader.DrawEffects` to pass a more general `TileDrawInfo` struct, allowing for much more adjustments to be made (in comparison to 1.3, which only allowed you to change the color, and in regards to `nextSpecialDrawIndex`, was prone to issues if it was not incremented).

#### Old sample code
```cs
public override void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex)
{
	drawColor.R = 255;
	
	Main.specX[nextSpecialDrawIndex] = i;
	Main.specY[nextSpecialDrawIndex] = j;
	nextSpecialDrawIndex++;
}
``` 

#### New sample code
```cs
public override void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref TileDrawInfo drawData)
{
    drawData.tileLight.R = 255;

    Main.instance.TilesRenderer.AddSpecialLegacyPoint(i, j);
}
```

### Are there alternatives to your fix?
The placement of `SpecialDraw` is slightly different to 1.3 due to 1.4 code having moved tree tops in a separate method. This MIGHT change the order of operations between tiles and tree tops.
