### PR TITLE
ZonePurity variable rename v2

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -118,6 +118,7 @@ namespace Terraria
 		public bool InModBiome(ModBiome baseInstance) => modBiomeFlags[baseInstance.ZeroIndexType];
 
 		/// <summary>
+<<<<<<< Updated upstream
 		/// The zone property storing if the player is in the purity/forest biome. Updated in <see cref="UpdateBiomes"/>
 		/// </summary>
 		public bool ZonePurity { get; set; } = false;
@@ -126,11 +127,65 @@ namespace Terraria
 		/// Calculates whether or not the player is in the purity/forest biome.
 		/// </summary>
 		public bool InZonePurity() {
+=======
+		/// The zone property storing if the player is in a "default" biome regardless of layer, such as the forest or caverns. Updated in <see cref="UpdateBiomes"/>
+		/// </summary>
+		public bool ZonePure { get; set; } = false;
+
+		/// <summary>
+		/// Calculates whether or not the player is in a "default" biome regardless of layer, such as the forest or caverns
+		/// </summary>
+		public bool InZonePure() {
+>>>>>>> Stashed changes
 			bool one = ZoneBeach || ZoneCorrupt || ZoneCrimson || ZoneDesert || ZoneDungeon || ZoneGemCave;
 			bool two = ZoneGlowshroom || ZoneGranite || ZoneGraveyard || ZoneHallow || ZoneHive || ZoneJungle;
 			bool three = ZoneLihzhardTemple || ZoneMarble || ZoneMeteor || ZoneSnow || ZoneUnderworldHeight;
 			bool four = modBiomeFlags.Cast<bool>().Contains(true);
 			return !(one || two || three || four);
 		}
+
+		/// <summary>
+		/// The zone property storing if the player is in the forest biome. Updated in <see cref="UpdateBiomes"/>
+		/// </summary>
+		public bool ZoneForest { get; set; } = false;
+
+		/// <summary>
+		/// Calculates whether or not the player is in the forest biome
+		/// </summary>
+		public bool InZoneForest() {
+
+
+			return ZonePure && !(ZoneSkyHeight || ZoneRockLayerHeight || ZoneDirtLayerHeight);
+		}
+
+		/// <summary>
+		/// The zone property storing if the player is in the default underground layer biome. Updated in <see cref="UpdateBiomes"/>
+		/// </summary>
+		public bool ZoneNormalUnderground { get; set; } = false;
+
+		/// <summary>
+		/// Calculates whether or not the player is in the default underground layer biome
+		/// </summary>
+		public bool InZoneNormalUnderground() {
+
+
+			return ZonePure && ZoneDirtLayerHeight;
+		}
+
+
+		/// <summary>
+		/// The zone property storing if the player is in the default cavern layer biome. Updated in <see cref="UpdateBiomes"/>
+		/// </summary>
+		public bool ZoneNormalCavern { get; set; } = false;
+
+		/// <summary>
+		/// Calculates whether or not the player is in the default cavern layer biome
+		/// </summary>
+		public bool InZoneNormalCavern() {
+
+
+			return ZonePure && ZoneRockLayerHeight;
+		}
+
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1866,11 +1866,19 @@
  			ManageSpecialBiomeVisuals("Stardust", ZoneTowerStardust, value4 - new Vector2(0f, 10f));
  			ManageSpecialBiomeVisuals("Nebula", ZoneTowerNebula, value3 - new Vector2(0f, 10f));
  			ManageSpecialBiomeVisuals("Vortex", ZoneTowerVortex, value2 - new Vector2(0f, 10f));
-@@ -11716,6 +_,8 @@
+@@ -11716,6 +_,12 @@
  				}
  			}
  
+<<<<<<< Updated upstream
 +			ZonePurity = InZonePurity();
+=======
++			ZonePure = InZonePure();
++			ZoneNormalUnderground = InZoneNormalUnderground();
++			ZoneNormalCavern = InZoneNormalCavern();
++
++
+>>>>>>> Stashed changes
 +			LoaderManager.Get<BiomeLoader>().PostUpdateBiome(this);
  			if (!dead) {
  				Point point2 = base.Center.ToTileCoordinates();


### PR DESCRIPTION
Alternative solution for the ZonePurity variable naming inconsistency based on Solxan's input on the previous PR, use THIS one instead of the former:

- instead of ZoneForest the the default biome flag is now named ZonePure and does not account for layers (the pure vs purity distinction was made because Pure implies a more general descriptor whereas Purity implies a specific zone, as ZonePure is now split up into different biome specific flags i went with the former, might be overthinking this a bit)

- ZoneForest is true if both ZonePure is true and the player is in the overworld layer, ZoneNormalUnderground and ZoneNormalCaverns are the same for the underground and cavern layers respectively