### PR TITLE
Fix extracted dll not being copied to references

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
@@ -93,7 +93,7 @@ namespace Terraria.ModLoader.UI
 							src.CopyTo(dst);
 					}
 
-					// Copy the dll to ModLoader\Mod Libraries for easy collaboration.
+					// Copy the dll/xml to ModLoader/Mod Sources/Mod Libraries for easy collaboration.
 					if (name == $"{mod.Name}.dll") {
 						string modReferencesPath = Path.Combine(ModCompile.ModSourcePath, "Mod Libraries");
 						Directory.CreateDirectory(modReferencesPath);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
@@ -94,7 +94,7 @@ namespace Terraria.ModLoader.UI
 					}
 
 					// Copy the dll to ModLoader\references\mods for easy collaboration.
-					if (name == "All.dll" || PlatformUtilities.IsXNA ? name == "Windows.dll" || name == $"{mod.Name}.XNA.dll" : name == "Mono.dll" || name == $"{mod.Name}.FNA.dll") {
+					if (name == "All.dll" || PlatformUtilities.IsXNA ? name == "Windows.dll" || name == $"{mod.Name}.XNA.dll" : name == "Mono.dll" || name == $"{mod.Name}.FNA.dll" || name == $"{mod.Name}.dll") {
 						string modReferencesPath = Path.Combine(Program.SavePath, "references", "mods");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.dll"), true);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
@@ -93,18 +93,18 @@ namespace Terraria.ModLoader.UI
 							src.CopyTo(dst);
 					}
 
-					// Copy the dll to ModLoader\references\mods for easy collaboration.
+					// Copy the dll to ModLoader\Mod Libraries for easy collaboration.
 					if (name == $"{mod.Name}.dll") {
-						string modReferencesPath = Path.Combine(Program.SavePath, "references", "mods");
+						string modReferencesPath = Path.Combine(Program.SavePath, "Mod Libraries");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.dll"), true);
-						log?.WriteLine("You can find this mod's .dll files under ModLoader\\references\\mods for easy mod collaboration!");
+						log?.WriteLine("You can find this mod's .dll files under ModLoader\\Mod Libraries for easy mod collaboration!");
 					}
 					if (name == $"{mod.Name}.xml" && !mod.properties.hideCode) {
-						string modReferencesPath = Path.Combine(Program.SavePath, "references", "mods");
+						string modReferencesPath = Path.Combine(Program.SavePath, "Mod Libraries");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.xml"), true);
-						log?.WriteLine("You can find this mod's documentation .xml file under ModLoader\\references\\mods for easy mod collaboration!");
+						log?.WriteLine("You can find this mod's documentation .xml file under ModLoader\\Mod Libraries for easy mod collaboration!");
 					}
 				};
 				Utils.OpenFolder(dir);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
@@ -94,7 +94,7 @@ namespace Terraria.ModLoader.UI
 					}
 
 					// Copy the dll to ModLoader\references\mods for easy collaboration.
-					if (name == "All.dll" || PlatformUtilities.IsXNA ? name == "Windows.dll" || name == $"{mod.Name}.XNA.dll" : name == "Mono.dll" || name == $"{mod.Name}.FNA.dll" || name == $"{mod.Name}.dll") {
+					if (name == $"{mod.Name}.dll") {
 						string modReferencesPath = Path.Combine(Program.SavePath, "references", "mods");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.dll"), true);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIExtractMod.cs
@@ -95,16 +95,16 @@ namespace Terraria.ModLoader.UI
 
 					// Copy the dll to ModLoader\Mod Libraries for easy collaboration.
 					if (name == $"{mod.Name}.dll") {
-						string modReferencesPath = Path.Combine(Program.SavePath, "Mod Libraries");
+						string modReferencesPath = Path.Combine(ModCompile.ModSourcePath, "Mod Libraries");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.dll"), true);
-						log?.WriteLine("You can find this mod's .dll files under ModLoader\\Mod Libraries for easy mod collaboration!");
+						log?.WriteLine("You can find this mod's .dll files under ModLoader/Mod Sources/Mod Libraries for easy mod collaboration!");
 					}
 					if (name == $"{mod.Name}.xml" && !mod.properties.hideCode) {
-						string modReferencesPath = Path.Combine(Program.SavePath, "Mod Libraries");
+						string modReferencesPath = Path.Combine(ModCompile.ModSourcePath, "Mod Libraries");
 						Directory.CreateDirectory(modReferencesPath);
 						File.Copy(path, Path.Combine(modReferencesPath, $"{mod.Name}_v{mod.modFile.Version}.xml"), true);
-						log?.WriteLine("You can find this mod's documentation .xml file under ModLoader\\Mod Libraries for easy mod collaboration!");
+						log?.WriteLine("You can find this mod's documentation .xml file under ModLoader/Mod Sources/Mod Libraries for easy mod collaboration!");
 					}
 				};
 				Utils.OpenFolder(dir);


### PR DESCRIPTION
### What is the bug?
#1677 
Extracted `.dll`s aren't copied to `references` because it doesn't expect dll files to be named `ModName.dll`

### How did you fix the bug?
Made the extractor know dll files can be named `ModName.dll`

### Are there alternatives to your fix?
Maybe
