### PR TITLE
[1.4] Fix horizontal acceleration for patreon wings, cleaner indexing

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Dinidini.cs
@@ -20,7 +20,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Body.Sets.HidesTopSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Body)] = true;
+			ArmorIDs.Body.Sets.HidesTopSkin[Item.bodySlot] = true;
 		}
 
 		public override void SetDefaults() {
@@ -37,7 +37,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Legs.Sets.OverridesLegs[Mod.GetEquipSlot(GetType().Name, EquipType.Legs)] = true;
+			ArmorIDs.Legs.Sets.OverridesLegs[Item.legSlot] = true;
 		}
 
 		public override void SetDefaults() {
@@ -54,7 +54,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Glory.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Glory.cs
@@ -29,7 +29,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Legs.Sets.OverridesLegs[Mod.GetEquipSlot(GetType().Name, EquipType.Legs)] = true;
+			ArmorIDs.Legs.Sets.OverridesLegs[Item.legSlot] = true;
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/POCKETS.cs
@@ -37,7 +37,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Polyblank.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Polyblank.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Body.Sets.HidesTopSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Body)] = true;
+			ArmorIDs.Body.Sets.HidesTopSkin[Item.bodySlot] = true;
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Remeus.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Remeus.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Body.Sets.HidesTopSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Body)] = true;
+			ArmorIDs.Body.Sets.HidesTopSkin[Item.bodySlot] = true;
 		}
 
 		public override void SetDefaults() {
@@ -35,7 +35,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Legs.Sets.HidesBottomSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Legs)] = true;
+			ArmorIDs.Legs.Sets.HidesBottomSkin[Item.legSlot] = true;
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Saethar.cs
@@ -37,7 +37,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Wing.Sets.Stats[Mod.GetEquipSlot(GetType().Name, EquipType.Wings)] = new WingStats(150);
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/toplayz.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/toplayz.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Body.Sets.HidesTopSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Body)] = true;
+			ArmorIDs.Body.Sets.HidesTopSkin[Item.bodySlot] = true;
 		}
 
 		public override void SetDefaults() {
@@ -36,7 +36,7 @@ namespace Terraria.ModLoader.Default.Patreon
 		public override void SetStaticDefaults() {
 			base.SetStaticDefaults();
 
-			ArmorIDs.Legs.Sets.HidesBottomSkin[Mod.GetEquipSlot(GetType().Name, EquipType.Legs)] = true;
+			ArmorIDs.Legs.Sets.HidesBottomSkin[Item.legSlot] = true;
 		}
 
 		public override void SetDefaults() {


### PR DESCRIPTION
### What is the bug?
Patreon wings were slightly slower than regular developer wings.

### How did you fix the bug?
Increased their speed from default (-1f which translates to 6f in most cases) to 7f, which now matches the code vanilla uses for them.

### Are there alternatives to your fix?
No
