### PR TITLE
[1.4] ReadOnlyTagCompound - readonly ref struct

### DIFF
--- a/ExampleMod/Common/Systems/DownedBossSystem.cs
+++ b/ExampleMod/Common/Systems/DownedBossSystem.cs
@@ -39,7 +39,7 @@ namespace ExampleMod.Common.Systems
 			// }
 		}
 
-		public override void LoadWorldData(TagCompound tag) {
+		public override void LoadWorldData(ReadOnlyTagCompound tag) {
 			downedMinionBoss = tag.ContainsKey("downedMinionBoss");
 			// downedOtherBoss = tag.ContainsKey("downedOtherBoss");
 		}

--- a/ExampleMod/Common/Systems/SimpleDataAtParticularLocations.cs
+++ b/ExampleMod/Common/Systems/SimpleDataAtParticularLocations.cs
@@ -46,7 +46,7 @@ namespace ExampleMod.Common.Systems
 		}
 
 		// We load our data sets using the provided TagCompound. Should mirror SaveWorldData()
-		public override void LoadWorldData(TagCompound tag) {
+		public override void LoadWorldData(ReadOnlyTagCompound tag) {
 
 			List<PosData<byte>> list = new List<PosData<byte>>();
 			foreach (var entry in tag.GetList<TagCompound>("myMap")) {

--- a/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
@@ -86,7 +86,7 @@ namespace ExampleMod.Content.Items.Consumables
 			tag["exampleLifeFruits"] = exampleLifeFruits;
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			exampleLifeFruits = (int) tag["exampleLifeFruits"];
 		}
 	}

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -44,7 +44,7 @@ namespace ExampleMod.Content.Items
 			tag["Colors"] = colors.ToList();
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			colors = tag.Get<List<Color>>("Colors").ToArray();
 		}
 

--- a/patches/tModLoader/Terraria/DataStructures/TileEntity.TML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntity.TML.cs
@@ -19,7 +19,7 @@ namespace Terraria.DataStructures
 		/// <br/><b>Try to write defensive loading code that won't crash if something's missing.</b>
 		/// </summary>
 		/// <param name="tag"> The TagCompound to load data from. </param>
-		public virtual void LoadData(TagCompound tag) { }
+		public virtual void LoadData(ReadOnlyTagCompound tag) { }
 
 		/// <summary>
 		/// Allows you to send custom data for this tile entity between client and server. This is called on the server while sending tile data (!lightSend) and when a MessageID.TileEntitySharing message is sent (lightSend)

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
@@ -11,7 +11,7 @@ namespace Terraria.GameContent.Tile_Entities
 			tag["dyes"] = PlayerIO.SaveInventory(_dyes);
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			PlayerIO.LoadInventory(_items, tag.GetList<TagCompound>("items"));
 			PlayerIO.LoadInventory(_dyes, tag.GetList<TagCompound>("dyes"));
 		}

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEFoodPlatter.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEFoodPlatter.TML.cs
@@ -9,7 +9,7 @@ namespace Terraria.GameContent.Tile_Entities
 			tag["item"] = ItemIO.Save(item);
 		}
 
-		public override void LoadData(TagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
+		public override void LoadData(ReadOnlyTagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
 
 		public override void NetSend(BinaryWriter writer) => ItemIO.Send(item, writer, true);
 

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEHatRack.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEHatRack.TML.cs
@@ -11,7 +11,7 @@ namespace Terraria.GameContent.Tile_Entities
 			tag["dyes"] = PlayerIO.SaveInventory(_dyes);
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			PlayerIO.LoadInventory(_items, tag.GetList<TagCompound>("items"));
 			PlayerIO.LoadInventory(_dyes, tag.GetList<TagCompound>("dyes"));
 		}

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEItemFrame.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEItemFrame.TML.cs
@@ -9,7 +9,7 @@ namespace Terraria.GameContent.Tile_Entities
 			tag["item"] = ItemIO.Save(item);
 		}
 
-		public override void LoadData(TagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
+		public override void LoadData(ReadOnlyTagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
 
 		public override void NetSend(BinaryWriter writer) => ItemIO.Send(item, writer, true);
 

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEWeaponsRack.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEWeaponsRack.TML.cs
@@ -9,7 +9,7 @@ namespace Terraria.GameContent.Tile_Entities
 			tag["item"] = ItemIO.Save(item);
 		}
 
-		public override void LoadData(TagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
+		public override void LoadData(ReadOnlyTagCompound tag) => item = ItemIO.Load(tag.GetCompound("item"));
 
 		public override void NetSend(BinaryWriter writer) => ItemIO.Send(item, writer, true);
 

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -9,7 +9,7 @@ namespace Terraria
 {
 	public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	{
-		public static readonly Func<TagCompound, Item> DESERIALIZER = ItemIO.Load;
+		public static readonly Func<TagCompound, Item> DESERIALIZER = tag => ItemIO.Load(tag);
 
 		private int currentUseAnimationCompensation;
 

--- a/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
@@ -87,8 +87,8 @@ namespace Terraria.ModLoader.Config
 
 		public static ItemDefinition FromString(string s) => new ItemDefinition(s);
 
-		public static readonly Func<TagCompound, ItemDefinition> DESERIALIZER = Load;
-		public static ItemDefinition Load(TagCompound tag) => new ItemDefinition(tag.GetString("mod"), tag.GetString("name"));
+		public static readonly Func<TagCompound, ItemDefinition> DESERIALIZER = tag => Load(tag);
+		public static ItemDefinition Load(ReadOnlyTagCompound tag) => new ItemDefinition(tag.GetString("mod"), tag.GetString("name"));
 	}
 
 	[TypeConverter(typeof(ToFromStringConverter<ProjectileDefinition>))]
@@ -103,8 +103,8 @@ namespace Terraria.ModLoader.Config
 
 		public static ProjectileDefinition FromString(string s) => new ProjectileDefinition(s);
 
-		public static readonly Func<TagCompound, ProjectileDefinition> DESERIALIZER = Load;
-		public static ProjectileDefinition Load(TagCompound tag) => new ProjectileDefinition(tag.GetString("mod"), tag.GetString("name"));
+		public static readonly Func<TagCompound, ProjectileDefinition> DESERIALIZER = tag => Load(tag);
+		public static ProjectileDefinition Load(ReadOnlyTagCompound tag) => new ProjectileDefinition(tag.GetString("mod"), tag.GetString("name"));
 	}
 
 	[TypeConverter(typeof(ToFromStringConverter<NPCDefinition>))]
@@ -119,8 +119,8 @@ namespace Terraria.ModLoader.Config
 
 		public static NPCDefinition FromString(string s) => new NPCDefinition(s);
 
-		public static readonly Func<TagCompound, NPCDefinition> DESERIALIZER = Load;
-		public static NPCDefinition Load(TagCompound tag) => new NPCDefinition(tag.GetString("mod"), tag.GetString("name"));
+		public static readonly Func<TagCompound, NPCDefinition> DESERIALIZER = tag => Load(tag);
+		public static NPCDefinition Load(ReadOnlyTagCompound tag) => new NPCDefinition(tag.GetString("mod"), tag.GetString("name"));
 	}
 
 	[TypeConverter(typeof(ToFromStringConverter<PrefixDefinition>))]
@@ -135,8 +135,8 @@ namespace Terraria.ModLoader.Config
 
 		public static PrefixDefinition FromString(string s) => new PrefixDefinition(s);
 
-		public static readonly Func<TagCompound, PrefixDefinition> DESERIALIZER = Load;
-		public static PrefixDefinition Load(TagCompound tag) => new PrefixDefinition(tag.GetString("mod"), tag.GetString("name"));
+		public static readonly Func<TagCompound, PrefixDefinition> DESERIALIZER = tag => Load(tag);
+		public static PrefixDefinition Load(ReadOnlyTagCompound tag) => new PrefixDefinition(tag.GetString("mod"), tag.GetString("name"));
 	}
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/Default/LegacyUnloadedTilesSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/LegacyUnloadedTilesSystem.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default
 			converted.Clear();
 		}
 
-		public override void LoadWorldData(TagCompound tag) {
+		public override void LoadWorldData(ReadOnlyTagCompound tag) {
 			foreach (var infoTag in tag.GetList<TagCompound>("list")) {
 				if (!infoTag.ContainsKey("mod")) {
 					infos.Add(TileInfo.Invalid);

--- a/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
@@ -41,7 +41,7 @@ namespace Terraria.ModLoader.Default
 			tag["items"] = items;
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			items = tag.Get<List<Item>>("items");
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -23,7 +23,7 @@ namespace Terraria.ModLoader.Default
 			}
 		}
 
-		public override void LoadData(Item item, TagCompound tag) {
+		public override void LoadData(Item item, ReadOnlyTagCompound tag) {
 			if (tag.ContainsKey("modData")) {
 				ItemIO.LoadGlobals(item, tag.GetList<TagCompound>("modData"));
 			}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -24,10 +24,10 @@ namespace Terraria.ModLoader.Default
 			Item.rare = 1;
 		}
 
-		internal void Setup(TagCompound tag) {
+		internal void Setup(ReadOnlyTagCompound tag) {
 			ModName = tag.GetString("mod");
 			ItemName = tag.GetString("name");
-			data = tag;
+			data = tag.Tag;
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
@@ -47,7 +47,7 @@ namespace Terraria.ModLoader.Default
 			}
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			Setup(tag);
 
 			if (ModContent.TryFind(ModName, ItemName, out ModItem modItem)) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPlayer.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default
 			tag["unloadedResearch"] = unloadedResearch;
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			PlayerIO.LoadModData(Player, tag.GetList<TagCompound>("list"));
 			PlayerIO.LoadResearch(Player, tag.GetList<TagCompound>("unloadedResearch"));
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
@@ -31,7 +31,7 @@ namespace Terraria.ModLoader.Default
 			tag["unloadedBestiaryChats"] = unloadedBestiaryChats;
 		}
 
-		public override void LoadWorldData(TagCompound tag) {
+		public override void LoadWorldData(ReadOnlyTagCompound tag) {
 			WorldIO.LoadModData(tag.GetList<TagCompound>("list"));
 			WorldIO.LoadNPCs(tag.GetList<TagCompound>("unloadedNPCs"));
 			WorldIO.LoadNPCKillCounts(tag.GetList<TagCompound>("unloadedKillCounts"));

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
@@ -13,7 +13,7 @@ namespace Terraria.ModLoader.Default
 			tileEntityName = tag.GetString("name");
 
 			if (tag.ContainsKey("data")) {
-				data = tag.GetCompound("data");
+				data = tag.GetCompound("data").Tag;
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
@@ -8,7 +8,7 @@ namespace Terraria.ModLoader.Default
 		private string tileEntityName;
 		private TagCompound data;
 
-		internal void SetData(TagCompound tag) {
+		internal void SetData(ReadOnlyTagCompound tag) {
 			modName = tag.GetString("mod");
 			tileEntityName = tag.GetString("name");
 
@@ -31,7 +31,7 @@ namespace Terraria.ModLoader.Default
 			}
 		}
 
-		public override void LoadData(TagCompound tag) {
+		public override void LoadData(ReadOnlyTagCompound tag) {
 			SetData(tag);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -840,7 +840,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="item"> The item. </param>
 		/// <param name="tag"> The TagCompound to load data from. </param>
-		public virtual void LoadData(Item item, TagCompound tag) { }
+		public virtual void LoadData(Item item, ReadOnlyTagCompound tag) { }
 
 		/// <summary>
 		/// Allows you to send custom data for the given item between client and server.

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -80,7 +80,7 @@ namespace Terraria.ModLoader.IO
 			return tag;
 		}
 
-		public static void Load(Item item, TagCompound tag)
+		public static void Load(Item item, ReadOnlyTagCompound tag)
 		{
 			string modName = tag.GetString("mod");
 			if (modName == "") {
@@ -112,11 +112,11 @@ namespace Terraria.ModLoader.IO
 			item.stack = tag.Get<int?>("stack") ?? 1;
 			item.favorited = tag.GetBool("fav");
 
-			if (!(item.ModItem is UnloadedItem))
+			if (item.ModItem is not UnloadedItem)
 				LoadGlobals(item, tag.GetList<TagCompound>("globalData"));
 		}
 
-		public static Item Load(TagCompound tag) {
+		public static Item Load(ReadOnlyTagCompound tag) {
 			var item = new Item();
 			Load(item, tag);
 			return item;

--- a/patches/tModLoader/Terraria/ModLoader/IO/ModEntry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ModEntry.cs
@@ -19,7 +19,7 @@
 
 		protected abstract string GetUnloadedType(ushort type);
 
-		protected ModEntry(TagCompound tag) {
+		protected ModEntry(ReadOnlyTagCompound tag) {
 			type = tag.Get<ushort>("value");
 			modName = tag.Get<string>("mod");
 			name = tag.Get<string>("name");

--- a/patches/tModLoader/Terraria/ModLoader/IO/ReadOnlyTagCompound.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ReadOnlyTagCompound.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+
+namespace Terraria.ModLoader.IO
+{
+	public readonly ref struct ReadOnlyTagCompound
+	{
+		public readonly TagCompound Tag;
+
+		public ReadOnlyTagCompound(TagCompound tag) {
+			Tag = tag;
+		}
+
+		public static implicit operator ReadOnlyTagCompound(TagCompound tag) => new(tag);
+
+		public T Get<T>(string key) => Tag.Get<T>(key);
+		public bool ContainsKey(string key) => Tag.ContainsKey(key);
+
+		//NBT spec getters
+		public byte GetByte(string key) => Tag.GetByte(key);
+		public short GetShort(string key) => Tag.GetShort(key);
+		public int GetInt(string key) => Tag.GetInt(key);
+		public long GetLong(string key) => Tag.GetLong(key);
+		public float GetFloat(string key) => Tag.GetFloat(key);
+		public double GetDouble(string key) => Tag.GetDouble(key);
+		public byte[] GetByteArray(string key) => Tag.GetByteArray(key);
+		public int[] GetIntArray(string key) => Tag.GetIntArray(key);
+		public string GetString(string key) => Tag.GetString(key);
+		public IList<T> GetList<T>(string key) => Tag.GetList<T>(key);
+		public TagCompound GetCompound(string key) => Tag.GetCompound(key);
+		public bool GetBool(string key) => Tag.GetBool(key);
+
+		//type expansion helpers
+		public short GetAsShort(string key) => Tag.GetAsShort(key);
+		public int GetAsInt(string key) => Tag.GetAsInt(key);
+		public long GetAsLong(string key) => Tag.GetAsLong(key);
+		public double GetAsDouble(string key) => Tag.GetAsDouble(key);
+
+		public override string ToString() => Tag.ToString();
+
+		public object this[string key] => Tag[key];
+		public int Count => Tag.Count;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/ReadOnlyTagCompound.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ReadOnlyTagCompound.cs
@@ -26,7 +26,7 @@ namespace Terraria.ModLoader.IO
 		public int[] GetIntArray(string key) => Tag.GetIntArray(key);
 		public string GetString(string key) => Tag.GetString(key);
 		public IList<T> GetList<T>(string key) => Tag.GetList<T>(key);
-		public TagCompound GetCompound(string key) => Tag.GetCompound(key);
+		public ReadOnlyTagCompound GetCompound(string key) => Tag.GetCompound(key);
 		public bool GetBool(string key) => Tag.GetBool(key);
 
 		//type expansion helpers

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagCompound.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagCompound.cs
@@ -13,10 +13,8 @@ namespace Terraria.ModLoader.IO
 	//Additional conversions can be added using TagConverter
 	public class TagCompound : IEnumerable<KeyValuePair<string, object>>, ICloneable
 	{
-		[ThreadStatic]
-		private static TagCompound emptyTagCache = new();
 
-		private Dictionary<string, object> dict = new Dictionary<string, object>();
+		private readonly Dictionary<string, object> dict = new();
 
 		public T Get<T>(string key) {
 			dict.TryGetValue(key, out object tag);
@@ -29,9 +27,6 @@ namespace Terraria.ModLoader.IO
 					$"entry={TagPrinter.Print(new KeyValuePair<string, object>(key, tag))})", e);
 			}
 		}
-
-		// adding default param to Set overload is a breaking changefor now.
-		public void Set(string key, object value) => Set(key, value, false);
 		
 		//if value is null, calls RemoveTag, also performs type checking
 		public void Set(string key, object value, bool replace = false) {
@@ -45,7 +40,7 @@ namespace Terraria.ModLoader.IO
 				serialized = TagIO.Serialize(value);
 			}
 			catch (IOException e) {
-				var valueInfo = "value=" + value;
+				string valueInfo = "value=" + value;
 				if (value.GetType().ToString() != value.ToString())
 					valueInfo = "type=" + value.GetType() + "," + valueInfo;
 				throw new IOException($"NBT Serialization (key={key},{valueInfo})", e);
@@ -107,8 +102,8 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public object this[string key] {
-			get { return Get<object>(key); }
-			set { Set(key, value, true); }
+			get => Get<object>(key);
+			set => Set(key, value, true);
 		}
 
 		//collection initialiser

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
@@ -275,7 +275,7 @@ namespace Terraria.ModLoader.IO
 			PayloadHandlers[id].Write(w, tag);
 		}
 
-		public static TagCompound FromFile(string path, bool compressed = true) {
+		public static ReadOnlyTagCompound FromFile(string path, bool compressed = true) {
 			try {
 				using (Stream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
 					return FromStream(fs, compressed);
@@ -285,12 +285,12 @@ namespace Terraria.ModLoader.IO
 			}
 		}
 
-		public static TagCompound FromStream(Stream stream, bool compressed = true) {
+		public static ReadOnlyTagCompound FromStream(Stream stream, bool compressed = true) {
 			if (compressed) stream = new GZipStream(stream, CompressionMode.Decompress);
 			return Read(new BigEndianReader(stream));
 		}
 
-		public static TagCompound Read(BinaryReader reader) {
+		public static ReadOnlyTagCompound Read(BinaryReader reader) {
 			var tag = ReadTag(reader, out string name);
 			if (tag is not TagCompound compound)
 				throw new IOException("Root tag not a TagCompound");

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
@@ -292,10 +292,10 @@ namespace Terraria.ModLoader.IO
 
 		public static TagCompound Read(BinaryReader reader) {
 			var tag = ReadTag(reader, out string name);
-			if (!(tag is TagCompound))
+			if (tag is not TagCompound compound)
 				throw new IOException("Root tag not a TagCompound");
 
-			return (TagCompound)tag;
+			return compound;
 		}
 
 		public static void ToFile(TagCompound root, string path, bool compress = true) {

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileEntry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileEntry.cs
@@ -15,7 +15,7 @@ namespace Terraria.ModLoader.IO
 			frameImportant = Main.tileFrameImportant[tile.Type];
 		}
 
-		public TileEntry(TagCompound tag) : base(tag) {
+		public TileEntry(ReadOnlyTagCompound tag) : base(tag) {
 			frameImportant = tag.GetBool("framed");
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Annequin.cs
@@ -128,7 +128,7 @@ namespace Terraria.ModLoader.IO
 			return tag;
 		}
 
-		internal static void LoadContainers(TagCompound tag) {
+		internal static void LoadContainers(ReadOnlyTagCompound tag) {
 			if (tag.ContainsKey("data"))
 				ReadContainers(new BinaryReader(new MemoryStream(tag.GetByteArray("data"))));
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -40,7 +40,7 @@ namespace Terraria.ModLoader.IO
 				return entries;
 			}
 
-			public void LoadEntries(TagCompound tag, out TEntry[] savedEntryLookup) {
+			public void LoadEntries(ReadOnlyTagCompound tag, out TEntry[] savedEntryLookup) {
 				var savedEntryList = tag.GetList<TEntry>(entriesKey);
 				var entries = CreateEntries();
 
@@ -72,7 +72,7 @@ namespace Terraria.ModLoader.IO
 
 			protected abstract void ReadData(Tile tile, TEntry entry, BinaryReader reader);
 
-			public void LoadData(TagCompound tag, TEntry[] savedEntryLookup) {
+			public void LoadData(ReadOnlyTagCompound tag, TEntry[] savedEntryLookup) {
 				if (!tag.ContainsKey(dataKey)) {
 					return;
 				}
@@ -219,7 +219,7 @@ namespace Terraria.ModLoader.IO
 		internal static WallIOImpl Walls = new WallIOImpl();
 
 		//NOTE: LoadBasics can't be separated into LoadWalls() and LoadTiles() because of LoadLegacy.
-		internal static void LoadBasics(TagCompound tag) {
+		internal static void LoadBasics(ReadOnlyTagCompound tag) {
 			Tiles.LoadEntries(tag, out var tileEntriesLookup);
 			Walls.LoadEntries(tag, out var wallEntriesLookup);
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Legacy.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Legacy.cs
@@ -21,7 +21,7 @@ namespace Terraria.ModLoader.IO
 			internal const byte NextModTile = 128;
 		}
 
-		internal static void LoadLegacy(TagCompound tag, TileEntry[] tileEntriesLookup, WallEntry[] wallEntriesLookup) {
+		internal static void LoadLegacy(ReadOnlyTagCompound tag, TileEntry[] tileEntriesLookup, WallEntry[] wallEntriesLookup) {
 			if (!tag.ContainsKey("data")) {
 				return;
 			}

--- a/patches/tModLoader/Terraria/ModLoader/IO/WallEntry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WallEntry.cs
@@ -9,7 +9,7 @@ namespace Terraria.ModLoader.IO
 
 		public WallEntry(ModWall wall) : base(wall) { }
 
-		public WallEntry(TagCompound tag) : base(tag) {}
+		public WallEntry(ReadOnlyTagCompound tag) : base(tag) {}
 
 		public override string DefaultUnloadedType => ModContent.GetInstance<UnloadedWall>().FullName;
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -311,7 +311,7 @@ namespace Terraria.ModLoader.IO
 			};
 		}
 
-		internal static void LoadAnglerQuest(TagCompound tag) {
+		internal static void LoadAnglerQuest(ReadOnlyTagCompound tag) {
 			// Don't try to load modded angler quest item if there isn't one
 			if (!tag.ContainsKey("mod")) {
 				return;
@@ -404,7 +404,7 @@ namespace Terraria.ModLoader.IO
 			};
 		}
 
-		internal static void LoadAlteredVanillaFields(TagCompound compound) {
+		internal static void LoadAlteredVanillaFields(ReadOnlyTagCompound compound) {
 			CultistRitual.delay = compound.GetDouble("timeCultists");
 			Main.rainTime = compound.GetDouble("timeRain");
 			Sandstorm.TimeLeft = compound.GetDouble("timeSandstorm");

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1758,7 +1758,7 @@ namespace Terraria.ModLoader
 			if (HasMethod(type, nameof(GlobalItem.SaveData), typeof(Item), typeof(TagCompound)))
 				saveMethods++;
 
-			if (HasMethod(type, nameof(GlobalItem.LoadData), typeof(Item), typeof(TagCompound)))
+			if (HasMethod(type, nameof(GlobalItem.LoadData), typeof(Item), typeof(ReadOnlyTagCompound)))
 				saveMethods++;
 
 			if (saveMethods == 1)

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -938,7 +938,7 @@ namespace Terraria.ModLoader
 		/// <br/><b>Try to write defensive loading code that won't crash if something's missing.</b>
 		/// </summary>
 		/// <param name="tag"> The TagCompound to load data from. </param>
-		public virtual void LoadData(TagCompound tag) { }
+		public virtual void LoadData(ReadOnlyTagCompound tag) { }
 
 		/// <summary>
 		/// Allows you to send custom data for this item between client and server.

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -88,7 +88,7 @@ namespace Terraria.ModLoader
 		/// <br/><b>Try to write defensive loading code that won't crash if something's missing.</b>
 		/// </summary>
 		/// <param name="tag"> The TagCompound to load data from. </param>
-		public virtual void LoadData(TagCompound tag) { }
+		public virtual void LoadData(ReadOnlyTagCompound tag) { }
 
 		/// <summary>
 		/// PreSavePlayer and PostSavePlayer wrap the vanilla player saving code (both are before the ModPlayer.Save). Useful for advanced situations where a save might be corrupted or rendered unusable by the values that normally would save.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -239,7 +239,7 @@ namespace Terraria.ModLoader
 		/// <br/><b>Try to write defensive loading code that won't crash if something's missing.</b>
 		/// </summary>
 		/// <param name="tag"> The TagCompound to load data from. </param>
-		public virtual void LoadWorldData(TagCompound tag) { }
+		public virtual void LoadWorldData(ReadOnlyTagCompound tag) { }
 
 		/// <summary>
 		/// Allows you to send custom data between clients and server. This is useful for syncing information such as bosses that have been defeated.

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -954,7 +954,7 @@ namespace Terraria.ModLoader
 			if (HasMethod(type, nameof(ModPlayer.SaveData), typeof(TagCompound)))
 				saveMethods++;
 
-			if (HasMethod(type, nameof(ModPlayer.LoadData), typeof(TagCompound)))
+			if (HasMethod(type, nameof(ModPlayer.LoadData), typeof(ReadOnlyTagCompound)))
 				saveMethods++;
 
 			if (saveMethods == 1)


### PR DESCRIPTION
### What is the new feature?
ReadOnlyTagCompound readonly ref struct

### Why should this be part of tModLoader?
Allows explicitly defining that a TagCompound should only be read from.

### Are there alternative designs?
interface => https://github.com/tModLoader/tModLoader/pull/1879

### Sample usage for the new feature
LoadData hooks

### ExampleMod updates
Fixes

