### PR TITLE
[1.4] Fix spike damage and bleeding application

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/TileID.cs.patch
@@ -23,3 +23,12 @@
  			public static bool[] AllowsSaveCompressionBatching = Factory.CreateBoolSet(true, 520, 423);
  			public static bool[] IsATreeTrunk = Factory.CreateBoolSet(false, 5, 72, 583, 584, 585, 586, 587, 588, 589, 596, 616);
  			public static bool[] IsShakeable = Factory.CreateBoolSet(false, 5, 72, 323, 583, 584, 585, 586, 587, 588, 589, 596, 616);
+@@ -185,7 +_,7 @@
+ 			public static int[] TouchDamageVines = Factory.CreateIntSet(0, 32, 10, 69, 17, 80, 6, 352, 10);
+ 			public static int[] TouchDamageSands = Factory.CreateIntSet(0, 53, 15, 112, 15, 116, 15, 123, 15, 224, 15, 234, 15, 57, 15, 69, 15);
+ 			public static int[] TouchDamageHot = Factory.CreateIntSet(0, 37, 20, 58, 20, 76, 20);
+-			public static int[] TouchDamageOther = Factory.CreateIntSet(0, 48, 40, 232, 60);
++			public static int[] TouchDamageOther = Factory.CreateIntSet(0, 48, 60, 232, 80);
+ 			public static bool[] Falling = Factory.CreateBoolSet(53, 234, 112, 116, 224, 123, 330, 331, 332, 333, 495);
+ 			public static bool[] BlockMergesWithMergeAllBlock = Factory.CreateBoolSet();
+ 			public static bool[] OreMergesWithMud = Factory.CreateBoolSet(7, 166, 6, 167, 9, 168, 8, 169, 22, 204, 37, 58, 107, 221, 108, 222, 111, 223);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2623,6 +2623,15 @@
  								crit = true;
  
  							float currentSpeed = Math.Abs(base.velocity.X) / maxRunSpeed;
+@@ -19361,7 +_,7 @@
+ 				else if (vector3.Y != 0f) {
+ 					int damage3 = Main.DamageVar(vector3.Y, 0f - luck);
+ 					Hurt(PlayerDeathReason.ByOther(3), damage3, 0, pvp: false, quiet: false, Crit: false, 0);
+-					if (vector3.Y == 60f || vector3.Y == 80f)
++					if (vector3.Y == 60f || vector3.Y == 80f) //These values have to match TileID.Sets.TouchDamageOther, which is unused in vanilla and was not up to date with 1.4 --direwolf420
+ 						AddBuff(30, Main.rand.Next(240, 600));
+ 				}
+ 				else {
 @@ -19447,7 +_,7 @@
  
  			if (num83) {


### PR DESCRIPTION
### What is the bug?
The Spike tile was not applying the Bleeding debuff, which was added to it in 1.4. Also, both Spike variants were dealing 20 less damage than intended.

### How did you fix the bug?
Fix the values in the unused vanilla set `TileID.Sets.TouchDamageOther` (vanilla hardcoded these values).
This fix is rather naive and can be improved, but would need more thought, see below.

### Are there alternatives to your fix?
Sadly vanilla also just checks for those hardcoded values before applying the bleeding debuff. A cleaner fix would involve just checking the tile type (which `Collision.HurtTiles` does not return), because otherwise modded tiles that share those hardcoded damage values will also apply the debuff.
Another possibility would be creating sets which map a tile type to the debuff it applies coupled with the duration, or it could be separated in a new method + hooks for tml to adjust damage and buffs a tile can inflict.
