### PR TITLE
[1.4] Add CanAutoReuseItem hooks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -50,6 +50,29 @@ namespace Terraria.ModLoader
 			return PlayerLoader.CanUseItem(player, item) & ItemLoader.CanUseItem(item, player);
 		}
 
+		// In Player.TryAllowingItemReuse_Inner
+		public static bool? CanAutoswing(Player player, Item item) {
+			bool? result = null;
+
+			bool ModifyResult(bool? nbool) {
+				if (nbool.HasValue) {
+					result = nbool.Value;
+				}
+
+				return result != false;
+			}
+
+			if (!ModifyResult(PlayerLoader.CanAutoswing(player, item))) {
+				return false;
+			}
+
+			if (!ModifyResult(ItemLoader.CanAutoswing(item, player))) {
+				return false;
+			}
+
+			return result;
+		}
+
 		public static bool CanShoot(Player player, Item item) {
 			return PlayerLoader.CanShoot(player, item) && ItemLoader.CanShoot(item, player);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -51,7 +51,7 @@ namespace Terraria.ModLoader
 		}
 
 		// In Player.TryAllowingItemReuse_Inner
-		public static bool? CanAutoswing(Player player, Item item) {
+		public static bool? CanAutoReuseItem(Player player, Item item) {
 			bool? result = null;
 
 			bool ModifyResult(bool? nbool) {
@@ -62,11 +62,11 @@ namespace Terraria.ModLoader
 				return result != false;
 			}
 
-			if (!ModifyResult(PlayerLoader.CanAutoswing(player, item))) {
+			if (!ModifyResult(PlayerLoader.CanAutoReuseItem(player, item))) {
 				return false;
 			}
 
-			if (!ModifyResult(ItemLoader.CanAutoswing(item, player))) {
+			if (!ModifyResult(ItemLoader.CanAutoReuseItem(item, player))) {
 				return false;
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -86,7 +86,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="item"> The item. </param>
 		/// <param name="player"> The player. </param>
-		public virtual bool? CanAutoswing(Item item, Player player) => null;
+		public virtual bool? CanAutoReuseItem(Item item, Player player) => null;
 
 		/// <summary>
 		/// Allows you to modify the location and rotation of any item in its use animation.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -80,6 +80,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the autoswing (auto-reuse) behavior of any item without having to mess with Item.autoReuse.
+		/// <br>Useful to create effects like the Feral Claws which makes melee weapons and whips auto-reusable.</br>
+		/// <br>Return true to enable autoswing (if not already enabled through autoReuse), return false to prevent autoswing. Returns null by default, which applies vanilla behavior.</br>
+		/// </summary>
+		/// <param name="item"> The item. </param>
+		/// <param name="player"> The player. </param>
+		public virtual bool? CanAutoswing(Item item, Player player) => null;
+
+		/// <summary>
 		/// Allows you to modify the location and rotation of any item in its use animation.
 		/// </summary>
 		/// <param name="item"> The item. </param>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -251,6 +251,38 @@ namespace Terraria.ModLoader
 			return flag;
 		}
 
+		private static HookList HookCanAutoswing = AddHook<Func<Item, Player, bool?>>(g => g.CanAutoswing);
+
+		public static bool? CanAutoswing(Item item, Player player) {
+			bool? flag = null;
+
+			foreach (var g in HookCanAutoswing.Enumerate(item.globalItems)) {
+				bool? allow = g.CanAutoswing(item, player);
+
+				if (allow.HasValue) {
+					if (!allow.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			if (item.ModItem != null) {
+				bool? allow = item.ModItem.CanAutoswing(player);
+
+				if (allow.HasValue) {
+					if (!allow.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
+
 		private static HookList HookUseStyle = AddHook<Action<Item, Player, Rectangle>>(g => g.UseStyle);
 		//in Terraria.Player.ItemCheck after useStyle if/else chain call ItemLoader.UseStyle(item, this)
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -251,13 +251,13 @@ namespace Terraria.ModLoader
 			return flag;
 		}
 
-		private static HookList HookCanAutoswing = AddHook<Func<Item, Player, bool?>>(g => g.CanAutoswing);
+		private static HookList HookCanAutoReuseItem = AddHook<Func<Item, Player, bool?>>(g => g.CanAutoReuseItem);
 
-		public static bool? CanAutoswing(Item item, Player player) {
+		public static bool? CanAutoReuseItem(Item item, Player player) {
 			bool? flag = null;
 
-			foreach (var g in HookCanAutoswing.Enumerate(item.globalItems)) {
-				bool? allow = g.CanAutoswing(item, player);
+			foreach (var g in HookCanAutoReuseItem.Enumerate(item.globalItems)) {
+				bool? allow = g.CanAutoReuseItem(item, player);
 
 				if (allow.HasValue) {
 					if (!allow.Value) {
@@ -269,7 +269,7 @@ namespace Terraria.ModLoader
 			}
 
 			if (item.ModItem != null) {
-				bool? allow = item.ModItem.CanAutoswing(player);
+				bool? allow = item.ModItem.CanAutoReuseItem(player);
 
 				if (allow.HasValue) {
 					if (!allow.Value) {

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -156,12 +156,12 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to modify the autoswing (auto-reuse) behavior of any item without having to mess with Item.autoReuse.
+		/// Allows you to modify the autoswing (auto-reuse) behavior of this item without having to mess with Item.autoReuse.
 		/// <br>Useful to create effects like the Feral Claws which makes melee weapons and whips auto-reusable.</br>
 		/// <br>Return true to enable autoswing (if not already enabled through autoReuse), return false to prevent autoswing. Returns null by default, which applies vanilla behavior.</br>
 		/// </summary>
 		/// <param name="player"> The player. </param>
-		public virtual bool? CanAutoswing(Player player) => null;
+		public virtual bool? CanAutoReuseItem(Player player) => null;
 
 		/// <summary>
 		/// Allows you to modify the location and rotation of this item in its use animation.

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -156,6 +156,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the autoswing (auto-reuse) behavior of any item without having to mess with Item.autoReuse.
+		/// <br>Useful to create effects like the Feral Claws which makes melee weapons and whips auto-reusable.</br>
+		/// <br>Return true to enable autoswing (if not already enabled through autoReuse), return false to prevent autoswing. Returns null by default, which applies vanilla behavior.</br>
+		/// </summary>
+		/// <param name="player"> The player. </param>
+		public virtual bool? CanAutoswing(Player player) => null;
+
+		/// <summary>
 		/// Allows you to modify the location and rotation of this item in its use animation.
 		/// </summary>
 		/// <param name="player"> The player. </param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -862,6 +862,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the autoswing (auto-reuse) behavior of any item without having to mess with Item.autoReuse.
+		/// <br>Useful to create effects like the Feral Claws which makes melee weapons and whips auto-reusable.</br>
+		/// <br>Return true to enable autoswing (if not already enabled through autoReuse), return false to prevent autoswing. Returns null by default, which applies vanilla behavior.</br>
+		/// </summary>
+		/// <param name="item"> The item. </param>
+		public virtual bool? CanAutoswing(Item item) => null;
+
+		/// <summary>
 		/// Called on the Client while the nurse chat is displayed. Return false to prevent the player from healing. If you return false, you need to set chatText so the user knows why they can't heal.
 		/// </summary>
 		/// <param name="nurse">The Nurse NPC instance.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -867,7 +867,7 @@ namespace Terraria.ModLoader
 		/// <br>Return true to enable autoswing (if not already enabled through autoReuse), return false to prevent autoswing. Returns null by default, which applies vanilla behavior.</br>
 		/// </summary>
 		/// <param name="item"> The item. </param>
-		public virtual bool? CanAutoswing(Item item) => null;
+		public virtual bool? CanAutoReuseItem(Item item) => null;
 
 		/// <summary>
 		/// Called on the Client while the nurse chat is displayed. Return false to prevent the player from healing. If you return false, you need to set chatText so the user knows why they can't heal.

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1031,6 +1031,26 @@ namespace Terraria.ModLoader
 			return result;
 		}
 
+		private static HookList HookCanAutoswing = AddHook<Func<Item, bool?>>(p => p.CanAutoswing);
+
+		public static bool? CanAutoswing(Player player, Item item) {
+			bool? flag = null;
+
+			foreach (int index in HookCanAutoswing.arr) {
+				bool? allow = player.modPlayers[index].CanAutoswing(item);
+
+				if (allow.HasValue) {
+					if (!allow.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
+
 		private delegate bool DelegateModifyNurseHeal(NPC npc, ref int health, ref bool removeDebuffs, ref string chatText);
 		private static HookList HookModifyNurseHeal = AddHook<DelegateModifyNurseHeal>(p => p.ModifyNurseHeal);
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1031,13 +1031,13 @@ namespace Terraria.ModLoader
 			return result;
 		}
 
-		private static HookList HookCanAutoswing = AddHook<Func<Item, bool?>>(p => p.CanAutoswing);
+		private static HookList HookCanAutoReuseItem = AddHook<Func<Item, bool?>>(p => p.CanAutoReuseItem);
 
-		public static bool? CanAutoswing(Player player, Item item) {
+		public static bool? CanAutoReuseItem(Player player, Item item) {
 			bool? flag = null;
 
-			foreach (int index in HookCanAutoswing.arr) {
-				bool? allow = player.modPlayers[index].CanAutoswing(item);
+			foreach (int index in HookCanAutoReuseItem.arr) {
+				bool? allow = player.modPlayers[index].CanAutoReuseItem(item);
 
 				if (allow.HasValue) {
 					if (!allow.Value) {

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -328,10 +328,10 @@ namespace Terraria
 		/// <summary>
 		/// Helper method for modders to check if the player is able to autoswing (auto-reuse) an item.
 		/// <br>This checks item.autoReuse &amp;&amp; !player.noItems, and if Feral Claws effect applies to the item.</br>
-		/// <br>Additionally, any effects applied through the CanAutoswing hooks.</br>
+		/// <br>Additionally, any effects applied through the CanAutoReuseItem hooks.</br>
 		/// </summary>
 		/// <param name="item">The item currently in use</param>
 		/// <returns>true if player can autoswing using the item</returns>
-		public bool UsingAutoswingableItem(Item item) => TryAllowingItemReuse_Inner(item);
+		public bool UsingAutoReusableItem(Item item) => TryAllowingItemReuse_Inner(item);
 	}
 }

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -324,5 +324,14 @@ namespace Terraria
 			return false;
 
 		}
+
+		/// <summary>
+		/// Helper method for modders to check if the player is able to autoswing (auto-reuse) an item.
+		/// <br>This checks item.autoReuse &amp;&amp; !player.noItems, and if Feral Claws effect applies to the item.</br>
+		/// <br>Additionally, any effects applied through the CanAutoswing hooks.</br>
+		/// </summary>
+		/// <param name="item">The item currently in use</param>
+		/// <returns>true if player can autoswing using the item</returns>
+		public bool UsingAutoswingableItem(Item item) => TryAllowingItemReuse_Inner(item);
 	}
 }

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -332,6 +332,6 @@ namespace Terraria
 		/// </summary>
 		/// <param name="item">The item currently in use</param>
 		/// <returns>true if player can autoswing using the item</returns>
-		public bool UsingAutoReusableItem(Item item) => TryAllowingItemReuse_Inner(item);
+		public bool ShouldAutoReuseItem(Item item) => TryAllowingItemReuse_Inner(item);
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4220,7 +4220,7 @@
 +		}
 +
 +		private bool TryAllowingItemReuse_Inner(Item sItem) {
-+			// Split into _Inner because it is used by UsingAutoReusableItem 
++			// Split into _Inner because it is used by ShouldAutoReuseItem 
 +			bool flag = false;
 +
 +			bool? allow = CombinedHooks.CanAutoReuseItem(this, sItem);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4220,10 +4220,10 @@
 +		}
 +
 +		private bool TryAllowingItemReuse_Inner(Item sItem) {
-+			// Split into _Inner because it is used by UsingAutoswingableItem 
++			// Split into _Inner because it is used by UsingAutoReusableItem 
 +			bool flag = false;
 +
-+			bool? allow = CombinedHooks.CanAutoswing(this, sItem);
++			bool? allow = CombinedHooks.CanAutoReuseItem(this, sItem);
 +			if (allow.HasValue) {
 +				if (allow.Value) {
 +					return !noItems; // Even if forced to true, respect noItems (Cursed debuff)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4184,7 +4184,8 @@
 +			//return;
 +
  			if (sItem.autoReuse && !noItems) {
- 				releaseUseItem = true;
+-				releaseUseItem = true;
++				//releaseUseItem = true; // Now useless as per TryAllowingItemReuse -- direwolf420
 +
 +				// The following lines of code have been removed because of the change in how remote players' items now work in multiplayer.
 +				// Remote players used to simulate using the items by just playing pretty much guessed animations.
@@ -4205,7 +4206,45 @@
  			}
  
  			TryAllowingItemReuse(sItem);
-@@ -36660,6 +_,7 @@
+@@ -36647,19 +_,43 @@
+ 
+ 		private void TryAllowingItemReuse(Item sItem) {
+ 			bool flag = false;
++
++			flag = TryAllowingItemReuse_Inner(sItem);
++
++			// _Inner code changed to utilize conditions from ItemCheck_HandleMPItemAnimation.
++			// Now the previous assignment inside that method is useless and thus commented out
++			if (flag)
++				releaseUseItem = true;
++		}
++
++		private bool TryAllowingItemReuse_Inner(Item sItem) {
++			// Split into _Inner because it is used by UsingAutoswingableItem 
++			bool flag = false;
++
++			bool? allow = CombinedHooks.CanAutoswing(this, sItem);
++			if (allow.HasValue) {
++				if (allow.Value) {
++					return !noItems; // Even if forced to true, respect noItems (Cursed debuff)
++				}
++
++				return false;
++			}
++
++			flag |= sItem.autoReuse && !noItems; // Conditions taken from ItemCheck_HandleMPItemAnimation
++
+ 			if (autoReuseGlove) {
+ 				flag |= sItem.melee;
+ 				flag |= (sItem.summon && ItemID.Sets.SummonerWeaponThatScalesWithAttackSpeed[sItem.type]);
+ 			}
+ 
+-			if (flag)
+-				releaseUseItem = true;
++			return flag;
+ 		}
+ 
+ 		private void ItemCheck_HandleMount() {
  			if (!mount.Active)
  				return;
  


### PR DESCRIPTION
### What is the new feature?
Adds a new hook called `CanAutoReuseItem` to `ModPlayer`, `ModItem`, and `GlobalItem`. Also added the `ShouldAutoReuseItem` method to `Player` for fetching the autoswing status of an item.

### Why should this be part of tModLoader?
To provide support for features similar to vanillas Feral Claws accessory ("Feral Claws give autoswing to all melee weapons and Whips") and better controllability over autoswing (auto-reuse) of items without having to necessarily mess with `Item.autoReuse`.

The way the hooks are implemented is the same as `CanHitNPC` (and related), where a single `return false` will shortcircuit and prevent the item from being auto-reused. `return true` will do the expected, whereas the default `return null` will just fall back to `Item.autoReuse`.

### Are there alternative designs?
Sure, I am open to a redesign. For this to work the way I elaborated above, I had to move the first assignment of `releaseUseItem` into the method that just handles the Feral Claws, and extend it to support more use cases. Everything should be documented properly via comments.

### Sample usage for the new feature
Usage of it in [Clicker Class](https://github.com/SamsonAllen13/ClickerClass/commit/cabdb4234697f091269e967d987fe1c1ef5791ca), which had to mess with `Item.autoReuse` in `CanUseItem` before. It benefits from the new hooks so that it can properly define autoswingability without messing with fields, aswell as fetching that information so it can reduce the use speed of the held weapon.

### ExampleMod updates
Nothing in ExampleMod yet. If there is interest, an accessory similar to Feral Claws but for a different class could be made.
