### PR TITLE
WIP: Added EditActiveRange Hook

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -450,6 +450,17 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the range at which NPCs are considered active (activeRange) and the time they will linger when out of screen but in active range (activeTime).
+		/// </summary>
+		/// <param name="npc"></param>
+		/// <param name="activeRangeX"></param>
+		/// <param name="activeRangeY"></param>
+		/// <param name="activeTime"></param>
+		public virtual void EditActiveRange(NPC npc, ref int activeRangeX, ref int activeRangeY,
+			ref int activeTime) {
+		}
+
+		/// <summary>
 		/// Allows you to control which NPCs can spawn and how likely each one is to spawn. The pool parameter maps NPC types to their spawning weights (likelihood to spawn compared to other NPCs). A type of 0 in the pool represents the default vanilla NPC spawning.
 		/// </summary>
 		/// <param name="pool"></param>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -785,6 +785,17 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateEditActiveRange(NPC npc, ref int activeRangeX, ref int activeRangeY,
+			ref int activeTime);
+		private static HookList HookEditActiveRange = AddHook<DelegateEditActiveRange>(g => g.EditActiveRange);
+
+		public static void EditActiveRange(NPC npc, ref int activeRangeX, ref int activeRangeY,
+			ref int activeTime) {
+			foreach (GlobalNPC g in HookEditActiveRange.Enumerate(globalNPCsArray)) {
+				g.EditActiveRange(npc, ref activeRangeX, ref activeRangeY, ref activeTime);
+			}
+		}
+
 		private static HookList HookEditSpawnPool = AddHook<Action<Dictionary<int, float>, NPCSpawnInfo>>(g => g.EditSpawnPool);
 
 		public static int? ChooseSpawn(NPCSpawnInfo spawnInfo) {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -434,7 +434,7 @@
  					NetMessage.SendTileSquare(-1, x, y, 3);
  				}
  
-@@ -54744,6 +_,9 @@
+@@ -54744,12 +_,19 @@
  			if (!active || DoesntDespawnToInactivity())
  				return;
  
@@ -444,6 +444,26 @@
  			if (townNPC) {
  				AddIntoPlayersTownNPCSlots();
  				return;
+ 			}
+ 
+ 			bool flag = false;
++			int _oldActiveRangeX = activeRangeX;
++			int _oldActiveRangeY = activeRangeY;
++			int _oldActiveTime = activeTime;
++			NPCLoader.EditActiveRange(this, ref activeRangeX, ref activeRangeY, ref activeTime);
+ 			Rectangle rectangle = new Rectangle((int)(position.X + (float)(width / 2) - (float)activeRangeX), (int)(position.Y + (float)(height / 2) - (float)activeRangeY), activeRangeX * 2, activeRangeY * 2);
+ 			Rectangle rectangle2 = new Rectangle((int)((double)(position.X + (float)(width / 2)) - (double)sWidth * 0.5 - (double)width), (int)((double)(position.Y + (float)(height / 2)) - (double)sHeight * 0.5 - (double)height), sWidth + width * 2, sHeight + height * 2);
+ 			for (int i = 0; i < 255; i++) {
+@@ -54812,6 +_,9 @@
+ 						break;
+ 				}
+ 			}
++			activeRangeX = _oldActiveRangeX;
++			activeRangeY = _oldActiveRangeY;
++			activeTime = _oldActiveTime;
+ 
+ 			timeLeft--;
+ 			if (timeLeft <= 0)
 @@ -54903,6 +_,9 @@
  				return;
  			}


### PR DESCRIPTION
### What is the new feature?

Added `EditActiveRange` hook to allow for NPC to linger longer when outside the screen or have them be active from further away.

### Why should this be part of tModLoader?

This feature was [requested](https://github.com/tModLoader/tModLoader/issues/355) (resolve #355) to allow NPCs with extended spawn range to actually survive if the spawn range is larger than the default active range.

### Are there alternative designs?

Probably a complete optional bypass and handling of the despawning mechanic might be usefull in some corner cases, but might be achieved by setting acrive range to 0.

Also the static screen size as a active time updating system might be useful to alter (e.g. having some npc spawn if they are in screen but far from the player for enough time.

### Sample usage for the new feature

In a GlobalNPC:
```C#
public override void EditActiveRange(NPC npc, ref int activeRangeX, ref int activeRangeY, ref int activeTime)
{
    base.EditActiveRange(npc, ref activeRangeX, ref activeRangeY, ref activeTime);
    if (npc.type == NPCID.BlueSlime)
    {
        // Have blue slime despawn on screen if not near the player
        activeRangeX = 20;
        activeRangeY = 20;
        activeTime = 1;
    } else if (npc.type == NPCID.SkeletonMerchant)
    {
        // Have SkeletonMerchant almost never despawning (yes this can be done better in other ways)
        activeRangeX = 10000;
        activeRangeY = 10000;
        activeTime = 1000000000;
    }
}
```

### Implementation detail

I put some `_old*` variables and restored the static variables instead of having locals to minimize the changes and potentially be more resistent on potential Terraria updates.
