### PR TITLE
[1.4] Fix ModSystem not fully unloading

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -29,7 +29,10 @@ namespace Terraria.ModLoader
 			modsSystems.Add(modSystem);
 		}
 
-		internal static void Unload() => Systems.Clear();
+		internal static void Unload() {
+			Systems.Clear();
+			SystemsByMod.Clear();
+		}
 
 		internal static void ResizeArrays() {
 			NetSystems = ModLoader.BuildGlobalHook<ModSystem, Action<BinaryWriter>>(Systems, s => s.NetSend);


### PR DESCRIPTION
### What is the bug?
#1956. 

### How did you fix the bug?
Clear SystemsByMod on unload.

### Are there alternatives to your fix?
Clearing NetSystems is not necessary as it instantiates on load anyway.
