### PR TITLE
[1.4] Publicise some vanilla methods

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1322,6 +1322,15 @@
  			chatMonitor.Update();
  			upTimer = (float)sw.Elapsed.TotalMilliseconds;
  			if (upTimerMaxDelay > 0f)
+@@ -13263,7 +_,7 @@
+ 				NPC.crimsonBoss = -1;
+ 		}
+ 
+-		private static bool IsNPCActiveAndOneOfTypes(int npcIndex, params int[] types) {
++		public static bool IsNPCActiveAndOneOfTypes(int npcIndex, params int[] types) {
+ 			if (npcIndex < 0)
+ 				return false;
+ 
 @@ -13404,7 +_,8 @@
  			if (!inputTextEnter || !chatRelease)
  				return;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -151,6 +151,24 @@
  
  			if (spawnparams.sizeScaleOverride.HasValue) {
  				int num2 = (int)((float)width * scale);
+@@ -10473,7 +_,7 @@
+ 			return balance;
+ 		}
+ 
+-		private float GetMyBalance() {
++		public float GetMyBalance() {
+ 			if (statsAreScaledForThisManyPlayers <= 1)
+ 				return 1f;
+ 
+@@ -10481,7 +_,7 @@
+ 			return balance;
+ 		}
+ 
+-		private static int GetActivePlayerCount() {
++		public static int GetActivePlayerCount() {
+ 			if (Main.netMode == 0)
+ 				return 1;
+ 
 @@ -10765,6 +_,7 @@
  					break;
  			}
@@ -554,6 +572,15 @@
  				if (Main.netMode == 2)
  					NetMessage.SendData(7);
  			}
+@@ -58748,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private bool GetWereThereAnyInteractions() {
++		public bool GetWereThereAnyInteractions() {
+ 			bool flag = false;
+ 			if (realLife >= 0)
+ 				return Main.npc[realLife].AnyInteractions();
 @@ -58940,8 +_,10 @@
  					NetMessage.SendData(106, -1, -1, null, (int)position.X, position.Y);
  				}
@@ -715,6 +742,15 @@
  			if (Main.npc[newNPC].type == 1 && Main.player[num7].RollLuck(180) == 0)
  				Main.npc[newNPC].SetDefaults(-4);
  
+@@ -62154,7 +_,7 @@
+ 			return spawnTileType;
+ 		}
+ 
+-		private static bool IsValidSpawningGroundTile(int x, int y) {
++		public static bool IsValidSpawningGroundTile(int x, int y) {
+ 			Tile tile = Main.tile[x, y];
+ 			if (!tile.nactive())
+ 				return false;
 @@ -62894,12 +_,14 @@
  			if (num2 < 0)
  				num2 = 0;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -17,6 +17,15 @@
  	{
  		public static class BuilderAccToggleIDs
  		{
+@@ -169,7 +_,7 @@
+ 			public float spawnRatePowerSliderValue;
+ 		}
+ 
+-		private class RandomTeleportationAttemptSettings
++		public class RandomTeleportationAttemptSettings
+ 		{
+ 			public bool mostlySolidFloor;
+ 			public bool avoidLava;
 @@ -186,15 +_,21 @@
  
  			public static void PlayerConnect(int playerIndex) {
@@ -1623,7 +1632,7 @@
  			int type = currentItem.type;
  			if (currentItem.wingSlot > 0)
  				wings = currentItem.wingSlot;
-@@ -9540,6 +_,8 @@
+@@ -9540,17 +_,23 @@
  				ApplyMusicBox(currentItem);
  
  			UpdateBootVisualEffects(currentItem);
@@ -1631,8 +1640,11 @@
 +			ItemLoader.UpdateVanity(currentItem, this);
  		}
  
- 		private WingStats GetWingStats(int wingID) {
-@@ -9549,8 +_,12 @@
+-		private WingStats GetWingStats(int wingID) {
++		public WingStats GetWingStats(int wingID) {
+ 			if (wingID <= 0 || wingID >= ArmorIDs.Wing.Sets.Stats.Length)
+ 				return default(WingStats);
+ 
  			return ArmorIDs.Wing.Sets.Stats[wingID];
  		}
  
@@ -2159,6 +2171,15 @@
  				for (int i = 0; i < num2; i++) {
  					WorldGen.KillTile_MakeTileDust(point.X, point.Y, tile);
  				}
+@@ -14209,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private int CollideWithNPCs(Rectangle myRect, float Damage, float Knockback, int NPCImmuneTime, int PlayerImmuneTime) {
++		public int CollideWithNPCs(Rectangle myRect, float Damage, float Knockback, int NPCImmuneTime, int PlayerImmuneTime) {
+ 			int num = 0;
+ 			for (int i = 0; i < 200; i++) {
+ 				NPC nPC = Main.npc[i];
 @@ -14293,7 +_,7 @@
  
  					Rectangle rect2 = nPC.getRect();
@@ -2287,6 +2308,15 @@
  			if (Main.tile[num - 1, num2].slope() != 0 || Main.tile[num, num2].slope() != 0 || Main.tile[num + 1, num2].slope() != 0)
  				num3 = -1;
  
+@@ -16475,7 +_,7 @@
+ 			runningOnSand = false;
+ 		}
+ 
+-		private static int GetFloorTileType(int x, int y) {
++		public static int GetFloorTileType(int x, int y) {
+ 			int result = -1;
+ 			if (Main.tile[x - 1, y] == null)
+ 				Main.tile[x - 1, y] = new Tile();
 @@ -16497,7 +_,7 @@
  		}
  
@@ -2596,7 +2626,7 @@
  			luck = GetLadyBugLuck() * 0.2f + torchLuck * 0.2f;
  			luck += (float)(int)luckPotion * 0.1f;
  			if (LanternNight.LanternsUp)
-@@ -19826,6 +_,9 @@
+@@ -19826,9 +_,12 @@
  
  			if (HasGardenGnomeNearby)
  				luck += 0.2f;
@@ -2605,7 +2635,11 @@
 +			PlayerLoader.ModifyLuck(this, ref luck);
  		}
  
- 		private static int GetMouseScrollDelta() => PlayerInput.ScrollWheelDelta / 120;
+-		private static int GetMouseScrollDelta() => PlayerInput.ScrollWheelDelta / 120;
++		public static int GetMouseScrollDelta() => PlayerInput.ScrollWheelDelta / 120;
+ 
+ 		private void UpdatePortableStoolUsage() {
+ 			bool flag = portableStoolInfo.HasAStool && controlUp && !gravControl && !mount.Active && velocity.X == 0f && velocity.Y == 0f && !pulley && grappling[0] == -1;
 @@ -19924,6 +_,8 @@
  
  			if (wingsLogic == 45 && (float)timeSinceLastDashStarted >= 60f)
@@ -2850,6 +2884,15 @@
  		}
  
  		public Color ChatColor() {
+@@ -24337,7 +_,7 @@
+ 				fallStart = (int)position.Y / 16;
+ 		}
+ 
+-		private bool CanAcceptItemIntoInventory(Item item) {
++		public bool CanAcceptItemIntoInventory(Item item) {
+ 			if (preventAllItemPickups)
+ 				return ItemID.Sets.IgnoresEncumberingStone[item.type];
+ 
 @@ -24350,11 +_,22 @@
  				if (!item.active || item.noGrabDelay != 0 || item.playerIndexTheItemIsReservedFor != i || !CanAcceptItemIntoInventory(item))
  					continue;
@@ -3274,6 +3317,15 @@
  						for (int i = 0; i < num2; i++) {
  							WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  						}
+@@ -27924,7 +_,7 @@
+ 			return true;
+ 		}
+ 
+-		private Item GetBestPickaxe() {
++		public Item GetBestPickaxe() {
+ 			Item item = null;
+ 			for (int i = 0; i < 50; i++) {
+ 				if (inventory[i].stack > 0 && inventory[i].pick > 0 && (item == null || inventory[i].pick > item.pick))
 @@ -27977,6 +_,7 @@
  				PlaceThing_Tiles_PlaceIt_AutoPaintAndActuate(typeCaches);
  				if (PlayerInput.UsingGamepad && ItemID.Sets.SingleUseInGamepad[inventory[selectedItem].type] && Main.myPlayer == whoAmI && !Main.SmartCursorEnabled)
@@ -3975,7 +4027,7 @@
  
  				if (projToShoot == 76) {
  					projToShoot += Main.rand.Next(3);
-@@ -33963,6 +_,10 @@
+@@ -33963,12 +_,16 @@
  				}
  			}
  			else if (sItem.useStyle == 5 || sItem.useStyle == 13) {
@@ -3986,6 +4038,13 @@
  				itemRotation = 0f;
  				NetMessage.SendData(41, -1, -1, null, whoAmI);
  			}
+ 		}
+ 
+-		private Vector2 GetFarthestSpawnPositionOnLine(Vector2 startPos, float speedX, float speedY) {
++		public Vector2 GetFarthestSpawnPositionOnLine(Vector2 startPos, float speedX, float speedY) {
+ 			Vector2 pointPoisition = Main.ReverseGravitySupport(Main.MouseScreen) + Main.screenPosition;
+ 			LimitPointToPlayerReachableArea(ref pointPoisition);
+ 			int num = 0;
 @@ -33994,7 +_,7 @@
  			return startPos;
  		}
@@ -4030,7 +4089,7 @@
  			if (isPettingAnimal) {
  				int num = miscCounter % 14 / 7;
  				CompositeArmStretchAmount stretch = CompositeArmStretchAmount.ThreeQuarters;
-@@ -34727,10 +_,12 @@
+@@ -34727,14 +_,16 @@
  				SetCompositeArmBack(enabled: true, stretch6, (float)Math.PI * -3f / 5f * (float)direction);
  				FlipItemLocationAndRotationForGravity();
  			}
@@ -4044,6 +4103,20 @@
  				manaRegenDelay = (int)maxRegenDelay;
  		}
  
+-		private Vector2 GetFrontHandPosition(CompositeArmStretchAmount stretch, float rotation) {
++		public Vector2 GetFrontHandPosition(CompositeArmStretchAmount stretch, float rotation) {
+ 			float num = rotation + (float)Math.PI / 2f;
+ 			Vector2 value = new Vector2((float)Math.Cos(num), (float)Math.Sin(num));
+ 			switch (stretch) {
+@@ -34764,7 +_,7 @@
+ 			return MountedCenter + value;
+ 		}
+ 
+-		private Vector2 GetBackHandPosition(CompositeArmStretchAmount stretch, float rotation) {
++		public Vector2 GetBackHandPosition(CompositeArmStretchAmount stretch, float rotation) {
+ 			float num = rotation + (float)Math.PI / 2f;
+ 			Vector2 value = new Vector2((float)Math.Cos(num), (float)Math.Sin(num));
+ 			switch (stretch) {
 @@ -34791,6 +_,10 @@
  		}
  
@@ -4729,6 +4802,15 @@
  				adjTile[n] = false;
  				oldAdjTile[n] = false;
  			}
+@@ -38479,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings) {
++		public Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings) {
+ 			int num = 0;
+ 			int num2 = 0;
+ 			int num3 = 0;
 @@ -38564,6 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria/PopupText.cs.patch
+++ b/patches/tModLoader/Terraria/PopupText.cs.patch
@@ -50,6 +50,15 @@
  				Main.popupText[num2].name = newItem.AffixName();
  				Main.popupText[num2].stack = stack;
  				Main.popupText[num2].velocity.Y = -7f;
+@@ -291,7 +_,7 @@
+ 			return num;
+ 		}
+ 
+-		private static string ValueToName(int coinValue) {
++		public static string ValueToName(int coinValue) {
+ 			int num = 0;
+ 			int num2 = 0;
+ 			int num3 = 0;
 @@ -398,6 +_,9 @@
  				color = new Color((byte)Main.DiscoR, (byte)Main.DiscoG, (byte)Main.DiscoB, Main.mouseTextColor);
  			else if (master)

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -400,6 +400,15 @@
  			}
  
  			if (true) {
+@@ -10260,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private static void EmitBlackLightningParticles(NPC targetNPC) {
++		public static void EmitBlackLightningParticles(NPC targetNPC) {
+ 			ParticleOrchestrator.RequestParticleSpawn(clientOnly: false, ParticleOrchestraType.BlackLightningHit, new ParticleOrchestraSettings {
+ 				PositionInWorld = targetNPC.Center
+ 			});
 @@ -10391,10 +_,15 @@
  				}
  			}
@@ -545,6 +554,24 @@
  			float num = maxRange;
  			int result = -1;
  			for (int i = 0; i < 200; i++) {
+@@ -30291,7 +_,7 @@
+ 			return (value2 + new Vector2(0f, master.gravDir * -21f) + vector).Floor();
+ 		}
+ 
+-		private void Minion_FindTargetInRange(int startAttackRange, ref int attackTarget, bool skipIfCannotHitWithOwnBody, Func<Entity, int, bool> customEliminationCheck = null) {
++		public void Minion_FindTargetInRange(int startAttackRange, ref int attackTarget, bool skipIfCannotHitWithOwnBody, Func<Entity, int, bool> customEliminationCheck = null) {
+ 			float num = startAttackRange;
+ 			float num2 = num;
+ 			float num3 = num;
+@@ -31430,7 +_,7 @@
+ 			Lighting.AddLight(base.Center, new Vector3(0.5f, 0.1f, 0.1f) * scale);
+ 		}
+ 
+-		private bool IsInRangeOfMeOrMyOwner(Entity entity, float maxDistance, out float myDistance, out float playerDistance, out bool closerIsMe) {
++		public bool IsInRangeOfMeOrMyOwner(Entity entity, float maxDistance, out float myDistance, out float playerDistance, out bool closerIsMe) {
+ 			myDistance = Vector2.Distance(entity.Center, base.Center);
+ 			if (myDistance < maxDistance && !CanHitWithOwnBody(entity))
+ 				myDistance = float.PositiveInfinity;
 @@ -32276,6 +_,9 @@
  					if (num3 > (float)num9)
  						ai[0] = 1f;


### PR DESCRIPTION
### What is the new feature?
Publicise various vanilla methods.

### Why should this be part of tModLoader?
Reduce boilerplate and the need for duplicate methods for modders.

### Are there alternative designs?
No. Either you publicise it or you don't.

### Sample usage for the new feature
List of methods publicided and why. Ones I am not sure about their use yet are marked with a (?).
```
* Main.IsNPCActiveAndOneOfTypes
- Broader version of NPC.AnyNPCs (which is already public)

* NPC.GetMyBalance
- Returns the "bossLifeScale" used in ModNPC.ScaleExpertStats
- Useful for bosses that also change AI-specific things (Golem swings fists faster)

* NPC.GetActivePlayerCount
- Returns the number of active players in the world (used in conjunction with the above method)

* NPC.GetWereThereAnyInteractions
- Worm (shared health pool) friendly way of calling AnyInteractions (which is already public)

* NPC.IsValidSpawningGroundTile
- Checks some properties of the tile at the given location
- Used in NPC spawning, can also be used to manually implement custom NPC spawning on demand, or for non-spawning purposes aswell

* Player.RandomTeleportationAttemptSettings
- Class used to consolidate parameters for the CheckForGoodTeleportationSpot method (see below)

* Player.GetWingStats (?)
- Boilerplate range check for ArmorIDs.Wing.Sets.Stats

* Player.CollideWithNPCs
- Used for custom collisions (mounts mostly)
- Using this, mods can easily parametrize and trigger damage onto NPCs akin to some mounts

* Player.GetFloorTileType
- Returns the tile type the player is standing on
- Used for floor visuals, but can also be used for other things

* Player.GetMouseScrollDelta
- Divides PlayerInput.ScrollWheelDelta by 120, which modders had to do all the time themselves before when dealing with anything scroll wheel related

* Player.CanAcceptItemIntoInventory
- Checks for Encumbering Stone related filters
- Useful for custom item grabbing code

* Player.GetBestPickaxe
- Iterates through the player inventory to find the pickaxe with highest power, and returns it
- Useful for mining mounts or other things that require the pickaxe

* Player.GetFarthestSpawnPositionOnLine
- Used for spawning projectiles directly at a location along a line, taking player range and tile collision into account, instead of having the projectile fly there by itself first
- A good example of this is https://terraria.fandom.com/wiki/Resonance_Scepter

* Player.GetFrontHandPosition and Player.GetBackHandPosition (?, the latter is not used by vanilla)
- Reduces boilerplate checks for composite hand positions

* Player.CheckForGoodTeleportationSpot
- Used by various teleporting tools to determine a suitable location for the player to teleport on
- Suitable for modded teleportation tools

* PopupText.ValueToName
- Converts coin value into a human readable string representation

* Projectile.EmitBlackLightningParticles (?)
- Spawns visuals
- Can be used in projectile AI

* Projectile.Minion_FindTargetInRange
- Used mostly by the newer 1.4 minion AI to reduce boilerplate in target finding

* Projectile.IsInRangeOfMeOrMyOwner
- Used in the above method, can be used separately aswell
```

### ExampleMod updates
Probably, I did not go through every file in the mod yet.

