### PR TITLE
[1.4] Decouple modded bestiary entries from vanilla IO

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCKillsTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCKillsTracker.cs.patch
@@ -9,7 +9,7 @@
  
  		public void Save(BinaryWriter writer) {
  			lock (_killCountsByNpcId) {
-+				var vanillaOnly = _killCountsByNpcId.Where(pair => ContentSamples.NpcNetIdsByPersistentIds[pair.Key] < NPCID.Count);
++				var vanillaOnly = _killCountsByNpcId.Where(pair => ContentSamples.NpcNetIdsByPersistentIds.TryGetValue(pair.Key, out int netId) && netId < NPCID.Count);
 -				writer.Write(_killCountsByNpcId.Count);
 +				writer.Write(vanillaOnly.Count());
 -				foreach (KeyValuePair<string, int> item in _killCountsByNpcId) {

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCKillsTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCKillsTracker.cs.patch
@@ -1,5 +1,22 @@
 --- src/Terraria/Terraria/GameContent/Bestiary/NPCKillsTracker.cs
 +++ src/tModLoader/Terraria/GameContent/Bestiary/NPCKillsTracker.cs
+@@ -1,3 +_,4 @@
++using System.Linq;
+ using System.Collections.Generic;
+ using System.IO;
+ using Terraria.GameContent.NetModules;
+@@ -46,8 +_,9 @@
+ 
+ 		public void Save(BinaryWriter writer) {
+ 			lock (_killCountsByNpcId) {
++				var vanillaOnly = _killCountsByNpcId.Where(pair => ContentSamples.NpcNetIdsByPersistentIds[pair.Key] < NPCID.Count);
+-				writer.Write(_killCountsByNpcId.Count);
++				writer.Write(vanillaOnly.Count());
+-				foreach (KeyValuePair<string, int> item in _killCountsByNpcId) {
++				foreach (KeyValuePair<string, int> item in vanillaOnly) {
+ 					writer.Write(item.Key);
+ 					writer.Write(item.Value);
+ 				}
 @@ -77,7 +_,9 @@
  
  		public void OnPlayerJoining(int playerIndex) {

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs.patch
@@ -1,0 +1,19 @@
+--- src/Terraria/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs
++++ src/tModLoader/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs
+@@ -1,3 +_,4 @@
++using System.Linq;
+ using System.Collections.Generic;
+ using System.IO;
+ using Terraria.GameContent.NetModules;
+@@ -41,8 +_,9 @@
+ 
+ 		public void Save(BinaryWriter writer) {
+ 			lock (_entryCreationLock) {
++				var vanillaOnly = _chattedWithPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds[persistentId] < NPCID.Count);
+-				writer.Write(_chattedWithPlayer.Count);
++				writer.Write(vanillaOnly.Count());
+-				foreach (string item in _chattedWithPlayer) {
++				foreach (string item in vanillaOnly) {
+ 					writer.Write(item);
+ 				}
+ 			}

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasChatWithTracker.cs.patch
@@ -9,7 +9,7 @@
  
  		public void Save(BinaryWriter writer) {
  			lock (_entryCreationLock) {
-+				var vanillaOnly = _chattedWithPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds[persistentId] < NPCID.Count);
++				var vanillaOnly = _chattedWithPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds.TryGetValue(persistentId, out int netId) && netId < NPCID.Count);
 -				writer.Write(_chattedWithPlayer.Count);
 +				writer.Write(vanillaOnly.Count());
 -				foreach (string item in _chattedWithPlayer) {

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
@@ -9,7 +9,7 @@
  
  		public void Save(BinaryWriter writer) {
  			lock (_entryCreationLock) {
-+				var vanillaOnly = _wasNearPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds[persistentId] < NPCID.Count);
++				var vanillaOnly = _wasNearPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds.TryGetValue(persistentId, out int netId) && netId < NPCID.Count);
 -				writer.Write(_wasNearPlayer.Count);
 +				writer.Write(vanillaOnly.Count());
 -				foreach (string item in _wasNearPlayer) {

--- a/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs.patch
@@ -1,5 +1,22 @@
 --- src/Terraria/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs
 +++ src/tModLoader/Terraria/GameContent/Bestiary/NPCWasNearPlayerTracker.cs
+@@ -1,3 +_,4 @@
++using System.Linq;
+ using Microsoft.Xna.Framework;
+ using System.Collections.Generic;
+ using System.IO;
+@@ -49,8 +_,9 @@
+ 
+ 		public void Save(BinaryWriter writer) {
+ 			lock (_entryCreationLock) {
++				var vanillaOnly = _wasNearPlayer.Where(persistentId => ContentSamples.NpcNetIdsByPersistentIds[persistentId] < NPCID.Count);
+-				writer.Write(_wasNearPlayer.Count);
++				writer.Write(vanillaOnly.Count());
+-				foreach (string item in _wasNearPlayer) {
++				foreach (string item in vanillaOnly) {
+ 					writer.Write(item);
+ 				}
+ 			}
 @@ -103,7 +_,9 @@
  
  		public void OnPlayerJoining(int playerIndex) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
@@ -9,18 +9,27 @@ namespace Terraria.ModLoader.Default
 		internal IList<TagCompound> data;
 		internal IList<TagCompound> unloadedNPCs;
 		internal IList<TagCompound> unloadedKillCounts;
+		internal IList<TagCompound> unloadedBestiaryKills;
+		internal IList<TagCompound> unloadedBestiarySights;
+		internal IList<TagCompound> unloadedBestiaryChats;
 
 		public override void OnWorldLoad() {
 			data = new List<TagCompound>();
 			unloadedNPCs = new List<TagCompound>();
 			unloadedKillCounts = new List<TagCompound>();
+			unloadedBestiaryKills = new List<TagCompound>();
+			unloadedBestiarySights = new List<TagCompound>();
+			unloadedBestiaryChats = new List<TagCompound>();
 		}
 
 		public override TagCompound SaveWorldData() {
 			return new TagCompound {
 				["list"] = data,
 				["unloadedNPCs"] = unloadedNPCs,
-				["unloadedKillCounts"] = unloadedKillCounts
+				["unloadedKillCounts"] = unloadedKillCounts,
+				["unloadedBestiaryKills"] = unloadedBestiaryKills,
+				["unloadedBestiarySights"] = unloadedBestiarySights,
+				["unloadedBestiaryChats"] = unloadedBestiaryChats
 			};
 		}
 
@@ -28,6 +37,9 @@ namespace Terraria.ModLoader.Default
 			WorldIO.LoadModData(tag.GetList<TagCompound>("list"));
 			WorldIO.LoadNPCs(tag.GetList<TagCompound>("unloadedNPCs"));
 			WorldIO.LoadNPCKillCounts(tag.GetList<TagCompound>("unloadedKillCounts"));
+			WorldIO.LoadBestiaryNPCKills(tag.GetList<TagCompound>("unloadedBestiaryKills"));
+			WorldIO.LoadBestiaryNPCSights(tag.GetList<TagCompound>("unloadedBestiarySights"));
+			WorldIO.LoadBestiaryNPCChats(tag.GetList<TagCompound>("unloadedBestiaryChats"));
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
@@ -37,9 +37,9 @@ namespace Terraria.ModLoader.Default
 			WorldIO.LoadModData(tag.GetList<TagCompound>("list"));
 			WorldIO.LoadNPCs(tag.GetList<TagCompound>("unloadedNPCs"));
 			WorldIO.LoadNPCKillCounts(tag.GetList<TagCompound>("unloadedKillCounts"));
-			WorldIO.LoadBestiaryNPCKills(tag.GetList<TagCompound>("unloadedBestiaryKills"));
-			WorldIO.LoadBestiaryNPCSights(tag.GetList<TagCompound>("unloadedBestiarySights"));
-			WorldIO.LoadBestiaryNPCChats(tag.GetList<TagCompound>("unloadedBestiaryChats"));
+			WorldIO.LoadNPCBestiaryKills(tag.GetList<TagCompound>("unloadedBestiaryKills"));
+			WorldIO.LoadNPCBestiarySights(tag.GetList<TagCompound>("unloadedBestiarySights"));
+			WorldIO.LoadNPCBestiaryChats(tag.GetList<TagCompound>("unloadedBestiaryChats"));
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -27,9 +27,9 @@ namespace Terraria.ModLoader.IO
 				["npcs"] = SaveNPCs(),
 				["tileEntities"] = TileIO.SaveTileEntities(),
 				["killCounts"] = SaveNPCKillCounts(),
-				["bestiaryKills"] = SaveBestiaryNPCKills(),
-				["bestiarySights"] = SaveBestiaryNPCSights(),
-				["bestiaryChats"] = SaveBestiaryNPCChats(),
+				["bestiaryKills"] = SaveNPCBestiaryKills(),
+				["bestiarySights"] = SaveNPCBestiarySights(),
+				["bestiaryChats"] = SaveNPCBestiaryChats(),
 				["anglerQuest"] = SaveAnglerQuest(),
 				["townManager"] = SaveTownManager(),
 				["modData"] = SaveModData()
@@ -68,9 +68,9 @@ namespace Terraria.ModLoader.IO
 			}
 			LoadChestInventory(tag.GetList<TagCompound>("chests")); // Must occur after tiles are loaded
 			LoadNPCKillCounts(tag.GetList<TagCompound>("killCounts"));
-			LoadBestiaryNPCKills(tag.GetList<TagCompound>("bestiaryKills"));
-			LoadBestiaryNPCSights(tag.GetList<TagCompound>("bestiarySights"));
-			LoadBestiaryNPCChats(tag.GetList<TagCompound>("bestiaryChats"));
+			LoadNPCBestiaryKills(tag.GetList<TagCompound>("bestiaryKills"));
+			LoadNPCBestiarySights(tag.GetList<TagCompound>("bestiarySights"));
+			LoadNPCBestiaryChats(tag.GetList<TagCompound>("bestiaryChats"));
 			LoadAnglerQuest(tag.GetCompound("anglerQuest"));
 			LoadTownManager(tag.GetList<TagCompound>("townManager"));
 			try {
@@ -210,7 +210,7 @@ namespace Terraria.ModLoader.IO
 			}
 		}
 
-		internal static List<TagCompound> SaveBestiaryNPCKills() {
+		internal static List<TagCompound> SaveNPCBestiaryKills() {
 			var list = new List<TagCompound>();
 			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
 				int killCount = Main.BestiaryTracker.Kills.GetKillCount(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
@@ -227,7 +227,7 @@ namespace Terraria.ModLoader.IO
 			return list;
 		}
 
-		internal static void LoadBestiaryNPCKills(IList<TagCompound> list) {
+		internal static void LoadNPCBestiaryKills(IList<TagCompound> list) {
 			foreach (var tag in list) {
 				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
 					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];
@@ -239,7 +239,7 @@ namespace Terraria.ModLoader.IO
 			}
 		}
 
-		internal static List<TagCompound> SaveBestiaryNPCSights() {
+		internal static List<TagCompound> SaveNPCBestiarySights() {
 			var list = new List<TagCompound>();
 			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
 				bool seen = Main.BestiaryTracker.Sights.GetWasNearbyBefore(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
@@ -255,7 +255,7 @@ namespace Terraria.ModLoader.IO
 			return list;
 		}
 
-		internal static void LoadBestiaryNPCSights(IList<TagCompound> list) {
+		internal static void LoadNPCBestiarySights(IList<TagCompound> list) {
 			foreach (var tag in list) {
 				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
 					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];
@@ -267,7 +267,7 @@ namespace Terraria.ModLoader.IO
 			}
 		}
 
-		internal static List<TagCompound> SaveBestiaryNPCChats() {
+		internal static List<TagCompound> SaveNPCBestiaryChats() {
 			var list = new List<TagCompound>();
 			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
 				bool chatted = Main.BestiaryTracker.Chats.GetWasChatWith(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
@@ -283,7 +283,7 @@ namespace Terraria.ModLoader.IO
 			return list;
 		}
 
-		internal static void LoadBestiaryNPCChats(IList<TagCompound> list) {
+		internal static void LoadNPCBestiaryChats(IList<TagCompound> list) {
 			foreach (var tag in list) {
 				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
 					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -27,6 +27,9 @@ namespace Terraria.ModLoader.IO
 				["npcs"] = SaveNPCs(),
 				["tileEntities"] = TileIO.SaveTileEntities(),
 				["killCounts"] = SaveNPCKillCounts(),
+				["bestiaryKills"] = SaveBestiaryNPCKills(),
+				["bestiarySights"] = SaveBestiaryNPCSights(),
+				["bestiaryChats"] = SaveBestiaryNPCChats(),
 				["anglerQuest"] = SaveAnglerQuest(),
 				["townManager"] = SaveTownManager(),
 				["modData"] = SaveModData()
@@ -65,6 +68,9 @@ namespace Terraria.ModLoader.IO
 			}
 			LoadChestInventory(tag.GetList<TagCompound>("chests")); // Must occur after tiles are loaded
 			LoadNPCKillCounts(tag.GetList<TagCompound>("killCounts"));
+			LoadBestiaryNPCKills(tag.GetList<TagCompound>("bestiaryKills"));
+			LoadBestiaryNPCSights(tag.GetList<TagCompound>("bestiarySights"));
+			LoadBestiaryNPCChats(tag.GetList<TagCompound>("bestiaryChats"));
 			LoadAnglerQuest(tag.GetCompound("anglerQuest"));
 			LoadTownManager(tag.GetList<TagCompound>("townManager"));
 			try {
@@ -179,13 +185,15 @@ namespace Terraria.ModLoader.IO
 		internal static List<TagCompound> SaveNPCKillCounts() {
 			var list = new List<TagCompound>();
 			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
-				if (NPC.killCount[type] <= 0)
+				int killCount = NPC.killCount[type];
+				if (killCount <= 0)
 					continue;
 
+				ModNPC modNPC = NPCLoader.GetNPC(type);
 				list.Add(new TagCompound {
-					["mod"] = NPCLoader.GetNPC(type).Mod.Name,
-					["name"] = NPCLoader.GetNPC(type).Name,
-					["count"] = NPC.killCount[type]
+					["mod"] = modNPC.Mod.Name,
+					["name"] = modNPC.Name,
+					["count"] = killCount
 				});
 			}
 			return list;
@@ -198,6 +206,91 @@ namespace Terraria.ModLoader.IO
 				}
 				else {
 					ModContent.GetInstance<UnloadedSystem>().unloadedKillCounts.Add(tag);
+				}
+			}
+		}
+
+		internal static List<TagCompound> SaveBestiaryNPCKills() {
+			var list = new List<TagCompound>();
+			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
+				int killCount = Main.BestiaryTracker.Kills.GetKillCount(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
+				if (killCount <= 0)
+					continue;
+
+				ModNPC modNPC = NPCLoader.GetNPC(type);
+				list.Add(new TagCompound {
+					["mod"] = modNPC.Mod.Name,
+					["name"] = modNPC.Name,
+					["count"] = killCount
+				});
+			}
+			return list;
+		}
+
+		internal static void LoadBestiaryNPCKills(IList<TagCompound> list) {
+			foreach (var tag in list) {
+				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
+					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];
+					Main.BestiaryTracker.Kills.SetKillCountDirectly(persistentId, tag.GetInt("count"));
+				}
+				else {
+					ModContent.GetInstance<UnloadedSystem>().unloadedBestiaryKills.Add(tag);
+				}
+			}
+		}
+
+		internal static List<TagCompound> SaveBestiaryNPCSights() {
+			var list = new List<TagCompound>();
+			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
+				bool seen = Main.BestiaryTracker.Sights.GetWasNearbyBefore(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
+				if (!seen)
+					continue;
+
+				ModNPC modNPC = NPCLoader.GetNPC(type);
+				list.Add(new TagCompound {
+					["mod"] = modNPC.Mod.Name,
+					["name"] = modNPC.Name
+				});
+			}
+			return list;
+		}
+
+		internal static void LoadBestiaryNPCSights(IList<TagCompound> list) {
+			foreach (var tag in list) {
+				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
+					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];
+					Main.BestiaryTracker.Sights.SetWasSeenDirectly(persistentId);
+				}
+				else {
+					ModContent.GetInstance<UnloadedSystem>().unloadedBestiarySights.Add(tag);
+				}
+			}
+		}
+
+		internal static List<TagCompound> SaveBestiaryNPCChats() {
+			var list = new List<TagCompound>();
+			for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++) {
+				bool chatted = Main.BestiaryTracker.Chats.GetWasChatWith(ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[type]);
+				if (!chatted)
+					continue;
+
+				ModNPC modNPC = NPCLoader.GetNPC(type);
+				list.Add(new TagCompound {
+					["mod"] = modNPC.Mod.Name,
+					["name"] = modNPC.Name
+				});
+			}
+			return list;
+		}
+
+		internal static void LoadBestiaryNPCChats(IList<TagCompound> list) {
+			foreach (var tag in list) {
+				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out ModNPC modNpc)) {
+					string persistentId = ContentSamples.NpcBestiaryCreditIdsByNpcNetIds[modNpc.Type];
+					Main.BestiaryTracker.Chats.SetWasChatWithDirectly(persistentId);
+				}
+				else {
+					ModContent.GetInstance<UnloadedSystem>().unloadedBestiaryChats.Add(tag);
 				}
 			}
 		}


### PR DESCRIPTION
### What is the bug?
"Persistent IDs" (internal name for vanilla, `ModType.FullName` for modded) were previously saved to vanilla` .wld` files, causing issues if those worlds contained those and were used in 1.4 vanilla.

### How did you fix the bug?
Prevent modded entries from being saved in the wld files. Worlds used on any previous 1.4 tml builds will still load just fine inside 1.4 tml (except the data is lost).
I mostly used the code already existing for the modded banner kill count IO.

### Are there alternatives to your fix?
Maybe.

