### PR TITLE
[1.4] Fix knockback value implicit cast to int

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4286,7 +4286,7 @@
 +
 +			float flat = 0;
 +			CombinedHooks.ModifyWeaponKnockback(this, sItem, ref kbModifier, ref flat);
-+			return Math.Max(0, KnockBack * kbModifier + flat);
++			return Math.Max(0f, KnockBack * kbModifier + flat);
  		}
  
  		public int GetWeaponCrit(Item sItem) {


### PR DESCRIPTION
### What is the bug?
#1825 

### How did you fix the bug?
Fix the call to the `Math.Max` method at the end of `Player.GetWeaponKnockback` to use the `float` overload, as it was using the `int` variant instead, due to this implicit operator cast defined in `StatModifier`:

```cs
public static implicit operator int(StatModifier m) => (int)(m.Additive * m.Multiplicative);
```

### Are there alternatives to your fix?
Remove the implicit operator instead?
