### PR TITLE
[1.4] make PlayerDrawLayerSlot reset children properly

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
@@ -65,7 +65,7 @@ namespace Terraria.ModLoader
 		/// <summary> Returns the layer's default position in regards to other layers. Make use of e.g <see cref="BeforeParent"/>/<see cref="AfterParent"/>, and provide a layer (usually a vanilla one from <see cref="PlayerDrawLayers"/>). </summary>
 		public abstract Position GetDefaultPosition();
 
-		protected internal virtual void ResetVisiblity(PlayerDrawSet drawInfo) {
+		internal void ResetVisiblity(PlayerDrawSet drawInfo) {
 			foreach (var child in ChildrenBefore)
 				child.ResetVisiblity(drawInfo);
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
@@ -62,9 +62,10 @@ namespace Terraria.ModLoader
 		/// <returns> Whether or not this layer will be visible by default. Modders can hide layers later, if needed.</returns>
 		public virtual bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => true;
 
+		/// <summary> Returns the layer's default position in regards to other layers. Make use of e.g <see cref="BeforeParent"/>/<see cref="AfterParent"/>, and provide a layer (usually a vanilla one from <see cref="PlayerDrawLayers"/>). </summary>
 		public abstract Position GetDefaultPosition();
 
-		internal void ResetVisiblity(PlayerDrawSet drawInfo) {
+		protected internal virtual void ResetVisiblity(PlayerDrawSet drawInfo) {
 			foreach (var child in ChildrenBefore)
 				child.ResetVisiblity(drawInfo);
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
@@ -17,21 +17,12 @@ namespace Terraria.ModLoader
 			Layer = layer;
 			Condition = cond;
 			_slot = slot;
+			AddChildAfter(Layer);
 		}
 
 		public override Position GetDefaultPosition() => throw new NotImplementedException();
 
-		protected override void Draw(ref PlayerDrawSet drawInfo) => Layer.DrawWithTransformationAndChildren(ref drawInfo);
-
-		protected internal override void ResetVisiblity(PlayerDrawSet drawInfo) {
-			foreach (var child in Layer.ChildrenBefore)
-				child.ResetVisiblity(drawInfo);
-
-			base.ResetVisiblity(drawInfo);
-
-			foreach (var child in Layer.ChildrenAfter)
-				child.ResetVisiblity(drawInfo);
-		}
+		protected override void Draw(ref PlayerDrawSet drawInfo) { }
 
 		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => Condition(drawInfo);
 	}

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
@@ -23,6 +23,16 @@ namespace Terraria.ModLoader
 
 		protected override void Draw(ref PlayerDrawSet drawInfo) => Layer.DrawWithTransformationAndChildren(ref drawInfo);
 
+		protected internal override void ResetVisiblity(PlayerDrawSet drawInfo) {
+			foreach (var child in Layer.ChildrenBefore)
+				child.ResetVisiblity(drawInfo);
+
+			base.ResetVisiblity(drawInfo);
+
+			foreach (var child in Layer.ChildrenAfter)
+				child.ResetVisiblity(drawInfo);
+		}
+
 		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => Condition(drawInfo);
 	}
 }


### PR DESCRIPTION
### What is the bug?
`PlayerDrawLayer`s which attach to the vanilla FrontAccFront or HeldItem layers do not get their visibility reset properly, which leads to `GetDefaultVisiblity` never being called on them.

### How did you fix the bug?
`PlayerDrawLayerSlot` (which handles the aforementioned vanilla layers) has a `Layer` property, before it was drawn manually. Now it is added as a child so that the regular update/draw code can handle it.

### Are there alternatives to your fix?
Make `ResetVisiblity` overridable and handle the `Layer`s children from `PlayerDrawLayerSlot` manually.

### Bonus
* Added docs to `GetDefaultPosition` with common usage example.
* Noticed typos in `ResetVisiblity` and `GetDefaultVisiblity`: missing "i" :pensive: 
