### PR TITLE
[1.4] ExampleSimpleMinion fixes, projectile comment

### DIFF
--- a/ExampleMod/Content/Projectiles/MinionBossEye.cs
+++ b/ExampleMod/Content/Projectiles/MinionBossEye.cs
@@ -37,6 +37,8 @@ namespace ExampleMod.Content.Projectiles
 		}
 
 		public override Color? GetAlpha(Color lightColor) {
+			//When overriding GetAlpha, you usually want to take the projectiles alpha into account. As it is a value between 0 and 255,
+			//it's annoying to convert it into a float to multiply. Luckily the Opacity property handles that for us (0f transparent, 1f opaque)
 			return Color.White * Projectile.Opacity;
 		}
 

--- a/ExampleMod/Content/Projectiles/MinionBossEye.cs
+++ b/ExampleMod/Content/Projectiles/MinionBossEye.cs
@@ -37,7 +37,7 @@ namespace ExampleMod.Content.Projectiles
 		}
 
 		public override Color? GetAlpha(Color lightColor) {
-			return Color.White * (1f - Projectile.alpha / 255f);
+			return Color.White * Projectile.Opacity;
 		}
 
 		private void FadeInAndOut() {
@@ -73,6 +73,7 @@ namespace ExampleMod.Content.Projectiles
 			//Accelerate
 			Projectile.velocity *= 1.01f;
 
+			//If the sprite points upwards, this will make it point towards the move direction (for other sprite orientations, change MathHelper.PiOver2)
 			Projectile.rotation = Projectile.velocity.ToRotation() + MathHelper.PiOver2;
 		}
 	}

--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -58,7 +58,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 			Item.useTime = 36;
 			Item.useAnimation = 36;
 			Item.useStyle = ItemUseStyleID.Swing; // how the player's arm moves when using the item
-			Item.sellPrice(gold: 30);
+			Item.value = Item.sellPrice(gold: 30);
 			Item.rare = ItemRarityID.Cyan;
 			Item.UseSound = SoundID.Item44; // What sound should play when using the item
 
@@ -116,7 +116,8 @@ namespace ExampleMod.Content.Projectiles.Minions
 
 			// These below are needed for a minion weapon
 			Projectile.friendly = true; // Only controls if it deals damage to enemies on contact (more on that later)
-			Projectile.minion = true; // Only determines the damage type								  
+			Projectile.minion = true; // Declares this as a minion (has many effects)
+			Projectile.DamageType = DamageClass.Summon; //Declares the damage type (needed for it to deal damage)
 			Projectile.minionSlots = 1f; // Amount of slots this minion occupies from the total minion slots available to the player (more on that later)
 			Projectile.penetrate = -1; // Needed so the minion doesn't despawn on collision with enemies or tiles
 		}


### PR DESCRIPTION
### What are the changes to ExampleMod?
* Fixes ExampleSimpleMinion not dealing any damage due to the damage class changes in tml 1.4. (missing `DamageType` assignment)
* Fixes its summon item not having any sell value
* Adds comments in MinionBossEye regarding rotation and opacity

### Do these changes need additional documentation?
I provided documentation for them

