### PR TITLE
Fix window sizing

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -37,8 +37,10 @@ namespace Terraria
 		public static Color MouseTextColorReal => new Color(mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f);
 		public static bool PlayerLoaded => CurrentFrameFlags.ActivePlayersCount > 0;
 
+		// Used to prevent situations where when going from borderless Fullscreen display to windowed display the width and height don't get resized to be able to access key window functions
+		// Does not effect resizing the window manually. May not be perfect, but will at least be sufficient to provide room to manually address this on the end user side
+		// Magic constant comes from default windows border settings: ~ 1377 / 1440 and 1033 / 1080.
 		private static int BorderedHeight(int height, bool state) => (int)(height * (state ? 1 : 0.95625));
-
 
 		private static Player _currentPlayerOverride;
 

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -37,6 +37,8 @@ namespace Terraria
 		public static Color MouseTextColorReal => new Color(mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f, mouseTextColor / 255f);
 		public static bool PlayerLoaded => CurrentFrameFlags.ActivePlayersCount > 0;
 
+		private static int BorderedHeight(int height, bool state) => (int)(height * (state ? 1 : 0.95625));
+
 
 		private static Player _currentPlayerOverride;
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3488,6 +3488,15 @@
  					array9[num24] = Lang.menu[5].Value;
  					if (selectedMenu == num24 || flag5) {
  						flag5 = false;
+@@ -37651,7 +_,7 @@
+ 						SoundEngine.PlaySound(12);
+ 						int num31 = 0;
+ 						for (int num32 = 0; num32 < numDisplayModes; num32++) {
+-							if (displayWidth[num32] == PendingResolutionWidth && displayHeight[num32] == PendingResolutionHeight) {
++							if (displayWidth[num32] == PendingResolutionWidth && BorderedHeight(displayHeight[num32], graphics.IsFullScreen) == PendingResolutionHeight) {
+ 								num31 = num32;
+ 								break;
+ 							}
 @@ -37659,7 +_,7 @@
  
  						num31 = (num31 + 1) % numDisplayModes;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -446,7 +446,7 @@
  			mouseBorderColorSlider.SetHSL(MouseBorderColor);
  			mouseBorderColorSlider.Alpha = (float)(int)MouseBorderColor.A / 255f;
 -			if (currentValue != 238)
-+			if (true || currentValue != Main.curRelease || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != BuildInfo.tMLVersion || (BuildInfo.Purpose == BuildInfo.BuildPurpose.Alpha && ModLoader.ModLoader.LastLaunchedTModLoaderAlphaSha != BuildInfo.CommitSHA)) {
++			if (currentValue != Main.curRelease || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != BuildInfo.tMLVersion || (BuildInfo.Purpose == BuildInfo.BuildPurpose.Alpha && ModLoader.ModLoader.LastLaunchedTModLoaderAlphaSha != BuildInfo.CommitSHA)) {
 +				ModLoader.ModLoader.MigrateSettings();
  				SaveSettings();
 +			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -416,13 +416,16 @@
  			if (Configuration.Save())
  				return PlayerInput.Save();
  
-@@ -3215,7 +_,12 @@
+@@ -3215,7 +_,15 @@
  					screenBorderlessPendingResizes = 1;
  
  				SetDisplayMode(currentValue2, currentValue3, fullscreen: false);
 -				TryPickingDefaultUIScale(currentValue3);
-+				TryPickingDefaultUIScale(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height);
 +			}
++			else {
++				FullscreenStartup();
++			}
++			TryPickingDefaultUIScale(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height);
 +
 +			if (Main.dedServ) {
 +				ModLoader.ModLoader.LoadConfiguration();
@@ -443,7 +446,7 @@
  			mouseBorderColorSlider.SetHSL(MouseBorderColor);
  			mouseBorderColorSlider.Alpha = (float)(int)MouseBorderColor.A / 255f;
 -			if (currentValue != 238)
-+			if (currentValue != Main.curRelease || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != BuildInfo.tMLVersion || (BuildInfo.Purpose == BuildInfo.BuildPurpose.Alpha && ModLoader.ModLoader.LastLaunchedTModLoaderAlphaSha != BuildInfo.CommitSHA)) {
++			if (true || currentValue != Main.curRelease || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != BuildInfo.tMLVersion || (BuildInfo.Purpose == BuildInfo.BuildPurpose.Alpha && ModLoader.ModLoader.LastLaunchedTModLoaderAlphaSha != BuildInfo.CommitSHA)) {
 +				ModLoader.ModLoader.MigrateSettings();
  				SaveSettings();
 +			}
@@ -3485,6 +3488,15 @@
  					array9[num24] = Lang.menu[5].Value;
  					if (selectedMenu == num24 || flag5) {
  						flag5 = false;
+@@ -37659,7 +_,7 @@
+ 
+ 						num31 = (num31 + 1) % numDisplayModes;
+ 						PendingResolutionWidth = displayWidth[num31];
+-						PendingResolutionHeight = displayHeight[num31];
++						PendingResolutionHeight = BorderedHeight(displayHeight[num31], graphics.IsFullScreen);
+ 					}
+ 
+ 					num30++;
 @@ -38363,7 +_,12 @@
  						}
  					}
@@ -4388,6 +4400,16 @@
  		}
  
  		public static int DamageVar(float dmg, float luck = 0f) {
+@@ -50393,7 +_,8 @@
+ 		}
+ 
+ 		public static void SetFullScreen(bool fullscreen) {
+-			SetDisplayMode(PendingResolutionWidth, PendingResolutionHeight, fullscreen);
++			// TML: Make the fullscreen reset to windowed display borders when downsizing
++			SetDisplayMode(PendingResolutionWidth, BorderedHeight(PendingResolutionHeight, fullscreen), fullscreen);
+ 		}
+ 
+ 		public static void SetResolution(int width, int height) {
 @@ -50438,7 +_,11 @@
  					width = (int)(num2 * (float)height);
  				}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3488,20 +3488,22 @@
  					array9[num24] = Lang.menu[5].Value;
  					if (selectedMenu == num24 || flag5) {
  						flag5 = false;
-@@ -37651,7 +_,7 @@
+@@ -37651,7 +_,8 @@
  						SoundEngine.PlaySound(12);
  						int num31 = 0;
  						for (int num32 = 0; num32 < numDisplayModes; num32++) {
++							// TML: Match the changeto follow so that resolution options provided on this settings menu still can be cycled correctly
 -							if (displayWidth[num32] == PendingResolutionWidth && displayHeight[num32] == PendingResolutionHeight) {
 +							if (displayWidth[num32] == PendingResolutionWidth && BorderedHeight(displayHeight[num32], graphics.IsFullScreen) == PendingResolutionHeight) {
  								num31 = num32;
  								break;
  							}
-@@ -37659,7 +_,7 @@
+@@ -37659,7 +_,8 @@
  
  						num31 = (num31 + 1) % numDisplayModes;
  						PendingResolutionWidth = displayWidth[num31];
 -						PendingResolutionHeight = displayHeight[num31];
++						// TML: Limit the resolution when going from fullscreen to windowed to be less than the full monitor size so that the key window edges are accessible
 +						PendingResolutionHeight = BorderedHeight(displayHeight[num31], graphics.IsFullScreen);
  					}
  


### PR DESCRIPTION
### What is the bug?
Fix #1889  & a support bug found where using fullscreen resolution leads to display settings getting reset on tmodloader updates.

### How did you fix the bug?
Wrapped display changes related to fullscreen with a boolean resolution correction to allow for windowed borders.
Added a set fullscreen display settings to occur before tmodloader writes settings (thus fixing the new version load order problem)

### Are there alternatives to your fix?
