### PR TITLE
Call ChooseXBackgroundStyle hooks

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3427,12 +3427,18 @@
  			if (WorldGen.oceanDepths((int)(screenPosition.X + (float)(screenHeight / 2)) / 16, (int)(screenPosition.Y + (float)(screenHeight / 2)) / 16)) {
  				num8 = (player[myPlayer].ZoneCorrupt ? 19 : (player[myPlayer].ZoneCrimson ? 21 : ((!player[myPlayer].ZoneHallow) ? 18 : 20)));
  			}
-@@ -39737,6 +_,10 @@
+@@ -39737,6 +_,16 @@
  			if (SceneMetrics.MushroomTileCount > SceneMetrics.MushroomTileMax)
  				num8 = 2;
  
 +			if (priority >= SceneEffectPriority.BiomeHigh) {
 +				num8 = modBG;
++			}
++
++			if (GlobalBackgroundStyleLoader.loaded) {
++				foreach (var hook in GlobalBackgroundStyleLoader.HookChooseUndergroundBackgroundStyle) {
++					hook(ref num8);
++				}
 +			}
 +
  			if (num8 != undergroundBackground) {
@@ -3877,13 +3883,18 @@
  			else {
  				num = 0;
  				if (num2 >= treeX[0]) {
-@@ -48966,7 +_,6 @@
+@@ -48964,6 +_,12 @@
+ 						num = 11;
+ 					else if (WorldGen.treeBG1 != WorldGen.treeBG4)
  						num = 12;
++				} // Patch context
++			}
++
++			if (GlobalBackgroundStyleLoader.loaded) {
++				foreach (var hook in GlobalBackgroundStyleLoader.HookChooseSurfaceBackgroundStyle) {
++					hook(ref num);
  				}
  			}
--
- 			return num;
- 		}
  
 @@ -49023,6 +_,13 @@
  		}

--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -312,9 +312,13 @@ namespace Terraria.ModLoader
 		internal static readonly IList<GlobalBackgroundStyle> globalBackgroundStyles = new List<GlobalBackgroundStyle>();
 
 		internal static bool loaded = false;
+
+		// Hooks
+
 		internal delegate void DelegateChooseUndergroundBackgroundStyle(ref int style);
-		internal static DelegateChooseUndergroundBackgroundStyle[] HookChooseUndergroundBackgroundStyle;
 		internal delegate void DelegateChooseSurfaceBackgroundStyle(ref int style);
+
+		internal static DelegateChooseUndergroundBackgroundStyle[] HookChooseUndergroundBackgroundStyle;
 		internal static DelegateChooseSurfaceBackgroundStyle[] HookChooseSurfaceBackgroundStyle;
 		internal static Action<int, int[]>[] HookFillUndergroundTextureArray;
 		internal static Action<int, float[], float>[] HookModifyFarSurfaceFades;

--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -312,10 +312,16 @@ namespace Terraria.ModLoader
 		internal static readonly IList<GlobalBackgroundStyle> globalBackgroundStyles = new List<GlobalBackgroundStyle>();
 
 		internal static bool loaded = false;
+		internal delegate void DelegateChooseUndergroundBackgroundStyle(ref int style);
+		internal static DelegateChooseUndergroundBackgroundStyle[] HookChooseUndergroundBackgroundStyle;
+		internal delegate void DelegateChooseSurfaceBackgroundStyle(ref int style);
+		internal static DelegateChooseSurfaceBackgroundStyle[] HookChooseSurfaceBackgroundStyle;
 		internal static Action<int, int[]>[] HookFillUndergroundTextureArray;
 		internal static Action<int, float[], float>[] HookModifyFarSurfaceFades;
 
 		internal static void ResizeAndFillArrays(bool unloading = false) {
+			ModLoader.BuildGlobalHook(ref HookChooseUndergroundBackgroundStyle, globalBackgroundStyles, g => g.ChooseUndergroundBackgroundStyle);
+			ModLoader.BuildGlobalHook(ref HookChooseSurfaceBackgroundStyle, globalBackgroundStyles, g => g.ChooseSurfaceBackgroundStyle);
 			ModLoader.BuildGlobalHook(ref HookFillUndergroundTextureArray, globalBackgroundStyles, g => g.FillUndergroundTextureArray);
 			ModLoader.BuildGlobalHook(ref HookModifyFarSurfaceFades, globalBackgroundStyles, g => g.ModifyFarSurfaceFades);
 


### PR DESCRIPTION
### What is the bug?
`GlobalBackgroundStyle.ChooseUndergroundBackgroundStyle` and `GlobalBackgroundStyle.ChooseSurfaceBackgroundStyle` weren't being called

### How did you fix the bug?
Created a global hook for them and called it

### Are there alternatives to your fix?
maybe