### PR TITLE
[1.4] World size logging, ExampleMod fixes, UnloadedTile mouseover, docs

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
@@ -17,11 +17,15 @@ namespace ExampleMod.Common.GlobalNPCs
 
 		public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot) {
 			if (!NPCID.Sets.CountsAsCritter[npc.type]) { //If npc is not a critter
-				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleItem>(), 1)); //Make it drop ExampleItem.
-				// ItemDropRule.Common is what you would use in most cases, it simply drops the item with a chance specified.
-				// The dropsOutOfY int is used for the numerator of the fractional chance of dropping this item.
-				// Likewise, the dropsXOutOfY int is used for the denominator.
-				// For example, if you had a dropsOutOfY as 7 and a dropsXOutOfY as 2, then the chance the item would drop is 2/7 or about 28%.
+				//Make it drop ExampleItem.
+				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleItem>(), 1));
+																						 
+				// ItemDropRule.Common is what you would use in most cases, it simply drops the item with a fractional chance specified.
+				// The chanceDenominator int is used for the denominator part of the fractional chance of dropping this item.
+
+				// ItemDropRule.Common(...) does not let you specify the numerator, so you can use new CommonDrop(...) instead.
+				// (1 by default if using ItemDropRule.Common)
+				// For example, if you had a chanceDenominator as 7 and a chanceNumerator as 2, then the chance the item would drop is 2/7 or about 28%.
 			}
 
 			// We will now use the Guide to explain many of the other types of drop rules.

--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -12,6 +12,7 @@ namespace ExampleMod.Content.Items.Accessories
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded shield.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Accessories/ExampleStatBonusAccessory.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleStatBonusAccessory.cs
@@ -1,5 +1,6 @@
 ﻿using ExampleMod.Content.DamageClasses;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items.Accessories
@@ -10,6 +11,8 @@ namespace ExampleMod.Content.Items.Accessories
 			Tooltip.SetDefault("20% increased damage\n"
 							 + "10% increased melee crit chance\n"
 							 + "100% increased example knockback");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Accessories/ExampleWings.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleWings.cs
@@ -17,6 +17,7 @@ namespace ExampleMod.Content.Items.Accessories
 
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded wing.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 
 			// These wings use the same values as the solar wings

--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -43,6 +43,7 @@ namespace ExampleMod.Content.Items.Accessories
 		public override void SetStaticDefaults() {
 			// We can use vanilla language keys to copy the tooltip from HiveBackpack
 			Tooltip.SetDefault("{$ItemTooltip.HiveBackpack}");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Ammo/ExampleBullet.cs
+++ b/ExampleMod/Content/Items/Ammo/ExampleBullet.cs
@@ -9,6 +9,7 @@ namespace ExampleMod.Content.Items.Ammo
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded bullet ammo."); // The item's description, can be set to whatever you want.
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 99;
 		}
 

--- a/ExampleMod/Content/Items/Ammo/ExampleCustomAmmo.cs
+++ b/ExampleMod/Content/Items/Ammo/ExampleCustomAmmo.cs
@@ -1,4 +1,5 @@
 ﻿using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +11,8 @@ namespace ExampleMod.Content.Items.Ammo
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("Chases enemies through walls"); // The item's description, can be set to whatever you want.
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 99;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Ammo/ExampleSolution.cs
+++ b/ExampleMod/Content/Items/Ammo/ExampleSolution.cs
@@ -18,6 +18,7 @@ namespace ExampleMod.Content.Items.Ammo
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Monochromatic Solution");
 			Tooltip.SetDefault("Used by the Clentaminator\nSpreads the example");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 99;
 		}
 

--- a/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
@@ -1,4 +1,5 @@
 ﻿using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -15,6 +16,8 @@ namespace ExampleMod.Content.Items.Armor
 			Tooltip.SetDefault("This is a modded body armor."
 				+ "\nImmunity to 'On Fire!'"
 				+ "\n+20 max mana and +1 max minions");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Armor/ExampleHelmet.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHelmet.cs
@@ -1,6 +1,7 @@
 ﻿using Terraria;
 using Terraria.ModLoader;
 using Terraria.ID;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Armor
 {
@@ -11,6 +12,8 @@ namespace ExampleMod.Content.Items.Armor
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded helmet.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Armor/ExampleHood.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHood.cs
@@ -1,4 +1,5 @@
 ﻿using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -11,6 +12,8 @@ namespace ExampleMod.Content.Items.Armor
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded hood.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Armor/ExampleLeggings.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleLeggings.cs
@@ -1,6 +1,7 @@
 ﻿using Terraria;
 using Terraria.ModLoader;
 using Terraria.ID;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Armor
 {
@@ -12,6 +13,8 @@ namespace ExampleMod.Content.Items.Armor
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded leg armor."
 				+ "\n5% increased movement speed");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Consumables/ExampleBuffPotion.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleBuffPotion.cs
@@ -9,6 +9,7 @@ namespace ExampleMod.Content.Items.Consumables
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("Gives a light defense buff.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 20;
 		}
 

--- a/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
@@ -67,8 +67,8 @@ namespace ExampleMod.Content.Items.Consumables
 		public int exampleLifeFruits;
 
 		public override void ResetEffects() {
-			//Increasing health in the ResetEffects hook in particular is important so it shows up properly in the player select menu
-			//and so that life regeneration properly scales with the bonus health
+			// Increasing health in the ResetEffects hook in particular is important so it shows up properly in the player select menu
+			// and so that life regeneration properly scales with the bonus health
 			Player.statLifeMax2 += exampleLifeFruits * ExampleLifeFruit.LifePerFruit;
 		}
 

--- a/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
@@ -20,6 +20,7 @@ namespace ExampleMod.Content.Items.Consumables
 
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault($"Permanently increases maximum life by {LifePerFruit}\nUp to {MaxExampleLifeFruits} can be used");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 10;
 		}
 
@@ -48,6 +49,7 @@ namespace ExampleMod.Content.Items.Consumables
 			// This handles the 2 achievements related to using any life increasing item or getting to exactly 500 hp and 200 mp.
 			// Ignored since our item is only useable after this achievement is reached
 			// AchievementsHelper.HandleSpecialEvent(player, 2);
+			// TODO re-add this when ModAchievement is merged?
 			return true;
 		}
 
@@ -65,6 +67,8 @@ namespace ExampleMod.Content.Items.Consumables
 		public int exampleLifeFruits;
 
 		public override void ResetEffects() {
+			//Increasing health in the ResetEffects hook in particular is important so it shows up properly in the player select menu
+			//and so that life regeneration properly scales with the bonus health
 			Player.statLifeMax2 += exampleLifeFruits * ExampleLifeFruit.LifePerFruit;
 		}
 

--- a/ExampleMod/Content/Items/Consumables/MinionBossBag.cs
+++ b/ExampleMod/Content/Items/Consumables/MinionBossBag.cs
@@ -2,6 +2,7 @@
 using Terraria.ID;
 using Terraria.ModLoader;
 using ExampleMod.Content.NPCs.MinionBoss;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Consumables
 {
@@ -13,6 +14,8 @@ namespace ExampleMod.Content.Items.Consumables
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Treasure Bag");
 			Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}"); //References a language key that says "Right Click To Open" in the language of the game
+			
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Consumables/MinionBossSummonItem.cs
+++ b/ExampleMod/Content/Items/Consumables/MinionBossSummonItem.cs
@@ -13,6 +13,7 @@ namespace ExampleMod.Content.Items.Consumables
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Minion Boss Summon Item");
 			Tooltip.SetDefault("Summons Minion Boss");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;
 			ItemID.Sets.SortingPriorityBossSpawns[Type] = 12; // This helps sort inventory know that this is a boss summoning Item.
 

--- a/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
+++ b/ExampleMod/Content/Items/Consumables/PlanteraItem.cs
@@ -12,6 +12,7 @@ namespace ExampleMod.Content.Items.Consumables
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Plantera");
 			Tooltip.SetDefault("The wrath of the jungle");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 3;
 			ItemID.Sets.SortingPriorityBossSpawns[Type] = 12; // This helps sort inventory know that this is a boss summoning Item.
 

--- a/ExampleMod/Content/Items/ExampleDataItem.cs
+++ b/ExampleMod/Content/Items/ExampleDataItem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items
@@ -14,6 +15,8 @@ namespace ExampleMod.Content.Items
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Hot Potato");
 			Tooltip.SetDefault("Something magical happens when the timer runs out...");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -10,6 +11,10 @@ namespace ExampleMod.Content.Items
 	public class ExampleInstancedItem : ModItem
 	{
 		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
+
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 99;
+		}
 
 		public override ModItem Clone(Item item) {
 			ExampleInstancedItem clone = (ExampleInstancedItem)base.Clone(item);

--- a/ExampleMod/Content/Items/ExampleMountItem.cs
+++ b/ExampleMod/Content/Items/ExampleMountItem.cs
@@ -1,4 +1,5 @@
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -9,6 +10,8 @@ namespace ExampleMod.Content.Items
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("ExampleMount Car key");
 			Tooltip.SetDefault("This summons a modded mount.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/ExampleQuestFish.cs
+++ b/ExampleMod/Content/Items/ExampleQuestFish.cs
@@ -9,6 +9,7 @@ namespace ExampleMod.Content.Items
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Upside-down Fish");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 2;
 		}
 

--- a/ExampleMod/Content/Items/ExampleSoul.cs
+++ b/ExampleMod/Content/Items/ExampleSoul.cs
@@ -16,8 +16,8 @@ namespace ExampleMod.Content.Items
 			// Registers a vertical animation with 4 frames and each one will last 5 ticks (1/12 second)
 			// Reminder, (4, 6) is an example of an item that draws a new frame every 6 ticks
 			Main.RegisterItemAnimation(Item.type, new DrawAnimationVertical(5, 4));
-			
-			ItemID.Sets.AnimatesAsSoul[Item.type] = true; // Makes the item have a 4-frame animation while in world (not held.)
+			ItemID.Sets.AnimatesAsSoul[Item.type] = true; // Makes the item have an animation while in world (not held.). Use in combination with RegisterItemAnimation
+
 			ItemID.Sets.ItemIconPulse[Item.type] = true; // The item pulses while in the player's inventory
 			ItemID.Sets.ItemNoGravity[Item.type] = true; // Makes the item have no gravity
 			

--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -1,3 +1,4 @@
+using Terraria.GameContent.Creative;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using Terraria;
@@ -13,8 +14,12 @@ namespace ExampleMod.Content.Items
 			// See here for help on using Tags: http://terraria.gamepedia.com/Chat#Tags
 			Tooltip.SetDefault("How are you feeling today?"
 				+ $"\n[c/FF0000:Colors ][c/00FF00:are ][c/0000FF:fun ]and so are items: [i:{Item.type}][i:{ModContent.ItemType<ExampleMountItem>()}][i/s123:{ItemID.Ectoplasm}]");
+			
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 
 			Main.RegisterItemAnimation(Item.type, new DrawAnimationVertical(30, 4));
+			ItemID.Sets.AnimatesAsSoul[Item.type] = true; // Makes the item have an animation while in world (not held.). Use in combination with RegisterItemAnimation
+
 			ItemID.Sets.ItemNoGravity[Item.type] = true;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
@@ -1,6 +1,7 @@
 using ExampleMod.Content.Tiles;
 using Terraria.ModLoader;
 using Terraria.ID;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Placeable
 {
@@ -8,6 +9,8 @@ namespace ExampleMod.Content.Items.Placeable
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Music Box (Marble Gallery)");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 
 			// The following code links the music box's item and tile with a music track:
 			//   When music with the given ID is playing, equipped music boxes have a chance to change their id to the given item type.

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded chair.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded chest.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded clock.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
@@ -9,6 +9,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded door.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExamplePlatform.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExamplePlatform.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded platform.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 200;
 		}
 

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded workbench.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
@@ -3,6 +3,7 @@ using Terraria.DataStructures;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Tools
 {
@@ -12,8 +13,10 @@ namespace ExampleMod.Content.Items.Tools
 			DisplayName.SetDefault("Example Fishing Rod");
 			Tooltip.SetDefault("Fires multiple lines at once. Can fish in lava.\n" +
 				"The fishing line never snaps.");
+
 			// Allows the pole to fish in lava
 			ItemID.Sets.CanFishInLava[Item.type] = true;
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Content.Items.Tools
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded hamaxe.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -12,6 +12,7 @@ namespace ExampleMod.Content.Items.Tools
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Example Hook"); // The item's name in-game.
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1; // Amount of this item needed to research and become available in Journey mode's duplication menu. Amount based on vanilla hooks' amount needed
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Content.Items.Tools
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded pickaxe.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
@@ -14,6 +14,7 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Meowmere V2");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomAmmoGun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomAmmoGun.cs
@@ -1,5 +1,6 @@
 ﻿using ExampleMod.Content.Items.Ammo;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -11,7 +12,9 @@ namespace ExampleMod.Content.Items.Weapons
 	public class ExampleCustomAmmoGun : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Tooltip.SetDefault("Uses CustomAmmo as ammo and shooting HomingProjectiles");
+			Tooltip.SetDefault("Uses ExampleCustomAmmo as ammo and shooting HomingProjectiles");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 		public override void SetDefaults() {
 			Item.width = 42; // The width of item hitbox

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomDamageWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomDamageWeapon.cs
@@ -1,6 +1,7 @@
 ﻿using ExampleMod.Content.DamageClasses;
 using ExampleMod.Content.Tiles.Furniture;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -9,6 +10,10 @@ namespace ExampleMod.Content.Items.Weapons
 	public class ExampleCustomDamageWeapon : ModItem
 	{
 		public override string Texture => "ExampleMod/Content/Items/Weapons/ExampleSword"; // TODO: remove when sprite is made for this
+
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
 
 		public override void SetDefaults() {
 			Item.DamageType = ModContent.GetInstance<ExampleDamageClass>(); // Makes our item use our custom damage type.

--- a/ExampleMod/Content/Items/Weapons/ExampleGun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleGun.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Terraria.DataStructures;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -9,6 +10,8 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded gun.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
@@ -8,6 +8,7 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is an example magic weapon");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -9,6 +10,8 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded minigun.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Weapons/ExampleModifiedProjectilesItem.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleModifiedProjectilesItem.cs
@@ -4,12 +4,18 @@ using Terraria.ModLoader;
 using Terraria.ID;
 using Microsoft.Xna.Framework;
 using ExampleMod.Common.GlobalProjectiles;
+using Terraria.GameContent.Creative;
 
 namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleModifiedProjectilesItem : ModItem
 	{
 		public override string Texture => "ExampleMod/Content/Items/Weapons/ExampleShootingSword";
+
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
+
 		public override void SetDefaults() {
 			Item.useTime = 20;
 			Item.useAnimation = 20;

--- a/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
@@ -16,6 +16,7 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded sword that shoots Star Wrath-like projectiles.");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +11,8 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded shotgun.");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
@@ -1,6 +1,7 @@
 ﻿using ExampleMod.Content.Projectiles;
 using Terraria;
 using Terraria.Audio;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -12,6 +13,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Tooltip.SetDefault("This is a modded spear");
 
 			ItemID.Sets.SkipsInitialUseSound[Item.type] = true; // This skips use animation-tied sound playback, so that we're able to make it be tied to use time instead in the UseItem() hook.
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSword.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override void SetStaticDefaults() {
 			Tooltip.SetDefault("This is a modded sword."); //The (English) text shown below your weapon's name.
+			
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -248,8 +248,8 @@ namespace ExampleMod.Content.NPCs
 		// 	}
 		//
 		// 	// todo: Here is an example of how your npc can sell items from other mods.
-		// 	// var modSummonersAssociation = ModLoader.GetMod("SummonersAssociation");
-		// 	// if (modSummonersAssociation != null) {
+		// 	// var modSummonersAssociation = ModLoader.TryGetMod("SummonersAssociation");
+		// 	// if (ModLoader.TryGetMod("SummonersAssociation", out Mod modSummonersAssociation)) {
 		// 	// 	shop.item[nextSlot].SetDefaults(modSummonersAssociation.ItemType("BloodTalisman"));
 		// 	// 	nextSlot++;
 		// 	// }

--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
@@ -12,6 +12,7 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Annoying Light");
 			Tooltip.SetDefault("Summons an annoying light");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetProjectile.cs
@@ -69,7 +69,7 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 
 			//Lights up area around it.
 			if (!Main.dedServ) {
-				Lighting.AddLight(Projectile.Center, (255 - Projectile.alpha) * 0.9f / 255f, (255 - Projectile.alpha) * 0.1f / 255f, (255 - Projectile.alpha) * 0.3f / 255f);
+				Lighting.AddLight(Projectile.Center, Projectile.Opacity * 0.9f, Projectile.Opacity * 0.1f, Projectile.Opacity * 0.3f);
 			}
 		}
 

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
@@ -12,6 +12,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Paper Airplane");
 			Tooltip.SetDefault("Summons a Paper Airplane to follow aimlessly behind you");
+
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
@@ -116,8 +116,8 @@ namespace ExampleMod.Content.Projectiles
 			// Get this frame on texture
 			Rectangle sourceRectangle = new Rectangle(0, startY, texture.Width, frameHeight);
 
-			//Alternatively, you can skip defining frameHeight and startY and use this:
-			//Rectangle sourceRectangle = texture.Frame(1, Main.projFrames[Projectile.type], frameY: Projectile.frame);
+			// Alternatively, you can skip defining frameHeight and startY and use this:
+			// Rectangle sourceRectangle = texture.Frame(1, Main.projFrames[Projectile.type], frameY: Projectile.frame);
 
 			Vector2 origin = sourceRectangle.Size() / 2f;
 

--- a/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -34,7 +35,7 @@ namespace ExampleMod.Content.Projectiles
 		// Returns null by default.
 		public override Color? GetAlpha(Color lightColor) {
 			//return Color.White;
-			return new Color(255, 255, 255, 0) * (1f - (float)Projectile.alpha / 255f);
+			return new Color(255, 255, 255, 0) * Projectile.Opacity;
 		}
 
 		public override void AI() {
@@ -108,15 +109,19 @@ namespace ExampleMod.Content.Projectiles
 			Texture2D texture = (Texture2D)ModContent.Request<Texture2D>(Texture);
 
 			// Calculating frameHeight and current Y pos dependence of frame
-			// If texture without animation frameHeight = texture.Height is always and startY is always 0
+			// If texture without animation frameHeight is always texture.Height and startY is always 0
 			int frameHeight = texture.Height / Main.projFrames[Projectile.type];
 			int startY = frameHeight * Projectile.frame;
 			
 			// Get this frame on texture
 			Rectangle sourceRectangle = new Rectangle(0, startY, texture.Width, frameHeight);
+
+			//Alternatively, you can skip defining frameHeight and startY and use this:
+			//Rectangle sourceRectangle = texture.Frame(1, Main.projFrames[Projectile.type], frameY: Projectile.frame);
+
 			Vector2 origin = sourceRectangle.Size() / 2f;
 
-			// If image isn't centered or symetrical you can specify origin of the sprite
+			// If image isn't centered or symmetrical you can specify origin of the sprite
 			// (0,0) for the upper-left corner 
 			float offsetX = 20f;
 			origin.X = (float)(Projectile.spriteDirection == 1 ? sourceRectangle.Width - offsetX : offsetX);
@@ -126,7 +131,7 @@ namespace ExampleMod.Content.Projectiles
 			// origin.Y = (float)(Projectile.spriteDirection == 1 ? sourceRectangle.Height - offsetY : offsetY);
 
 
-			// Appling lighting and draw current frame
+			// Applying lighting and draw current frame
 			Color drawColor = Projectile.GetAlpha(lightColor);
 			Main.EntitySpriteDraw(texture,
 				Projectile.Center - Main.screenPosition + new Vector2(0f, Projectile.gfxOffY),
@@ -141,6 +146,10 @@ namespace ExampleMod.Content.Projectiles
 	internal class ExampleAdvancedAnimatedProjectileItem : ModItem
 	{
 		public override string Texture => $"Terraria/Images/Item_{ItemID.NebulaBlaze}";
+
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
 
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.NebulaBlaze);

--- a/ExampleMod/Content/Projectiles/ExamplePiercingProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExamplePiercingProjectile.cs
@@ -1,11 +1,13 @@
 ﻿using ExampleMod.Content.Items;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Projectiles
 {
 	// This file showcases the concept of piercing.
+	// The code of the item that spawns it is located at the bottom.
 
 	// NPC.immune determines if an npc can be hit by a item or projectile owned by a particular player (it is an array, each slot corresponds to different players (whoAmI))
 	// NPC.immune is decremented towards 0 every update
@@ -70,6 +72,10 @@ namespace ExampleMod.Content.Projectiles
 	internal class ExamplePiercingProjectileItem : ModItem
 	{
 		public override string Texture => $"Terraria/Images/Item_{ItemID.FlintlockPistol}";
+
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
 
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.FlintlockPistol);

--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using System;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -46,6 +47,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 			DisplayName.SetDefault("Example Minion Item");
 			Tooltip.SetDefault("Summons an example minion to fight for you");
 
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 			ItemID.Sets.GamepadWholeScreenUseRange[Item.type] = true; // This lets the player target anywhere on the whole screen while using a controller
 			ItemID.Sets.LockOnIgnoresCollision[Item.type] = true;
 		}

--- a/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -65,14 +66,14 @@ namespace ExampleMod.Content.Tiles
 			int frameYOffset = Main.tileFrame[Type] * AnimationFrameHeight;
 
 			// Firstly we draw the original texture and then glow mask texture
-			Main.spriteBatch.Draw(
+			spriteBatch.Draw(
 				texture, 
 				new Vector2(i * 16 - (int)Main.screenPosition.X, j * 16 - (int)Main.screenPosition.Y) + zero,
 				new Rectangle(tile.frameX, tile.frameY + frameYOffset, 16, height),
 				Lighting.GetColor(i, j), 0f, default, 1f, SpriteEffects.None, 0f);
 			// Make sure to draw with Color.White or at least a color that is fully opaque
 			// Achieve opaqueness by increasing the alpha channel closer to 255. (lowering closer to 0 will achieve transparency)
-			Main.spriteBatch.Draw(
+			spriteBatch.Draw(
 				glowTexture,
 				new Vector2(i * 16 - (int)Main.screenPosition.X, j * 16 - (int)Main.screenPosition.Y) + zero,
 				new Rectangle(tile.frameX, tile.frameY + frameYOffset, 16, height),
@@ -85,6 +86,10 @@ namespace ExampleMod.Content.Tiles
 
 	internal class ExampleAnimatedGlowmaskTileItem : ModItem
 	{
+		public override void SetStaticDefaults() {
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
+
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.VoidMonolith);
 			Item.createTile = ModContent.TileType<ExampleAnimatedGlowmaskTile>();

--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -141,6 +142,8 @@ namespace ExampleMod.Content.Tiles
 	{
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Red Firefly in a Bottle");
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -25,7 +25,7 @@
  			public static List<int> ItemsThatAreProcessedAfterNormalContentSample = new List<int> {
  				1533,
  				1534,
-@@ -907,7 +_,8 @@
+@@ -907,10 +_,14 @@
  			public static bool[] CommonCoin = Factory.CreateBoolSet(71, 72, 73, 74);
  			public static bool[] ItemIconPulse = Factory.CreateBoolSet(520, 521, 575, 549, 548, 547, 3456, 3457, 3458, 3459, 3580, 3581);
  			public static bool[] ItemNoGravity = Factory.CreateBoolSet(520, 521, 575, 549, 548, 547, 3453, 3454, 3455, 3456, 3457, 3458, 3459, 3580, 3581, 4143);
@@ -35,3 +35,9 @@
  			public static int[] StaffMinionSlotsRequired = Factory.CreateIntSet(1);
  			public static bool[] ExoticPlantsForDyeTrade = Factory.CreateBoolSet(3385, 3386, 3387, 3388);
  			public static bool[] NebulaPickup = Factory.CreateBoolSet(3453, 3454, 3455);
++			/// <summary>
++			/// Use in conjunction with Main.RegisterItemAnimation to enable its animation in the world
++			/// </summary>
+ 			public static bool[] AnimatesAsSoul = Factory.CreateBoolSet(575, 547, 520, 548, 521, 549, 3580, 3581);
+ 			public static bool[] gunProj = Factory.CreateBoolSet(3475, 3540, 3854, 3930);
+ 			public static int[] SortingPriorityBossSpawns = Factory.CreateIntSet(-1, 43, 1, 560, 2, 70, 3, 1331, 3, 361, 4, 1133, 5, 4988, 5, 544, 6, 556, 7, 557, 8, 2495, 9, 2673, 10, 602, 11, 1844, 12, 1958, 13, 1293, 14, 2767, 15, 4271, 15, 3601, 16, 1291, 17, 109, 18, 29, 19, 50, 20, 3199, 20, 3124, 21);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -315,6 +315,19 @@
  			return result;
  		}
  
+@@ -2758,6 +_,12 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Registers an animation for an item type to draw inside UI (not world or held item on player).
++		/// To enable its animation in the world, use ItemID.Sets.AnimatesAsSoul in conjunction with this
++		/// </summary>
++		/// <param name="index">Item type</param>
++		/// <param name="animation">Draw animation</param>
+ 		public static void RegisterItemAnimation(int index, DrawAnimation animation) {
+ 			if (!itemAnimationsRegistered.Contains(index))
+ 				itemAnimationsRegistered.Add(index);
 @@ -2804,11 +_,13 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTile.cs
@@ -1,3 +1,4 @@
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader.Default
@@ -5,7 +6,7 @@ namespace Terraria.ModLoader.Default
 	public abstract class UnloadedTile : ModTile
 	{ 
 		public override void MouseOver(int i, int j) {
-			if (Main.netMode != 0) {
+			if (Main.netMode != NetmodeID.SinglePlayer) {
 				return;
 			}
 
@@ -24,7 +25,5 @@ namespace Terraria.ModLoader.Default
 			player.cursorItemIconID = -1;
 			player.cursorItemIconText = $"{info.modName}: {info.name}";
 		}
-
-		public override void MouseOverFar(int i, int j) => MouseOver(i, j);
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -39,7 +39,7 @@
  			}
  
  			public static void EnterWorld(int playerIndex) {
-+				Logging.Terraria.InfoFormat("Entering world with player: {0}, IsCloud={1}", Main.ActivePlayerFileData.Name, Main.ActivePlayerFileData.IsCloudSave);
++				Logging.Terraria.InfoFormat("Entering world with player: {0}, IsCloud={1}, Size={2}x{3}", Main.ActivePlayerFileData.Name, Main.ActivePlayerFileData.IsCloudSave, Main.maxTilesX, Main.maxTilesY);
 +				Interface.ResetData();
  				if (Hooks.OnEnterWorld != null)
  					Hooks.OnEnterWorld(Main.player[playerIndex]);

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -173,7 +173,7 @@
  		}
  
  		public static void serverLoadWorldCallBack() {
-+			Logging.Terraria.InfoFormat("Loading World: {0}, IsCloud={1}", Main.ActiveWorldFileData.Name, Main.ActiveWorldFileData.IsCloudSave);
++			Logging.Terraria.InfoFormat("Loading World: {0}, IsCloud={1}, Size={2}x{3}", Main.ActiveWorldFileData.Name, Main.ActiveWorldFileData.IsCloudSave, Main.ActiveWorldFileData.WorldSizeX, Main.ActiveWorldFileData.WorldSizeY);
  			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
  			WorldFile.LoadWorld(Main.ActiveWorldFileData.IsCloudSave);
  			if (loadFailed || !loadSuccess) {


### PR DESCRIPTION
### What is the new feature?
First of all, sorry for the bloated PR.

1. Adds world size logging to the server on world load, and to the client entering world. In singleplayer, only the latter will show, so no duplicate info in that case
2. Removes the `MouseOverFar` from `UnloadedTile`, to make it like in 1.3
3. ExampleMod:
    * Makes every item journeymode-researchable
    * Fixes comments regarding `ItemDropRule.Common` (outdated sig and param names)
    * Fixes comments and usages of `ItemID.Sets.AnimatesAsSoul`
    * Add more usages of `Projectile.Opacity` instead of alpha
    * Add bonus comment for easy framing of a texture
4. Documentation for `Main.RegisterItemAnimation` and `ItemID.Sets.AnimatesAsSoul`

### Why should this be part of tModLoader?
1. World size: Debugging, information for modders getting reports about features not working correctly which might be tied to world size.
2. MouseOverFar: Distracting and unnecessary in cases where you are surrounded with unloaded tiles. And most of the time nothing stops you to get close to a tile to inspect it. (Out of all tiles in vanilla, only things like graves or signs display text when mouseovering far away. I would not put unloaded tiles into that category.)
3. ExampleMod: Self-explanatory
4. Docs: The two methods are usually misunderstood in what they do, especially since the latter ID set was changed in it's purpose for 1.3, but kept its "old" name

