### PR TITLE
[1.4] Publicise setter of all SceneMetrics.HasX bools

### DIFF
--- a/patches/tModLoader/Terraria/SceneMetrics.cs.patch
+++ b/patches/tModLoader/Terraria/SceneMetrics.cs.patch
@@ -17,6 +17,54 @@
  		private readonly World _world;
  		private readonly List<Point> _oreFinderTileLocations = new List<Point>(512);
  		public int bestOre;
+@@ -110,32 +_,32 @@
+ 
+ 		public bool HasSunflower {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public bool HasGardenGnome {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public bool HasClock {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public bool HasCampfire {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public bool HasStarInBottle {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public bool HasHeartLantern {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public int ActiveFountainColor {
+@@ -160,7 +_,7 @@
+ 
+ 		public bool HasCatBast {
+ 			get;
+-			private set;
++			set;
+ 		}
+ 
+ 		public int GraveyardTileCount {
 @@ -198,6 +_,8 @@
  			if (settings.ScanOreFinderData)
  				_oreFinderTileLocations.Clear();


### PR DESCRIPTION
### What is the bug?
In 1.3, flags for nearby tiles that give effects/buffs (i.e. `Main.campfire`) were public and freely accessible by mods, and were necessary to implement vanilla-like content or toggle these effects in other ways.
In 1.4, these flags relocated into a different class, and their setter turned private, meaning that mods cannot change/set these anymore.

### How did you fix the bug?
Publicise setter of all SceneMetrics.HasX bools, so it can be set again.

```cs
public override void ModTile.NearbyEffects(int i, int j, bool closer) {
     if (closer) {
          Main.campfire = true; //Old
          SceneMetrics.HasCampfire = true; //New
     }
}
```

### Are there alternatives to your fix?
Dunno
