### PR TITLE
Fix Display Doll Accessory Place Issue

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -431,7 +431,7 @@ namespace Terraria.ModLoader
 		/// Invokes directly ItemSlot.AccCheck & ModSlot.CanAcceptItem
 		/// </summary>
 		public bool ModSlotCheck(Item checkItem, int slot, int context) => CanAcceptItem(slot, checkItem, context) &&
-			!ItemSlot.AccCheck(Player.armor.Concat(ModSlotPlayer(Player).exAccessorySlot).ToArray(), checkItem, slot + Player.armor.Length);
+			!ItemSlot.AccCheck(Player.armor.Concat(ModSlotPlayer(Player).exAccessorySlot).ToArray(), checkItem, slot + Player.armor.Length, context);
 
 		/// <summary>
 		/// After checking for empty slots in ItemSlot.AccessorySwap, this allows for changing what the target slot will be if the accessory isn't already equipped.

--- a/patches/tModLoader/Terraria/UI/ItemSlot.TML.cs
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.TML.cs
@@ -26,7 +26,7 @@ namespace Terraria.UI
 			if (accSlotToSwapTo < 0) {
 				for (int i = 0; i < accessories.Length / 2; i++) {
 					if (accLoader.ModdedIsAValidEquipmentSlotForIteration(i, player)) {
-						if (accessories[i].type == 0 && accLoader.CanAcceptItem(i, item, (int)ItemSlotContext.ModdedAccessorySlot) && ItemLoader.CanEquipAccessory(item, i, true)) {
+						if (accessories[i].type == 0 && accLoader.CanAcceptItem(i, item, (int)Context.ModdedAccessorySlot) && ItemLoader.CanEquipAccessory(item, i, true)) {
 							accSlotToSwapTo = i + 20;
 							break;
 						}
@@ -35,8 +35,6 @@ namespace Terraria.UI
 			}
 
 			accLoader.ModifyDefaultSwapSlot(item, ref accSlotToSwapTo);
-
-			accSlotToSwapTo = Math.Max(accSlotToSwapTo, 0);
 
 			//TML: Check if there is an existing copy of the item in any slot (including vanity)
 			// Will also replace wings with wings
@@ -50,22 +48,26 @@ namespace Terraria.UI
 
 			//TML: Do the same check for our modded slots
 			for (int j = 0; j < accessories.Length; j++) {
-				if (item.IsTheSameAs(accessories[j]) && accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)ItemSlotContext.ModdedAccessorySlot : (int)ItemSlotContext.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
+				if (item.IsTheSameAs(accessories[j]) && accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)Context.ModdedAccessorySlot : (int)Context.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
 					accSlotToSwapTo = j + 20;
 
 				if (j < accLoader.list.Count && (item.wingSlot > 0 && accessories[j].wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(accessories[j], item)) 
-					&& accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)ItemSlotContext.ModdedAccessorySlot : (int)ItemSlotContext.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
+					&& accLoader.CanAcceptItem(j, item, j < accessories.Length / 2 ? (int)Context.ModdedAccessorySlot : (int)Context.ModdedVanityAccessorySlot) && ItemLoader.CanEquipAccessory(item, j, true))
 					accSlotToSwapTo = j + 20;
 			}
 
+			// No slot found, and it can't go in slot zero, than return
+			if (accSlotToSwapTo == -1 && !ItemLoader.CanEquipAccessory(item, 0, false))
+				return false;
+
+			accSlotToSwapTo = Math.Max(accSlotToSwapTo, 0);
 			if (accSlotToSwapTo >= 20) {
 				int num3 = accSlotToSwapTo - 20;
 				if (isEquipLocked(accessories[num3].type)) {
 					result =  item;
 					return false;
 				}
-					
-
+				
 				result = accessories[num3].Clone();
 				accessories[num3] = item.Clone();
 			}
@@ -127,7 +129,7 @@ namespace Terraria.UI
 					return false;
 
 				if (itemCollection[slot].wingSlot > 0 && item.wingSlot > 0 || !ItemLoader.CanAccessoryBeEquippedWith(itemCollection[slot], item))
-					return !ItemLoader.CanEquipAccessory(item, slot, slot >= 20);
+					return !ItemLoader.CanEquipAccessory(item, slot % 20, slot >= 20);
 			}
 
 			var modSlotPlayer = AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer);
@@ -149,21 +151,7 @@ namespace Terraria.UI
 					return true;
 			}
 
-			return !ItemLoader.CanEquipAccessory(item, slot, slot >= 20);
+			return !ItemLoader.CanEquipAccessory(item, slot % 20, slot >= 20);
 		}
-	}
-
-	//TODO: This is a work in progress enumerable table for Item Slot context variable. Mostly for sanity for anyone wondering. Added to as figured out.
-	public enum ItemSlotContext
-	{
-		ModdedAccessorySlot = -10,
-		ModdedVanityAccessorySlot = -11,
-		ModdedDyeSlot = -12,
-		Mouse = 0,
-		ArmorSlot = 8,
-		VanitySlot = 9,
-		AccessorySlot = 10,
-		VanityAccessorySlot = 11,
-		DyeSlot = 12
 	}
 }

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -23,6 +23,16 @@
  	{
  		public class Options
  		{
+@@ -25,6 +_,9 @@
+ 
+ 		public class Context
+ 		{
++			public const int ModdedAccessorySlot = -10;
++			public const int ModdedVanityAccessorySlot = -11;
++			public const int ModdedDyeSlot = -12;
+ 			public const int InventoryItem = 0;
+ 			public const int InventoryCoin = 1;
+ 			public const int InventoryAmmo = 2;
 @@ -81,7 +_,7 @@
  
  		public static bool DrawGoldBGForCraftingMaterial;
@@ -233,12 +243,12 @@
  					}
  				}
  			}
-@@ -900,7 +_,12 @@
+@@ -900,18 +_,24 @@
  						result = 1;
  					break;
  				case 10:
 -					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor, checkItem, slot)))
-+					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot)))
++					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot, context)))
 +						result = 1;
 +					break;
 +				case -10:
@@ -247,12 +257,13 @@
  						result = 1;
  					break;
  				case 24:
-@@ -908,10 +_,11 @@
+-					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(inv, checkItem, slot)))
++					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(inv, checkItem, slot, context)))
  						result = 1;
  					break;
  				case 11:
 -					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor, checkItem, slot)))
-+					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot)))
++					if (checkItem.type == 0 || (checkItem.accessory && !AccCheck(Main.LocalPlayer.armor.Concat(AccessorySlotLoader.ModSlotPlayer(Main.LocalPlayer).exAccessorySlot).ToArray(), checkItem, slot, context)))
  						result = 1;
  					break;
  				case 12:
@@ -541,22 +552,28 @@
  				}
  			}
  
-@@ -1940,7 +_,9 @@
+@@ -1940,7 +_,18 @@
  			return true;
  		}
  
 -		private static bool AccCheck(Item[] itemCollection, Item item, int slot) {
-+		internal static bool AccCheck(Item[] itemCollection, Item item, int slot) {
-+			return AccCheck_Inner(itemCollection, item, slot);
-+			/*
++		internal static bool AccCheck(Item[] itemCollection, Item item, int slot, int context) {
++			switch (context) {
++				case Context.ModdedAccessorySlot:
++				case Context.ModdedVanityAccessorySlot:
++				case Context.ModdedDyeSlot:
++				case Context.EquipDye:
++				case Context.EquipAccessoryVanity:
++				case Context.EquipAccessory:
++					return AccCheck_Inner(itemCollection, item, slot);
++			}
++			
++			// Vanilla code for Display Dolls, etc.
  			if (isEquipLocked(item.type))
  				return true;
  
-@@ -1966,8 +_,10 @@
- 			}
- 
+@@ -1968,6 +_,7 @@
  			return false;
-+			*/
  		}
  
 +		//TML: I (Solxan), have not been able to get this to ever run in-game. I suspect this code path is deprecated.


### PR DESCRIPTION
And fix an issue with the wrong slot value being provided for modded slots in AccCheck()
---------------

Two bugs:
1) This PR replaces the PR #1929  to fix Display Doll accessory bounds issues
2) This PR fixes an issue with ItemSlot.AccCheck_inner where the slot value provided to CanEquipAccessory was 20 higher than modders expect.
