### PR TITLE
[1.4] Fix Error in NPCWasNearPlayerTracker.OnPlayerJoining

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
@@ -1,0 +1,13 @@
+--- src/Terraria/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs
++++ src/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs
+@@ -103,7 +_,9 @@
+ 
+ 		public void OnPlayerJoining(int playerIndex) {
+ 			foreach (string item in _wasNearPlayer) {
+-				int npcNetId = ContentSamples.NpcNetIdsByPersistentIds[item];
++				if (!ContentSamples.NpcNetIdsByPersistentIds.TryGetValue(item, out int npcNetId))
++					continue;
++
+ 				NetManager.Instance.SendToClient(NetBestiaryModule.SerializeSight(npcNetId), playerIndex);
+ 			}
+ 		}


### PR DESCRIPTION
### What is the bug?
When a player joins a server, he sends data about his saved found NPCs in the bestiary using unique string IDs. These can be from mods that are either not present on the server, or the NPCs have been deleted from the mod (so the lookup fails).

### How did you fix the bug?
Add a `TryGetValue` check similar to two other uses of `OnPlayerJoining` in the same context.

### Are there alternatives to your fix?
No, it just adds the same check the other two uses had but this had missing for some reason.
