### PR TITLE
Switch from attribute to higher control IsLoadingEnabled

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModDust.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModDust.cs
@@ -8,7 +8,6 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class represents a type of dust that is added by a mod. Only one instance of this class will ever exist for each type of dust you add.
 	/// </summary>
-	[Autoload(Side = ModSide.Client)]
 	public abstract class ModDust : ModTexturedType
 	{
 		/// <summary> Allows you to choose a type of dust for this type of dust to copy the behavior of. Defaults to -1, which means that no behavior is copied. </summary>
@@ -69,5 +68,7 @@ namespace Terraria.ModLoader
 		/// Allows you to override the color this dust will draw in. Return null to draw it in the normal light color; returns null by default. Note that the dust.noLight field makes the dust ignore lighting and draw in full brightness, and can be set in OnSpawn instead of having to return Color.White here.
 		/// </summary>
 		public virtual Color? GetAlpha(Dust dust, Color lightColor) => null;
+
+		public override bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Client;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModGore.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModGore.cs
@@ -50,5 +50,7 @@ namespace Terraria.ModLoader
 		/// Allows you to determine whether or not this gore will draw behind tiles, etc. Returns false by default.
 		/// </summary>
 		public virtual bool DrawBehind(Gore gore) => false;
+
+		public override bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Client;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -310,5 +310,7 @@ namespace Terraria.ModLoader
 		/// <br/> The <paramref name="tileCounts"/> parameter is a read-only span (treat this as an array) that stores the tile count indexed by tile type.
 		/// </summary>
 		public virtual void TileCountsAvailable(ReadOnlySpan<int> tileCounts) { }
+
+		public override bool IsLoadingEnabled(Mod mod) => true;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -182,7 +182,7 @@ namespace Terraria.ModLoader
 			ModTypeLookup<ModTileEntity>.Register(this);
 		}
 
-		public virtual bool IsLoadingEnabled(Mod mod) => true;
+		public virtual bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Both;
 
 		public virtual void Unload(){}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -36,7 +36,7 @@
 		/// Allows you to stop <see cref="Mod.AddContent"/> from actually adding this content. Useful for items that can be disabled by a config.
 		/// </summary>
 		/// <param name="mod">The mod adding this content</param>
-		public virtual bool IsLoadingEnabled(Mod mod) => true;
+		public virtual bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Both;
 
 		/// <summary>
 		/// If you make a new ModType, seal this override.

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -8,7 +8,6 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// Represents a style of water that gets drawn, based on factors such as the background. This is used to determine the color of the water, as well as other things as determined by the hooks below.
 	/// </summary>
-	[Autoload(Side = ModSide.Client)]
 	public abstract class ModWaterStyle : ModTexturedType
 	{
 		/// <summary>
@@ -60,12 +59,13 @@ namespace Terraria.ModLoader
 		public virtual Color BiomeHairColor() {
 			return new Color(28, 216, 94);
 		}
+
+		public override bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Client;
 	}
 
 	/// <summary>
 	/// Represents a style of waterfalls that gets drawn. This is mostly used to determine the color of the waterfall.
 	/// </summary>
-	[Autoload(Side = ModSide.Client)]
 	public abstract class ModWaterfallStyle : ModTexturedType
 	{
 		/// <summary>
@@ -94,5 +94,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void ColorMultiplier(ref float r, ref float g, ref float b, float a) {
 		}
+
+		public override bool IsLoadingEnabled(Mod mod) => mod.Side == ModSide.Client;
 	}
 }


### PR DESCRIPTION
### What is the bug?
Currently, a lot of ModTypes require being designed for both client and server. 
This can lead to undiagnosed errors, for example when a mod labelled as a client mod adds a ModItem.

### How did you fix the bug?
Swapped from using Autoload(Side = ModSide.Client) to the more robust ILoadable.IsLoadingEnabled, and defaulted all ModTypes to only load when mod.Side is Both. 
Overrode ModSystem to no limit, and selected client only to only


### Are there alternatives to your fix?
1) Could modify to toss an error or log a line when a content is skipped in Mod.AddContent
2) The defaulting to only autoload when mod side is both may cause issues for NoSync mods, so some more thought than what I've done here may be worthwhile.
