### PR TITLE
Add clearing the Installed localmod to delete routine

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -16,7 +16,7 @@ namespace Terraria.ModLoader.UI.ModBrowser
 		public readonly string PublishId;
 		public readonly bool HasUpdate;
 		public readonly bool UpdateIsDowngrade;
-		public readonly LocalMod Installed;
+		public LocalMod Installed { get; internal set; }
 		public readonly string Version;
 
 		internal readonly string Author;

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
@@ -240,6 +240,12 @@ namespace Terraria.ModLoader.UI.ModBrowser
 			return UpdateNeeded = true;
 		}
 
+		internal void ModifyUIModDownloadItemInstalled(string modName, Core.LocalMod installed) {
+			var modbrowsermod = _items.IndexOf(_items.FirstOrDefault(x => x.ModDownload.ModName.Equals(modName, StringComparison.OrdinalIgnoreCase)));
+			if (modbrowsermod >= 0)
+				_items[modbrowsermod].ModDownload.Installed = installed;
+		}
+
 		/// <summary>
 		///     Enqueues a list of mods, if found on the browser (also used for ModPacks)
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
@@ -241,9 +241,9 @@ namespace Terraria.ModLoader.UI.ModBrowser
 		}
 
 		internal void ModifyUIModDownloadItemInstalled(string modName, Core.LocalMod installed) {
-			var modbrowsermod = _items.IndexOf(_items.FirstOrDefault(x => x.ModDownload.ModName.Equals(modName, StringComparison.OrdinalIgnoreCase)));
-			if (modbrowsermod >= 0)
-				_items[modbrowsermod].ModDownload.Installed = installed;
+			var modDownload = _items.Select(x => x.ModDownload).FirstOrDefault(x => x.ModName.Equals(modName, StringComparison.OrdinalIgnoreCase));
+			if (modDownload != null)
+				modDownload.Installed = installed;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
@@ -1,22 +1,14 @@
-using System;
-using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Security;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Newtonsoft.Json.Linq;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
-using Terraria.ModLoader.UI.ModBrowser;
+using Terraria.Social.Steam;
 using Terraria.UI;
 using Terraria.UI.Gamepad;
 
@@ -198,7 +190,7 @@ namespace Terraria.ModLoader.UI
 
 				Social.Base.AWorkshopEntry.TryReadingManifest(manifest, out var info);
 
-				var modManager = new Social.Steam.WorkshopHelper.ModManager(new Steamworks.PublishedFileId_t(info.workshopEntryId));
+				var modManager = new WorkshopHelper.ModManager(new Steamworks.PublishedFileId_t(info.workshopEntryId));
 
 				modManager.Uninstall(parentDir);
 			}
@@ -206,6 +198,7 @@ namespace Terraria.ModLoader.UI
 				File.Delete(tmodPath);
 			}
 
+			Interface.modBrowser.ModifyUIModDownloadItemInstalled(_localMod.Name, null);
 
 			Main.menuMode = _gotoMenu;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -480,6 +480,8 @@ namespace Terraria.ModLoader.UI
 				File.Delete(tmodPath);
 			}
 
+			Interface.modBrowser.ModifyUIModDownloadItemInstalled(_mod.Name, null);
+
 			CloseDialog(evt, listeningElement);
 			Interface.modsMenu.Activate();
 		}


### PR DESCRIPTION
Bug fix for #1943 

This isn't a perfect fix, although it eliminates the crash scenario, it still leaves a visual error on the mod browser where the mod is both installed and not installed on the main UI, but correctly shown in the ModInfo UI.

Reloading the browser obviously fixes this now graphical error.
