### PR TITLE
Mimic unfix

### DIFF
--- a/PortingNotes_1.4.3.1.txt
+++ b/PortingNotes_1.4.3.1.txt
@@ -1,7 +1,3 @@
-Notes:
-
-- "//Removed to avoid an exception on load" patch in ItemDropDatabase.cs is probably no longer needed?
-
 Failed Patches:
 
 Collision.cs:

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -44,13 +44,3 @@
  		}
  
  		private void RegisterFoodDrops() {
-@@ -914,7 +_,8 @@
- 			RegisterToNPC(476, ItemDropRule.Common(2676, 3, 2, 4));
- 			RegisterToNPC(476, ItemDropRule.Common(2272, 3));
- 			RegisterToNPC(476, ItemDropRule.Common(4731, 3));
-+			//Removed to avoid an exception on load
--			RegisterToNPC(476, ItemDropRule.Common(4986, 3, 69, 69));
-+			//RegisterToNPC(476, ItemDropRule.Common(4986, 3, 69, 69));
- 			int[] npcNetIds4 = new int[3] {
- 				473,
- 				474,


### PR DESCRIPTION
Previously, the Jungle Mimic had a buggy drop with Sparkle Slime Balloon, and a previous PR made it crash on launch so it was commented out
1.4.3.1 fixed this drop so it doesn't need to be commented out anymore