### PR TITLE
Use Correct Reference Assemblies in CSharpCompiler

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -1,4 +1,5 @@
 #if NETCORE
+using Basic.Reference.Assemblies;
 using log4net.Core;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -359,7 +360,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 
 			// TODO: do we need to always compile against reference assemblies?
 			// add framework assemblies
-			refs.AddRange(GetFrameworkReferences());
+			//refs.AddRange(GetFrameworkReferences());
 
 			//libs added by the mod
 			refs.AddRange(mod.properties.dllReferences.Select(dllName => DllRefPath(mod, dllName)));
@@ -456,6 +457,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			var emitOptions = new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb);
 
 			var refs = references.Select(s => MetadataReference.CreateFromFile(s));
+			refs = refs.Concat(Net60.All);
 
 			var src = files.Select(f => SyntaxFactory.ParseSyntaxTree(File.ReadAllText(f), parseOptions, f, Encoding.UTF8));
 
@@ -470,6 +472,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			return results.Diagnostics.Where(d => d.Severity >= DiagnosticSeverity.Warning).ToArray();
 		}
 
+		/*
 		private static IEnumerable<string> GetFrameworkReferences() {
 			var frameworkAssembliesPath = Path.GetDirectoryName(typeof(File).Assembly.Location);
 			return FilterUnmanagedFrameworkDllsViaBlacklist(Directory.GetFiles(frameworkAssembliesPath, "*.dll", SearchOption.AllDirectories));
@@ -518,6 +521,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			
 			return refs.Where(r => !unmanagedDLLs.Any(r.Contains));
 		}
+		*/
 	}
 }
 #endif

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -358,10 +358,6 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			//everything used to compile the tModLoader for the target platform
 			refs.AddRange(GetTerrariaReferences());
 
-			// TODO: do we need to always compile against reference assemblies?
-			// add framework assemblies
-			//refs.AddRange(GetFrameworkReferences());
-
 			//libs added by the mod
 			refs.AddRange(mod.properties.dllReferences.Select(dllName => DllRefPath(mod, dllName)));
 
@@ -471,57 +467,6 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			pdb = pdbStream.ToArray();
 			return results.Diagnostics.Where(d => d.Severity >= DiagnosticSeverity.Warning).ToArray();
 		}
-
-		/*
-		private static IEnumerable<string> GetFrameworkReferences() {
-			var frameworkAssembliesPath = Path.GetDirectoryName(typeof(File).Assembly.Location);
-			return FilterUnmanagedFrameworkDllsViaBlacklist(Directory.GetFiles(frameworkAssembliesPath, "*.dll", SearchOption.AllDirectories));
-		}
-
-		private static IEnumerable<string> FilterUnmanagedFrameworkDlls(IEnumerable<string> refs) {
-			var actualAssemblies = new List<string>();
-			var forwarderAssemblies = new List<string>();
-
-			// Separate assemblies into complete assemblies and assemblies that forward to an assembly, at a heavy toll on performance. Will generate the full list of forwarding assemblies to blacklist; Useful for maintenance.
-			foreach (string test in refs) {
-				try {
-					var a = Assembly.LoadFile(test);
-					actualAssemblies.Add(test);
-				}
-				catch (Exception) {
-					if (test.Contains("Private.CoreLib")) { // This assembly can't be loaded directly, but isn't a forwarding assembly and instead is the recipient of forwarding.
-						actualAssemblies.Add(test);
-					}
-					forwarderAssemblies.Add(test);
-				}
-			}
-
-			return actualAssemblies;
-		}
-
-		private static IEnumerable<string> FilterUnmanagedFrameworkDllsViaBlacklist(IEnumerable<string> refs) {
-			// Separate out known forward-only assemblies via string blacklisting.
-			string[] unmanagedDLLs = new string[] {
-				".Native",
-				"api-ms",
-				"clrcompression",
-				"clretwrc",
-				"clrjit",
-				"coreclr",
-				"dbgshim",
-				"Microsoft.DiaSymReader.Native.amd64",
-				"mscordaccore",
-				"mscordaccore_amd64_amd64",
-				"mscordbi",
-				"mscorrc",
-				"ucrtbase",
-				"hostpolicy",
-				"msquic"
-			};
-			
-			return refs.Where(r => !unmanagedDLLs.Any(r.Contains));
-		}
-		*/
 	}
 }
 #endif

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -52,7 +52,7 @@
      <EmbeddedResource Include="GameContent/Creative/Content/*" />
      <EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
      <EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -47,16 +_,28 @@
+@@ -47,16 +_,29 @@
    <ItemGroup>
      <Compile Remove="Social/WeGame/AsyncTaskHelper.cs" />
      <Compile Remove="Social/WeGame/CurrentThreadRunner.cs" />
@@ -65,6 +65,7 @@
 +    <Content Include="release_extras/**" CopyToOutputDirectory="PreserveNewest" Link="%(RecursiveDir)%(Filename)%(Extension)" />
 +  </ItemGroup>
 +  <ItemGroup>
++    <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.2.4" />
 +    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.11.1.1" />
 +    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0-6.final" />
 +    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.0-6.final" />


### PR DESCRIPTION
The existing code for getting framework references is only valid for net framework.
We have to change what we do for .netcore (and thus .net6)

The issue is that the old code utilizes the .... I'm tired. Just read this https://github.com/jaredpar/basic-reference-assemblies

This swaps to use the net6 package from the library that one person made to fix the bug.
Reference assemblies aren't default provided by the SDK anywho so modders would have headache, so might as well go for the lib at that point and just eat the 5 MB heft.
