### PR TITLE
[1.4] Remove legacy cast

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/PrefixDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/PrefixDefinitionElement.cs
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader.Config.UI
 				string modname = option.definition.mod;
 
 				if (option.type >= PrefixID.Count)
-					modname = PrefixLoader.GetPrefix((byte)option.type).Mod.DisplayName; // or internal name?
+					modname = PrefixLoader.GetPrefix(option.type).Mod.DisplayName; // or internal name?
 
 				if (modname.IndexOf(chooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)
 					continue;


### PR DESCRIPTION
### What is the bug?
TML changed `Prefix.type` from `byte` to `int`, but a cast to byte was not removed

### How did you fix the bug?
Remove the cast to byte

### Are there alternatives to your fix?
No
