### PR TITLE
[1.4] Remove unneeded ModItem in-world animation handling

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -289,15 +289,6 @@
  			return result;
  		}
  
-@@ -2763,6 +_,8 @@
- 				itemAnimationsRegistered.Add(index);
- 
- 			itemAnimations[index] = animation;
-+			if (ItemLoader.IsModItem(index))
-+				ItemLoader.animations.Add(index);
- 		}
- 
- 		public static void InitializeItemAnimations() {
 @@ -2804,11 +_,13 @@
  			}
  		}
@@ -2405,18 +2396,6 @@
  			int num2 = item.glowMask;
  			if (!gamePaused && base.IsActive && (item.IsACoin || item.type == 58 || item.type == 109) && color.R > 60 && (float)rand.Next(500) - (Math.Abs(item.velocity.X) + Math.Abs(item.velocity.Y)) * 10f < (float)((int)color.R / 50)) {
  				int type = 43;
-@@ -27903,6 +_,11 @@
- 			if (item.type == 3779)
- 				num2 = -1;
- 
-+			if (ItemLoader.animations.Contains(item.type)) {
-+				ItemLoader.DrawAnimatedItem(item, whoami, color, currentColor, num, scale);
-+				goto PostDraw;
-+			}
-+
- 			spriteBatch.Draw(texture, vector2, frame, currentColor, num, vector, scale, SpriteEffects.None, 0f);
- 			if (item.color != Microsoft.Xna.Framework.Color.Transparent)
- 				spriteBatch.Draw(texture, vector2, frame, item.GetColor(color), num, vector, scale, SpriteEffects.None, 0f);
 @@ -27910,11 +_,15 @@
  			if (num2 != -1)
  				spriteBatch.Draw(TextureAssets.GlowMask[num2].Value, vector2, frame, new Microsoft.Xna.Framework.Color(250, 250, 250, item.alpha), num, vector, scale, SpriteEffects.None, 0f);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -28,7 +28,6 @@ namespace Terraria.ModLoader
 		internal static readonly IList<ModItem> items = new List<ModItem>();
 		internal static readonly IList<GlobalItem> globalItems = new List<GlobalItem>();
 		internal static GlobalItem[] NetGlobals;
-		internal static readonly ISet<int> animations = new HashSet<int>();
 		internal static readonly int vanillaQuestFishCount = 41;
 		internal static readonly int[] vanillaWings = new int[Main.maxWings];
 
@@ -137,7 +136,6 @@ namespace Terraria.ModLoader
 			items.Clear();
 			nextItem = ItemID.Count;
 			globalItems.Clear();
-			animations.Clear();
 			modHooks.Clear();
 		}
 
@@ -177,44 +175,6 @@ namespace Terraria.ModLoader
 			}
 
 			item.ModItem?.OnCreate(context);
-		}
-		
-		//near end of Terraria.Main.DrawItem before default drawing call
-		//  if(ItemLoader.animations.Contains(item.type))
-		//  { ItemLoader.DrawAnimatedItem(item, whoAmI, color, alpha, rotation, scale); return; }
-		internal static void DrawAnimatedItem(Item item, int whoAmI, Color color, Color alpha, float rotation, float scale) {
-			int frameCount = Main.itemAnimations[item.type].FrameCount;
-			int frameDuration = Main.itemAnimations[item.type].TicksPerFrame;
-
-			Main.itemFrameCounter[whoAmI]++;
-
-			if (Main.itemFrameCounter[whoAmI] >= frameDuration) {
-				Main.itemFrameCounter[whoAmI] = 0;
-				Main.itemFrame[whoAmI]++;
-			}
-
-			if (Main.itemFrame[whoAmI] >= frameCount) {
-				Main.itemFrame[whoAmI] = 0;
-			}
-
-			var texture = TextureAssets.Item[item.type].Value;
-
-			Rectangle frame = texture.Frame(1, frameCount, 0, Main.itemFrame[whoAmI]);
-			float offX = item.width * 0.5f - frame.Width * 0.5f;
-			float offY = item.height - frame.Height;
-			
-			Main.spriteBatch.Draw(texture, new Vector2(item.position.X - Main.screenPosition.X + frame.Width / 2 + offX, item.position.Y - Main.screenPosition.Y + frame.Height / 2 + offY), new Rectangle?(frame), alpha, rotation, frame.Size() / 2f, scale, SpriteEffects.None, 0f);
-			
-			if (item.color != default) {
-				Main.spriteBatch.Draw(texture, new Vector2(item.position.X - Main.screenPosition.X + frame.Width / 2 + offX, item.position.Y - Main.screenPosition.Y + frame.Height / 2 + offY), new Rectangle?(frame), item.GetColor(color), rotation, frame.Size() / 2f, scale, SpriteEffects.None, 0f);
-			}
-		}
-
-		private static Rectangle AnimatedItemFrame(Item item) {
-			int frameCount = Main.itemAnimations[item.type].FrameCount;
-			int frameDuration = Main.itemAnimations[item.type].TicksPerFrame;
-
-			return Main.itemAnimations[item.type].GetFrame(TextureAssets.Item[item.type].Value);
 		}
 
 		private static HookList HookChoosePrefix = AddHook<Func<Item, UnifiedRandom, int>>(g => g.ChoosePrefix);


### PR DESCRIPTION
### What is the bug?
Modded items that animate (using `Main.RegisterItemAnimation`) animate twice as fast.

### How did you fix the bug?
Legacy code from 1.3, 1.4 now animates items in DrawItem -> DrawItem_GetBasics -> DrawItem_AnimateSlot when `ItemID.Sets.AnimatesAsSoul` is true for the given item. That sets only purpose is to animate the item the same way tmodloader used to animate back in 1.3 (because item animations were hardcoded per item type with set speeds before, but 1.4 has more general code now).

I simply removed tmodloaders' own animation code.
Now this below code works exactly the same as in 1.3.
```cs
Main.RegisterItemAnimation(Item.type, new DrawAnimationVertical(speed, framecount));
ItemID.Sets.AnimatesAsSoul[Item.type] = true;
```

### Are there alternatives to your fix?
Dunno
