### PR TITLE
[1.4] Fix patreon wing logic

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ID;
+﻿using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
@@ -50,6 +51,12 @@ namespace Terraria.ModLoader.Default.Patreon
 	[AutoloadEquip(EquipType.Wings)]
 	internal class dinidini_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+		}
+
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -57,10 +64,6 @@ namespace Terraria.ModLoader.Default.Patreon
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
@@ -32,16 +34,18 @@ namespace Terraria.ModLoader.Default.Patreon
 	[AutoloadEquip(EquipType.Wings)]
 	internal class POCKETS_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+		}
+
 		public override void SetDefaults() {
 			base.SetDefaults();
 			Item.vanity = false;
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace Terraria.ModLoader.Default.Patreon
 {
@@ -32,16 +34,18 @@ namespace Terraria.ModLoader.Default.Patreon
 	[AutoloadEquip(EquipType.Wings)]
 	internal class Saethar_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+		}
+
 		public override void SetDefaults() {
 			base.SetDefaults();
 			Item.vanity = false;
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }


### PR DESCRIPTION
### What is the bug?
Patreon wings are not using the new 1.4 feature called `WingStats` which dictates how horizontal wing movement works. Because of this, you have no horizontal acceleration in the air.

### How did you fix the bug?
Add `WingStats` to every wing.

### Are there alternatives to your fix?
No.
