### PR TITLE
Fix #2009  with Shelling to Server

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -38,8 +38,10 @@ namespace Terraria.Social.Steam
 		}
 
 		internal static void OnGameExitCleanup() {
-			if (ModManager.SteamUser)
+			if (ModManager.SteamUser) {
+				SteamAPI.Shutdown();
 				return;
+			}
 
 			GameServer.Shutdown();
 		}


### PR DESCRIPTION
This PR fixes #2009 by shelling the ServerSide mods to the Server to publish.

The existing Command Line publish is sufficient for this use case.

This PR also explicitly shuts down the SteamAPI, which fixes some of the on close segfaults that Steamworks was tossing.