### PR TITLE
[1.4] API breaking: rename PlayerDrawLayer.GetDefaultVisiblity

### DIFF
--- a/ExampleMod/Common/ExamplePlayerDrawLayer.cs
+++ b/ExampleMod/Common/ExamplePlayerDrawLayer.cs
@@ -15,7 +15,7 @@ namespace ExampleMod.Common
 		//Returning true in this property makes this layer appear on the minimap player head icon.
 		public override bool IsHeadLayer => true;
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) {
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo) {
 			//The layer will be visible only if the player is holding an ExampleItem in their hands. Or if another modder forces this layer to be visible.
 			return drawInfo.drawPlayer.HeldItem?.type == ModContent.ItemType<ExampleItem>();
 

--- a/patches/tModLoader/Terraria/DataStructures/VanillaPlayerDrawLayer.cs
+++ b/patches/tModLoader/Terraria/DataStructures/VanillaPlayerDrawLayer.cs
@@ -34,7 +34,7 @@ namespace Terraria.DataStructures
 			_isHeadLayer = isHeadLayer;
 		}
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => condition?.Invoke(drawInfo) ?? true;
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo) => condition?.Invoke(drawInfo) ?? true;
 
 		public override Position GetDefaultPosition() {
 			if (position != null)

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenArmorDrawLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenArmorDrawLayer.cs
@@ -10,7 +10,7 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 
 		public abstract DrawDataInfo GetData(PlayerDrawSet info);
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) {
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo) {
 			var player = drawInfo.drawPlayer;
 
 			return drawInfo.shadow == 0f && !player.invis && player.GetModPlayer<JofairdenArmorEffectPlayer>().LayerStrength > 0f;

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenBodyShader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenBodyShader.cs
@@ -8,8 +8,8 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 	{
 		private static Asset<Texture2D> _shaderTexture;
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo)
-			=> drawInfo.drawPlayer.body == ModContent.GetInstance<Jofairden_Body>().Item.bodySlot && base.GetDefaultVisiblity(drawInfo);
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo)
+			=> drawInfo.drawPlayer.body == ModContent.GetInstance<Jofairden_Body>().Item.bodySlot && base.GetDefaultVisibility(drawInfo);
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
 			_shaderTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.Jofairden_Body_Body_Shader");

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenHeadGlow.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenHeadGlow.cs
@@ -10,8 +10,8 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 
 		public override bool IsHeadLayer => true;
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo)
-			=> drawInfo.drawPlayer.head == ModContent.GetInstance<Jofairden_Head>().Item.headSlot && base.GetDefaultVisiblity(drawInfo);
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo)
+			=> drawInfo.drawPlayer.head == ModContent.GetInstance<Jofairden_Head>().Item.headSlot && base.GetDefaultVisibility(drawInfo);
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
 			_glowTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.Jofairden_Head_Head_Glow");

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenLegsGlow.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/Layers/JofairdenLegsGlow.cs
@@ -8,8 +8,8 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 	{
 		private static Asset<Texture2D> _glowTexture;
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo)
-			=> drawInfo.drawPlayer.legs == ModContent.GetInstance<Jofairden_Legs>().Item.legSlot && base.GetDefaultVisiblity(drawInfo);
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo)
+			=> drawInfo.drawPlayer.legs == ModContent.GetInstance<Jofairden_Legs>().Item.legSlot && base.GetDefaultVisibility(drawInfo);
 
 		public override DrawDataInfo GetData(PlayerDrawSet info) {
 			_glowTexture ??= ModContent.Request<Texture2D>("ModLoader/Developer.Jofairden.Jofairden_Legs_Legs_Glow");

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -741,7 +741,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to modify the visiblity of layers about to be drawn
+		/// Allows you to modify the visibility of layers about to be drawn
 		/// </summary>
 		/// <param name="layers"></param>
 		public virtual void HideDrawLayers(PlayerDrawSet drawInfo) {

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayer.cs
@@ -60,19 +60,19 @@ namespace Terraria.ModLoader
 
 		/// <summary> Returns the layer's default visibility. This is usually called as a layer is queued for drawing, but modders can call it too for information. </summary>
 		/// <returns> Whether or not this layer will be visible by default. Modders can hide layers later, if needed.</returns>
-		public virtual bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => true;
+		public virtual bool GetDefaultVisibility(PlayerDrawSet drawInfo) => true;
 
 		/// <summary> Returns the layer's default position in regards to other layers. Make use of e.g <see cref="BeforeParent"/>/<see cref="AfterParent"/>, and provide a layer (usually a vanilla one from <see cref="PlayerDrawLayers"/>). </summary>
 		public abstract Position GetDefaultPosition();
 
-		internal void ResetVisiblity(PlayerDrawSet drawInfo) {
+		internal void ResetVisibility(PlayerDrawSet drawInfo) {
 			foreach (var child in ChildrenBefore)
-				child.ResetVisiblity(drawInfo);
+				child.ResetVisibility(drawInfo);
 
-			Visible = GetDefaultVisiblity(drawInfo);
+			Visible = GetDefaultVisibility(drawInfo);
 
 			foreach (var child in ChildrenAfter)
-				child.ResetVisiblity(drawInfo);
+				child.ResetVisibility(drawInfo);
 		}
 
 		/// <summary> Draws this layer. </summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerLoader.cs
@@ -65,7 +65,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static PlayerDrawLayer[] GetDrawLayers(PlayerDrawSet drawInfo) {
 			foreach (var layer in _drawOrder) {
-				layer.ResetVisiblity(drawInfo);
+				layer.ResetVisibility(drawInfo);
 			}
 
 			PlayerLoader.HideDrawLayers(drawInfo);

--- a/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerDrawLayerSlot.cs
@@ -24,6 +24,6 @@ namespace Terraria.ModLoader
 
 		protected override void Draw(ref PlayerDrawSet drawInfo) { }
 
-		public override bool GetDefaultVisiblity(PlayerDrawSet drawInfo) => Condition(drawInfo);
+		public override bool GetDefaultVisibility(PlayerDrawSet drawInfo) => Condition(drawInfo);
 	}
 }


### PR DESCRIPTION
`PlayerDrawLayer.GetDefaultVisiblity` and `ResetVisiblity` had typos which this PR fixes. The former fix is API breaking.

