### PR TITLE
[1.4] Modded town NPC move in fix

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
@@ -1,5 +1,10 @@
 --- src/Terraria/Terraria/GameContent/UI/EmoteBubble.cs
 +++ src/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs
+@@ -1,3 +_,4 @@
++using Terraria.ModLoader;
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Graphics;
+ using System;
 @@ -9,7 +_,7 @@
  {
  	public class EmoteBubble
@@ -9,3 +14,21 @@
  		public static Dictionary<int, EmoteBubble> byID = new Dictionary<int, EmoteBubble>();
  		private static List<int> toClean = new List<int>();
  		public static int NextID;
+@@ -337,7 +_,7 @@
+ 		}
+ 
+ 		private void ProbeTownNPCs(List<int> list) {
+-			for (int i = 0; i < 668; i++) {
++			for (int i = 0; i < NPCLoader.NPCCount; i++) {
+ 				CountNPCs[i] = 0;
+ 			}
+ 
+@@ -347,7 +_,7 @@
+ 			}
+ 
+ 			int type = ((NPC)anchor.entity).type;
+-			for (int k = 0; k < 668; k++) {
++			for (int k = 0; k < NPCLoader.NPCCount; k++) {
+ 				if (NPCID.Sets.FaceEmote[k] > 0 && CountNPCs[k] > 0 && k != type)
+ 					list.Add(NPCID.Sets.FaceEmote[k]);
+ 			}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -31,6 +31,15 @@
  
  		public static UnifiedRandom genRand {
  			get {
+@@ -1215,7 +_,7 @@
+ 				}
+ 			}
+ 
+-			for (int j = 0; j < 668; j++) {
++			for (int j = 0; j < NPCLoader.NPCCount; j++) {
+ 				if (!Main.townNPCCanSpawn[j] || !CheckSpecialTownNPCSpawningConditions(j))
+ 					continue;
+ 
 @@ -1255,7 +_,7 @@
  			}
  


### PR DESCRIPTION
### What is the bug?
Modded town NPCs would never move in.

### How did you fix the bug?
Extend the vanilla NPCID.Count to NPCLoader.NPCCount where it actually checks for `Main.townNPCCanSpawn`.
As a bonus, applied the fix to some emote interactions.

### Are there alternatives to your fix?
No
