### PR TITLE
[1.4] Fix a few buff, item, and NPC head limit checks

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/NPCDebuffImmunityData.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/NPCDebuffImmunityData.cs.patch
@@ -1,0 +1,17 @@
+--- src/Terraria/Terraria/DataStructures/NPCDebuffImmunityData.cs
++++ src/tModLoader/Terraria/DataStructures/NPCDebuffImmunityData.cs
+@@ -1,4 +_,5 @@
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.DataStructures
+ {
+@@ -10,7 +_,7 @@
+ 
+ 		public void ApplyToNPC(NPC npc) {
+ 			if (ImmuneToWhips || ImmuneToAllBuffsThatAreNotWhips) {
+-				for (int i = 1; i < 327; i++) {
++				for (int i = 1; i < BuffLoader.BuffCount; i++) {
+ 					bool flag = BuffID.Sets.IsAnNPCWhipDebuff[i];
+ 					bool flag2 = false;
+ 					flag2 |= (flag && ImmuneToWhips);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2662,6 +2662,15 @@
  						inventoryBack = color5;
  					}
  				}
+@@ -30876,7 +_,7 @@
+ 				if (npc[j].active && !_npcTypesThatAlreadyDrewAHead.Contains(npc[j].type)) {
+ 					ITownNPCProfile profile;
+ 					int num4 = (!TownNPCProfiles.Instance.GetProfile(npc[j].type, out profile)) ? NPC.TypeToDefaultHeadIndex(npc[j].type) : profile.GetHeadTextureIndex(npc[j]);
+-					if (num4 > 0 && num4 <= 46 && !NPCHeadID.Sets.CannotBeDrawnInHousingUI[num4] && _npcIndexWhoHoldsHeadIndex[num4] == -1) {
++					if (num4 > 0 && num4 < NPCHeadLoader.NPCHeadCount && !NPCHeadID.Sets.CannotBeDrawnInHousingUI[num4] && _npcIndexWhoHoldsHeadIndex[num4] == -1) {
+ 						_npcIndexWhoHoldsHeadIndex[num4] = j;
+ 						_npcTypesThatAlreadyDrewAHead.Add(npc[j].type);
+ 					}
 @@ -30980,7 +_,7 @@
  			else {
  				text = Lang.inter[21].Value + " " + guideItem.Name;

--- a/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
@@ -33,6 +33,8 @@ namespace Terraria.ModLoader
 
 		internal static int ReserveHeadSlot() => nextHead++;
 
+		public static int NPCHeadCount => nextHead;
+
 		internal static int ReserveBossHeadSlot(string texture) {
 			if (bossHeads.TryGetValue(texture, out int existing)) {
 				return existing;
@@ -83,6 +85,7 @@ namespace Terraria.ModLoader
 
 			//Etc
 
+			Array.Resize(ref NPCHeadID.Sets.CannotBeDrawnInHousingUI, nextHead);
 			Array.Resize(ref Main.instance._npcIndexWhoHoldsHeadIndex, nextHead);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Terraria.GameContent;
 using Terraria.Graphics.Renderers;
 using Terraria.ID;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
@@ -78,14 +79,13 @@ namespace Terraria.ModLoader
 			}
 
 			//Sets. The arrays modified here are resized in NPCLoader.
+			LoaderUtils.ResetStaticMembers(typeof(NPCHeadID), true);
 
 			foreach (int npc in npcToBossHead.Keys) {
 				NPCID.Sets.BossHeadTextures[npc] = npcToBossHead[npc];
 			}
 
 			//Etc
-
-			Array.Resize(ref NPCHeadID.Sets.CannotBeDrawnInHousingUI, nextHead);
 			Array.Resize(ref Main.instance._npcIndexWhoHoldsHeadIndex, nextHead);
 		}
 

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -773,6 +773,15 @@
  					if (buffTime[i] < time)
  						buffTime[i] = time;
  
+@@ -70294,7 +_,7 @@
+ 		}
+ 
+ 		public void RequestBuffRemoval(int buffTypeToRemove) {
+-			if (buffTypeToRemove < 0 || buffTypeToRemove >= 327 || !BuffID.Sets.CanBeRemovedByNetMessage[buffTypeToRemove])
++			if (buffTypeToRemove < 0 || buffTypeToRemove >= BuffLoader.BuffCount || !BuffID.Sets.CanBeRemovedByNetMessage[buffTypeToRemove])
+ 				return;
+ 
+ 			int num = FindBuffIndex(buffTypeToRemove);
 @@ -70482,7 +_,7 @@
  				if (NPCID.Sets.NoMultiplayerSmoothingByType[type]) {
  					netOffset *= 0f;

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -102,8 +102,12 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1016,7 +_,9 @@
- 					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < 5088 && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
+@@ -1013,10 +_,12 @@
+ 							Recipe.FindRecipes();
+ 						}
+ 					}
+-					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < 5088 && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
++					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < ItemLoader.ItemCount && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
  						if (Main.mouseRightRelease) {
  							player.OpenFishingCrate(inv[slot].type);
 +							if (ItemLoader.ConsumeItem(inv[slot], player))


### PR DESCRIPTION
### What is the bug?
1. Two places where whip buffs are involved do not have proper upper bound type checks. Modded whip buffs will not work as intended there.
a) `NPCDebuffImmunityData.ApplyToNPC` has special checks for whip buffs, which ignore modded buffs currently.
b) `NPC.RequestBuffRemoval` is used to remove a specific debuff from an NPC after striking again with a [Firecracker](https://terraria.fandom.com/wiki/Firecracker) whip. The fix itself is rather for the netcode side or other calls by mods.

2. Modded items registering into `ItemID.Sets.IsFishingCrate` are being ignored for the "crate" context in `OpenVanillaBag` related Item hooks.

3. `NPCHeadID.Sets.CannotBeDrawnInHousingUI` is not resized, meaning any modded head slot index will end up in an IOOB.
In addition to that, the upper bound check for it was expanded using the new `NPCHeadLoader.NPCHeadCount` property.
Code that would fail due to IOOB if you wanted to make a travelling merchant-like NPC:
```cs
//Head added through AutoloadHead
int headIndex = NPC.TypeToDefaultHeadIndex(NPC.type);
NPCHeadID.Sets.CannotBeDrawnInHousingUI[headIndex] = true;
```

### How did you fix the bug?
Add proper upper bound checks and array resizes where necessary.

### Are there alternatives to your fix?
Dunno
