### PR TITLE
[1.4] Fix player research saving

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPlayer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Terraria.ModLoader.IO;
 
@@ -8,17 +7,24 @@ namespace Terraria.ModLoader.Default
 	public class UnloadedPlayer : ModPlayer
 	{
 		internal IList<TagCompound> data;
+		internal IList<TagCompound> unloadedResearch;
 
 		public override void Initialize() {
 			data = new List<TagCompound>();
+			unloadedResearch = new List<TagCompound>();
 		}
 
 		public override TagCompound Save() {
-			return new TagCompound { ["list"] = data };
+			return new TagCompound
+			{
+				["list"] = data,
+				["unloadedResearch"] = unloadedResearch
+			};
 		}
 
 		public override void Load(TagCompound tag) {
 			PlayerIO.LoadModData(Player, tag.GetList<TagCompound>("list"));
+			PlayerIO.LoadResearch(Player, tag.GetList<TagCompound>("unloadedResearch"));
 		}
 
 		public override IEnumerable<Item> AddStartingItems(bool mediumCoreDeath) {

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -101,14 +101,14 @@ namespace Terraria.ModLoader.IO
 
 		public static List<TagCompound> SaveResearch(Player player) {
 			var list = new List<TagCompound>();
-			Dictionary<string, int> dictionary = new Dictionary<string, int>(player.creativeTracker.ItemSacrifices._sacrificeCountByItemPersistentId);
-			foreach (KeyValuePair<string, int> item in dictionary) {
-				ContentSamples.ItemNetIdsByPersistentIds.TryGetValue(item.Key, out int netID);
-				ContentSamples.ItemsByType.TryGetValue(netID, out Item realItem);
-				if (ItemLoader.NeedsModSaving(realItem)) {
+			var dictionary = new Dictionary<int, int>(player.creativeTracker.ItemSacrifices.SacrificesCountByItemIdCache);
+			foreach (var item in dictionary) {
+				ModItem modItem = ItemLoader.GetItem(item.Key);
+				if (modItem != null) {
 					TagCompound tag = new TagCompound {
-						["sacrificeCount"] = item.Value,
-						["persistentID"] = item.Key
+						["mod"] = modItem.Mod.Name,
+						["name"] = modItem.Name,
+						["sacrificeCount"] = item.Value
 					};
 					list.Add(tag);
 				}
@@ -118,12 +118,23 @@ namespace Terraria.ModLoader.IO
 
 		public static void LoadResearch(Player player, IList<TagCompound> list) {
 			foreach (var tag in list) {
-				ContentSamples.ItemNetIdsByPersistentIds.TryGetValue(tag.GetString("persistentID"), out int netID);
-				ContentSamples.ItemsByType.TryGetValue(netID, out Item realItem);
-				if (ItemLoader.NeedsModSaving(realItem)) {
-					player.creativeTracker.ItemSacrifices._sacrificeCountByItemPersistentId[tag.GetString("persistentID")] = tag.GetInt("sacrificeCount");
-					if (ContentSamples.ItemNetIdsByPersistentIds.TryGetValue(tag.GetString("persistentID"), out int value2))
-						player.creativeTracker.ItemSacrifices.SacrificesCountByItemIdCache[value2] = tag.GetInt("sacrificeCount");
+				if (tag.ContainsKey("persistentID"))
+					continue; //Discard tags from previous insufficient implementation pre-alpha so they are not carried over to unloadedResearch
+
+				string modName = tag.GetString("mod");
+				string modItemName = tag.GetString("name");
+
+				if (ModContent.TryFind(modName, modItemName, out ModItem modItem)) {
+					int netId = modItem.Type;
+					string persistentId = ContentSamples.ItemPersistentIdsByNetIds[netId];
+
+					int sacrificeCount = tag.GetInt("sacrificeCount");
+					var itemSacrifices = player.creativeTracker.ItemSacrifices;
+					itemSacrifices._sacrificeCountByItemPersistentId[persistentId] = sacrificeCount;
+					itemSacrifices.SacrificesCountByItemIdCache[netId] = sacrificeCount;
+				}
+				else {
+					player.GetModPlayer<UnloadedPlayer>().unloadedResearch.Add(tag);
 				}
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -118,8 +118,8 @@ namespace Terraria.ModLoader.IO
 
 		public static void LoadResearch(Player player, IList<TagCompound> list) {
 			foreach (var tag in list) {
-				if (tag.ContainsKey("persistentID"))
-					continue; //Discard tags from previous insufficient implementation pre-alpha so they are not carried over to unloadedResearch
+				if (!tag.ContainsKey("mod") || !tag.ContainsKey("name"))
+					continue; // Discard tags from previous insufficient implementation pre-alpha so they are not carried over to unloadedResearch
 
 				string modName = tag.GetString("mod");
 				string modItemName = tag.GetString("name");


### PR DESCRIPTION
### What is the bug?
#1659, #1672
Research data was using `persistentId` to save modded content, which is incompatible with how modded data is usually saved.

### How did you fix the bug?
To preserve research state for unloaded mods/items, it now saves using mod/name pairs to handle safe retrieval.

### Are there alternatives to your fix?
This brings it in line with other saving (such as unloaded `ModPlayer` data, or unloaded kill counts).

I also included a check to not carry over the old data pre-PR that was on the player regarding `persistentId` to not keep it as baggage in `unloadedResearch`. Please tell me if I should remove it again.

```cs
if (tag.ContainsKey("persistentID"))
    continue;
```
