### PR TITLE
[1.4] [DRAFT] ModAchievement

### DIFF
--- a/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
@@ -1,0 +1,18 @@
+﻿using Terraria.Localization;
+
+namespace Terraria.Achievements
+{
+	partial class Achievement
+	{
+		// Override this so we can set it manually.
+		public override string Name { get; }
+
+		// Always globally saved.
+		public override AchievementType SaveType => AchievementType.Global;
+
+		// Override these to replace them with the expected vanilla translations.
+		public override LocalizedText FriendlyName => Language.GetText("Achievements." + Name + "_Name");
+
+		public override LocalizedText Description => Language.GetText("Achievements." + Name + "_Description");
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
@@ -13,9 +13,9 @@ namespace Terraria.Achievements
 		public override AchievementType SaveType => AchievementType.Global;
 
 		// Override these to replace them with the expected vanilla translations.
-		public override LocalizedText FriendlyName => Language.GetText("Achievements." + Name + "_Name");
+		public override string FriendlyName => Language.GetTextValue("Achievements." + Name + "_Name");
 
-		public override LocalizedText Description => Language.GetText("Achievements." + Name + "_Description");
+		public override string Description => Language.GetTextValue("Achievements." + Name + "_Description");
 
 		public override string Texture => VanillaTextureIndicator;
 	}

--- a/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.TML.cs
@@ -4,6 +4,8 @@ namespace Terraria.Achievements
 {
 	partial class Achievement
 	{
+		public const string VanillaTextureIndicator = "vanilla";
+
 		// Override this so we can set it manually.
 		public override string Name { get; }
 
@@ -14,5 +16,7 @@ namespace Terraria.Achievements
 		public override LocalizedText FriendlyName => Language.GetText("Achievements." + Name + "_Name");
 
 		public override LocalizedText Description => Language.GetText("Achievements." + Name + "_Description");
+
+		public override string Texture => VanillaTextureIndicator;
 	}
 }

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Achievements/Achievement.cs
 +++ src/tModLoader/Terraria/Achievements/Achievement.cs
-@@ -2,53 +_,55 @@
+@@ -2,74 +_,76 @@
  using Newtonsoft.Json.Linq;
  using System.Collections.Generic;
  using Terraria.Localization;
@@ -24,6 +24,8 @@
 -		public readonly int Id = _totalAchievements++;
 -		private AchievementCategory _category;
 -		private IAchievementTracker _tracker;
+-		[JsonProperty("Conditions")]
+-		private Dictionary<string, AchievementCondition> _conditions = new Dictionary<string, AchievementCondition>();
 +		// private static int _totalAchievements; // See Id field for explanation.
 +		// public readonly string Name; // We use IModType.Name instead. (See: Achievement.TML.cs)
 +		// public readonly LocalizedText FriendlyName; // These are properties in IAchievement.
@@ -31,8 +33,8 @@
 +		// public readonly int Id = _totalAchievements++; // No need for IDs, we can compare by Name now!
 +		// private AchievementCategory _category;
 +		// private IAchievementTracker _tracker;
- 		[JsonProperty("Conditions")]
- 		private Dictionary<string, AchievementCondition> _conditions = new Dictionary<string, AchievementCondition>();
++		//[JsonProperty("Conditions")]
++		//private Dictionary<string, AchievementCondition> _conditions = new Dictionary<string, AchievementCondition>();
  		private int _completedCount;
  
 -		public AchievementCategory Category => _category;
@@ -42,7 +44,7 @@
 +		// public bool HasTracker => _tracker != null;
  
 -		public bool IsCompleted => _completedCount == _conditions.Count;
-+		public override bool IsCompleted => _completedCount == _conditions.Count;
++		public override bool IsCompleted => _completedCount == Conditions.Count;
  
 -		public event AchievementCompleted OnCompleted;
 +		// public event AchievementCompleted OnCompleted;
@@ -62,7 +64,8 @@
 -		public void ClearProgress() {
 +		public override void ClearProgress() {
  			_completedCount = 0;
- 			foreach (KeyValuePair<string, AchievementCondition> condition in _conditions) {
+-			foreach (KeyValuePair<string, AchievementCondition> condition in _conditions) {
++			foreach (KeyValuePair<string, AchievementCondition> condition in Conditions) {
  				condition.Value.Clear();
  			}
  
@@ -75,9 +78,11 @@
 -		public void Load(Dictionary<string, JObject> conditions) {
 +		public override void Load(Dictionary<string, JObject> conditions) {
  			foreach (KeyValuePair<string, JObject> condition in conditions) {
- 				if (_conditions.TryGetValue(condition.Key, out AchievementCondition value)) {
+-				if (_conditions.TryGetValue(condition.Key, out AchievementCondition value)) {
++				if (Conditions.TryGetValue(condition.Key, out AchievementCondition value)) {
  					value.Load(condition.Value);
-@@ -57,11 +_,11 @@
+ 					if (value.IsCompleted)
+ 						_completedCount++;
  				}
  			}
  
@@ -89,13 +94,15 @@
  
 -		public void AddCondition(AchievementCondition condition) {
 +		public override void AddCondition(AchievementCondition condition) {
- 			_conditions[condition.Name] = condition;
+-			_conditions[condition.Name] = condition;
++			Conditions[condition.Name] = condition;
  			condition.OnComplete += OnConditionComplete;
  		}
-@@ -69,7 +_,7 @@
+ 
  		private void OnConditionComplete(AchievementCondition condition) {
  			_completedCount++;
- 			if (_completedCount == _conditions.Count) {
+-			if (_completedCount == _conditions.Count) {
++			if (_completedCount == Conditions.Count) {
 -				if (_tracker == null && SocialAPI.Achievements != null)
 +				if (Tracker == null && SocialAPI.Achievements != null)
  					SocialAPI.Achievements.CompleteAchievement(Name);
@@ -110,7 +117,23 @@
  		}
  
  		public void UseTrackerFromCondition(string conditionName) {
-@@ -104,9 +_,9 @@
+@@ -88,7 +_,7 @@
+ 
+ 		public void UseConditionsCompletedTracker() {
+ 			ConditionsCompletedTracker conditionsCompletedTracker = new ConditionsCompletedTracker();
+-			foreach (KeyValuePair<string, AchievementCondition> condition in _conditions) {
++			foreach (KeyValuePair<string, AchievementCondition> condition in Conditions) {
+ 				conditionsCompletedTracker.AddCondition(condition.Value);
+ 			}
+ 
+@@ -98,17 +_,17 @@
+ 		public void UseConditionsCompletedTracker(params string[] conditions) {
+ 			ConditionsCompletedTracker conditionsCompletedTracker = new ConditionsCompletedTracker();
+ 			foreach (string key in conditions) {
+-				conditionsCompletedTracker.AddCondition(_conditions[key]);
++				conditionsCompletedTracker.AddCondition(Conditions[key]);
+ 			}
+ 
  			UseTracker(conditionsCompletedTracker);
  		}
  
@@ -120,15 +143,19 @@
 -		}
 +		}*/
  
- 		private IAchievementTracker GetConditionTracker(string name) => _conditions[name].GetAchievementTracker();
+-		private IAchievementTracker GetConditionTracker(string name) => _conditions[name].GetAchievementTracker();
++		private IAchievementTracker GetConditionTracker(string name) => Conditions[name].GetAchievementTracker();
  
+ 		public void AddConditions(params AchievementCondition[] conditions) {
+ 			for (int i = 0; i < conditions.Length; i++) {
 @@ -116,15 +_,15 @@
  			}
  		}
  
 -		public AchievementCondition GetCondition(string conditionName) {
 +		public override AchievementCondition GetCondition(string conditionName) {
- 			if (_conditions.TryGetValue(conditionName, out AchievementCondition value))
+-			if (_conditions.TryGetValue(conditionName, out AchievementCondition value))
++			if (Conditions.TryGetValue(conditionName, out AchievementCondition value))
  				return value;
  
  			return null;

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Achievements/Achievement.cs
 +++ src/tModLoader/Terraria/Achievements/Achievement.cs
-@@ -2,27 +_,29 @@
+@@ -2,53 +_,55 @@
  using Newtonsoft.Json.Linq;
  using System.Collections.Generic;
  using Terraria.Localization;
@@ -22,13 +22,14 @@
 -		public readonly LocalizedText Description;
 -		public readonly int Id = _totalAchievements++;
 -		private AchievementCategory _category;
+-		private IAchievementTracker _tracker;
 +		// private static int _totalAchievements; // See Id field for explanation.
 +		// public readonly string Name; // We use IModType.Name instead. (See: Achievement.TML.cs)
 +		// public readonly LocalizedText FriendlyName; // These are properties in IAchievement.
 +		// public readonly LocalizedText Description; // We override them in Achievement.TML.cs to use the proper localization.
 +		// public readonly int Id = _totalAchievements++; // No need for IDs, we can compare by Name now!
 +		// private AchievementCategory _category;
- 		private IAchievementTracker _tracker;
++		// private IAchievementTracker _tracker;
  		[JsonProperty("Conditions")]
  		private Dictionary<string, AchievementCondition> _conditions = new Dictionary<string, AchievementCondition>();
  		private int _completedCount;
@@ -36,9 +37,16 @@
 -		public AchievementCategory Category => _category;
 +		// public AchievementCategory Category => _category;
  
- 		public bool HasTracker => _tracker != null;
+-		public bool HasTracker => _tracker != null;
++		// public bool HasTracker => _tracker != null;
  
-@@ -34,8 +_,8 @@
+-		public bool IsCompleted => _completedCount == _conditions.Count;
++		public override bool IsCompleted => _completedCount == _conditions.Count;
+ 
+ 		public event AchievementCompleted OnCompleted;
+ 
+-		public IAchievementTracker GetTracker() => _tracker;
++		// public IAchievementTracker GetTracker() => _tracker;
  
  		public Achievement(string name) {
  			Name = name;
@@ -48,8 +56,78 @@
 +			// Description = Language.GetText("Achievements." + name + "_Description");
  		}
  
- 		public void ClearProgress() {
-@@ -123,8 +_,8 @@
+-		public void ClearProgress() {
++		public override void ClearProgress() {
+ 			_completedCount = 0;
+ 			foreach (KeyValuePair<string, AchievementCondition> condition in _conditions) {
+ 				condition.Value.Clear();
+ 			}
+ 
+-			if (_tracker != null)
++			if (Tracker != null)
+-				_tracker.Clear();
++				Tracker.Clear();
+ 		}
+ 
+-		public void Load(Dictionary<string, JObject> conditions) {
++		public override void Load(Dictionary<string, JObject> conditions) {
+ 			foreach (KeyValuePair<string, JObject> condition in conditions) {
+ 				if (_conditions.TryGetValue(condition.Key, out AchievementCondition value)) {
+ 					value.Load(condition.Value);
+@@ -57,11 +_,11 @@
+ 				}
+ 			}
+ 
+-			if (_tracker != null)
++			if (Tracker != null)
+-				_tracker.Load();
++				Tracker.Load();
+ 		}
+ 
+-		public void AddCondition(AchievementCondition condition) {
++		public override void AddCondition(AchievementCondition condition) {
+ 			_conditions[condition.Name] = condition;
+ 			condition.OnComplete += OnConditionComplete;
+ 		}
+@@ -69,7 +_,7 @@
+ 		private void OnConditionComplete(AchievementCondition condition) {
+ 			_completedCount++;
+ 			if (_completedCount == _conditions.Count) {
+-				if (_tracker == null && SocialAPI.Achievements != null)
++				if (Tracker == null && SocialAPI.Achievements != null)
+ 					SocialAPI.Achievements.CompleteAchievement(Name);
+ 
+ 				if (this.OnCompleted != null)
+@@ -79,7 +_,7 @@
+ 
+ 		private void UseTracker(IAchievementTracker tracker) {
+ 			tracker.ReportAs("STAT_" + Name);
+-			_tracker = tracker;
++			Tracker = tracker;
+ 		}
+ 
+ 		public void UseTrackerFromCondition(string conditionName) {
+@@ -104,9 +_,9 @@
+ 			UseTracker(conditionsCompletedTracker);
+ 		}
+ 
+-		public void ClearTracker() {
++		/*public void ClearTracker() {
+ 			_tracker = null;
+-		}
++		}*/
+ 
+ 		private IAchievementTracker GetConditionTracker(string name) => _conditions[name].GetAchievementTracker();
+ 
+@@ -116,15 +_,15 @@
+ 			}
+ 		}
+ 
+-		public AchievementCondition GetCondition(string conditionName) {
++		public override AchievementCondition GetCondition(string conditionName) {
+ 			if (_conditions.TryGetValue(conditionName, out AchievementCondition value))
+ 				return value;
+ 
  			return null;
  		}
  

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -93,9 +93,9 @@
  		}
  
 -		public void AddCondition(AchievementCondition condition) {
-+		public override void AddCondition(AchievementCondition condition) {
 -			_conditions[condition.Name] = condition;
-+			Conditions[condition.Name] = condition;
++		public override void AddCondition(AchievementCondition condition) {
++			base.AddCondition(condition); // Conditions[condition.Name] = condition;
  			condition.OnComplete += OnConditionComplete;
  		}
  
@@ -153,13 +153,14 @@
  		}
  
 -		public AchievementCondition GetCondition(string conditionName) {
-+		public override AchievementCondition GetCondition(string conditionName) {
++		/*public override AchievementCondition GetCondition(string conditionName) {
 -			if (_conditions.TryGetValue(conditionName, out AchievementCondition value))
 +			if (Conditions.TryGetValue(conditionName, out AchievementCondition value))
  				return value;
  
  			return null;
- 		}
+-		}
++		}*/
  
 -		public void SetCategory(AchievementCategory category) {
 -			_category = category;

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -1,0 +1,62 @@
+--- src/Terraria/Terraria/Achievements/Achievement.cs
++++ src/tModLoader/Terraria/Achievements/Achievement.cs
+@@ -2,27 +_,29 @@
+ using Newtonsoft.Json.Linq;
+ using System.Collections.Generic;
+ using Terraria.Localization;
++using Terraria.ModLoader;
+ using Terraria.Social;
+ 
+ namespace Terraria.Achievements
+ {
+ 	[JsonObject(MemberSerialization.OptIn)]
+-	public class Achievement
++	[Autoload(false)]
++	public sealed partial class Achievement : ModAchievement
+ 	{
+ 		public delegate void AchievementCompleted(Achievement achievement);
+ 
+-		private static int _totalAchievements;
+-		public readonly string Name;
+-		public readonly LocalizedText FriendlyName;
+-		public readonly LocalizedText Description;
+-		public readonly int Id = _totalAchievements++;
+-		private AchievementCategory _category;
++		// private static int _totalAchievements; // See Id field for explanation.
++		// public readonly string Name; // We use IModType.Name instead. (See: Achievement.TML.cs)
++		// public readonly LocalizedText FriendlyName; // These are properties in IAchievement.
++		// public readonly LocalizedText Description; // We override them in Achievement.TML.cs to use the proper localization.
++		// public readonly int Id = _totalAchievements++; // No need for IDs, we can compare by Name now!
++		// private AchievementCategory _category;
+ 		private IAchievementTracker _tracker;
+ 		[JsonProperty("Conditions")]
+ 		private Dictionary<string, AchievementCondition> _conditions = new Dictionary<string, AchievementCondition>();
+ 		private int _completedCount;
+ 
+-		public AchievementCategory Category => _category;
++		// public AchievementCategory Category => _category;
+ 
+ 		public bool HasTracker => _tracker != null;
+ 
+@@ -34,8 +_,8 @@
+ 
+ 		public Achievement(string name) {
+ 			Name = name;
+-			FriendlyName = Language.GetText("Achievements." + name + "_Name");
++			// FriendlyName = Language.GetText("Achievements." + name + "_Name");
+-			Description = Language.GetText("Achievements." + name + "_Description");
++			// Description = Language.GetText("Achievements." + name + "_Description");
+ 		}
+ 
+ 		public void ClearProgress() {
+@@ -123,8 +_,8 @@
+ 			return null;
+ 		}
+ 
+-		public void SetCategory(AchievementCategory category) {
+-			_category = category;
++		internal void SetCategory(AchievementCategory category) { // Keep for vanilla compatibility
++			Category = category;
+ 		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -14,7 +14,8 @@
 +	[Autoload(false)]
 +	public sealed partial class Achievement : ModAchievement
  	{
- 		public delegate void AchievementCompleted(Achievement achievement);
+-		public delegate void AchievementCompleted(Achievement achievement);
++		public delegate void AchievementCompleted(IAchievement achievement);
  
 -		private static int _totalAchievements;
 -		public readonly string Name;
@@ -43,7 +44,8 @@
 -		public bool IsCompleted => _completedCount == _conditions.Count;
 +		public override bool IsCompleted => _completedCount == _conditions.Count;
  
- 		public event AchievementCompleted OnCompleted;
+-		public event AchievementCompleted OnCompleted;
++		// public event AchievementCompleted OnCompleted;
  
 -		public IAchievementTracker GetTracker() => _tracker;
 +		// public IAchievementTracker GetTracker() => _tracker;
@@ -134,8 +136,9 @@
  
 -		public void SetCategory(AchievementCategory category) {
 -			_category = category;
-+		internal void SetCategory(AchievementCategory category) { // Keep for vanilla compatibility
+-		}
++		/*internal void SetCategory(AchievementCategory category) {
 +			Category = category;
- 		}
++		}*/
  	}
  }

--- a/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/Achievement.cs.patch
@@ -48,7 +48,8 @@
 -		public IAchievementTracker GetTracker() => _tracker;
 +		// public IAchievementTracker GetTracker() => _tracker;
  
- 		public Achievement(string name) {
+-		public Achievement(string name) {
++		internal Achievement(string name) {
  			Name = name;
 -			FriendlyName = Language.GetText("Achievements." + name + "_Name");
 +			// FriendlyName = Language.GetText("Achievements." + name + "_Name");

--- a/patches/tModLoader/Terraria/Achievements/AchievementCondition.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementCondition.cs.patch
@@ -7,12 +7,3 @@
  
  namespace Terraria.Achievements
  {
-@@ -30,6 +_,8 @@
- 		}
- 
- 		public virtual void Complete() {
-+			if (Steam.IsSteamApp) return;
-+
- 			if (!_isCompleted) {
- 				_isCompleted = true;
- 				if (this.OnComplete != null)

--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -9,3 +9,78 @@
  using Terraria.Social;
  using Terraria.UI;
  using Terraria.Utilities;
+@@ -23,7 +_,7 @@
+ 
+ 		private string _savePath;
+ 		private bool _isCloudSave;
+-		private Dictionary<string, Achievement> _achievements = new Dictionary<string, Achievement>();
++		private Dictionary<string, IAchievement> _achievements = new Dictionary<string, IAchievement>();
+ 		private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings();
+ 		private byte[] _cryptoKey;
+ 		private Dictionary<string, int> _achievementIconIndexes = new Dictionary<string, int>();
+@@ -73,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		public List<Achievement> CreateAchievementsList() => _achievements.Values.ToList();
++		public List<IAchievement> CreateAchievementsList() => _achievements.Values.ToList();
+ 
+ 		public void Load() {
+ 			Load(_savePath, _isCloudSave);
+@@ -110,7 +_,7 @@
+ 				}
+ 
+ 				if (SocialAPI.Achievements != null) {
+-					foreach (KeyValuePair<string, Achievement> achievement in _achievements) {
++					foreach (KeyValuePair<string, IAchievement> achievement in _achievements) {
+ 						if (achievement.Value.IsCompleted && !SocialAPI.Achievements.IsAchievementCompleted(achievement.Key)) {
+ 							flag = true;
+ 							achievement.Value.ClearProgress();
+@@ -127,20 +_,20 @@
+ 			if (SocialAPI.Achievements != null)
+ 				return;
+ 
+-			foreach (KeyValuePair<string, Achievement> achievement in _achievements) {
++			foreach (KeyValuePair<string, IAchievement> achievement in _achievements) {
+ 				achievement.Value.ClearProgress();
+ 			}
+ 
+ 			Save();
+ 		}
+ 
+-		private void AchievementCompleted(Achievement achievement) {
++		private void AchievementCompleted(IAchievement achievement) {
+ 			Save();
+ 			if (this.OnAchievementCompleted != null)
+ 				this.OnAchievementCompleted(achievement);
+ 		}
+ 
+-		public void Register(Achievement achievement) {
++		public void Register(IAchievement achievement) {
+ 			_achievements.Add(achievement.Name, achievement);
+ 			achievement.OnCompleted += AchievementCompleted;
+ 		}
+@@ -150,11 +_,11 @@
+ 		}
+ 
+ 		public void RegisterAchievementCategory(string achievementName, AchievementCategory category) {
+-			_achievements[achievementName].SetCategory(category);
++			_achievements[achievementName].Category = category;
+ 		}
+ 
+-		public Achievement GetAchievement(string achievementName) {
++		public IAchievement GetAchievement(string achievementName) {
+-			if (_achievements.TryGetValue(achievementName, out Achievement value))
++			if (_achievements.TryGetValue(achievementName, out IAchievement value))
+ 				return value;
+ 
+ 			return null;
+@@ -163,7 +_,7 @@
+ 		public T GetCondition<T>(string achievementName, string conditionName) where T : AchievementCondition => GetCondition(achievementName, conditionName) as T;
+ 
+ 		public AchievementCondition GetCondition(string achievementName, string conditionName) {
+-			if (_achievements.TryGetValue(achievementName, out Achievement value))
++			if (_achievements.TryGetValue(achievementName, out IAchievement value))
+ 				return value.GetCondition(conditionName);
+ 
+ 			return null;

--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -1,10 +1,11 @@
 --- src/Terraria/Terraria/Achievements/AchievementManager.cs
 +++ src/tModLoader/Terraria/Achievements/AchievementManager.cs
-@@ -7,6 +_,8 @@
+@@ -7,6 +_,9 @@
  using System.Linq;
  using System.Security.Cryptography;
  using System.Text;
 +using Steamworks;
++using Terraria.ModLoader;
 +using Terraria.ModLoader.Engine;
  using Terraria.Social;
  using Terraria.UI;
@@ -14,35 +15,95 @@
  		private string _savePath;
  		private bool _isCloudSave;
 -		private Dictionary<string, Achievement> _achievements = new Dictionary<string, Achievement>();
-+		private Dictionary<string, IAchievement> _achievements = new Dictionary<string, IAchievement>();
++		private Dictionary<string, Dictionary<string, IAchievement>> _achievements = new Dictionary<string, Dictionary<string, IAchievement>>();
  		private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings();
  		private byte[] _cryptoKey;
  		private Dictionary<string, int> _achievementIconIndexes = new Dictionary<string, int>();
+@@ -56,15 +_,15 @@
+ 					SocialAPI.Achievements.StoreStats();
+ 
+ 				try {
+-					using (MemoryStream memoryStream = new MemoryStream()) {
++					using (StreamWriter memoryStream = new StreamWriter(path)) {
+-						using (CryptoStream cryptoStream = new CryptoStream(memoryStream, new RijndaelManaged().CreateEncryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Write)) {
++						//using (CryptoStream cryptoStream = new CryptoStream(memoryStream, new RijndaelManaged().CreateEncryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Write)) {
+-							using (BsonWriter bsonWriter = new BsonWriter(cryptoStream)) {
++							using (JsonWriter bsonWriter = new JsonTextWriter(memoryStream)) {
+ 								JsonSerializer.Create(_serializerSettings).Serialize(bsonWriter, _achievements);
+-								bsonWriter.Flush();
++								// bsonWriter.Flush();
+-								cryptoStream.FlushFinalBlock();
++								// cryptoStream.FlushFinalBlock();
+-								FileUtilities.WriteAllBytes(path, memoryStream.ToArray(), cloud);
++								// FileUtilities.WriteAllBytes(path, memoryStream.ToArray(), cloud);
+ 							}
+-						}
++						//}
+ 					}
+ 				}
+ 				catch (Exception exception) {
 @@ -73,7 +_,7 @@
  			}
  		}
  
 -		public List<Achievement> CreateAchievementsList() => _achievements.Values.ToList();
-+		public List<IAchievement> CreateAchievementsList() => _achievements.Values.ToList();
++		public List<IAchievement> CreateAchievementsList() => _achievements.Values.SelectMany(modGroup => modGroup.Values).ToList();
  
  		public void Load() {
  			Load(_savePath, _isCloudSave);
-@@ -110,7 +_,7 @@
+@@ -86,12 +_,12 @@
+ 					return;
+ 
+ 				byte[] buffer = FileUtilities.ReadAllBytes(path, cloud);
+-				Dictionary<string, StoredAchievement> dictionary = null;
++				Dictionary<string, Dictionary<string, StoredAchievement>> dictionary = null;
+ 				try {
+ 					using (MemoryStream stream = new MemoryStream(buffer)) {
+ 						using (CryptoStream stream2 = new CryptoStream(stream, new RijndaelManaged().CreateDecryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Read)) {
+ 							using (BsonReader reader = new BsonReader(stream2)) {
+-								dictionary = JsonSerializer.Create(_serializerSettings).Deserialize<Dictionary<string, StoredAchievement>>(reader);
++								dictionary = JsonSerializer.Create(_serializerSettings).Deserialize<Dictionary<string, Dictionary<string, StoredAchievement>>>(reader);
+ 							}
+ 						}
+ 					}
+@@ -103,20 +_,23 @@
+ 
+ 				if (dictionary == null)
+ 					return;
++				foreach (string mod in dictionary.Keys) {
++				if (!_achievements.ContainsKey(mod))
+-
++					continue;
+-				foreach (KeyValuePair<string, StoredAchievement> item in dictionary) {
++				foreach (KeyValuePair<string, StoredAchievement> item in dictionary[mod]) {
+-					if (_achievements.ContainsKey(item.Key))
++					if (_achievements[mod].ContainsKey(item.Key))
+-						_achievements[item.Key].Load(item.Value.Conditions);
++						_achievements[mod][item.Key].Load(item.Value.Conditions);
  				}
  
  				if (SocialAPI.Achievements != null) {
 -					foreach (KeyValuePair<string, Achievement> achievement in _achievements) {
-+					foreach (KeyValuePair<string, IAchievement> achievement in _achievements) {
++					foreach (KeyValuePair<string, IAchievement> achievement in _achievements[mod]) {
  						if (achievement.Value.IsCompleted && !SocialAPI.Achievements.IsAchievementCompleted(achievement.Key)) {
  							flag = true;
  							achievement.Value.ClearProgress();
-@@ -127,20 +_,20 @@
+ 						}
+ 					}
+ 				}
++				}
+ 			}
+ 
+ 			if (flag)
+@@ -127,21 +_,34 @@
  			if (SocialAPI.Achievements != null)
  				return;
  
 -			foreach (KeyValuePair<string, Achievement> achievement in _achievements) {
-+			foreach (KeyValuePair<string, IAchievement> achievement in _achievements) {
- 				achievement.Value.ClearProgress();
+-				achievement.Value.ClearProgress();
++			foreach (Dictionary<string, IAchievement> achievements in _achievements.Values) {
++				foreach (IAchievement achievement in achievements.Values)
++					achievement.ClearProgress();
  			}
  
  			Save();
@@ -56,31 +117,61 @@
  		}
  
 -		public void Register(Achievement achievement) {
-+		public void Register(IAchievement achievement) {
- 			_achievements.Add(achievement.Name, achievement);
+-			_achievements.Add(achievement.Name, achievement);
++		internal void Register(IAchievement achievement) {
++			if (achievement.Mod is null) {
++				if (!_achievements.ContainsKey("Terraria"))
++					_achievements.Add("Terraria", new Dictionary<string, IAchievement>());
++
++				_achievements["Terraria"].Add(achievement.Name, achievement);
++			}
++			else {
++				if (!_achievements.ContainsKey(achievement.Name))
++					_achievements.Add(achievement.Mod.Name, new Dictionary<string, IAchievement>());
++
++				_achievements[achievement.Name].Add(achievement.Name, achievement);
++			}
++			// _achievements.Add(achievement.Name, achievement);
  			achievement.OnCompleted += AchievementCompleted;
  		}
-@@ -150,11 +_,11 @@
+ 
+@@ -149,22 +_,32 @@
+ 			_achievementIconIndexes.Add(achievementName, iconIndex);
  		}
  
- 		public void RegisterAchievementCategory(string achievementName, AchievementCategory category) {
+-		public void RegisterAchievementCategory(string achievementName, AchievementCategory category) {
 -			_achievements[achievementName].SetCategory(category);
-+			_achievements[achievementName].Category = category;
++		internal void RegisterAchievementCategory(string achievementName, AchievementCategory category) {
++			if (!_achievements.ContainsKey("Terraria")) 
++				return;
++			_achievements["Terraria"][achievementName].Category = category;
  		}
  
 -		public Achievement GetAchievement(string achievementName) {
-+		public IAchievement GetAchievement(string achievementName) {
 -			if (_achievements.TryGetValue(achievementName, out Achievement value))
-+			if (_achievements.TryGetValue(achievementName, out IAchievement value))
++		public IAchievement GetAchievement(string achievementName, Mod mod = null) {
++			if (mod is null && _achievements.ContainsKey("Terraria") && _achievements["Terraria"].TryGetValue(achievementName, out IAchievement value))
  				return value;
  
++			if (mod is not null && _achievements.ContainsKey(mod.Name) && _achievements[mod.Name].TryGetValue(achievementName, out IAchievement modValue))
++				return modValue;
++			/*if (_achievements.TryGetValue(achievementName, out IAchievement value))
++					return value;*/
++
  			return null;
-@@ -163,7 +_,7 @@
- 		public T GetCondition<T>(string achievementName, string conditionName) where T : AchievementCondition => GetCondition(achievementName, conditionName) as T;
+ 		}
  
- 		public AchievementCondition GetCondition(string achievementName, string conditionName) {
+-		public T GetCondition<T>(string achievementName, string conditionName) where T : AchievementCondition => GetCondition(achievementName, conditionName) as T;
++		public T GetCondition<T>(string achievementName, string conditionName, Mod mod = null) where T : AchievementCondition => GetCondition(achievementName, conditionName, mod) as T;
+ 
+-		public AchievementCondition GetCondition(string achievementName, string conditionName) {
 -			if (_achievements.TryGetValue(achievementName, out Achievement value))
-+			if (_achievements.TryGetValue(achievementName, out IAchievement value))
++		public AchievementCondition GetCondition(string achievementName, string conditionName, Mod mod = null) {
++			if (mod is null && _achievements.ContainsKey("Terraria") && _achievements["Terraria"].TryGetValue(achievementName, out IAchievement value))
  				return value.GetCondition(conditionName);
++
++			if (mod is not null && _achievements.ContainsKey(mod.Name) && _achievements[mod.Name].TryGetValue(achievementName, out IAchievement modValue))
++				return modValue.GetCondition(conditionName);
  
  			return null;
+ 		}

--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -19,23 +19,19 @@
  		private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings();
  		private byte[] _cryptoKey;
  		private Dictionary<string, int> _achievementIconIndexes = new Dictionary<string, int>();
-@@ -56,15 +_,15 @@
- 					SocialAPI.Achievements.StoreStats();
+@@ -57,14 +_,14 @@
  
  				try {
--					using (MemoryStream memoryStream = new MemoryStream()) {
-+					using (StreamWriter memoryStream = new StreamWriter(path)) {
+ 					using (MemoryStream memoryStream = new MemoryStream()) {
 -						using (CryptoStream cryptoStream = new CryptoStream(memoryStream, new RijndaelManaged().CreateEncryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Write)) {
 +						//using (CryptoStream cryptoStream = new CryptoStream(memoryStream, new RijndaelManaged().CreateEncryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Write)) {
 -							using (BsonWriter bsonWriter = new BsonWriter(cryptoStream)) {
-+							using (JsonWriter bsonWriter = new JsonTextWriter(memoryStream)) {
++							using (BsonWriter bsonWriter = new BsonWriter(memoryStream)) {
  								JsonSerializer.Create(_serializerSettings).Serialize(bsonWriter, _achievements);
--								bsonWriter.Flush();
-+								// bsonWriter.Flush();
+ 								bsonWriter.Flush();
 -								cryptoStream.FlushFinalBlock();
 +								// cryptoStream.FlushFinalBlock();
--								FileUtilities.WriteAllBytes(path, memoryStream.ToArray(), cloud);
-+								// FileUtilities.WriteAllBytes(path, memoryStream.ToArray(), cloud);
+ 								FileUtilities.WriteAllBytes(path, memoryStream.ToArray(), cloud);
  							}
 -						}
 +						//}
@@ -51,7 +47,7 @@
  
  		public void Load() {
  			Load(_savePath, _isCloudSave);
-@@ -86,12 +_,12 @@
+@@ -86,14 +_,14 @@
  					return;
  
  				byte[] buffer = FileUtilities.ReadAllBytes(path, cloud);
@@ -59,13 +55,18 @@
 +				Dictionary<string, Dictionary<string, StoredAchievement>> dictionary = null;
  				try {
  					using (MemoryStream stream = new MemoryStream(buffer)) {
- 						using (CryptoStream stream2 = new CryptoStream(stream, new RijndaelManaged().CreateDecryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Read)) {
- 							using (BsonReader reader = new BsonReader(stream2)) {
+-						using (CryptoStream stream2 = new CryptoStream(stream, new RijndaelManaged().CreateDecryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Read)) {
++						//using (CryptoStream stream2 = new CryptoStream(stream, new RijndaelManaged().CreateDecryptor(_cryptoKey, _cryptoKey), CryptoStreamMode.Read)) {
+-							using (BsonReader reader = new BsonReader(stream2)) {
++							using (BsonReader reader = new BsonReader(stream)) {
 -								dictionary = JsonSerializer.Create(_serializerSettings).Deserialize<Dictionary<string, StoredAchievement>>(reader);
 +								dictionary = JsonSerializer.Create(_serializerSettings).Deserialize<Dictionary<string, Dictionary<string, StoredAchievement>>>(reader);
  							}
- 						}
+-						}
++						//}
  					}
+ 				}
+ 				catch (Exception) {
 @@ -103,20 +_,23 @@
  
  				if (dictionary == null)
@@ -110,7 +111,7 @@
  		}
  
 -		private void AchievementCompleted(Achievement achievement) {
-+		private void AchievementCompleted(IAchievement achievement) {
++		public void AchievementCompleted(IAchievement achievement) {
  			Save();
  			if (this.OnAchievementCompleted != null)
  				this.OnAchievementCompleted(achievement);
@@ -129,7 +130,7 @@
 +				if (!_achievements.ContainsKey(achievement.Name))
 +					_achievements.Add(achievement.Mod.Name, new Dictionary<string, IAchievement>());
 +
-+				_achievements[achievement.Name].Add(achievement.Name, achievement);
++				_achievements[achievement.Mod.Name].Add(achievement.Name, achievement);
 +			}
 +			// _achievements.Add(achievement.Name, achievement);
  			achievement.OnCompleted += AchievementCompleted;

--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -9,26 +9,3 @@
  using Terraria.Social;
  using Terraria.UI;
  using Terraria.Utilities;
-@@ -51,6 +_,7 @@
- 		}
- 
- 		private void Save(string path, bool cloud) {
-+			if (Steam.IsSteamApp) return;
- 			lock (_ioLock) {
- 				if (SocialAPI.Achievements != null)
- 					SocialAPI.Achievements.StoreStats();
-@@ -76,10 +_,13 @@
- 		public List<Achievement> CreateAchievementsList() => _achievements.Values.ToList();
- 
- 		public void Load() {
-+			if (Steam.IsSteamApp) return;
- 			Load(_savePath, _isCloudSave);
- 		}
- 
--		private void Load(string path, bool cloud) {
-+		private void Load(string path, bool cloud)
-+		{
-+			if (Steam.IsSteamApp) return;
- 			bool flag = false;
- 			lock (_ioLock) {
- 				if (!FileUtilities.Exists(path, cloud))

--- a/patches/tModLoader/Terraria/Achievements/AchievementTracker.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/AchievementTracker.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Achievements
+{
+	partial class AchievementTracker<T>
+	{
+		public abstract string GetProgressText();
+
+		public abstract float GetProgress();
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/AchievementTracker.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementTracker.cs.patch
@@ -1,0 +1,34 @@
+--- src/Terraria/Terraria/Achievements/AchievementTracker.cs
++++ src/tModLoader/Terraria/Achievements/AchievementTracker.cs
+@@ -2,26 +_,26 @@
+ 
+ namespace Terraria.Achievements
+ {
+-	public abstract class AchievementTracker<T> : IAchievementTracker
++	public abstract partial class AchievementTracker<T> : IAchievementTracker
+ 	{
+ 		protected T _value;
+ 		protected T _maxValue;
+ 		protected string _name;
+-		private TrackerType _type;
++		// private TrackerType _type;
+ 
+ 		public T Value => _value;
+ 
+ 		public T MaxValue => _maxValue;
+ 
+-		protected AchievementTracker(TrackerType type) {
++		/*protected AchievementTracker(TrackerType type) {
+ 			_type = type;
+-		}
++		}*/
+ 
+ 		void IAchievementTracker.ReportAs(string name) {
+ 			_name = name;
+ 		}
+ 
+-		TrackerType IAchievementTracker.GetTrackerType() => _type;
++		// TrackerType IAchievementTracker.GetTrackerType() => _type;
+ 
+ 		void IAchievementTracker.Clear() {
+ 			SetValue(default(T));

--- a/patches/tModLoader/Terraria/Achievements/AchievementType.cs
+++ b/patches/tModLoader/Terraria/Achievements/AchievementType.cs
@@ -1,0 +1,18 @@
+﻿namespace Terraria.Achievements
+{
+	/// <summary>
+	///		Achievement saving type.
+	/// </summary>
+	public enum AchievementType
+	{
+		/// <summary>
+		///		Globally-saved, not attached to a player.
+		/// </summary>
+		Global,
+
+		/// <summary>
+		///		Saved to the player, allows for an achievement to be achieved on different players.
+		/// </summary>
+		Player
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.TML.cs
@@ -2,8 +2,8 @@
 {
 	partial class ConditionFloatTracker
 	{
-		public override string GetProgressText() => $"{_value} / {_maxValue}";
+		public override string GetProgressText() => $"{(int) _value} / {(int )_maxValue}"; // vanilla casts to an int, preserve that
 
-		public override float GetProgress() => (int) _value / (int )_maxValue; // vanilla casts to an int, preserve that
+		public override float GetProgress() => _value / _maxValue;
 	}
 }

--- a/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Achievements
+{
+	partial class ConditionFloatTracker
+	{
+		public override string GetProgressText() => $"{_value} / {_maxValue}";
+
+		public override float GetProgress() => (int) _value / (int )_maxValue; // vanilla casts to an int, preserve that
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/ConditionFloatTracker.cs.patch
@@ -1,0 +1,21 @@
+--- src/Terraria/Terraria/Achievements/ConditionFloatTracker.cs
++++ src/tModLoader/Terraria/Achievements/ConditionFloatTracker.cs
+@@ -2,15 +_,15 @@
+ 
+ namespace Terraria.Achievements
+ {
+-	public class ConditionFloatTracker : AchievementTracker<float>
++	public partial class ConditionFloatTracker : AchievementTracker<float>
+ 	{
+ 		public ConditionFloatTracker(float maxValue)
+-			: base(TrackerType.Float) {
++			/*: base(TrackerType.Float)*/ {
+ 			_maxValue = maxValue;
+ 		}
+ 
+ 		public ConditionFloatTracker()
+-			: base(TrackerType.Float) {
++			/*: base(TrackerType.Float)*/ {
+ 		}
+ 
+ 		public override void ReportUpdate() {

--- a/patches/tModLoader/Terraria/Achievements/ConditionIntTracker.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/ConditionIntTracker.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Achievements
+{
+	partial class ConditionIntTracker
+	{
+		public override string GetProgressText() => $"{_value} / {_maxValue}";
+
+		public override float GetProgress() => _value / _maxValue;
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/ConditionIntTracker.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/ConditionIntTracker.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/Achievements/ConditionIntTracker.cs
++++ src/tModLoader/Terraria/Achievements/ConditionIntTracker.cs
+@@ -2,14 +_,14 @@
+ 
+ namespace Terraria.Achievements
+ {
+-	public class ConditionIntTracker : AchievementTracker<int>
++	public partial class ConditionIntTracker : AchievementTracker<int>
+ 	{
+ 		public ConditionIntTracker()
+-			: base(TrackerType.Int) {
++			/*: base(TrackerType.Int)*/ {
+ 		}
+ 
+ 		public ConditionIntTracker(int maxValue)
+-			: base(TrackerType.Int) {
++			/*: base(TrackerType.Int)*/ {
+ 			_maxValue = maxValue;
+ 		}
+ 

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace Terraria.Achievements
@@ -11,9 +10,9 @@ namespace Terraria.Achievements
 
 		AchievementType SaveType { get; }
 
-		LocalizedText FriendlyName { get; }
+		string FriendlyName { get; }
 
-		LocalizedText Description { get; }
+		string Description { get; }
 
 		AchievementCategory Category { get; set; }
 

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -1,0 +1,14 @@
+﻿using Terraria.Localization;
+using Terraria.ModLoader;
+
+namespace Terraria.Achievements
+{
+	public interface IAchievement
+	{
+		AchievementType SaveType { get; }
+
+		LocalizedText FriendlyName { get; }
+
+		LocalizedText Description { get; }
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -1,5 +1,6 @@
-﻿using Terraria.Localization;
-using Terraria.ModLoader;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using Terraria.Localization;
 
 namespace Terraria.Achievements
 {
@@ -12,5 +13,17 @@ namespace Terraria.Achievements
 		LocalizedText Description { get; }
 
 		AchievementCategory Category { get; }
+
+		IAchievementTracker Tracker { get; }
+
+		bool IsCompleted { get; }
+
+		void ClearProgress();
+
+		void Load(Dictionary<string, JObject> conditions);
+
+		void AddCondition(AchievementCondition condition);
+
+		AchievementCondition GetCondition(string conditionName);
 	}
 }

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -21,6 +21,8 @@ namespace Terraria.Achievements
 
 		bool IsCompleted { get; }
 
+		Dictionary<string, AchievementCondition> Conditions { get; set; }
+
 		Achievement.AchievementCompleted OnCompleted { get; set; }
 
 		void ClearProgress();

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -1,22 +1,27 @@
 ﻿using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Terraria.Localization;
+using Terraria.ModLoader;
 
 namespace Terraria.Achievements
 {
-	public interface IAchievement
+	public interface IAchievement : IModType
 	{
+		string Texture { get; }
+
 		AchievementType SaveType { get; }
 
 		LocalizedText FriendlyName { get; }
 
 		LocalizedText Description { get; }
 
-		AchievementCategory Category { get; }
+		AchievementCategory Category { get; set; }
 
 		IAchievementTracker Tracker { get; }
 
 		bool IsCompleted { get; }
+
+		Achievement.AchievementCompleted OnCompleted { get; set; }
 
 		void ClearProgress();
 

--- a/patches/tModLoader/Terraria/Achievements/IAchievement.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievement.cs
@@ -10,5 +10,7 @@ namespace Terraria.Achievements
 		LocalizedText FriendlyName { get; }
 
 		LocalizedText Description { get; }
+
+		AchievementCategory Category { get; }
 	}
 }

--- a/patches/tModLoader/Terraria/Achievements/IAchievementTracker.TML.cs
+++ b/patches/tModLoader/Terraria/Achievements/IAchievementTracker.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Achievements
+{
+	partial interface IAchievementTracker
+	{
+		string GetProgressText();
+
+		float GetProgress();
+	}
+}

--- a/patches/tModLoader/Terraria/Achievements/IAchievementTracker.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/IAchievementTracker.cs.patch
@@ -1,0 +1,15 @@
+--- src/Terraria/Terraria/Achievements/IAchievementTracker.cs
++++ src/tModLoader/Terraria/Achievements/IAchievementTracker.cs
+@@ -1,10 +_,10 @@
+ namespace Terraria.Achievements
+ {
+-	public interface IAchievementTracker
++	public partial interface IAchievementTracker
+ 	{
+ 		void ReportAs(string name);
+ 
+-		TrackerType GetTrackerType();
++		// TrackerType GetTrackerType();
+ 
+ 		void Load();
+ 

--- a/patches/tModLoader/Terraria/Achievements/TrackerType.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/TrackerType.cs.patch
@@ -1,0 +1,13 @@
+--- src/Terraria/Terraria/Achievements/TrackerType.cs
++++ src/tModLoader/Terraria/Achievements/TrackerType.cs
+@@ -1,4 +_,4 @@
+-namespace Terraria.Achievements
++/*namespace Terraria.Achievements
+ {
+ 	public enum TrackerType
+ 	{
+@@ -6,3 +_,4 @@
+ 		Int
+ 	}
+ }
++*/

--- a/patches/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs
-@@ -9,9 +_,9 @@
+@@ -9,10 +_,10 @@
  	{
  		private class AchievementSnippet : TextSnippet
  		{
@@ -9,9 +9,11 @@
  
 -			public AchievementSnippet(Achievement achievement)
 +			public AchievementSnippet(IAchievement achievement)
- 				: base(achievement.FriendlyName.Value, Color.LightBlue) {
+-				: base(achievement.FriendlyName.Value, Color.LightBlue) {
++				: base(achievement.FriendlyName, Color.LightBlue) {
  				CheckForHover = true;
  				_achievement = achievement;
+ 			}
 @@ -24,13 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs.patch
@@ -1,0 +1,30 @@
+--- src/Terraria/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs
++++ src/tModLoader/Terraria/GameContent/UI/Chat/AchievementTagHandler.cs
+@@ -9,9 +_,9 @@
+ 	{
+ 		private class AchievementSnippet : TextSnippet
+ 		{
+-			private Achievement _achievement;
++			private IAchievement _achievement;
+ 
+-			public AchievementSnippet(Achievement achievement)
++			public AchievementSnippet(IAchievement achievement)
+ 				: base(achievement.FriendlyName.Value, Color.LightBlue) {
+ 				CheckForHover = true;
+ 				_achievement = achievement;
+@@ -24,13 +_,13 @@
+ 		}
+ 
+ 		TextSnippet ITagHandler.Parse(string text, Color baseColor, string options) {
+-			Achievement achievement = Main.Achievements.GetAchievement(text);
++			IAchievement achievement = Main.Achievements.GetAchievement(text);
+ 			if (achievement == null)
+ 				return new TextSnippet(text);
+ 
+ 			return new AchievementSnippet(achievement);
+ 		}
+ 
+-		public static string GenerateTag(Achievement achievement) => "[a:" + achievement.Name + "]";
++		public static string GenerateTag(IAchievement achievement) => "[a:" + achievement.Name + "]";
+ 	}
+ }

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -25,31 +25,28 @@
  				float num5 = 80f;
  				Color color2 = new Color(100, 255, 100);
  				if (!base.IsMouseHovering)
-@@ -166,12 +_,12 @@
+@@ -166,11 +_,11 @@
  
  		public Achievement GetAchievement() => _achievement;
  
 -		private Tuple<decimal, decimal> GetTrackerValues() {
-+		private IAchievementTracker GetTrackerValues() {
- 			if (!_achievement.HasTracker)
+-			if (!_achievement.HasTracker)
 -				return Tuple.Create(0m, 0m);
-+				return null; // Tuple.Create(0m, 0m);
++		private IAchievementTracker GetTrackerValues() {
++			//if (!_achievement.HasTracker)
++				return _achievement.Tracker; // Tuple.Create(0m, 0m);
  
- 			IAchievementTracker tracker = _achievement.GetTracker();
--			if (tracker.GetTrackerType() == TrackerType.Int) {
-+			/*if (tracker.GetTrackerType() == TrackerType.Int) {
+-			IAchievementTracker tracker = _achievement.GetTracker();
++			/*IAchievementTracker tracker = _achievement.GetTracker();
+ 			if (tracker.GetTrackerType() == TrackerType.Int) {
  				AchievementTracker<int> achievementTracker = (AchievementTracker<int>)tracker;
  				return Tuple.Create((decimal)achievementTracker.Value, (decimal)achievementTracker.MaxValue);
- 			}
-@@ -179,9 +_,9 @@
- 			if (tracker.GetTrackerType() == TrackerType.Float) {
- 				AchievementTracker<float> achievementTracker2 = (AchievementTracker<float>)tracker;
+@@ -181,7 +_,7 @@
  				return Tuple.Create((decimal)achievementTracker2.Value, (decimal)achievementTracker2.MaxValue);
--			}
-+			}*/
+ 			}
  
 -			return Tuple.Create(0m, 0m);
-+			return tracker; // Tuple.Create(0m, 0m);
++			return tracker; // Tuple.Create(0m, 0m);*/
  		}
  
  		private void DrawProgressBar(SpriteBatch spriteBatch, float progress, Vector2 spot, float Width = 169f, Color BackColor = default(Color), Color FillingColor = default(Color), Color BlipColor = default(Color)) {

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -8,6 +8,24 @@
  using Terraria.UI;
  using Terraria.UI.Chat;
  
+@@ -11,7 +_,7 @@
+ {
+ 	public class UIAchievementListItem : UIPanel
+ 	{
+-		private Achievement _achievement;
++		private IAchievement _achievement;
+ 		private UIImageFramed _achievementIcon;
+ 		private UIImage _achievementIconBorders;
+ 		private const int _iconSize = 64;
+@@ -27,7 +_,7 @@
+ 		private bool _locked;
+ 		private bool _large;
+ 
+-		public UIAchievementListItem(Achievement achievement, bool largeForOtherLanguages) {
++		public UIAchievementListItem(IAchievement achievement, bool largeForOtherLanguages) {
+ 			_large = largeForOtherLanguages;
+ 			BackgroundColor = new Color(26, 40, 89) * 0.8f;
+ 			BorderColor = new Color(13, 20, 44) * 0.8f;
 @@ -39,6 +_,7 @@
  			Width.Set(0f, 1f);
  			PaddingTop = 8f;
@@ -58,15 +76,18 @@
  				float num5 = 80f;
  				Color color2 = new Color(100, 255, 100);
  				if (!base.IsMouseHovering)
-@@ -166,11 +_,11 @@
+@@ -164,13 +_,13 @@
+ 			BorderColor = new Color(13, 20, 44) * 0.8f;
+ 		}
  
- 		public Achievement GetAchievement() => _achievement;
+-		public Achievement GetAchievement() => _achievement;
++		public IAchievement GetAchievement() => _achievement;
  
 -		private Tuple<decimal, decimal> GetTrackerValues() {
--			if (!_achievement.HasTracker)
--				return Tuple.Create(0m, 0m);
 +		private IAchievementTracker GetTrackerValues() {
+-			if (!_achievement.HasTracker)
 +			//if (!_achievement.HasTracker)
+-				return Tuple.Create(0m, 0m);
 +				return _achievement.Tracker; // Tuple.Create(0m, 0m);
  
 -			IAchievementTracker tracker = _achievement.GetTracker();

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -1,5 +1,58 @@
 --- src/Terraria/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
+@@ -72,9 +_,9 @@
+ 			CalculatedStyle dimensions = _achievementIconBorders.GetDimensions();
+ 			float num2 = dimensions.X + dimensions.Width;
+ 			Vector2 value2 = new Vector2(num2 + 7f, innerDimensions.Y);
+-			Tuple<decimal, decimal> trackerValues = GetTrackerValues();
++			IAchievementTracker trackerValues = GetTrackerValues();
+ 			bool flag = false;
+-			if ((!(trackerValues.Item1 == 0m) || !(trackerValues.Item2 == 0m)) && _locked)
++			if (trackerValues != null && _locked)
+ 				flag = true;
+ 
+ 			float num3 = innerDimensions.Width - dimensions.Width + 1f - (float)(num * 2);
+@@ -111,10 +_,10 @@
+ 			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.ItemStack.Value, text, position, value4, 0f, Vector2.Zero, baseScale2);
+ 			if (flag) {
+ 				Vector2 vector2 = vector + Vector2.UnitX * num3 + Vector2.UnitY;
+-				string text2 = (int)trackerValues.Item1 + "/" + (int)trackerValues.Item2;
++				string text2 = trackerValues.GetProgressText(); // (int)trackerValues.Item1 + "/" + (int)trackerValues.Item2;
+ 				Vector2 baseScale3 = new Vector2(0.75f);
+ 				Vector2 stringSize2 = ChatManager.GetStringSize(FontAssets.ItemStack.Value, text2, baseScale3);
+-				float progress = (float)(trackerValues.Item1 / trackerValues.Item2);
++				float progress = trackerValues.GetProgress(); // (float)(trackerValues.Item1 / trackerValues.Item2);
+ 				float num5 = 80f;
+ 				Color color2 = new Color(100, 255, 100);
+ 				if (!base.IsMouseHovering)
+@@ -166,12 +_,12 @@
+ 
+ 		public Achievement GetAchievement() => _achievement;
+ 
+-		private Tuple<decimal, decimal> GetTrackerValues() {
++		private IAchievementTracker GetTrackerValues() {
+ 			if (!_achievement.HasTracker)
+-				return Tuple.Create(0m, 0m);
++				return null; // Tuple.Create(0m, 0m);
+ 
+ 			IAchievementTracker tracker = _achievement.GetTracker();
+-			if (tracker.GetTrackerType() == TrackerType.Int) {
++			/*if (tracker.GetTrackerType() == TrackerType.Int) {
+ 				AchievementTracker<int> achievementTracker = (AchievementTracker<int>)tracker;
+ 				return Tuple.Create((decimal)achievementTracker.Value, (decimal)achievementTracker.MaxValue);
+ 			}
+@@ -179,9 +_,9 @@
+ 			if (tracker.GetTrackerType() == TrackerType.Float) {
+ 				AchievementTracker<float> achievementTracker2 = (AchievementTracker<float>)tracker;
+ 				return Tuple.Create((decimal)achievementTracker2.Value, (decimal)achievementTracker2.MaxValue);
+-			}
++			}*/
+ 
+-			return Tuple.Create(0m, 0m);
++			return tracker; // Tuple.Create(0m, 0m);
+ 		}
+ 
+ 		private void DrawProgressBar(SpriteBatch spriteBatch, float progress, Vector2 spot, float Width = 169f, Color BackColor = default(Color), Color FillingColor = default(Color), Color BlipColor = default(Color)) {
 @@ -225,7 +_,7 @@
  			if (!_achievement.IsCompleted && uIAchievementListItem._achievement.IsCompleted)
  				return 1;

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -1,5 +1,38 @@
 --- src/Terraria/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
+@@ -4,6 +_,7 @@
+ using System;
+ using Terraria.Achievements;
+ using Terraria.Localization;
++using Terraria.ModLoader;
+ using Terraria.UI;
+ using Terraria.UI.Chat;
+ 
+@@ -39,6 +_,7 @@
+ 			Width.Set(0f, 1f);
+ 			PaddingTop = 8f;
+ 			PaddingLeft = 9f;
++			if (achievement.Texture == Achievement.VanillaTextureIndicator) {
+ 			int num4 = _iconIndex = Main.Achievements.GetIconIndex(achievement.Name);
+ 			_iconFrameUnlocked = new Rectangle(num4 % 8 * 66, num4 / 8 * 66, 64, 64);
+ 			_iconFrameLocked = _iconFrameUnlocked;
+@@ -49,6 +_,16 @@
+ 			_achievementIcon.Left.Set(num2, 0f);
+ 			_achievementIcon.Top.Set(num3, 0f);
+ 			Append(_achievementIcon);
++			}
++			else {
++				_iconFrameUnlocked = new Rectangle(0, 0, 64, 64);
++				_iconFrameLocked = new Rectangle(66, 0, 64, 64);
++				_iconFrame = _iconFrameLocked;
++				UpdateIconFrame();
++				_achievementIcon = new UIImageFramed(ModContent.Request<Texture2D>(achievement.Texture, AssetRequestMode.ImmediateLoad), _iconFrame);
++				_achievementIcon.Left.Set(num2, 0f);
++				_achievementIcon.Top.Set(num3, 0f);
++			}
+ 			_achievementIconBorders = new UIImage(Main.Assets.Request<Texture2D>("Images/UI/Achievement_Borders"));
+ 			_achievementIconBorders.Left.Set(-4f + num2, 0f);
+ 			_achievementIconBorders.Top.Set(-4f + num3, 0f);
 @@ -72,9 +_,9 @@
  			CalculatedStyle dimensions = _achievementIconBorders.GetDimensions();
  			float num2 = dimensions.X + dimensions.Width;

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -51,7 +51,7 @@
  			_achievementIconBorders = new UIImage(Main.Assets.Request<Texture2D>("Images/UI/Achievement_Borders"));
  			_achievementIconBorders.Left.Set(-4f + num2, 0f);
  			_achievementIconBorders.Top.Set(-4f + num3, 0f);
-@@ -72,9 +_,9 @@
+@@ -72,18 +_,18 @@
  			CalculatedStyle dimensions = _achievementIconBorders.GetDimensions();
  			float num2 = dimensions.X + dimensions.Width;
  			Vector2 value2 = new Vector2(num2 + 7f, innerDimensions.Y);
@@ -63,6 +63,26 @@
  				flag = true;
  
  			float num3 = innerDimensions.Width - dimensions.Width + 1f - (float)(num * 2);
+ 			Vector2 baseScale = new Vector2(0.85f);
+ 			Vector2 baseScale2 = new Vector2(0.92f);
+-			string text = FontAssets.ItemStack.Value.CreateWrappedText(_achievement.Description.Value, (num3 - 20f) * (1f / baseScale2.X), Language.ActiveCulture.CultureInfo);
++			string text = FontAssets.ItemStack.Value.CreateWrappedText(_achievement.Description, (num3 - 20f) * (1f / baseScale2.X), Language.ActiveCulture.CultureInfo);
+ 			Vector2 stringSize = ChatManager.GetStringSize(FontAssets.ItemStack.Value, text, baseScale2, num3);
+ 			if (!_large)
+-				stringSize = ChatManager.GetStringSize(FontAssets.ItemStack.Value, _achievement.Description.Value, baseScale2, num3);
++				stringSize = ChatManager.GetStringSize(FontAssets.ItemStack.Value, _achievement.Description, baseScale2, num3);
+ 
+ 			float num4 = 38f + (float)(_large ? 20 : 0);
+ 			if (stringSize.Y > num4)
+@@ -102,7 +_,7 @@
+ 			spriteBatch.Draw(_categoryTexture.Value, vector, _categoryTexture.Frame(4, 2, (int)category), base.IsMouseHovering ? Color.White : Color.Silver, 0f, Vector2.Zero, 0.5f, SpriteEffects.None, 0f);
+ 			vector.X += 4f;
+ 			vector.X += 17f;
+-			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.ItemStack.Value, _achievement.FriendlyName.Value, vector, value3, 0f, Vector2.Zero, baseScale, num3);
++			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.ItemStack.Value, _achievement.FriendlyName, vector, value3, 0f, Vector2.Zero, baseScale, num3);
+ 			vector.X -= 17f;
+ 			Vector2 position = value2 + Vector2.UnitY * 27f + value;
+ 			DrawPanelBottom(spriteBatch, position, num3, color);
 @@ -111,10 +_,10 @@
  			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.ItemStack.Value, text, position, value4, 0f, Vector2.Zero, baseScale2);
  			if (flag) {

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/UIAchievementListItem.cs
+@@ -225,7 +_,7 @@
+ 			if (!_achievement.IsCompleted && uIAchievementListItem._achievement.IsCompleted)
+ 				return 1;
+ 
+-			return _achievement.Id.CompareTo(uIAchievementListItem._achievement.Id);
++			return string.Compare(_achievement.Name, uIAchievementListItem._achievement.Name, StringComparison.Ordinal);
+ 		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIImage.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIImage.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/GameContent/UI/Elements/UIImage.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/UIImage.cs
+@@ -7,7 +_,7 @@
+ {
+ 	public class UIImage : UIElement
+ 	{
+-		private Asset<Texture2D> _texture;
++		protected  Asset<Texture2D> _texture;
+ 		public float ImageScale = 1f;
+ 		public float Rotation;
+ 		public bool ScaleToFit;

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIAchievementsMenu.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIAchievementsMenu.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/GameContent/UI/States/UIAchievementsMenu.cs
++++ src/tModLoader/Terraria/GameContent/UI/States/UIAchievementsMenu.cs
+@@ -66,7 +_,7 @@
+ 			uITextPanel2.OnClick += GoBackClick;
+ 			uIElement.Append(uITextPanel2);
+ 			_backpanel = uITextPanel2;
+-			List<Achievement> list = Main.Achievements.CreateAchievementsList();
++			List<IAchievement> list = Main.Achievements.CreateAchievementsList();
+ 			for (int i = 0; i < list.Count; i++) {
+ 				UIAchievementListItem item = new UIAchievementListItem(list[i], flag);
+ 				_achievementsList.Add(item);
+@@ -139,7 +_,7 @@
+ 			SetupGamepadPoints(spriteBatch);
+ 		}
+ 
+-		public void GotoAchievement(Achievement achievement) {
++		public void GotoAchievement(IAchievement achievement) {
+ 			_achievementsList.Goto(delegate (UIElement element) {
+ 				UIAchievementListItem uIAchievementListItem = element as UIAchievementListItem;
+ 				return uIAchievementListItem != null && uIAchievementListItem.GetAchievement() == achievement;

--- a/patches/tModLoader/Terraria/IngameOptions.cs.patch
+++ b/patches/tModLoader/Terraria/IngameOptions.cs.patch
@@ -58,25 +58,6 @@
  			if (flag5 && DrawLeftSide(sb, Lang.menu[147].Value, num10, vector, vector2, leftScale)) {
  				leftHover = num10;
  				if (flag4) {
-@@ -257,6 +_,7 @@
- 			if (flag5)
- 				num10++;
- 
-+			if(!Steam.IsSteamApp) {
- 			if (DrawLeftSide(sb, Lang.menu[131].Value, num10, vector, vector2, leftScale)) {
- 				leftHover = num10;
- 				if (flag4) {
-@@ -264,8 +_,9 @@
- 					IngameFancyUI.OpenAchievements();
- 				}
- 			}
--
- 			num10++;
-+			}
-+
- 			if (DrawLeftSide(sb, Lang.menu[118].Value, num10, vector, vector2, leftScale)) {
- 				leftHover = num10;
- 				if (flag4)
 @@ -276,6 +_,8 @@
  			if (DrawLeftSide(sb, Lang.inter[35].Value, num10, vector, vector2, leftScale)) {
  				leftHover = num10;

--- a/patches/tModLoader/Terraria/Initializers/AchievementInitializer.cs.patch
+++ b/patches/tModLoader/Terraria/Initializers/AchievementInitializer.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/Initializers/AchievementInitializer.cs
++++ src/tModLoader/Terraria/Initializers/AchievementInitializer.cs
+@@ -557,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		private static void OnAchievementCompleted(Achievement achievement) {
++		private static void OnAchievementCompleted(IAchievement achievement) {
+ 			Main.NewText(Language.GetTextValue("Achievements.Completed", AchievementTagHandler.GenerateTag(achievement)));
+ 			if (SoundEngine.FindActiveSound(SoundID.AchievementComplete) == null)
+ 				SoundEngine.PlayTrackedSound(SoundID.AchievementComplete);

--- a/patches/tModLoader/Terraria/Initializers/ChatInitializer.cs.patch
+++ b/patches/tModLoader/Terraria/Initializers/ChatInitializer.cs.patch
@@ -8,16 +8,3 @@
  	public static class ChatInitializer
  	{
  		public static void Load() {
-@@ -24,10 +_,12 @@
- 				"name"
- 			});
- 
-+			/* AchievementTagHandler removed since achievements also removed 
- 			ChatManager.Register<AchievementTagHandler>(new string[2] {
- 				"a",
- 				"achievement"
- 			});
-+			*/
- 
- 			ChatManager.Register<GlyphTagHandler>(new string[2] {
- 				"g",

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -73,6 +73,17 @@
  		public static FileMetadata WorldFileMetadata;
  		public static FileMetadata MapFileMetadata;
  		public static PingMapLayer Pings = new PingMapLayer();
+@@ -267,8 +_,8 @@
+ 		public static CreativeUI CreativeMenu = new CreativeUI();
+ 		private static Vector2 _lastPingMousePosition = Vector2.Zero;
+ 		private static double _lastPingMouseDownTime = 0.0;
+-		private AchievementManager _achievements;
++		internal AchievementManager _achievements;
+-		private AchievementAdvisor _achievementAdvisor;
++		internal AchievementAdvisor _achievementAdvisor;
+ 		public static BigProgressBarSystem BigBossProgressBar = new BigProgressBarSystem();
+ 		public static UserInterface MenuUI = new UserInterface();
+ 		public static UserInterface InGameUI = new UserInterface();
 @@ -511,12 +_,12 @@
  		public static bool showSplash = true;
  		public static bool ignoreErrors = true;

--- a/patches/tModLoader/Terraria/ModLoader/AchievementLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AchievementLoader.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Terraria.Achievements;
+using Terraria.Initializers;
+using Terraria.UI;
+
+namespace Terraria.ModLoader
+{
+	public class AchievementLoader : ILoader
+	{
+		private static readonly List<ModAchievement> _achievementsToLoad = new();
+
+		internal static void AddAchievement(ModAchievement achievement) {
+			_achievementsToLoad.Add(achievement); // Main.Achievements.Register(achievement);
+			ModTypeLookup<ModAchievement>.Register(achievement);
+		}
+
+		void ILoader.ResizeArrays() {
+			Main.instance._achievements = new AchievementManager();
+			Main.instance._achievementAdvisor = new AchievementAdvisor();
+			AchievementInitializer.Load();
+
+			foreach (ModAchievement achievement in _achievementsToLoad)
+				Main.Achievements.Register(achievement);
+		}
+
+		void ILoader.Unload() {
+			Main.Achievements.Save();
+			_achievementsToLoad.Clear();
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -1,0 +1,32 @@
+﻿using Terraria.Achievements;
+using Terraria.Localization;
+
+namespace Terraria.ModLoader
+{
+	public abstract class ModAchievement : ModType, IAchievement
+	{
+		/// <summary>
+		///		Achievement saving method. Saved either globally or per-player.
+		/// </summary>
+		public abstract AchievementType SaveType { get; }
+
+		public virtual LocalizedText FriendlyName => Language.GetText($"Mods.{Mod.Name}.AchievementName.{Name}");
+
+		public virtual LocalizedText Description => Language.GetText($"Mods.{Mod.Name}.AchievementDescription.{Name}");
+
+		protected ModTranslation DisplayName { get; private set; }
+
+		protected ModTranslation DisplayDescription { get; private set; }
+
+		public virtual AchievementCategory Category { get; set; } = AchievementCategory.None;
+
+		protected sealed override void Register() {
+			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementName.{Name}");
+			DisplayDescription = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementDescription.{Name}");
+		}
+
+		public override void SetupContent() {
+			SetStaticDefaults();
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -1,4 +1,6 @@
-﻿using Terraria.Achievements;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using Terraria.Achievements;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader
@@ -20,6 +22,10 @@ namespace Terraria.ModLoader
 
 		public virtual AchievementCategory Category { get; set; } = AchievementCategory.None;
 
+		public virtual IAchievementTracker Tracker { get; set; }
+
+		public virtual bool IsCompleted { get; set; }
+
 		protected sealed override void Register() {
 			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementName.{Name}");
 			DisplayDescription = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementDescription.{Name}");
@@ -28,5 +34,16 @@ namespace Terraria.ModLoader
 		public override void SetupContent() {
 			SetStaticDefaults();
 		}
+
+		public virtual void ClearProgress() {
+		}
+
+		public virtual void Load(Dictionary<string, JObject> conditions) {
+		}
+
+		public virtual void AddCondition(AchievementCondition condition) {
+		}
+
+		public virtual AchievementCondition GetCondition(string conditionName) => null;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Terraria.Achievements;
-using Terraria.DataStructures;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader
@@ -15,9 +14,9 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public abstract AchievementType SaveType { get; }
 
-		public virtual LocalizedText FriendlyName => Language.GetText($"Mods.{Mod.Name}.AchievementName.{Name}");
+		public virtual string FriendlyName => DisplayName.GetTranslation(Language.ActiveCulture);
 
-		public virtual LocalizedText Description => Language.GetText($"Mods.{Mod.Name}.AchievementDescription.{Name}");
+		public virtual string Description => DisplayDescription.GetTranslation(Language.ActiveCulture);
 
 		protected ModTranslation DisplayName { get; private set; }
 
@@ -37,6 +36,8 @@ namespace Terraria.ModLoader
 		protected sealed override void Register() {
 			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementName.{Name}");
 			DisplayDescription = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementDescription.{Name}");
+
+			AchievementLoader.AddAchievement(this);
 		}
 
 		public override void SetupContent() {
@@ -50,8 +51,14 @@ namespace Terraria.ModLoader
 		}
 
 		public virtual void AddCondition(AchievementCondition condition) {
+			Conditions[condition.Name] = condition;
 		}
 
-		public virtual AchievementCondition GetCondition(string conditionName) => null;
+		public virtual AchievementCondition GetCondition(string conditionName) {
+			if (Conditions.TryGetValue(conditionName, out AchievementCondition value))
+				return value;
+
+			return null;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -1,11 +1,12 @@
 ﻿using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Terraria.Achievements;
+using Terraria.DataStructures;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader
 {
-	public abstract class ModAchievement : ModType, IAchievement
+	public abstract class ModAchievement : ModTexturedType, IAchievement
 	{
 		/// <summary>
 		///		Achievement saving method. Saved either globally or per-player.

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using Terraria.Achievements;
 using Terraria.DataStructures;
@@ -6,6 +7,7 @@ using Terraria.Localization;
 
 namespace Terraria.ModLoader
 {
+	[JsonObject(MemberSerialization.OptIn)]
 	public abstract class ModAchievement : ModTexturedType, IAchievement
 	{
 		/// <summary>
@@ -26,6 +28,9 @@ namespace Terraria.ModLoader
 		public virtual IAchievementTracker Tracker { get; set; }
 
 		public virtual bool IsCompleted { get; set; }
+
+		[JsonProperty("Conditions")]
+		public virtual Dictionary<string, AchievementCondition> Conditions { get; set; } = new();
 
 		public Achievement.AchievementCompleted OnCompleted { get; set; }
 

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -27,6 +27,8 @@ namespace Terraria.ModLoader
 
 		public virtual bool IsCompleted { get; set; }
 
+		public Achievement.AchievementCompleted OnCompleted { get; set; }
+
 		protected sealed override void Register() {
 			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementName.{Name}");
 			DisplayDescription = LocalizationLoader.GetOrCreateTranslation(Mod, $"AchievementDescription.{Name}");

--- a/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
+++ b/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
@@ -10,6 +10,17 @@
  
  namespace Terraria.UI
  {
+@@ -106,8 +_,8 @@
+ 				PlayerInput.SetZoom_UI();
+ 				Item item = new Item();
+ 				item.SetDefaults(0, noMatCheck: true);
+-				item.SetNameOverride(_hoveredCard.achievement.FriendlyName.Value);
++				item.SetNameOverride(_hoveredCard.achievement.FriendlyName);
+-				item.ToolTip = ItemTooltip.FromLanguageKey(_hoveredCard.achievement.Description.Key);
++				item.ToolTip = ItemTooltip.FromLanguageKey(_hoveredCard.achievement.Description);
+ 				item.type = 1;
+ 				item.scale = 0f;
+ 				item.rare = 10;
 @@ -138,8 +_,8 @@
  			}
  

--- a/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
+++ b/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
@@ -1,0 +1,23 @@
+--- src/Terraria/Terraria/UI/AchievementAdvisor.cs
++++ src/tModLoader/Terraria/UI/AchievementAdvisor.cs
+@@ -3,7 +_,9 @@
+ using ReLogic.Content;
+ using System.Collections.Generic;
+ using System.Linq;
++using Terraria.Achievements;
+ using Terraria.GameInput;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.UI
+ {
+@@ -138,8 +_,8 @@
+ 			}
+ 
+ 			Rectangle frame = card.frame;
+-			frame.X += 528;
+-			spriteBatch.Draw(_achievementsTexture.Value, position, frame, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
++			frame.X += _hoveredCard.achievement.Texture == Achievement.VanillaTextureIndicator ? 528 : 0;
++			spriteBatch.Draw(_hoveredCard.achievement.Texture == Achievement.VanillaTextureIndicator ? _achievementsTexture.Value : ModContent.Request<Texture2D>(_hoveredCard.achievement.Texture, AssetRequestMode.ImmediateLoad).Value, position, frame, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
+ 			spriteBatch.Draw(_achievementsBorderTexture.Value, position + value, null, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
+ 			if (hovered)
+ 				spriteBatch.Draw(value3, position + value2, null, Main.OurFavoriteColor, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);

--- a/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
+++ b/patches/tModLoader/Terraria/UI/AchievementAdvisor.cs.patch
@@ -16,8 +16,8 @@
  			Rectangle frame = card.frame;
 -			frame.X += 528;
 -			spriteBatch.Draw(_achievementsTexture.Value, position, frame, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
-+			frame.X += _hoveredCard.achievement.Texture == Achievement.VanillaTextureIndicator ? 528 : 0;
-+			spriteBatch.Draw(_hoveredCard.achievement.Texture == Achievement.VanillaTextureIndicator ? _achievementsTexture.Value : ModContent.Request<Texture2D>(_hoveredCard.achievement.Texture, AssetRequestMode.ImmediateLoad).Value, position, frame, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
++			frame.X += card.achievement.Texture == Achievement.VanillaTextureIndicator ? 528 : 0;
++			spriteBatch.Draw(card.achievement.Texture == Achievement.VanillaTextureIndicator ? _achievementsTexture.Value : ModContent.Request<Texture2D>(card.achievement.Texture, AssetRequestMode.ImmediateLoad).Value, position, frame, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
  			spriteBatch.Draw(_achievementsBorderTexture.Value, position + value, null, color, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);
  			if (hovered)
  				spriteBatch.Draw(value3, position + value2, null, Main.OurFavoriteColor, 0f, Vector2.Zero, scale, SpriteEffects.None, 0f);

--- a/patches/tModLoader/Terraria/UI/AchievementAdvisorCard.cs.patch
+++ b/patches/tModLoader/Terraria/UI/AchievementAdvisorCard.cs.patch
@@ -1,6 +1,17 @@
 --- src/Terraria/Terraria/UI/AchievementAdvisorCard.cs
 +++ src/tModLoader/Terraria/UI/AchievementAdvisorCard.cs
-@@ -17,7 +_,7 @@
+@@ -8,16 +_,16 @@
+ 		private const int _iconSize = 64;
+ 		private const int _iconSizeWithSpace = 66;
+ 		private const int _iconsPerRow = 8;
+-		public Achievement achievement;
++		public IAchievement achievement;
+ 		public float order;
+ 		public Rectangle frame;
+ 		public int achievementIndex;
+ 
+-		public AchievementAdvisorCard(Achievement achievement, float order) {
++		public AchievementAdvisorCard(IAchievement achievement, float order) {
  			this.achievement = achievement;
  			this.order = order;
  			achievementIndex = Main.Achievements.GetIconIndex(achievement.Name);

--- a/patches/tModLoader/Terraria/UI/AchievementAdvisorCard.cs.patch
+++ b/patches/tModLoader/Terraria/UI/AchievementAdvisorCard.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/UI/AchievementAdvisorCard.cs
++++ src/tModLoader/Terraria/UI/AchievementAdvisorCard.cs
+@@ -17,7 +_,7 @@
+ 			this.achievement = achievement;
+ 			this.order = order;
+ 			achievementIndex = Main.Achievements.GetIconIndex(achievement.Name);
+-			frame = new Rectangle(achievementIndex % 8 * 66, achievementIndex / 8 * 66, 64, 64);
++			frame = achievement.Texture == Achievement.VanillaTextureIndicator ? new Rectangle(achievementIndex % 8 * 66, achievementIndex / 8 * 66, 64, 64) : new Rectangle(0, 0, 64, 64);
+ 		}
+ 
+ 		public bool IsAchievableInWorld() {

--- a/patches/tModLoader/Terraria/UI/InGameNotificationsTracker.cs.patch
+++ b/patches/tModLoader/Terraria/UI/InGameNotificationsTracker.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/UI/InGameNotificationsTracker.cs
++++ src/tModLoader/Terraria/UI/InGameNotificationsTracker.cs
+@@ -57,7 +_,7 @@
+ 			}
+ 		}
+ 
+-		public static void AddCompleted(Achievement achievement) {
++		public static void AddCompleted(IAchievement achievement) {
+ 			if (Main.netMode != 2)
+ 				_notifications.Add(new InGamePopups.AchievementUnlockedPopup(achievement));
+ 		}

--- a/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
+++ b/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
@@ -1,0 +1,21 @@
+--- src/Terraria/Terraria/UI/InGamePopups.cs
++++ src/tModLoader/Terraria/UI/InGamePopups.cs
+@@ -4,6 +_,7 @@
+ using Terraria.Achievements;
+ using Terraria.GameContent;
+ using Terraria.GameInput;
++using Terraria.ModLoader;
+ using Terraria.Social.Base;
+ 
+ namespace Terraria.UI
+@@ -61,8 +_,8 @@
+ 				_theAchievement = achievement;
+ 				_title = achievement.FriendlyName.Value;
+ 				int num = _iconIndex = Main.Achievements.GetIconIndex(achievement.Name);
+-				_achievementIconFrame = new Rectangle(num % 8 * 66, num / 8 * 66, 64, 64);
+-				_achievementTexture = Main.Assets.Request<Texture2D>("Images/UI/Achievements", AssetRequestMode.AsyncLoad);
++				_achievementIconFrame = achievement.Texture == Achievement.VanillaTextureIndicator ? new Rectangle(num % 8 * 66, num / 8 * 66, 64, 64) : new Rectangle(0, 0, 64, 64);
++				_achievementTexture = achievement.Texture == Achievement.VanillaTextureIndicator ? Main.Assets.Request<Texture2D>("Images/UI/Achievements", AssetRequestMode.AsyncLoad) : ModContent.Request<Texture2D>(achievement.Texture, AssetRequestMode.ImmediateLoad);
+ 				_achievementBorderTexture = Main.Assets.Request<Texture2D>("Images/UI/Achievement_Borders", AssetRequestMode.AsyncLoad);
+ 			}
+ 

--- a/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
+++ b/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
@@ -26,7 +26,8 @@
  				CreationObject = achievement;
  				_ingameDisplayTimeLeft = 300;
  				_theAchievement = achievement;
- 				_title = achievement.FriendlyName.Value;
+-				_title = achievement.FriendlyName.Value;
++				_title = achievement.FriendlyName;
  				int num = _iconIndex = Main.Achievements.GetIconIndex(achievement.Name);
 -				_achievementIconFrame = new Rectangle(num % 8 * 66, num / 8 * 66, 64, 64);
 -				_achievementTexture = Main.Assets.Request<Texture2D>("Images/UI/Achievements", AssetRequestMode.AsyncLoad);

--- a/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
+++ b/patches/tModLoader/Terraria/UI/InGamePopups.cs.patch
@@ -8,7 +8,23 @@
  using Terraria.Social.Base;
  
  namespace Terraria.UI
-@@ -61,8 +_,8 @@
+@@ -12,7 +_,7 @@
+ 	{
+ 		public class AchievementUnlockedPopup : IInGameNotification
+ 		{
+-			private Achievement _theAchievement;
++			private IAchievement _theAchievement;
+ 			private Asset<Texture2D> _achievementTexture;
+ 			private Asset<Texture2D> _achievementBorderTexture;
+ 			private const int _iconSize = 64;
+@@ -55,14 +_,14 @@
+ 				}
+ 			}
+ 
+-			public AchievementUnlockedPopup(Achievement achievement) {
++			public AchievementUnlockedPopup(IAchievement achievement) {
+ 				CreationObject = achievement;
+ 				_ingameDisplayTimeLeft = 300;
  				_theAchievement = achievement;
  				_title = achievement.FriendlyName.Value;
  				int num = _iconIndex = Main.Achievements.GetIconIndex(achievement.Name);

--- a/patches/tModLoader/Terraria/UI/IngameFancyUI.cs.patch
+++ b/patches/tModLoader/Terraria/UI/IngameFancyUI.cs.patch
@@ -10,6 +10,15 @@
  using Terraria.UI.Gamepad;
  
  namespace Terraria.UI
+@@ -36,7 +_,7 @@
+ 			Main.InGameUI.SetState(Main.AchievementsMenu);
+ 		}
+ 
+-		public static void OpenAchievementsAndGoto(Achievement achievement) {
++		public static void OpenAchievementsAndGoto(IAchievement achievement) {
+ 			OpenAchievements();
+ 			Main.AchievementsMenu.GotoAchievement(achievement);
+ 		}
 @@ -85,6 +_,9 @@
  							Main.defaultChestName = Lang.chestType2[tile.frameX / 36].Value;
  						else if (tile.type == 88)


### PR DESCRIPTION
### What is the new feature?
Modded achievements for tModLoader.

### Why should this be part of tModLoader?
Achievements are a vanilla achievement that should definitely exist in tML as well. A lot of modders want to make them and a lot of players want to collect them.

### Are there alternative designs?
Probably, further discussion required. I want to also discuss using Terraria's `Achievement` as the base class with `ModAchievement` as a layer on top of it, or making it work the same way `Item`/`ModItem` does, where they're separate and have an instance of the other linked to themselves.

### Sample usage for the new feature
TODO

### ExampleMod updates
N/A, TODO: Example.

Code To-Do List:
- [ ] Remove `IAchievement` in favor of the base `ModAchievement` class.
- [ ] Figure out a clean way to access both modded and vanilla localizations with the same property. Easiest solution is `LocalizedText`, not very clean. Further discussion needed.
- [ ] Make images work.
- [ ] Make serialization and deserialization work.
- [ ] Modify existing conditions to serialize into mod-friendly IDs.
- [ ] Multiple achievement saving types (per-world and global).
- [ ] Eventually get around to reducing patch sizes and lessen code exposure.