### PR TITLE
[1.4] Fix special moon styles (frost/pumpkin/smiley) not showing

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4102,7 +4102,7 @@
  
  				moonColor *= num13;
  				Vector2 position2 = new Vector2(num6, num7 + moonModY) + sceneArea.SceneLocalScreenPositionOffset;
-+				if (menu != null) {
++				if (Main.gameMenu && menu != null) {
 +					bool needsVanillaFraming = value2 == TextureAssets.Moon[num].Value;
 +					spriteBatch.Draw(value2, position2, new Rectangle(0, needsVanillaFraming ? TextureAssets.Moon[num].Width() * moonPhase : 0, needsVanillaFraming ? TextureAssets.Moon[num].Width() : value2.Width, needsVanillaFraming ? TextureAssets.Moon[num].Width() : value2.Width), moonColor, num9, new Vector2(needsVanillaFraming ? TextureAssets.Moon[num].Width() / 2 : value2.Width / 2), num8, SpriteEffects.None, 0f);
 +				}


### PR DESCRIPTION
### What is the bug?
currently the three special moons (frost/pumpkin/drunkworld) are never drawn even when conditions are true

### How did you fix the bug?
The code for drawing moons in the main menu through ModMenus was invoking ingame. Added a Main.gameMenu check for that

### Are there alternatives to your fix?
null `menu` using the same condition instead.