### PR TITLE
Hook for sign text changed.

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2555,6 +2555,15 @@
  				if (npc[player[myPlayer].talkNPC].type == 20) {
  					SoundEngine.PlaySound(12);
  					npcChatText = Lang.GetDryadWorldStatusDialog();
+@@ -29565,6 +_,8 @@
+ 			editSign = false;
+ 			if (netMode == 1)
+ 				NetMessage.SendData(47, -1, -1, null, num);
++			Sign.TextDidChange();
++			
+ 		}
+ 
+ 		private int NPCBannerSorter(int npcIndex1, int npcIndex2) => -npc[npcIndex1].housingCategory.CompareTo(npc[npcIndex2].housingCategory);
 @@ -30063,7 +_,7 @@
  					num29++;
  

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -430,5 +430,12 @@ namespace Terraria.ModLoader
 		/// <param name="manual">Set this to true to bypass the code playing the unlock sound, adjusting the tile frame, and spawning dust. Network syncing will still happen.</param>
 		/// <returns>Return true if this tile truly is a locked chest and the chest can be unlocked</returns>
 		public virtual bool UnlockChest(int i, int j, ref short frameXAdjustment, ref int dustType, ref bool manual) => false;
+
+		// <summary>
+		/// Allows customization of what happens after the text on a sign has been changed.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		public virtual void SignDidChange(int i, int j){}
 	}
 }

--- a/patches/tModLoader/Terraria/Sign.cs.patch
+++ b/patches/tModLoader/Terraria/Sign.cs.patch
@@ -1,0 +1,29 @@
+--- src/Terraria/Terraria/Sign.cs
++++ src/tModLoader/Terraria/Sign.cs
+@@ -1,3 +_,6 @@
++using Terraria.ModLoader;
++
++
+ namespace Terraria
+ {
+ 	public class Sign
+@@ -54,6 +_,19 @@
+ 				Main.sign[i] = null;
+ 			else
+ 				Main.sign[i].text = text;
++		}
++
++		public static void TextDidChange(int i) {
++			if (Main.tile[Main.sign[i].x, Main.sign[i].y] == null || !Main.tile[Main.sign[i].x, Main.sign[i].y].active() || !Main.tileSign[Main.tile[Main.sign[i].x, Main.sign[i].y].type])
++				//Do nothing.
++			else 
++			{
++				int x = Main.sign[i].x;
++				int y = Main.sign[i].y;
++				ushort type = Main.tile[x, y].type;
++				ModTile tile = ModContent.GetModTile(type);
++				tile.SignDidChange(x, y);
++			}
+ 		}
+ 
+ 		public override string ToString() => "x" + x + "\ty" + y + "\t" + text;


### PR DESCRIPTION
### What is the new feature?
When a sign is finished being edited, I want to notify the tile that an update has been made.

### Why should this be part of tModLoader?
I want to create a mod that allows a user to create trackers using signs, notifying the tile that the sign has been updated, I can cleanly update text on the mini map, to what the sign says.

### Are there alternative designs?
I have spent many days and haven't found one.

### Sample usage for the new feature
```
public override void SignDidChange(int i, int j)
{
  string text = Main.sign[Sign.ReadSign(i, j, true)].text;

  ModTranslation name = CreateMapEntryName();
  name.SetDefault(text);
  AddMapEntry(new Color(19, 255, 0), name);

  entryCount++;
}
```