### PR TITLE
[1.4] [DRAFT] XML comments cleanup and addressing warnings in general (in a very lax way) [fixed]

### DIFF
--- a/patches/tModLoader/Terraria/ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/BuffID.cs.patch
@@ -1,14 +1,11 @@
 --- src/Terraria/Terraria/ID/BuffID.cs
 +++ src/tModLoader/Terraria/ID/BuffID.cs
-@@ -1,5 +_,8 @@
+@@ -1,4 +_,5 @@
  using ReLogic.Reflection;
- 
-+using ReLogic.Reflection;
 +using Terraria.ModLoader;
-+
+ 
  namespace Terraria.ID
  {
- 	public class BuffID
 @@ -12,7 +_,7 @@
  				public bool faceLeft;
  			}

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -21,7 +21,7 @@ namespace Terraria
 
 		private DamageClass _damageClass = DamageClass.Generic;
 		/// <summary>
-		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or ModContent.GetInstance&lt;T&gt;() for custom damage types.
 		/// </summary>
 		public DamageClass DamageType {
 			get => _damageClass;

--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -24,7 +24,7 @@ namespace Terraria.ModLoader
 		public AccessorySlotLoader() => Initialize(0);
 
 		public ModAccessorySlot Get(int id, Player player) => list[id % ModSlotPlayer(player).SlotCount()];
-		public ModAccessorySlot Get(int id) => Get(id, Player);
+		public new ModAccessorySlot Get(int id) => Get(id, Player);
 
 		public const int MaxVanillaSlotCount = 2 + 5;
 
@@ -259,7 +259,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Is run in AccessorySlotLoader.Draw. 
-		/// Creates & sets up Hide Visibility Button.
+		/// Creates &amp; sets up Hide Visibility Button.
 		/// </summary>
 		internal bool DrawVisibility(ref bool visbility, int context, int xLoc, int yLoc, out int xLoc2, out int yLoc2, out Texture2D value4) {
 			yLoc2 = yLoc - 2;
@@ -419,7 +419,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Checks if the provided item can go in to the provided slot. 
 		/// Includes checking if the item already exists in either of Player.Armor or ModSlotPlayer.exAccessorySlot
-		/// Invokes directly ItemSlot.AccCheck & ModSlot.CanAcceptItem
+		/// Invokes directly ItemSlot.AccCheck &amp; ModSlot.CanAcceptItem
 		/// </summary>
 		public bool ModSlotCheck(Item checkItem, int slot, int context) => CanAcceptItem(slot, checkItem, context) &&
 			!ItemSlot.AccCheck(Player.armor.Concat(ModSlotPlayer(Player).exAccessorySlot).ToArray(), checkItem, slot + Player.armor.Length);

--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -259,7 +259,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Is run in AccessorySlotLoader.Draw. 
-		/// Creates &amp; sets up Hide Visibility Button.
+		/// Creates and sets up Hide Visibility Button.
 		/// </summary>
 		internal bool DrawVisibility(ref bool visbility, int context, int xLoc, int yLoc, out int xLoc2, out int yLoc2, out Texture2D value4) {
 			yLoc2 = yLoc - 2;
@@ -419,7 +419,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Checks if the provided item can go in to the provided slot. 
 		/// Includes checking if the item already exists in either of Player.Armor or ModSlotPlayer.exAccessorySlot
-		/// Invokes directly ItemSlot.AccCheck &amp; ModSlot.CanAcceptItem
+		/// Invokes directly ItemSlot.AccCheck and ModSlot.CanAcceptItem
 		/// </summary>
 		public bool ModSlotCheck(Item checkItem, int slot, int context) => CanAcceptItem(slot, checkItem, context) &&
 			!ItemSlot.AccCheck(Player.armor.Concat(ModSlotPlayer(Player).exAccessorySlot).ToArray(), checkItem, slot + Player.armor.Length);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -177,7 +177,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="item">The item being used</param>
 		/// <param name="player">The player using the item</param>
-		/// <param name="add">Used for additively stacking buffs (most common). Only ever use += on this field. Things with effects like "5% increased MyDamageClass damage" would use this: `add += 0.05f`</param>
+		/// <param name="add">Used for additively stacking buffs (most common). Only ever use += on this field. Things with effects like "5% increased MyDamageClass damage" would use this: <c>add += 0.05f</c></param>
 		/// <param name="mult">Use to directly multiply the player's effective damage. Good for debuffs, or things which should stack separately (eg ammo type buffs)</param>
 		/// <param name="flat">This is a flat damage bonus that will be added after add and mult are applied. It facilitates effects like "4 more damage from weapons"</param>
 		public virtual void ModifyWeaponDamage(Item item, Player player, ref StatModifier damage, ref float flat) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -36,7 +36,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Returns a clone of this GlobalNPC. 
 		/// By default this will return a memberwise clone; you will want to override this if your GlobalNPC contains object references. 
-		/// Only called if CloneNewInstances && InstancePerEntity
+		/// Only called if CloneNewInstances &amp;&amp; InstancePerEntity
 		/// </summary>
 		public virtual GlobalNPC Clone() => (GlobalNPC)MemberwiseClone();
 
@@ -120,7 +120,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to make things happen whenever an NPC is hit, such as creating dust or gores. This hook is client side. Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for `if (npc.life <= 0)` to do client-side death effects, such as spawning dust, gore, or death sounds.
+		/// Allows you to make things happen whenever an NPC is hit, such as creating dust or gores. This hook is client side. Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for <c>if (npc.life &lt;= 0)</c> to do client-side death effects, such as spawning dust, gore, or death sounds.
 		/// </summary>
 		/// <param name="npc"></param>
 		/// <param name="hitDirection"></param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -34,7 +34,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Returns a clone of this GlobalProjectile. 
 		/// By default this will return a memberwise clone; you will want to override this if your GlobalProjectile contains object references. 
-		/// Only called if CloneNewInstances && InstancePerEntity
+		/// Only called if CloneNewInstances &amp;&amp; InstancePerEntity
 		/// </summary>
 		public virtual GlobalProjectile Clone() => (GlobalProjectile)MemberwiseClone();
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/BackupIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BackupIO.cs
@@ -153,7 +153,7 @@ namespace Terraria.ModLoader
 			}
 
 			/// <summary>
-			/// Write cloud files, which will get the relevant part of the path and write map & tmap files
+			/// Write cloud files, which will get the relevant part of the path and write map &amp; tmap files
 			/// </summary>
 			private static void WriteCloudFiles(ZipFile zip, string path) {
 				// Path is still equal to local path

--- a/patches/tModLoader/Terraria/ModLoader/InfoDisplay.cs
+++ b/patches/tModLoader/Terraria/ModLoader/InfoDisplay.cs
@@ -1,6 +1,5 @@
 using Terraria.Localization;
 using Microsoft.Xna.Framework.Graphics;
-using Terraria.Localization;
 
 namespace Terraria.ModLoader
 {

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Hooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Hooks.cs
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Close is called before Unload, and may be called at any time when mod unloading is imminent (such as when downloading an update, or recompiling)
 		/// Use this to release any additional file handles, or stop streaming music. 
-		/// Make sure to call `base.Close()` at the end
+		/// Make sure to call <c>base.Close()</c> at the end
 		/// May be called multiple times before Unload
 		/// </summary>
 		public virtual void Close() {

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -235,7 +235,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to make things happen whenever this NPC is hit, such as creating dust or gores. This hook is client side. Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for `if (npc.life <= 0)` to do client-side death effects, such as spawning dust, gore, or death sounds.
+		/// Allows you to make things happen whenever this NPC is hit, such as creating dust or gores. This hook is client side. Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for <c>if (npc.life &lt;= 0)</c> to do client-side death effects, such as spawning dust, gore, or death sounds.
 		/// </summary>
 		/// <param name="hitDirection"></param>
 		/// <param name="damage"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -413,7 +413,7 @@ namespace Terraria.ModLoader
 		/// Allows you to temporarily modify this weapon's damage based on player buffs, etc. This is useful for creating new classes of damage, or for making subclasses of damage (for example, Shroomite armor set boosts).
 		/// </summary>
 		/// <param name="item">The item being used</param>
-		/// <param name="add">Used for additively stacking buffs (most common). Only ever use += on this field. Things with effects like "5% increased MyDamageClass damage" would use this: `add += 0.05f`</param>
+		/// <param name="add">Used for additively stacking buffs (most common). Only ever use += on this field. Things with effects like "5% increased MyDamageClass damage" would use this: <c>add += 0.05f</c></param>
 		/// <param name="mult">Use to directly multiply the player's effective damage. Good for debuffs, or things which should stack separately (eg ammo type buffs)</param>
 		/// <param name="flat">This is a flat damage bonus that will be added after add and mult are applied. It facilitates effects like "4 more damage from weapons"</param>
 		public virtual void ModifyWeaponDamage(Item item, ref StatModifier damage, ref float flat) {
@@ -898,7 +898,7 @@ namespace Terraria.ModLoader
 		/// You can use this method to add items to the player's starting inventory, as well as their inventory when they respawn in mediumcore.
 		/// </summary>
 		/// <param name="mediumCoreDeath">Whether you are setting up a mediumcore player's inventory after their death.</param>
-		/// <returns>An enumerable of the items you want to add. If you want to add nothing, return Enumerable.Empty<Item>().</returns>
+		/// <returns>An enumerable of the items you want to add. If you want to add nothing, return Enumerable.Empty&lt;Item&gt;().</returns>
 		public virtual IEnumerable<Item> AddStartingItems(bool mediumCoreDeath) {
 			return Enumerable.Empty<Item>();
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -205,7 +205,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to control what happens when this projectile is killed (for example, creating dust or making sounds). Also useful for creating retrievable ammo. Called on all clients and the server in multiplayer, so be sure to use `if (projectile.owner == Main.myPlayer)` if you are spawning retrievable ammo. (As seen in ExampleJavelinProjectile)
+		/// Allows you to control what happens when this projectile is killed (for example, creating dust or making sounds). Also useful for creating retrievable ammo. Called on all clients and the server in multiplayer, so be sure to use <c>if (projectile.owner == Main.myPlayer)</c> if you are spawning retrievable ammo. (As seen in ExampleJavelinProjectile)
 		/// </summary>
 		public virtual void Kill(int timeLeft) {
 		}

--- a/patches/tModLoader/Terraria/ModLoader/PosData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PosData.cs
@@ -107,8 +107,8 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Gets a Position ID based on the x,y position. If using in an order sensitive case, see NextLocation.
 		/// </summary>
-		/// <param name="posX"></param>
-		/// <param name="posY"></param>
+		/// <param name="x"></param>
+		/// <param name="y"></param>
 		/// <returns></returns>
 		public static int CoordsToPos(int x, int y) => x * Main.maxTilesY + y;
 
@@ -143,13 +143,13 @@ namespace Terraria.ModLoader
 		};
 
 		/// <summary>
-		/// General purpose lookup function. Always returns a value (even if that value is `default`).
+		/// General purpose lookup function. Always returns a value (even if that value is <c>default</c>).
 		/// See <see cref="PosData{T}.OrderedSparseLookupBuilder.OrderedSparseLookupBuilder(int, bool, bool)"/>for more info
 		/// </summary>
 		public static T Lookup<T>(this PosData<T>[] posMap, int x, int y) => posMap.Lookup(CoordsToPos(x, y));
 
 		/// <summary>
-		/// General purpose lookup function. Always returns a value (even if that value is `default`).
+		/// General purpose lookup function. Always returns a value (even if that value is <c>default</c>).
 		/// See <see cref="PosData{T}.OrderedSparseLookupBuilder.OrderedSparseLookupBuilder(int, bool, bool)"/>for more info
 		/// </summary>
 		public static T Lookup<T>(this PosData<T>[] posMap, int pos) => posMap.Find(pos).value;

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -15,7 +15,7 @@ namespace Terraria
 
 		/// <summary>
 		/// Assign a special boss bar, vanilla or modded. Not used by vanilla.
-		/// <para>To assign a modded boss bar, use NPC.BossBar = ModContent.GetInstance<ExampleBossBar>(); where ExampleBossBar is a ModBossBar</para>
+		/// <para>To assign a modded boss bar, use NPC.BossBar = ModContent.GetInstance&lt;ExampleBossBar&gt;(); where ExampleBossBar is a ModBossBar</para>
 		/// <para>To assign a vanilla boss bar for whatever reason, fetch it first through the NPC type using Main.BigBossProgressBar.TryGetSpecialVanillaBossBar</para>
 		/// </summary>
 		public IBigProgressBar BossBar { get; set; }

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -38,7 +38,7 @@ namespace Terraria
 		}
 
 		/// <summary>
-		/// Ensure sufficient stack size (4MB) on MacOS &amp; Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+		/// Ensure sufficient stack size (4MB) on MacOS and Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
 		/// </summary>
 		private static void EnsureMinimumStackSizeOnThreads() {
 			// Doesn't work on .NET5, as the COMPlus_DefaultStackSize env var is used during runtime initialization (ie prior to reaching tML code)

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -38,7 +38,7 @@ namespace Terraria
 		}
 
 		/// <summary>
-		/// Ensure sufficient stack size (4MB) on MacOS & Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
+		/// Ensure sufficient stack size (4MB) on MacOS &amp; Windows secondary threads, doesn't hurt for Linux. 16^5 = 1MB, value in hex 
 		/// </summary>
 		private static void EnsureMinimumStackSizeOnThreads() {
 			// Doesn't work on .NET5, as the COMPlus_DefaultStackSize env var is used during runtime initialization (ie prior to reaching tML code)

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -14,7 +14,7 @@ namespace Terraria
 
 		private DamageClass _damageClass = DamageClass.Generic;
 		/// <summary>
-		/// The damage type of this Projectile. Assign to DamageClass.Generic/Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance<T>() for custom damage types.
+		/// The damage type of this Projectile. Assign to DamageClass.Generic/Melee/Ranged/Magic/Summon/Throwing, or ModContent.GetInstance&lt;T&gt;() for custom damage types.
 		/// </summary>
 		public DamageClass DamageType {
 			get => _damageClass;


### PR DESCRIPTION
Doesn't really fall into a bugfix or new feature category, just some cleanup following reasonable VS warnings avoiding big changes (i.e. no addressing deprecated uses of functions like in Lang).

This is the fixed tree version of #1898

Other changes in progress:
- [ ] Fixing silent override or hiding of methods
- [ ] Removing or fixing non matching `<param />` elements (adding missing ones seems like a thing to do later, muffling the warnings with a dumb no-op description for argument feels not productive nor useful)
