### PR TITLE
Swap to Release Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,8 +318,8 @@ jobs:
       - name: Download build artifact from build job
         uses: actions/download-artifact@v2
         with:
-          name: Debug Build
-          path: artifacts/Debug
+          name: Release Build
+          path: artifacts/Release
       - name: View build artifact files
         run: |
           echo pwd is: ${PWD}


### PR DESCRIPTION
At some point, we will have to make the judgement call to swap over to using the Release Build instead of the Debug build.

This should be done during a period where there is ample support presence, and minimal other ongoing changes in case something goes wrong.

This PR reminds us to do this in the coming months.
