### PR TITLE
Move StartPlaying packet after all world data has been sent

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -170,16 +170,25 @@
  						if (Netplay.Connection.State == 3) {
  							Main.windSpeedCurrent = Main.windSpeedTarget;
  							Netplay.Connection.State = 4;
-@@ -703,6 +_,9 @@
+@@ -703,12 +_,17 @@
  							NetMessage.TrySendData(83, whoAmI, -1, null, num180);
  						}
  
 +						for (int type = NPCID.Count; type < NPCLoader.NPCCount; type++)
 +							NetMessage.SendData(MessageID.NPCKillCountDeathTally, whoAmI, -1, null, type, 0f, 0f, 0f, 0, 0, 0);
 +
- 						NetMessage.TrySendData(49, whoAmI);
++						// tML - move 49 (StartPlaying) to the end, so the player joins a more fully complete world. Should be compatible with vanilla
+-						NetMessage.TrySendData(49, whoAmI);
++						// NetMessage.TrySendData(49, whoAmI);
  						NetMessage.TrySendData(57, whoAmI);
  						NetMessage.TrySendData(7, whoAmI);
+ 						NetMessage.TrySendData(103, -1, -1, null, NPC.MoonLordCountdown);
+ 						NetMessage.TrySendData(101, whoAmI);
+ 						NetMessage.TrySendData(136, whoAmI);
++						NetMessage.TrySendData(49, whoAmI); // tML - moved from above
+ 						Main.BestiaryTracker.OnPlayerJoining(whoAmI);
+ 						CreativePowerManager.Instance.SyncThingsToJoiningPlayer(whoAmI);
+ 						Main.PylonSystem.OnPlayerJoining(whoAmI);
 @@ -1144,8 +_,8 @@
  						int num181 = reader.ReadInt16();
  						Vector2 position3 = reader.ReadVector2();


### PR DESCRIPTION
### What is the bug?

`ModPlayer.OnEnterWorld` is called on the client, before all world data has arrived, limiting the usefulness of the hook. Not even the world UUID has arrived.

### How did you fix the bug?

Reordered some packets in `MessageBuffer` when replying to `SpawnTileData = 8`.
`StartPlaying = 49` which spawns the player, is now sent after:
- `TileCounts = 57`
- `WorldData = 7` this includes `WorldIO.ReceiveModData`
- `MoonlordCountdown = 103`
- `UpdateTowerShieldStrengths = 101`
- `SyncCavernMonsterType = 136`

All the packets which are reordered just read data into static variables, and have no interaction with player spawn logic and data.

The change should also be compatible with vanilla clients.

### Are there alternatives to your fix?

Nope. If left as is, modders have to set a flag in `OnEnterWorld`, and run logic which depends on world data on the first `PreUpdate`
