### PR TITLE
Use aiStyle -1 by default for modded NPCs

### DIFF
--- a/patches/tModLoader/Terraria/ID/NPCAIStyleID.cs
+++ b/patches/tModLoader/Terraria/ID/NPCAIStyleID.cs
@@ -6,6 +6,10 @@ namespace Terraria.ID
 	{
 		public static readonly IdDictionary Search = IdDictionary.Create<NPCAIStyleID, short>();
 		/// <summary>
+		/// Used by: <see cref="NPCID.BoundGoblin"/>, <see cref="NPCID.BoundWizard"/>, <see cref="NPCID.BoundMechanic"/>, <see cref="NPCID.WebbedStylist"/>, <see cref="NPCID.SleepingAngler"/>, <see cref="NPCID.BartenderUnconscious"/>, <see cref="NPCID.GolferRescue"/>
+		/// </summary>
+		public const short FaceClosestPlayer = 0;
+		/// <summary>
 		/// Used by: <see cref="NPCID.BigCrimslime"/>, <see cref="NPCID.LittleCrimslime"/>, <see cref="NPCID.JungleSlime"/>, <see cref="NPCID.YellowSlime"/>, <see cref="NPCID.RedSlime"/>, <see cref="NPCID.PurpleSlime"/>, <see cref="NPCID.BlackSlime"/>, <see cref="NPCID.BabySlime"/>, <see cref="NPCID.Pinky"/>, <see cref="NPCID.GreenSlime"/>, <see cref="NPCID.Slimer2"/>, <see cref="NPCID.Slimeling"/>, <see cref="NPCID.BlueSlime"/>, <see cref="NPCID.MotherSlime"/>, <see cref="NPCID.LavaSlime"/>, <see cref="NPCID.DungeonSlime"/>, <see cref="NPCID.CorruptSlime"/>, <see cref="NPCID.IlluminantSlime"/>, <see cref="NPCID.ToxicSludge"/>, <see cref="NPCID.IceSlime"/>, <see cref="NPCID.Crimslime"/>, <see cref="NPCID.SpikedIceSlime"/>, <see cref="NPCID.SpikedJungleSlime"/>, <see cref="NPCID.UmbrellaSlime"/>, <see cref="NPCID.RainbowSlime"/>, <see cref="NPCID.SlimeMasked"/>, <see cref="NPCID.HoppinJack"/>, <see cref="NPCID.SlimeRibbonWhite"/>, <see cref="NPCID.SlimeRibbonYellow"/>, <see cref="NPCID.SlimeRibbonGreen"/>, <see cref="NPCID.SlimeRibbonRed"/>, <see cref="NPCID.Grasshopper"/>, <see cref="NPCID.GoldGrasshopper"/>, <see cref="NPCID.SlimeSpiked"/>, <see cref="NPCID.SandSlime"/>, <see cref="NPCID.QueenSlimeMinionBlue"/>, <see cref="NPCID.QueenSlimeMinionPink"/>, <see cref="NPCID.GoldenSlime"/>
 		/// </summary>
 		public const short Slime = 1;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -138,7 +138,7 @@
  				buffImmune[l] = false;
  			}
  
-+			aiStyle = 0; //Added by tML.
++			aiStyle = type < NPCID.Count ? 0 : -1; //Added by tML - use aiStyle -1 for modded NPCs by default so they don't always face the nearest player, and trigger net updates
  			setFrameSize = false;
  			netSkip = -2;
  			realLife = -1;


### PR DESCRIPTION
### What is the bug?
`NPC.aiStyle` 0 is undocumented in the id list, and has functionality making it an unreasonable default for modded NPCs.
Many modders use aiStyle -1 to get no vanilla ai, but it's not immediately clear that negative values are permitted.

### How did you fix the bug?
Default modded npcs to aiStyle -1

### Are there alternatives to your fix?
Add a new aiStyle for modded NPCs called 'DoNothing'
Add a new aiStyle for the bound vanilla NPCs