### PR TITLE
[1.4] Separate finch nest from head draw code

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -281,21 +281,18 @@
  					item = new DrawData(TextureAssets.AccFace[drawinfo.drawPlayer.faceFlower].Value, helmetOffset + new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect, drawinfo.drawPlayer.bodyFrame, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
  					item.shader = drawinfo.cFaceFlower;
  					drawinfo.DrawDataCache.Add(item);
-@@ -1800,11 +_,13 @@
+@@ -1800,7 +_,11 @@
  					drawinfo.DrawDataCache.Add(item);
  				}
  			}
 +		}
  
 +		public static void DrawPlayer_21_2_FinchNest(ref PlayerDrawSet drawinfo) {
++			DrawData item;
++			
  			if (drawinfo.drawPlayer.babyBird) {
  				Rectangle bodyFrame5 = drawinfo.drawPlayer.bodyFrame;
  				bodyFrame5.Y = 0;
--				item = new DrawData(TextureAssets.Extra[100].Value, new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect + Main.OffsetsPlayerHeadgear[drawinfo.drawPlayer.bodyFrame.Y / drawinfo.drawPlayer.bodyFrame.Height] * drawinfo.drawPlayer.gravDir, bodyFrame5, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
-+				DrawData item = new DrawData(TextureAssets.Extra[100].Value, new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect + Main.OffsetsPlayerHeadgear[drawinfo.drawPlayer.bodyFrame.Y / drawinfo.drawPlayer.bodyFrame.Height] * drawinfo.drawPlayer.gravDir, bodyFrame5, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
- 				drawinfo.DrawDataCache.Add(item);
- 			}
- 		}
 @@ -1856,7 +_,7 @@
  		private static void DrawPlayer_21_Head_TheFace(ref PlayerDrawSet drawinfo) {
  			bool flag = drawinfo.drawPlayer.head == 38 || drawinfo.drawPlayer.head == 135 || drawinfo.drawPlayer.head == 269;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -281,6 +281,21 @@
  					item = new DrawData(TextureAssets.AccFace[drawinfo.drawPlayer.faceFlower].Value, helmetOffset + new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect, drawinfo.drawPlayer.bodyFrame, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
  					item.shader = drawinfo.cFaceFlower;
  					drawinfo.DrawDataCache.Add(item);
+@@ -1800,11 +_,13 @@
+ 					drawinfo.DrawDataCache.Add(item);
+ 				}
+ 			}
++		}
+ 
++		public static void DrawPlayer_21_2_FinchNest(ref PlayerDrawSet drawinfo) {
+ 			if (drawinfo.drawPlayer.babyBird) {
+ 				Rectangle bodyFrame5 = drawinfo.drawPlayer.bodyFrame;
+ 				bodyFrame5.Y = 0;
+-				item = new DrawData(TextureAssets.Extra[100].Value, new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect + Main.OffsetsPlayerHeadgear[drawinfo.drawPlayer.bodyFrame.Y / drawinfo.drawPlayer.bodyFrame.Height] * drawinfo.drawPlayer.gravDir, bodyFrame5, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
++				DrawData item = new DrawData(TextureAssets.Extra[100].Value, new Vector2((int)(drawinfo.Position.X - Main.screenPosition.X - (float)(drawinfo.drawPlayer.bodyFrame.Width / 2) + (float)(drawinfo.drawPlayer.width / 2)), (int)(drawinfo.Position.Y - Main.screenPosition.Y + (float)drawinfo.drawPlayer.height - (float)drawinfo.drawPlayer.bodyFrame.Height + 4f)) + drawinfo.drawPlayer.headPosition + drawinfo.headVect + Main.OffsetsPlayerHeadgear[drawinfo.drawPlayer.bodyFrame.Y / drawinfo.drawPlayer.bodyFrame.Height] * drawinfo.drawPlayer.gravDir, bodyFrame5, drawinfo.colorArmorHead, drawinfo.drawPlayer.headRotation, drawinfo.headVect, 1f, drawinfo.playerEffect, 0);
+ 				drawinfo.DrawDataCache.Add(item);
+ 			}
+ 		}
 @@ -1856,7 +_,7 @@
  		private static void DrawPlayer_21_Head_TheFace(ref PlayerDrawSet drawinfo) {
  			bool flag = drawinfo.drawPlayer.head == 38 || drawinfo.drawPlayer.head == 135 || drawinfo.drawPlayer.head == 269;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
@@ -98,6 +98,9 @@ namespace Terraria.DataStructures
 		/// <summary> Draws the player's head, including hair, armor, and etc. </summary>
 		public static readonly PlayerDrawLayer Head = new VanillaPlayerDrawLayer(nameof(Head), DrawPlayer_21_Head, TorsoGroup, isHeadLayer: true);
 
+		/// <summary> Draws a finch nest on the player's head, if the player has a finch summoned. </summary>
+		public static readonly PlayerDrawLayer FinchNest = new VanillaPlayerDrawLayer(nameof(FinchNest), DrawPlayer_21_2_FinchNest, TorsoGroup, isHeadLayer: true);
+
 		/// <summary> Draws the player's face accessory. </summary>
 		public static readonly PlayerDrawLayer FaceAcc = new VanillaPlayerDrawLayer(nameof(FaceAcc), DrawPlayer_22_FaceAcc, TorsoGroup);
 
@@ -190,6 +193,7 @@ namespace Terraria.DataStructures
 			WaistAcc,
 			NeckAcc,
 			Head,
+			FinchNest,
 			FaceAcc,
 			MountFront,
 			Pulley,


### PR DESCRIPTION
### What is the new feature?
Adds a new layer called `FinchNest`, as previously its code was at the very end of the `Head` layer.

### Why should this be part of tModLoader?
The finch nest draws over all vanilla head draws, but the current tml implementation only allows either drawing before or after the Head layer. In the latter case, any draws will also draw over that nest. Splitting the code up into its own layer lets modders insert things between the head and finch nest draw code.

Before PR:
![before](https://user-images.githubusercontent.com/15894498/128612578-1936b817-d88f-4981-84b6-edc1fdbc66b4.png)

After PR:
![after](https://user-images.githubusercontent.com/15894498/128612584-6deea28d-2a91-4f0b-9c3c-0b5c60b5cd97.png)


### Are there alternative designs?
This implementation is in line with many special vanilla draws that have their own layer. The same can be applied to the finch nest.

### Sample usage for the new feature
Special visuals or glowmasks on helmets which reach over the area the finch nest covers up.

### ExampleMod updates
None
