### PR TITLE
Remedy for duplicate item use on remote clients. Fixes #1817, #1745

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3676,7 +3676,7 @@
 -				if (whoAmI == Main.myPlayer) {
 +
 +				// TML attempts to make ApplyItemTime calls run on remote players, so this check is removed. #ItemTimeOnAllClients
-+				if (whoAmI == Main.myPlayer || true) {
++				if (true) {// previously: if (whoAmI == Main.myPlayer)
  					bool flag4 = true;
  					int type2 = item.type;
  					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3659,7 +3659,7 @@
  			if (itemTime > 0) {
  				itemTime--;
  				if (ItemTimeIsZero && whoAmI == Main.myPlayer) {
-@@ -30319,11 +_,19 @@
+@@ -30319,11 +_,20 @@
  				}
  			}
  
@@ -3673,10 +3673,11 @@
  				ItemCheck_EmitHeldItemLight(item);
  				ItemCheck_EmitFoodParticles(item);
  				ItemCheck_EmitDrinkParticles(item);
--				if (whoAmI == Main.myPlayer) {
 +
 +				// TML attempts to make ApplyItemTime calls run on remote players, so this check is removed. #ItemTimeOnAllClients
-+				if (true) {// previously: if (whoAmI == Main.myPlayer)
+-				if (whoAmI == Main.myPlayer) {
++				// if (whoAmI == Main.myPlayer) {
++				if (true) { 
  					bool flag4 = true;
  					int type2 = item.type;
  					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3675,12 +3675,12 @@
  				ItemCheck_EmitDrinkParticles(item);
 -				if (whoAmI == Main.myPlayer) {
 +
-+				// TML attempts to make ApplyItemTime calls run on remote players, so this check is removed.
++				// TML attempts to make ApplyItemTime calls run on remote players, so this check is removed. #ItemTimeOnAllClients
 +				if (whoAmI == Main.myPlayer || true) {
  					bool flag4 = true;
  					int type2 = item.type;
  					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)
-@@ -30354,7 +_,7 @@
+@@ -30354,9 +_,13 @@
  
  					ItemCheck_TurretAltFeatureUse(item, flag4);
  					ItemCheck_MinionAltFeatureUse(item, flag4);
@@ -3688,7 +3688,21 @@
 +					if (item.shoot > 0 && itemAnimation > 0 && ItemTimeIsZero && flag4 && ItemLoader.CheckProjOnSwing(this, item))
  						ItemCheck_Shoot(i, item, weaponDamage);
  
++					// Added by TML. #ItemTimeOnAllClients - TODO: item time application with these item types
++					if (whoAmI != Main.myPlayer)
++						goto endItemChecks;
++
  					ItemCheck_UseWiringTools(item);
+ 					ItemCheck_UseLawnMower(item);
+ 					ItemCheck_PlayInstruments(item);
+@@ -30401,6 +_,7 @@
+ 						Vector2 vector = DirectionTo(ApplyRangeCompensation(0.2f, center, Main.MouseWorld)) * 10f;
+ 						Projectile.NewProjectile(GetProjectileSource_Accessory(boneGloveItem), center.X, center.Y, vector.X, vector.Y, 532, 25, 5f, whoAmI);
+ 					}
++					endItemChecks: {}
+ 				}
+ 
+ 				if (((item.damage >= 0 && item.type > 0 && !item.noMelee) || item.type == 1450 || item.type == 1991 || item.type == 3183 || item.type == 4821 || item.type == 3542 || item.type == 3779) && itemAnimation > 0) {
 @@ -30417,7 +_,8 @@
  
  						if (Main.myPlayer == i && item.damage > 0) {
@@ -4019,7 +4033,7 @@
  			int Damage = weaponDamage;
  			float KnockBack = sItem.knockBack;
 +
-+			// WhoAmI check added by TML.
++			// WhoAmI check added by TML. #ItemTimeOnAllClients
 -			if (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331) {
 +			if (whoAmI == Main.myPlayer && (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331)) {
  				grappling[0] = -1;
@@ -4029,7 +4043,7 @@
  			}
  
  			if (canShoot) {
-+				// Added by TML.
++				// Added by TML. #ItemTimeOnAllClients
 +				if (whoAmI != Main.myPlayer) {
 +					ApplyItemTime(sItem);
 +					return;
@@ -4077,7 +4091,7 @@
  				}
  			}
  			else if (sItem.useStyle == 5 || sItem.useStyle == 13) {
-+				// Added by TML.
++				// Added by TML. #ItemTimeOnAllClients
 +				if (whoAmI != Main.myPlayer)
 +					return;
 +
@@ -4099,7 +4113,7 @@
  			if (sItem.shoot > 0 && ProjectileID.Sets.MinionTargettingFeature[sItem.shoot] && altFunctionUse == 2 && cShoot && ItemTimeIsZero) {
  				ApplyItemTime(sItem);
 +
-+				// Added by TML.
++				// Added by TML. #ItemTimeOnAllClients
 +				if (whoAmI != Main.myPlayer)
 +					return;
 +
@@ -4111,8 +4125,8 @@
  
  			ApplyItemTime(sItem);
 +
-+			// Added by TML.
-+			if(whoAmI != Main.myPlayer)
++			// Added by TML. #ItemTimeOnAllClients
++			if (whoAmI != Main.myPlayer)
 +				return;
 +
  			for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
## This is a REMEDY and not the correct long term fix

Introduced by #1437

In Vanilla, when a remote player uses an item, none of the logic for whether the item use is possible, or using the item runs.
tModLoader attempts to make `ApplyItemTime` called on remote players. It does so by disabling the vanilla remote player check, allowing the code to run the 'can use item' test, applying item time, and then returns before the item is actually used.

Unfortunately, this was only correctly implemented (and presumambly tested) on `ItemCheck_TurretAltFeatureUse`, `ItemCheck_MinionAltFeatureUse` and `ItemCheck_Shoot`. Meaning that all other item uses ran on remote clients as well, often using substituted incorrect information from the remote client (such as cursor position).

This currently affects wiring tools, lawn mower, instruments, buckets, mining tools, rod of discord, life/mana crystal/fruit, demon heart, torch god's favor, event items, boss spawners, combat book, pet licenses, golf ball state, all placement functions, critter releasing and the bone glove.

### How did you fix the bug?
I inserted the remote player check to skip the above listed functions (and applying item time for them).

### Are there alternatives to your fix?
Apply the splitting of can use item, apply item time and use item correctly into all vanilla code (many places, hard).
Also note that in many places, item usability depends on non synchronised state, such as cursor position, and therefore can't be determined correctly on remote players. 

A potential solution would be actually syncing the `ApplyItemTime` call itself, in addition to the current approach of syncing the item use attempt.

