### PR TITLE
[1.4] Fix empty Materials tab in Journey Mode

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -403,6 +403,7 @@ namespace Terraria.ModLoader
 			RecipeGroupHelper.ResetRecipeGroups();
 			RecipeLoader.setupRecipes = true;
 			Recipe.SetupRecipes();
+			ContentSamples.FixItemsAfterRecipesAreAdded();
 			RecipeLoader.setupRecipes = false;
 		}
 


### PR DESCRIPTION
### What is the bug?
The Materials tab in the Journey Mode Item menu is empty.

### How did you fix the bug?
Add `ContentSamples.FixItemsAfterRecipesAreAdded` after the tml call to `Recipe.SetupRecipes` to mirror the behavior found in `Main.Initialize`.

### Are there alternatives to your fix?
No
