### PR TITLE
Unlock more freedoms with Vanity slots in ModAccessorySlot

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModAccessorySlot.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAccessorySlot.cs
@@ -83,11 +83,18 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Override to set conditions on what can be placed in the slot. Return false to prevent the item going in slot. Return true for dyes, if you want dyes. Example: only wings can go in slot.
+		/// Override to set conditions on what can be placed in the slot. Default is to return false only when item property FitsAccessoryVanity says can't go in to a vanity slot. 
+		/// Return false to prevent the item going in slot. Return true for dyes, if you want dyes. Example: only wings can go in slot.
 		/// Receives data:
 		/// <para><paramref name="checkItem"/> :: the item that is attempting to enter the slot </para>
 		/// </summary>
-		public virtual bool CanAcceptItem(Item checkItem, AccessorySlotType context) => true;
+		public virtual bool CanAcceptItem(Item checkItem, AccessorySlotType context) {
+			if (context == AccessorySlotType.VanitySlot) {
+				return checkItem.FitsAccessoryVanitySlot;
+			}
+
+			return true;
+		}
 
 		/// <summary>
 		/// After checking for empty slots in ItemSlot.AccessorySwap, this allows for changing what the default target slot (accSlotToSwapTo) will be.

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -67,7 +67,7 @@
 +					if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(inv[slot], slot, context < 0))
 +						break;
 -					if (context == 11 && !inv[slot].FitsAccessoryVanitySlot)
-+					if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
++					if (context == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
  						break;
 +					if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, inv[slot], context))
 +						break;
@@ -91,7 +91,7 @@
  					if (Main.mouseItem.stack == 1 && Main.mouseItem.type > 0 && inv[slot].type > 0 && inv[slot].IsNotTheSameAs(Main.mouseItem) && (context != 11 || Main.mouseItem.FitsAccessoryVanitySlot)) {
 +						if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(Main.mouseItem, slot, context < 0))
 +							break;
-+						if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
++						if (context == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
 +							break;
 +						if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, Main.mouseItem, context))
 +							break;
@@ -115,7 +115,7 @@
  					else if (Main.mouseItem.type > 0 && inv[slot].type == 0 && (context != 11 || Main.mouseItem.FitsAccessoryVanitySlot)) {
 +						if (new int[6] { -10, -11, -12, 10, 11, 12 }.Contains(context) && !ItemLoader.CanEquipAccessory(Main.mouseItem, slot, context < 0))
 +							break;
-+						if (Math.Abs(context) == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
++						if (context == 11 && !Main.mouseItem.FitsAccessoryVanitySlot)
 +							break;
 +						if (context < 0 && !LoaderManager.Get<AccessorySlotLoader>().CanAcceptItem(slot, Main.mouseItem, context))
 +							break;


### PR DESCRIPTION
Currently, vanity accessory slots in ModAccessorySlot can't easily control whether or not items that have "ItemCanGoInVanitySlot" as false can still go in to them.

This change updates that by moving the can go in vanity check to be a part of the virtual method CanAcceptItem in ModAccessorySlot.