### PR TITLE
[1.4] Reset TilePaintSystem on unload to reset all tile/wall textures

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -239,6 +239,7 @@ namespace Terraria.ModLoader
 			trees.Clear();
 			palmTrees.Clear();
 			cacti.Clear();
+			Main.instance.TilePaintSystem.Reset();
 			Array.Resize(ref TileID.Sets.RoomNeeds.CountsAsChair, vanillaChairCount);
 			Array.Resize(ref TileID.Sets.RoomNeeds.CountsAsTable, vanillaTableCount);
 			Array.Resize(ref TileID.Sets.RoomNeeds.CountsAsTorch, vanillaTorchCount);


### PR DESCRIPTION
### What is the bug?
If mods add/remove tiles between reloads while the game is open, the game renders the wrong tile textures for modded tiles. This is because it keeps hold of the textures in `Main.instance.TilePaintSystem`.

### How did you fix the bug?
Call `Main.instance.TilePaintSystem.Reset();` in `TileLoader.Unload`.

### Are there alternatives to your fix?
No, that's how the game does it for resetting textures on texture pack changes.
