### PR TITLE
[1.4] Hypothetical hyper-simplified use time fix

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -249,24 +249,6 @@
  				return;
  
  			Vector2 zero = Vector2.Zero;
-@@ -2195,7 +_,7 @@
- 				drawinfo.itemColor = drawinfo.itemColor.MultiplyRGBA(new Color(Vector4.Lerp(Vector4.One, new Vector4(0f, 0.12f, 0.16f, 0f), 1f - num4)));
- 			}
- 
--			bool flag = drawinfo.drawPlayer.itemAnimation > 0 && heldItem.useStyle != 0;
-+			bool flag = drawinfo.drawPlayer.InItemAnimation && heldItem.useStyle != 0;
- 			bool flag2 = heldItem.holdStyle != 0 && !drawinfo.drawPlayer.pulley;
- 			if (!drawinfo.drawPlayer.CanVisuallyHoldItem(heldItem))
- 				flag2 = false;
-@@ -2217,7 +_,7 @@
- 			}
- 
- 			Vector2 origin = new Vector2((float)sourceRect.Value.Width * 0.5f - (float)sourceRect.Value.Width * 0.5f * (float)drawinfo.drawPlayer.direction, sourceRect.Value.Height);
--			if (heldItem.useStyle == 9 && drawinfo.drawPlayer.itemAnimation > 0) {
-+			if (heldItem.useStyle == 9 && drawinfo.drawPlayer.InItemAnimation) {
- 				Vector2 value2 = new Vector2(0.5f, 0.4f);
- 				if (heldItem.type == 5009 || heldItem.type == 5042) {
- 					value2 = new Vector2(0.26f, 0.5f);
 @@ -2452,7 +_,7 @@
  			if (drawinfo.usesCompositeTorso) {
  				DrawPlayer_28_ArmOverItemComposite(ref drawinfo);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3495,7 +3495,7 @@
  			if (!controlUseItem)
  				channel = false;
  
-+			goto HandleItemHolding;
++			goto ItemCheckPart2;
 +
 +			DecrementItemAnimation:
 +
@@ -3519,7 +3519,7 @@
  
  			releaseUseItem = !controlUseItem;
 +
-+			goto ItemCheckPart2;
++			return; // This is the end of our spaghetti trip!
 +
 +			// See the comment at DecrementItemAnimation for explanation
 +			DecrementItemTime:
@@ -3687,6 +3687,15 @@
  							if (item.stack > 0)
  								item.stack--;
  
+@@ -30342,6 +_,8 @@
+ 
+ 			if (itemAnimation == 0)
+ 				JustDroppedAnItem = false;
++
++			goto HandleItemHolding;
+ 		}
+ 
+ 		private void ItemCheck_EmitFoodParticles(Item sItem) {
 @@ -30594,11 +_,18 @@
  				if (i == whoAmI || !player.active || !player.hostile || player.immune || player.dead || (team != 0 && team == player.team) || !itemRectangle.Intersects(player.Hitbox) || !CanHit(player))
  					continue;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3447,15 +3447,36 @@
  			if (CCed) {
  				channel = false;
  				itemAnimation = (itemAnimationMax = 0);
-@@ -29770,6 +_,14 @@
+@@ -29770,6 +_,35 @@
  			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
  				controlUseItem = true;
  
-+			goto DecrementItemAnimation;
 +			// Gotos are admittedly not the cleanest way of doing this but they're the most patch-friendly
 +			// TLDR: this moves the blocks responsible for decrementing itemTime and itemAnimation to the start of the method
 +			// This is done so that itemTime and itemAnimation cannot be decremented in the same tick as the one they're set in, which should fix a lot of use time issues
 +			// -- ThomasThePencil
++			//
++			// Here's a map of vanilla's execution order compared to TML's
++			//
++			// VANILLA:
++			// 1. Reuse delay is applied
++			// 2. Item animation is applied if button is pressed
++			// 3. Item animation is reduced
++			// 4. Hold / Use styles are invoked
++			// 5. Item time is reduced
++			// 6. Item logic applies item time
++			//
++			// TML:
++			// 1. Item animation is reduced
++			// 2. Item time is reduced
++			// 3. Reuse delay is applied
++			// 4. Item animation is applied if button is pressed
++			// 5. Item logic applies item time
++			// 6. Hold / Use styles are invoked
++			//
++			// Way more sane and way less confusing!
++
++			goto DecrementItemAnimation;
 +
 +			ItemCheckPart1:
 +

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3432,11 +3432,14 @@
  			if (CCed) {
  				channel = false;
  				itemAnimation = (itemAnimationMax = 0);
-@@ -29769,7 +_,9 @@
+@@ -29769,7 +_,12 @@
  			Item item = inventory[selectedItem];
  			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
  				controlUseItem = true;
 +			goto DecrementItemAnimation;
++			// gotos are admittedly not the cleanest way of doing this but they're the most patch-friendly
++			// tl;dr this moves the blocks responsible for decrementing itemTime and itemAnimation to the start of the method
++			// this is done so that itemTime and itemAnimation cannot be decremented in the same tick as the one they're set in, which should fix a lot of use time issues
  
 +			ItemCheckPart1:
  			ItemCheck_HandleMount();
@@ -3492,12 +3495,13 @@
  
  			if (itemAnimation > 0)
  				ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
-@@ -29849,6 +_,9 @@
+@@ -29849,6 +_,10 @@
  				ItemCheck_ApplyHoldStyle(heightOffsetHitboxCenter, item2, drawHitbox);
  
  			releaseUseItem = !controlUseItem;
 +			goto ItemCheckPart2;
 +
++			// see comment at DecrementItemAnimation for explanation
 +			DecrementItemTime:
  			if (itemTime > 0) {
  				itemTime--;
@@ -3948,11 +3952,13 @@
  			if (sItem.type != 3269 && (!spaceGun || (sItem.type != 127 && sItem.type != 4347 && sItem.type != 4348))) {
  				if (statMana >= num) {
  					if (!flag2)
-@@ -36048,7 +_,7 @@
+@@ -36048,7 +_,9 @@
  		private void ItemCheck_HandleMPItemAnimation(Item sItem) {
  			if (sItem.autoReuse && !noItems) {
  				releaseUseItem = true;
 -				if (itemAnimation == 1 && sItem.stack > 0) {
++				// itemAnimation check changed to 0 and made it also check for itemTime
++				// realistically this method may be invalidated entirely by this use time fix but further investigation is needed
 +				if (itemAnimation == 0 && itemTime == 0 && sItem.stack > 0) {
  					if (sItem.shoot > 0 && whoAmI != Main.myPlayer && controlUseItem && sItem.useStyle == 5 && sItem.reuseDelay == 0) {
  						ApplyItemAnimation(sItem);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3456,7 +3456,7 @@
  			if (CCed) {
  				channel = false;
  				itemAnimation = (itemAnimationMax = 0);
-@@ -29770,6 +_,12 @@
+@@ -29770,6 +_,14 @@
  			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
  				controlUseItem = true;
  
@@ -3464,6 +3464,8 @@
 +			// Gotos are admittedly not the cleanest way of doing this but they're the most patch-friendly
 +			// TLDR: this moves the blocks responsible for decrementing itemTime and itemAnimation to the start of the method
 +			// This is done so that itemTime and itemAnimation cannot be decremented in the same tick as the one they're set in, which should fix a lot of use time issues
++			// -- ThomasThePencil
++
 +			ItemCheckPart1:
 +
  			ItemCheck_HandleMount();

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3432,6 +3432,16 @@
  			if (CCed) {
  				channel = false;
  				itemAnimation = (itemAnimationMax = 0);
+@@ -29769,7 +_,9 @@
+ 			Item item = inventory[selectedItem];
+ 			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
+ 				controlUseItem = true;
++			goto DecrementItemAnimation;
+ 
++			ItemCheckPart1:
+ 			ItemCheck_HandleMount();
+ 			int weaponDamage = GetWeaponDamage(item);
+ 			ItemCheck_HandleMPItemAnimation(item);
 @@ -29783,8 +_,17 @@
  			if (itemAnimation == 0 && reuseDelay > 0)
  				ApplyReuseDelay();
@@ -3461,22 +3471,47 @@
  					FreeUpPetsAndMinions(item);
  
  				if (flag3)
-@@ -29843,12 +_,15 @@
+@@ -29822,7 +_,9 @@
+ 
+ 			if (!controlUseItem)
+ 				channel = false;
++			goto HandleItemHolding;
+ 
++			DecrementItemAnimation:
+ 			Item item2 = (itemAnimation > 0) ? lastVisualizedSelectedItem : item;
+ 			Rectangle drawHitbox = Item.GetDrawHitbox(item2.type, this);
+ 			compositeFrontArm.enabled = false;
+@@ -29842,6 +_,10 @@
+ 
  				itemAnimation--;
  			}
- 
-+			ItemLoader.HoldItem(item, this);
++			goto DecrementItemTime;
 +
++			HandleItemHolding:
++			ItemLoader.HoldItem(item, this);
+ 
  			if (itemAnimation > 0)
  				ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
- 			else
+@@ -29849,6 +_,9 @@
  				ItemCheck_ApplyHoldStyle(heightOffsetHitboxCenter, item2, drawHitbox);
  
  			releaseUseItem = !controlUseItem;
++			goto ItemCheckPart2;
 +
++			DecrementItemTime:
  			if (itemTime > 0) {
  				itemTime--;
  				if (ItemTimeIsZero && whoAmI == Main.myPlayer) {
+@@ -29861,7 +_,9 @@
+ 					PlayerInput.TryEndingFastUse();
+ 				}
+ 			}
++			goto ItemCheckPart1;
+ 
++			ItemCheckPart2:
+ 			if (!JustDroppedAnItem) {
+ 				ItemCheck_EmitHeldItemLight(item);
+ 				ItemCheck_EmitFoodParticles(item);
 @@ -29891,7 +_,7 @@
  
  					ItemCheck_TurretAltFeatureUse(item, flag4);
@@ -3913,6 +3948,15 @@
  			if (sItem.type != 3269 && (!spaceGun || (sItem.type != 127 && sItem.type != 4347 && sItem.type != 4348))) {
  				if (statMana >= num) {
  					if (!flag2)
+@@ -36048,7 +_,7 @@
+ 		private void ItemCheck_HandleMPItemAnimation(Item sItem) {
+ 			if (sItem.autoReuse && !noItems) {
+ 				releaseUseItem = true;
+-				if (itemAnimation == 1 && sItem.stack > 0) {
++				if (itemAnimation == 0 && itemTime == 0 && sItem.stack > 0) {
+ 					if (sItem.shoot > 0 && whoAmI != Main.myPlayer && controlUseItem && sItem.useStyle == 5 && sItem.reuseDelay == 0) {
+ 						ApplyItemAnimation(sItem);
+ 						if (sItem.UseSound != null)
 @@ -36078,6 +_,7 @@
  			if (!mount.Active)
  				return;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2997,15 +2997,6 @@
  			if (mount.Active) {
  				legFrameCounter = 0.0;
  				legFrame.Y = legFrame.Height * 6;
-@@ -25493,7 +_,7 @@
- 				_ = legFrame;
- 				reference5.Y = 0;
- 			}
--			else if (itemAnimation > 0 && inventory[selectedItem].useStyle != 10 && flag4) {
-+			else if (InItemAnimation && inventory[selectedItem].useStyle != 10 && flag4) {
- 				if (inventory[selectedItem].useStyle == 1 || inventory[selectedItem].type == 0) {
- 					if ((double)itemAnimation < (double)itemAnimationMax * 0.333)
- 						bodyFrame.Y = bodyFrame.Height * 3;
 @@ -25576,6 +_,8 @@
  						}
  					}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3511,23 +3511,19 @@
  			Item item2 = (itemAnimation > 0) ? lastVisualizedSelectedItem : item;
  			Rectangle drawHitbox = Item.GetDrawHitbox(item2.type, this);
  			compositeFrontArm.enabled = false;
-@@ -29840,8 +_,14 @@
- 					itemWidth = drawHitbox.Width;
- 				}
- 
--				itemAnimation--;
-+				//itemAnimation--;
+@@ -29843,12 +_,24 @@
+ 				itemAnimation--;
  			}
-+
+ 
 +			goto DecrementItemTime;
 +
 +			HandleItemHolding:
 +
 +			ItemLoader.HoldItem(item, this);
- 
++
  			if (itemAnimation > 0)
  				ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
-@@ -29849,6 +_,12 @@
+ 			else
  				ItemCheck_ApplyHoldStyle(heightOffsetHitboxCenter, item2, drawHitbox);
  
  			releaseUseItem = !controlUseItem;
@@ -3700,17 +3696,6 @@
  							if (item.stack > 0)
  								item.stack--;
  
-@@ -30340,6 +_,10 @@
- 				}
- 			}
- 
-+			if (itemAnimation > 0) {
-+				itemAnimation--;
-+			}
-+
- 			if (itemAnimation == 0)
- 				JustDroppedAnItem = false;
- 		}
 @@ -30594,11 +_,18 @@
  				if (i == whoAmI || !player.active || !player.hostile || player.immune || player.dead || (team != 0 && team == player.team) || !itemRectangle.Intersects(player.Hitbox) || !CanHit(player))
  					continue;


### PR DESCRIPTION
All this really does is move the `itemTime` and `itemAnimation` decrements to the start of the method. As it turns out, they were placed after most common cases of `ApplyItemTime` and `ApplyItemAnimation` for the longest time, meaning they could be decremented on the same tick as them getting set --- this is what is very likely, and what I believe, to be the true root cause of the odd behavior we've been observing with item use times for a very long time.