### PR TITLE
[1.4] Fix ItemIO for conditional GlobalItem

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -133,7 +133,7 @@ namespace Terraria.ModLoader.IO
 
 		internal static void LoadGlobals(Item item, IList<TagCompound> list) {
 			foreach (var tag in list) {
-				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out GlobalItem globalItem)) {
+				if (ModContent.TryFind(tag.GetString("mod"), tag.GetString("name"), out GlobalItem globalItemBase) && item.TryGetGlobalItem(globalItemBase, out var globalItem)) {
 					var globalItemInstance = globalItem.Instance(item);
 					try {
 						globalItemInstance.Load(item, tag.GetCompound("data"));
@@ -143,6 +143,7 @@ namespace Terraria.ModLoader.IO
 					}
 				}
 				else {
+					//Unloaded GlobalItems and GlobalItems that are no longer valid on an item (e.g. through AppliesToEntity)
 					item.GetGlobalItem<UnloadedGlobalItem>().data.Add(tag);
 				}
 			}
@@ -185,8 +186,10 @@ namespace Terraria.ModLoader.IO
 		public static void SendModData(Item item, BinaryWriter writer) {
 			if (item.IsAir) return;
 			writer.SafeWrite(w => item.ModItem?.NetSend(w));
-			foreach (var globalItem in ItemLoader.NetGlobals)
-				writer.SafeWrite(w => globalItem.Instance(item).NetSend(item, w));
+			foreach (var netGlobal in ItemLoader.NetGlobals) {
+				if (item.TryGetGlobalItem(netGlobal, out var globalItem))
+					writer.SafeWrite(w => globalItem.Instance(item).NetSend(item, w));
+			}
 		}
 
 		public static void ReceiveModData(Item item, BinaryReader reader) {
@@ -199,13 +202,14 @@ namespace Terraria.ModLoader.IO
 				Logging.tML.Error($"Above IOException error caused by {item.ModItem.Name} from the {item.ModItem.Mod.Name} mod.");
 			}
 
-			foreach (var globalItem in ItemLoader.NetGlobals) {
+			foreach (var netGlobal in ItemLoader.NetGlobals) {
 				try {
-					reader.SafeRead(r => globalItem.Instance(item).NetReceive(item, r));
+					if (item.TryGetGlobalItem(netGlobal, out var globalItem))
+						reader.SafeRead(r => globalItem.Instance(item).NetReceive(item, r));
 				}
 				catch (IOException e) {
 					Logging.tML.Error(e.ToString());
-					Logging.tML.Error($"Above IOException error caused by {globalItem.Name} from the {globalItem.Mod.Name} mod while reading {item.Name}.");
+					Logging.tML.Error($"Above IOException error caused by {netGlobal.Name} from the {netGlobal.Mod.Name} mod while reading {item.Name}.");
 				}
 			}
 		}


### PR DESCRIPTION
### What is the bug?
`GlobalItem`s that override `AppliesToEntity` and have a possibility to return false will cause exceptions during tag IO and net IO under certain circumstances. For tag IO, this is a problem if the modder changes the code inside `AppliesToEntity` later down the line and data was already saved under the previous conditions. For net IO, this is just a problem in general.

Minimal reproduction example for both issues:
```cs
public class ConditionalGlobalItem : GlobalItem
{
	int val = 0;

	public override bool InstancePerEntity => true;

	public override GlobalItem Clone(Item item, Item itemClone) => base.Clone(item, itemClone);

	public override bool? UseItem(Item item, Player player) {
		val = 1;
		return true;
	}

	public override bool AppliesToEntity(Item entity, bool lateInstantiation) => lateInstantiation && entity.type == ItemID.IronPickaxe;

	public override bool NeedsSaving(Item item) => val > 0;

	public override TagCompound Save(Item item) => new TagCompound() { ["val"] = val };

	public override void Load(Item item, TagCompound tag) => val = tag.GetInt("val");

	//Do not need to write anything to trigger the bug
	public override void NetSend(Item item, BinaryWriter writer) => base.NetSend(item, writer);

	public override void NetReceive(Item item, BinaryReader reader) => base.NetReceive(item, reader);
}
```

#### Tag IO Error:
1. Add the example to any mod
2. Load into a world, get an iron pickaxe, and swing it once, so that val gets set to 1
3. Leave the world so that it saves.
4. Now change `== ItemID.IronPickaxe` to `!= ItemID.IronPickaxe`, build the mod (or continue if using VS eac), and try playing singleplayer.
5. This error will appear:
![Screenshot_4](https://user-images.githubusercontent.com/15894498/131696474-b119254a-fd0d-49c5-8f05-d69d34b3ae42.png)

#### Net IO Error:
1. Add the example to any mod
2. Host a server, have a client join it
3. This error will appear (client and server, depending on what you are debugging or checking the log of):
![Screenshot_5](https://user-images.githubusercontent.com/15894498/131696720-847236df-cd78-43d1-9cdf-cdfe0561fc08.png)

### How did you fix the bug?
#### Tag IO Error:
Utilize `TryGetGlobalItem` in `LoadGlobals`, and only continue if this returns true. Add it to unloaded data if false.
`SaveGlobals` does not need the check, it already does the same thing as TryGetGlobalItem by checking if the instance is null before calling `NeedsSaving`.

#### Net IO Error:
Utilize `TryGetGlobalItem` in both `SendModData` and `ReceiveModData`, and only continue if this returns true.

### Are there alternatives to your fix?
Possibly, especially the decision to save things `AppliesToEntity` returns false for.
The check in `ReceiveModData` might not be necessary.