### PR TITLE
[1.4] Reimplement ModPlayer.DrawEffects

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -31,3 +31,15 @@
  			}
  
  			drawPlayer.GetHairSettings(out fullHair, out hatHair, out hideHair, out backHairDraw, out drawsBackHairWithoutHeadgear);
+@@ -1049,8 +_,10 @@
+ 				DustCache.Add(dust21.dustIndex);
+ 			}
+ 
++			bool fullBright = false;
++			PlayerHooks.DrawEffects(this, ref num12, ref num13, ref num14, ref num15, ref fullBright);
+ 			if (num12 != 1f || num13 != 1f || num14 != 1f || num15 != 1f) {
+-				if (drawPlayer.onFire || drawPlayer.onFire2 || drawPlayer.onFrostBurn || drawPlayer.onFire3 || drawPlayer.onFrostBurn2) {
++				if (drawPlayer.onFire || drawPlayer.onFire2 || drawPlayer.onFrostBurn || drawPlayer.onFire3 || drawPlayer.onFrostBurn2 || fullBright) {
+ 					colorEyeWhites = drawPlayer.GetImmuneAlpha(Color.White, shadow);
+ 					colorEyes = drawPlayer.GetImmuneAlpha(drawPlayer.eyeColor, shadow);
+ 					colorHair = drawPlayer.GetImmuneAlpha(drawPlayer.GetHairColor(useLighting: false), shadow);

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -708,7 +708,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to create special effects when this player is drawn, such as creating dust, modifying the color the player is drawn in, etc. The fullBright parameter makes it so that the drawn player ignores the modified color and lighting. Note that the fullBright parameter only works if r, g, b, and/or a is not equal to 1. Make sure to add the indexes of any dusts you create to Main.playerDrawDust, and the indexes of any gore you create to Main.playerDrawGore.
+		/// Allows you to create special effects when this player is drawn, such as creating dust, modifying the color the player is drawn in, etc. The fullBright parameter makes it so that the drawn player ignores the modified color and lighting. Note that the fullBright parameter only works if r, g, b, and/or a is not equal to 1. Make sure to add the indexes of any dusts you create to drawInfo.DustCache, and the indexes of any gore you create to drawInfo.GoreCache.
 		/// </summary>
 		/// <param name="drawInfo"></param>
 		/// <param name="r"></param>


### PR DESCRIPTION
### What is the bug?
`ModPlayer.DrawEffects` was not called

### How did you fix the bug?
Make it be called in the exact same place 1.3 was, and in the same relation to other player draw hooks.
Also, changed documentation slightly to accomodate for new 1.4 code.

### Are there alternatives to your fix?
Dunno
