### PR TITLE
[1.4] Add ObsidianLockBox to OpenVanillaBag methods

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -494,7 +494,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to make vanilla bags drop your own items and stop the default items from being dropped. 
 		/// Return false to stop the default items from being dropped; returns true by default. 
-		/// Context will either be "present", "bossBag", "crate", "lockBox", "herbBag", or "goodieBag". 
+		/// Context will either be "present", "bossBag", "crate", "lockBox", "obsidianLockBox", "herbBag", or "goodieBag". 
 		/// For boss bags and crates, arg will be set to the type of the item being opened.
 		/// This method is also called for modded bossBags that are properly implemented.
 		/// 
@@ -507,7 +507,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to make vanilla bags drop your own items in addition to the default items.
 		/// This method will not be called if any other GlobalItem returns false for PreOpenVanillaBag.
-		/// Context will either be "present", "bossBag", "crate", "lockBox", "herbBag", or "goodieBag".
+		/// Context will either be "present", "bossBag", "crate", "lockBox", "obsidianLockBox", "herbBag", or "goodieBag".
 		/// For boss bags and crates, arg will be set to the type of the item being opened.
 		/// This method is also called for modded bossBags that are properly implemented.
 		/// 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1083,7 +1083,7 @@ namespace Terraria.ModLoader
 
 		//in Terraria.UI.ItemSlot add this to boss bag check
 		/// <summary>
-		/// Returns whether ModItem.bossBagNPC is greater than 0. Returns false if item is not a modded item.
+		/// Returns whether ModItem.BossBagNPC is greater than 0. Returns false if item is not a modded item.
 		/// </summary>
 		public static bool IsModBossBag(Item item) {
 			return item.ModItem != null && item.ModItem.BossBagNPC > 0;
@@ -1092,7 +1092,7 @@ namespace Terraria.ModLoader
 		//in Terraria.Player.OpenBossBag after setting num14 call
 		//  ItemLoader.OpenBossBag(type, this, ref num14);
 		/// <summary>
-		/// If the item is a modded item and ModItem.bossBagNPC is greater than 0, calls ModItem.OpenBossBag and sets npc to ModItem.bossBagNPC.
+		/// If the item is a modded item and ModItem.BossBagNPC is greater than 0, calls ModItem.OpenBossBag and sets npc to ModItem.BossBagNPC.
 		/// </summary>
 		public static void OpenBossBag(int type, Player player, ref int npc) {
 			ModItem modItem = GetItem(type);
@@ -1103,10 +1103,10 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPreOpenVanillaBag = AddHook<Func<string, Player, int, bool>>(g => g.PreOpenVanillaBag);
-		//in beginning of Terraria.Player.openBag methods add
+		//in beginning of Terraria.Player.OpenBag methods add
 		//  if(!ItemLoader.PreOpenVanillaBag("bagName", this, arg)) { return; }
 		//at the end of the following methods in Player.cs, add: NPCLoader.blockLoot.Clear(); // clear blockloot
-		//methods: OpenBossBag, openCrate, openGoodieBag, openHerbBag, openLockbox, openPresent
+		//methods: OpenBossBag, OpenCrate, OpenGoodieBag, OpenHerbBag, OpenLockbox, OpenShadowLockbox, openPresent
 		/// <summary>
 		/// Calls each GlobalItem.PreOpenVanillaBag hook until one of them returns false. Returns true if all of them returned true.
 		/// </summary>
@@ -1125,7 +1125,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookOpenVanillaBag = AddHook<Action<string, Player, int>>(g => g.OpenVanillaBag);
-		//in Terraria.Player.openBag methods after PreOpenVanillaBag if statements
+		//in Terraria.Player.OpenBag methods after PreOpenVanillaBag if statements
 		//  add ItemLoader.OpenVanillaBag("bagname", this, arg);
 		/// <summary>
 		/// Calls all GlobalItem.OpenVanillaBag hooks.

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -854,7 +854,23 @@
  					if (inventory[i].stack <= 0)
  						inventory[i].SetDefaults();
  
-@@ -5941,6 +_,10 @@
+@@ -5909,6 +_,10 @@
+ 		}
+ 
+ 		public void OpenShadowLockbox() {
++			if (!ItemLoader.PreOpenVanillaBag("obsidianLockBox", this, 0))
++				return;
++
++			ItemLoader.OpenVanillaBag("obsidianLockBox", this, 0);
+ 			bool flag = true;
+ 			while (flag) {
+ 				flag = false;
+@@ -5938,9 +_,15 @@
+ 				if (Main.netMode == 1)
+ 					NetMessage.SendData(21, -1, -1, null, number, 1f);
+ 			}
++
++			NPCLoader.blockLoot.Clear(); // clear blockloot
  		}
  
  		public void OpenLockBox() {

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -150,6 +150,17 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
+@@ -1119,7 +_,9 @@
+ 					}
+ 					else if (Main.mouseRight && inv[slot].type == 4879) {
+ 						if (Main.mouseRightRelease && player.HasItem(329)) {
++							if (ItemLoader.ConsumeItem(inv[slot], player))
+-							inv[slot].stack--;
++								inv[slot].stack--;
++
+ 							if (inv[slot].stack == 0)
+ 								inv[slot].SetDefaults();
+ 
 @@ -1132,7 +_,9 @@
  					}
  					else if (Main.mouseRight && inv[slot].type == 1869) {


### PR DESCRIPTION
### What is the bug?
The opening of the "ObsidianLockBox" item, which is new in 1.4, was not concidered by any of these hooks that are usually used in that context: `ConsumeItem`, `PreOpenVanillaBag`, and `OpenVanillaBag`.
I also adjusted the comments/docs to the updated code (all but 1 method was renamed to uppercase, and also a property not related to the PR was referenced with the wrong casing in a comment)

### How did you fix the bug?
Add the method calls in the proper contexts

### Are there alternatives to your fix?
You can make an argument for renaming the "lockBox" parameter to "goldenLockBox" as it would avoid ambiguity. (But the ItemID is still just called `LockBox`)
