### PR TITLE
[1.4] ModBuff -> BuffID.Sets

### DIFF
--- a/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
+++ b/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
@@ -1,4 +1,5 @@
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Buffs
@@ -13,7 +14,7 @@ namespace ExampleMod.Content.Buffs
 			Main.debuff[Type] = true;  // Is it a debuff?
 			Main.pvpBuff[Type] = true; // Players can give other players buffs, which are listed as pvpBuff
 			Main.buffNoSave[Type] = true; // It means the buff won't save when you exit the world
-			LongerExpertDebuff = true; // If this buff is a debuff, setting this to true will make this buff last twice as long on players in expert mode
+			BuffID.Sets.LongerExpertDebuff[Type] = true; // If this buff is a debuff, setting this to true will make this buff last twice as long on players in expert mode
 		}
 
 		// Allows you to make this buff give certain effects to the given player

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="../tModLoader.targets" />
+  <Import Project="..\tModLoader.targets" />
   <PropertyGroup>
     <AssemblyName>ExampleMod</AssemblyName>
     <TargetFramework>net6.0</TargetFramework>

--- a/PortingNotes_1.4.3.2.txt
+++ b/PortingNotes_1.4.3.2.txt
@@ -1,3 +1,0 @@
-Notes:
-
-- BuffLoader.CanBeCleared to be cleaned up & modernized heavily. CanBeCleared method calls were removed, since vanilla added BuffID.Sets.NurseCannotRemoveDebuff.

--- a/patches/tModLoader/Terraria/ID/BuffID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/BuffID.TML.cs
@@ -1,0 +1,13 @@
+namespace Terraria.ID;
+
+public partial class BuffID
+{
+	public partial class Sets
+	{
+		/// <summary>
+		/// Set for debuffs.
+		/// Causes debuffs to last twice as long on players in expert mode. Defaults to false.
+		/// </summary>
+		public static bool[] LongerExpertDebuff = Factory.CreateBoolSet(20, 22, 23, 24, 30, 31, 32, 33, 35, 36, 39, 44, 46, 47, 69, 70, 80);
+	}
+}

--- a/patches/tModLoader/Terraria/ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/BuffID.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/ID/BuffID.cs
 +++ src/tModLoader/Terraria/ID/BuffID.cs
-@@ -1,5 +_,8 @@
+@@ -1,10 +_,13 @@
  using ReLogic.Reflection;
  
 +using ReLogic.Reflection;
@@ -8,7 +8,14 @@
 +
  namespace Terraria.ID
  {
- 	public class BuffID
+-	public class BuffID
++	public partial class BuffID
+ 	{
+-		public class Sets
++		public partial class Sets
+ 		{
+ 			public class BuffMountData
+ 			{
 @@ -12,7 +_,7 @@
  				public bool faceLeft;
  			}

--- a/patches/tModLoader/Terraria/ModLoader/BuffLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuffLoader.cs
@@ -19,8 +19,6 @@ namespace Terraria.ModLoader
 		private static int nextBuff = BuffID.Count;
 		internal static readonly IList<ModBuff> buffs = new List<ModBuff>();
 		internal static readonly IList<GlobalBuff> globalBuffs = new List<GlobalBuff>();
-		private static readonly bool[] vanillaLongerExpertDebuff = new bool[BuffID.Count];
-		private static readonly bool[] vanillaCanBeCleared = new bool[BuffID.Count];
 
 		private delegate void DelegateUpdatePlayer(int type, Player player, ref int buffIndex);
 		private static DelegateUpdatePlayer[] HookUpdatePlayer;
@@ -32,40 +30,6 @@ namespace Terraria.ModLoader
 		private static DelegateModifyBuffTip[] HookModifyBuffTip;
 		private static Action<string, List<Vector2>>[] HookCustomBuffTipSize;
 		private static Action<string, SpriteBatch, int, int>[] HookDrawCustomBuffTip;
-
-		static BuffLoader() {
-			for (int k = 0; k < BuffID.Count; k++) {
-				vanillaCanBeCleared[k] = true;
-			}
-			vanillaLongerExpertDebuff[BuffID.Poisoned] = true;
-			vanillaLongerExpertDebuff[BuffID.Darkness] = true;
-			vanillaLongerExpertDebuff[BuffID.Cursed] = true;
-			vanillaLongerExpertDebuff[BuffID.OnFire] = true;
-			vanillaLongerExpertDebuff[BuffID.Bleeding] = true;
-			vanillaLongerExpertDebuff[BuffID.Confused] = true;
-			vanillaLongerExpertDebuff[BuffID.Slow] = true;
-			vanillaLongerExpertDebuff[BuffID.Weak] = true;
-			vanillaLongerExpertDebuff[BuffID.Silenced] = true;
-			vanillaLongerExpertDebuff[BuffID.BrokenArmor] = true;
-			vanillaLongerExpertDebuff[BuffID.CursedInferno] = true;
-			vanillaLongerExpertDebuff[BuffID.Frostburn] = true;
-			vanillaLongerExpertDebuff[BuffID.Chilled] = true;
-			vanillaLongerExpertDebuff[BuffID.Frozen] = true;
-			vanillaLongerExpertDebuff[BuffID.Ichor] = true;
-			vanillaLongerExpertDebuff[BuffID.Venom] = true;
-			vanillaLongerExpertDebuff[BuffID.Blackout] = true;
-			// TODO: ALL of this is horrendous. Move everything to Sets.
-			vanillaCanBeCleared[BuffID.PotionSickness] = false;
-			vanillaCanBeCleared[BuffID.Werewolf] = false;
-			vanillaCanBeCleared[BuffID.Merfolk] = false;
-			vanillaCanBeCleared[BuffID.WaterCandle] = false;
-			vanillaCanBeCleared[BuffID.Campfire] = false;
-			vanillaCanBeCleared[BuffID.HeartLamp] = false;
-			vanillaCanBeCleared[BuffID.NoBuilding] = false;
-			vanillaCanBeCleared[332] = false;
-			vanillaCanBeCleared[333] = false;
-			vanillaCanBeCleared[334] = false;
-		}
 
 		internal static int ReserveBuffID() {
 			if (ModNet.AllowVanillaClients) throw new Exception("Adding buffs breaks vanilla client compatibility");
@@ -176,10 +140,6 @@ namespace Terraria.ModLoader
 			}
 			return false;
 		}
-
-		public static bool LongerExpertDebuff(int buff) => GetBuff(buff)?.LongerExpertDebuff ?? vanillaLongerExpertDebuff[buff];
-
-		public static bool CanBeCleared(int buff) => GetBuff(buff)?.CanBeCleared ?? vanillaCanBeCleared[buff];
 
 		public static void ModifyBuffTip(int buff, ref string tip, ref int rare) {
 			if (IsModBuff(buff)) {

--- a/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBuff.cs
@@ -18,12 +18,6 @@ namespace Terraria.ModLoader
 		/// <summary> The translations of this buff's description. </summary>
 		public ModTranslation Description { get; internal set; }
 
-		/// <summary> If this buff is a debuff, setting this to true will make this buff last twice as long on players in expert mode. Defaults to false. </summary>
-		public bool LongerExpertDebuff { get; set; }
-
-		/// <summary> Whether or not it is always safe to call Player.DelBuff on this buff. Setting this to false will prevent the nurse from being able to remove this debuff. Defaults to true. </summary>
-		public bool CanBeCleared { get; set; } = true;
-
 		protected override sealed void Register() {
 			ModTypeLookup<ModBuff>.Register(this);
 
@@ -36,9 +30,9 @@ namespace Terraria.ModLoader
 
 		public sealed override void SetupContent() {
 			TextureAssets.Buff[Type] = ModContent.Request<Texture2D>(Texture);
-			
+
 			SetStaticDefaults();
-			
+
 			BuffID.Search.Add(FullName, Type);
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -354,7 +354,7 @@
  		private int AddBuff_DetermineBuffTimeToAdd(int type, int time1) {
  			int num = time1;
 -			if (Main.expertMode && whoAmI == Main.myPlayer && (type == 20 || type == 22 || type == 23 || type == 24 || type == 30 || type == 31 || type == 32 || type == 33 || type == 35 || type == 36 || type == 39 || type == 44 || type == 46 || type == 47 || type == 69 || type == 70 || type == 80)) {
-+			if (Main.expertMode && whoAmI == Main.myPlayer && (type == 20 || type == 22 || type == 23 || type == 24 || type == 30 || type == 31 || type == 32 || type == 33 || type == 35 || type == 36 || type == 39 || type == 44 || type == 46 || type == 47 || type == 69 || type == 70 || type == 80 || BuffLoader.LongerExpertDebuff(type))) {
++			if (Main.expertMode && whoAmI == Main.myPlayer && BuffID.Sets.LongerExpertDebuff[type]) {
  				float debuffTimeMultiplier = Main.GameModeInfo.DebuffTimeMultiplier;
  				if (Main.GameModeInfo.IsJourneyMode) {
  					if (Main.masterMode)


### PR DESCRIPTION
Removed the `ModBuff.CanBeCleared` method in favor of the vanilla `BuffID.Sets.NurseCannotRemoveDebuff` set
Replaced the `ModBuff.LongerExpertDebuff` method with the `BuffID.Sets.LongerExpertDebuff` set
