### PR TITLE
[1.4] Minion contact damage fix + ExampleMod adjustment

### DIFF
--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -29,7 +29,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 		}
 
 		public override void Update(Player player, ref int buffIndex) {
-			// if the minions exist reset the buff time, otherwise remove the buff from the player.
+			// If the minions exist reset the buff time, otherwise remove the buff from the player
 			if (player.ownedProjectileCounts[ModContent.ProjectileType<ExampleSimpleMinion>()] > 0) {
 				player.buffTime[buffIndex] = 18000;
 			}
@@ -46,7 +46,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 			DisplayName.SetDefault("Example Minion Item");
 			Tooltip.SetDefault("Summons an example minion to fight for you");
 
-			ItemID.Sets.GamepadWholeScreenUseRange[Item.type] = true; // This lets the player target anywhere on the whole screen while using a controller.
+			ItemID.Sets.GamepadWholeScreenUseRange[Item.type] = true; // This lets the player target anywhere on the whole screen while using a controller
 			ItemID.Sets.LockOnIgnoresCollision[Item.type] = true;
 		}
 
@@ -65,24 +65,24 @@ namespace ExampleMod.Content.Projectiles.Minions
 
 			// These below are needed for a minion weapon
 			Item.noMelee = true; // this item doesn't do any melee damage
-			Item.DamageType = DamageClass.Summon; // Makes the damage register as summon. If your item does not have any damage type, it becomes true damage (which means that damage scalars will not affect it). Be sure to have a damage type.
+			Item.DamageType = DamageClass.Summon; // Makes the damage register as summon. If your item does not have any damage type, it becomes true damage (which means that damage scalars will not affect it). Be sure to have a damage type
 			Item.buffType = ModContent.BuffType<ExampleSimpleMinionBuff>();
 			// No buffTime because otherwise the item tooltip would say something like "1 minute duration"
-			Item.shoot = ModContent.ProjectileType<ExampleSimpleMinion>(); // This item creates the minion projectile.
+			Item.shoot = ModContent.ProjectileType<ExampleSimpleMinion>(); // This item creates the minion projectile
 		}
 
 		public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback) {
-			// This is needed so the buff that keeps your minion alive and allows you to despawn it properly applies
-			player.AddBuff(Item.buffType, 2);
-
-			// Here you can change where the minion is spawned. Most vanilla minions spawn at the cursor position.
+			// Here you can change where the minion is spawned. Most vanilla minions spawn at the cursor position
 			position = Main.MouseWorld;
 		}
 
 		public override bool Shoot(Player player, ProjectileSource_Item_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {
-			//Minions have to be spawned manually, then have originalDamage assigned to the damage used to spawn them
+			// This is needed so the buff that keeps your minion alive and allows you to despawn it properly applies
+			player.AddBuff(Item.buffType, 2);
+
+			//Minions have to be spawned manually, then have originalDamage assigned to the damage of the summon item
 			var projectile = Projectile.NewProjectileDirect(source, position, velocity, type, damage, knockback, Main.myPlayer);
-			projectile.originalDamage = damage;
+			projectile.originalDamage = Item.damage;
 
 			//Since we spawned the projectile manually already, we do not need the game to spawn it for ourselves anymore, so return false
 			return false;

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -340,17 +340,17 @@ namespace Terraria.ModLoader
 		private static HookList HookMinionContactDamage = AddHook<Func<Projectile, bool>>(g => g.MinionContactDamage);
 
 		public static bool MinionContactDamage(Projectile projectile) {
-			if (projectile.ModProjectile != null && !projectile.ModProjectile.MinionContactDamage()) {
-				return false;
+			if (projectile.ModProjectile != null && projectile.ModProjectile.MinionContactDamage()) {
+				return true;
 			}
 
 			foreach (GlobalProjectile g in HookMinionContactDamage.Enumerate(projectile.globalProjectiles)) {
-				if (!g.MinionContactDamage(projectile)) {
-					return false;
+				if (g.MinionContactDamage(projectile)) {
+					return true;
 				}
 			}
 
-			return true;
+			return false;
 		}
 
 		private delegate void DelegateModifyDamageHitbox(Projectile projectile, ref Rectangle hitbox);


### PR DESCRIPTION
### What is the bug?
1. Contact damage:
Vanilla minions were always dealing contact damage regardless of custom "idle" conditions (finch staff being the easiest to test, just use any critter summon item and spawn it on your idle finch).
2. ExampleSimpleMinion:
Wrong damage assignment to originalDamage.

### How did you fix the bug?
1.
Reverted [this commit](https://github.com/tModLoader/tModLoader/commit/9406237badaa2be45db74c1ee4c7f78822885a9e) which was operating under a badly placed `MinionContactDamage` hook, which was fixed much later in [this commit](https://github.com/direwolf420/tModLoader/commit/5a7845b0364233e5646ea1302506da41f5af4868).
Now both modded and vanilla minions behave as intended.

2.
May cause it to have different damage, as vanilla directly sets it to Item.damage, whereas this used the possibly modifed damage (that went through hooks like `ModifyWeaponDamage`).

### Are there alternatives to your fix?
Both changes bring it closer in line with vanilla, so no.
