### PR TITLE
[1.4] EntityDefinition.IsUnloaded Type range fix + TryGetId

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
@@ -52,7 +52,8 @@ namespace Terraria.ModLoader.Config
 			return new { mod, name }.GetHashCode();
 		}
 
-		public bool IsUnloaded => Type == 0 && !(mod == "Terraria" && name == "None" || mod == "" && name == "");
+		//Check if the type is invalid and the mod/name pair is NOT vanilla
+		public bool IsUnloaded => Type <= 0 && !(mod == "Terraria" && name == "None" || mod == "" && name == "");
 
 		[JsonIgnore]
 		public abstract int Type { get; }
@@ -98,7 +99,7 @@ namespace Terraria.ModLoader.Config
 		public ProjectileDefinition(string key) : base(key) { }
 		public ProjectileDefinition(string mod, string name) : base(mod, name) { }
 
-		public override int Type => ProjectileID.Search.GetId(mod != "Terraria" ? $"{mod}/{name}" : name);
+		public override int Type => ProjectileID.Search.TryGetId(mod != "Terraria" ? $"{mod}/{name}" : name, out int id) ? id : -1;
 
 		public static ProjectileDefinition FromString(string s) => new ProjectileDefinition(s);
 
@@ -114,7 +115,7 @@ namespace Terraria.ModLoader.Config
 		public NPCDefinition(string key) : base(key) { }
 		public NPCDefinition(string mod, string name) : base(mod, name) { }
 
-		public override int Type => NPCID.Search.GetId(mod != "Terraria" ? $"{mod}/{name}" : name);
+		public override int Type => NPCID.Search.TryGetId(mod != "Terraria" ? $"{mod}/{name}" : name, out int id) ? id : -1;
 
 		public static NPCDefinition FromString(string s) => new NPCDefinition(s);
 
@@ -130,7 +131,7 @@ namespace Terraria.ModLoader.Config
 		public PrefixDefinition(string key) : base(key) { }
 		public PrefixDefinition(string mod, string name) : base(mod, name) { }
 
-		public override int Type => PrefixID.Search.GetId(mod != "Terraria" ? $"{mod}/{name}" : name);
+		public override int Type => PrefixID.Search.TryGetId(mod != "Terraria" ? $"{mod}/{name}" : name, out int id) ? id : -1;
 
 		public static PrefixDefinition FromString(string s) => new PrefixDefinition(s);
 


### PR DESCRIPTION
### What is the bug?
#1799

### How did you fix the bug?
1. Change existing `GetId` to `TryGetId` to prevent crashing
2. Change the `Type == 0` check to `Type <= 0` check to cover the invalid -1 return if something is not found within the dictionary from `TryGetId`

### Are there alternatives to your fix?
Could change the fallback from -1 to 0 and keep the == 0, haven't tested what implications it might have though.
