### PR TITLE
[1.4] Fix GlobalItem.Clone in CloneWithModdedDataFrom

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -766,8 +766,8 @@
 +			Item newItem = (Item)MemberwiseClone();
 +
 +			newItem.ModItem = dataSource.ModItem?.Clone(newItem);
-+			newItem.globalItems = globalItems
-+				.Select(g => new Instanced<GlobalItem>(g.index, g.instance?.Clone(this, newItem)))
++			newItem.globalItems = dataSource.globalItems
++				.Select(g => new Instanced<GlobalItem>(g.index, g.instance?.Clone(dataSource, newItem)))
 +				.ToArray();
 +
 +			return newItem;


### PR DESCRIPTION
### Description
`Item.CloneWithModdedDataFrom`, which is used for reforging in the Goblin Tinkerer, uses faulty code for cloning `GlobalItem` data by not utilizing the `dataSource` parameter properly. This causes automatic loss of any global data on the item that is about to be reforged.

The 1.3 counterpart uses it for both access to the correct `globalItems` array aswell as passing it into `GlobalItem.Clone`. This PR adds it back so the usages are the same in 1.3 and 1.4.