### PR TITLE
[1.4] Missing patches from 1.4.3(.1)

### DIFF
--- a/PortingNotes_1.4.3.0.txt
+++ b/PortingNotes_1.4.3.0.txt
@@ -1,6 +1,5 @@
 Notes:
 
-- BossBarLoader.InsertMenu needs checking
 - Replace the cast in 'timeLeft -= (int)Main.dayRate;' in NPC.AI_123_DeerClops.
 
 Failed Patches:

--- a/PortingNotes_1.4.3.1.txt
+++ b/PortingNotes_1.4.3.1.txt
@@ -6,17 +6,6 @@ Failed Patches:
 
 Collision.cs:
 
-@@ -2113,7 +2113,7 @@
- 						num6 -= 8;
- 					}
- 
--					if (type == 32 || type == 69 || type == 80 || type == 352 || (type == 80 && Main.dontStarveWorld)) {
-+					if (TileID.Sets.TouchDamageVines[type] > 0 || (type == 80 && Main.dontStarveWorld)) {
- 						if (!(vector.X + (float)Width > vector2.X) || !(vector.X < vector2.X + 16f) || !(vector.Y + (float)Height > vector2.Y) || !(vector.Y < vector2.Y + (float)num6 + 0.011f))
- 							continue;
-							
-Collision.cs:
-
 @@ -2140,7 +2132,7 @@
  						return new Vector2(num7, num5);
 

--- a/PortingNotes_1.4.3.1.txt
+++ b/PortingNotes_1.4.3.1.txt
@@ -4,15 +4,4 @@ Notes:
 
 Failed Patches:
 
-Collision.cs:
-
-@@ -2140,7 +2132,7 @@
- 						return new Vector2(num7, num5);
-
- 					}
- 
--					if (type == 53 || type == 112 || type == 116 || type == 123 || type == 224 || type == 234) {
-+					else if (TileID.Sets.TouchDamageSands[type] == 15 && type != 57 && type != 69) {
- 						if (vector.X + (float)Width - 2f >= vector2.X && vector.X + 2f <= vector2.X + 16f && vector.Y + (float)Height - 2f >= vector2.Y && vector.Y + 2f <= vector2.Y + (float)num6) {
- 							int num8 = 1;
- 							if (vector.X + (float)(Width / 2) < vector2.X + 8f)
+- None!

--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -9,6 +9,22 @@
  						continue;
  
  					vector2.X = i * 16;
+@@ -2113,11 +_,15 @@
+ 						num6 -= 8;
+ 					}
+ 
++
+ 					switch (type) {
++						/*
+ 						case 32:
+ 						case 69:
+ 						case 80:
+ 						case 352: {
++						*/
++						case int _ when TileID.Sets.TouchDamageVines[type] > 0: {
+ 								if (!(vector.X + (float)Width > vector2.X) || !(vector.X < vector2.X + 16f) || !(vector.Y + (float)Height > vector2.Y) || !(vector.Y < vector2.Y + (float)num6 + 0.011f))
+ 									continue;
+ 
 @@ -2125,6 +_,7 @@
  								if (vector.X + (float)(Width / 2) < vector2.X + 8f)
  									num8 = -1;

--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -42,6 +42,22 @@
  
  								if (type == 32 || type == 69 || type == 352) {
  									WorldGen.KillTile(i, j);
+@@ -2143,12 +_,15 @@
+ 
+ 								return new Vector2(num8, num5);
+ 							}
++						/*
+ 						case 53:
+ 						case 112:
+ 						case 116:
+ 						case 123:
+ 						case 224:
+ 						case 234:
++						*/
++						case int _ when TileID.Sets.TouchDamageSands[type] > 0 && type != 57 && type != 69:
+ 							if (vector.X + (float)Width - 2f >= vector2.X && vector.X + 2f <= vector2.X + 16f && vector.Y + (float)Height - 2f >= vector2.Y && vector.Y + 2f <= vector2.Y + (float)num6) {
+ 								int num7 = 1;
+ 								if (vector.X + (float)(Width / 2) < vector2.X + 8f)
 @@ -2165,14 +_,11 @@
  						if (vector.X + (float)(Width / 2) < vector2.X + 8f)
  							num9 = -1;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -707,6 +707,16 @@
  			active = false;
  		}
  
+@@ -52684,6 +_,9 @@
+ 			if (Main.tileDungeon[Main.tile[x, y].type] || TileID.Sets.BasicChest[Main.tile[x, y].type])
+ 				return false;
+ 
++			if (!TileLoader.CanExplode(x, y))
++				return false;
++
+ 			switch (Main.tile[x, y].type) {
+ 				case 26:
+ 				case 88:
 @@ -52744,7 +_,7 @@
  
  					for (int k = i - 1; k <= i + 1; k++) {


### PR DESCRIPTION
### Description
Add three missing patches, confirmed the correct position of a previous patch

PortingNotes_1.4.3.1.txt can be deleted as it should be empty after the merge.

Fixes #1983 