### PR TITLE
Begin Migration from 105600 Cloud

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
@@ -144,14 +144,15 @@
  		private void DeleteMouseOut(UIMouseEvent evt, UIElement listeningElement) {
  			_deleteButtonLabel.SetText("");
  		}
-@@ -178,8 +_,12 @@
+@@ -178,8 +_,13 @@
  		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
  			if (_data.IsCloudSave)
  				_data.MoveToLocal();
 -			else
 +			else {
 +				ModLoader.Engine.Steam.RecalculateAvailableSteamCloudStorage(); //Only recalculate when about to put the file to cloud
-+				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
++				// Disable Putting on 105600 Cloud Temporarily Nov 23 2021 - Solxan
++				if (true || !ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
 +					return; //Don't allow both the move to cloud, and the setting of the label
  				_data.MoveToCloud();
 +			}

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.cs.patch
@@ -77,14 +77,15 @@
  		}
  
  		private void PlayMouseOver(UIMouseEvent evt, UIElement listeningElement) {
-@@ -229,8 +_,12 @@
+@@ -229,8 +_,13 @@
  		private void CloudButtonClick(UIMouseEvent evt, UIElement listeningElement) {
  			if (_data.IsCloudSave)
  				_data.MoveToLocal();
 -			else
 +			else {
 +				ModLoader.Engine.Steam.RecalculateAvailableSteamCloudStorage(); //Only recalculate when about to put the file to cloud
-+				if (!ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
++				// Disable Putting on 105600 Cloud Temporarily Nov 23 2021 - Solxan
++				if (true || !ModLoader.Engine.Steam.CheckSteamCloudStorageSufficient(_fileSize))
 +					return; //Don't allow both the move to cloud, and the setting of the label
  				_data.MoveToCloud();
 +			}

--- a/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.TML.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System.Linq;
+using Terraria.Utilities;
+
+namespace Terraria.Social.Steam
+{
+	public partial class CloudSocialModule : Base.CloudSocialModule
+	{
+		/// <summary>
+		/// This method is for migrating cloud files from 105600 to 1281930 in Steam.
+		/// This method was introduced in Nov 2021.
+		/// All original 105600 files not transitioned using this method can be found at:
+		/// https://store.steampowered.com/account/remotestorageapp/?appid=105600
+		/// </summary>
+		/// <returns></returns>
+		public bool MigrateFrom105600() {
+			var files = GetFiles().Where(file => file.Contains("ModLoader")).ToList();
+
+			if (files.Count == 0)
+				return true;
+
+			foreach (var item in files) {
+				var bytes = Read(item);
+
+				string target = Path.Combine(Main.SavePath, item.Split("ModLoader/")[1]);
+				string dir = Path.GetDirectoryName(target);
+				if(!Directory.Exists(dir))
+					Directory.CreateDirectory(dir);
+
+				if (!File.Exists(target)) 
+					File.WriteAllBytes(target, bytes);
+
+				Delete(item);
+			}
+
+			Utils.LogAndConsoleInfoMessage("Cloud files migrated from 105600 to Save File Directory");
+			return true;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.cs.patch
@@ -9,3 +9,11 @@
  	{
  		private const uint WRITE_CHUNK_SIZE = 1024u;
  		private object ioLock = new object();
+@@ -13,6 +_,7 @@
+ 
+ 		public override void Initialize() {
+ 			base.Initialize();
++			MigrateFrom105600();
+ 		}
+ 
+ 		public override void Shutdown() {

--- a/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/CloudSocialModule.cs.patch
@@ -1,0 +1,11 @@
+--- src/Terraria/Terraria/Social/Steam/CloudSocialModule.cs
++++ src/tModLoader/Terraria/Social/Steam/CloudSocialModule.cs
+@@ -5,7 +_,7 @@
+ 
+ namespace Terraria.Social.Steam
+ {
+-	public class CloudSocialModule : Terraria.Social.Base.CloudSocialModule
++	public partial class CloudSocialModule : Terraria.Social.Base.CloudSocialModule
+ 	{
+ 		private const uint WRITE_CHUNK_SIZE = 1024u;
+ 		private object ioLock = new object();


### PR DESCRIPTION
This PR moves us away from 105600 cloud file usage.
A similar PR will be needed to modify 1.3.

Resolves #1993, #1996 by removing cloud files off of Steam.

The core outcomes of this PR are:
1) Migrate all files off of 105600 cloud and into the SaveFile directory
2) Prevent players from moving files on to the cloud during the transition period.

The following is pertinent information to announce to Steam Users:
1) That we are in the process of changing Steam Cloud 'providers' and will be disabling adding new files to the Cloud in the short term of the next two weeks
2) That players should either run tModLoader to migrate their files off of the old Steam Cloud provider and in to their Save File directory, or download the files manually via https://store.steampowered.com/account/remotestorageapp/?appid=105600
3) This change applies to both 1.3 release and 1.4 Alpha, and will be completed by Dec. 15th, so we ask that all players take the time to migrate during this window. After this window, files will only be available to download manually via the aforementioned link.
