### PR TITLE
Logging exceptions for ModifyWorldGenTasks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -335,21 +335,21 @@ namespace Terraria.ModLoader
 		}
 
 		public static void ModifyWorldGenTasks(List<GenPass> passes, ref float totalWeight) {
-			foreach (var system in HookModifyWorldGenTasks.arr) {
-				try {
+			try {
+				foreach (var system in HookModifyWorldGenTasks.arr) {
 					system.ModifyWorldGenTasks(passes, ref totalWeight);
 				}
-				catch(Exception e) {
-					string message = string.Join(
-						"\n",
-						Language.GetTextValue("tModLoader.WorldGenError"),
-						e
-					);
-					Logging.tML.Error(message);
-					Interface.errorMessage.Show(message, 0);
+			}
+			catch (Exception e) {
+				string message = string.Join(
+					"\n",
+					Language.GetTextValue("tModLoader.WorldGenError"),
+					e
+				);
+				Logging.tML.Error(message);
+				Interface.errorMessage.Show(message, 0);
 
-					throw;
-				}
+				throw;
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
 using Terraria.Localization;
+using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.WorldBuilding;
 
@@ -335,7 +336,20 @@ namespace Terraria.ModLoader
 
 		public static void ModifyWorldGenTasks(List<GenPass> passes, ref float totalWeight) {
 			foreach (var system in HookModifyWorldGenTasks.arr) {
-				system.ModifyWorldGenTasks(passes, ref totalWeight);
+				try {
+					system.ModifyWorldGenTasks(passes, ref totalWeight);
+				}
+				catch(Exception e) {
+					string message = string.Join(
+						"\n",
+						Language.GetTextValue("tModLoader.WorldGenError"),
+						e
+					);
+					Logging.tML.Error(message);
+					Interface.errorMessage.Show(message, 0);
+
+					throw;
+				}
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -345,8 +345,7 @@ namespace Terraria.ModLoader
 						system.FullName + " : " + Language.GetTextValue("tModLoader.WorldGenError"),
 						e
 					);
-					Logging.tML.Error(message);
-					Interface.errorMessage.Show(message, 0);
+					Utils.ShowFancyErrorMessage(message, 0);
 
 					throw;
 				}

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -335,21 +335,21 @@ namespace Terraria.ModLoader
 		}
 
 		public static void ModifyWorldGenTasks(List<GenPass> passes, ref float totalWeight) {
-			try {
-				foreach (var system in HookModifyWorldGenTasks.arr) {
+			foreach (var system in HookModifyWorldGenTasks.arr) {
+				try {
 					system.ModifyWorldGenTasks(passes, ref totalWeight);
 				}
-			}
-			catch (Exception e) {
-				string message = string.Join(
-					"\n",
-					Language.GetTextValue("tModLoader.WorldGenError"),
-					e
-				);
-				Logging.tML.Error(message);
-				Interface.errorMessage.Show(message, 0);
+				catch (Exception e) {
+					string message = string.Join(
+						"\n",
+						system.FullName + " : " + Language.GetTextValue("tModLoader.WorldGenError"),
+						e
+					);
+					Logging.tML.Error(message);
+					Interface.errorMessage.Show(message, 0);
 
-				throw;
+					throw;
+				}
 			}
 		}
 
@@ -398,11 +398,14 @@ namespace Terraria.ModLoader
 			return hijacked;
 		}
 
-		internal static bool HijackSendData(int whoAmI, int msgType, int remoteClient, int ignoreClient, NetworkText text, int number, float number2, float number3, float number4, int number5, int number6, int number7) {
+		internal static bool HijackSendData(int whoAmI, int msgType, int remoteClient, int ignoreClient,
+			NetworkText text, int number, float number2, float number3, float number4, int number5, int number6,
+			int number7) {
 			bool result = false;
 
 			foreach (var system in HookHijackSendData.arr) {
-				result |= system.HijackSendData(whoAmI, msgType, remoteClient, ignoreClient, text, number, number2, number3, number4, number5, number6, number7);
+				result |= system.HijackSendData(whoAmI, msgType, remoteClient, ignoreClient, text, number, number2,
+					number3, number4, number5, number6, number7);
 			}
 
 			return result;

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -398,14 +398,11 @@ namespace Terraria.ModLoader
 			return hijacked;
 		}
 
-		internal static bool HijackSendData(int whoAmI, int msgType, int remoteClient, int ignoreClient,
-			NetworkText text, int number, float number2, float number3, float number4, int number5, int number6,
-			int number7) {
+		internal static bool HijackSendData(int whoAmI, int msgType, int remoteClient, int ignoreClient, NetworkText text, int number, float number2, float number3, float number4, int number5, int number6, int number7) {
 			bool result = false;
 
 			foreach (var system in HookHijackSendData.arr) {
-				result |= system.HijackSendData(whoAmI, msgType, remoteClient, ignoreClient, text, number, number2,
-					number3, number4, number5, number6, number7);
+				result |= system.HijackSendData(whoAmI, msgType, remoteClient, ignoreClient, text, number, number2, number3, number4, number5, number6, number7);
 			}
 
 			return result;

--- a/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
+++ b/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
@@ -22,7 +22,7 @@
  		private readonly WorldGenConfiguration _configuration;
  		public static GenerationProgress CurrentGenerationProgress;
  
-@@ -39,7 +_,23 @@
+@@ -39,7 +_,22 @@
  				Main.rand = new UnifiedRandom(_seed);
  				stopwatch.Start();
  				progress.Start(pass2.Weight);
@@ -37,8 +37,7 @@
 +						pass2.Name,
 +						e
 +					);
-+					Logging.tML.Error(message);
-+					Interface.errorMessage.Show(message, 0);
++					Utils.ShowFancyErrorMessage(message, 0);
 +
 +					//We need to shutdown the thread without it saving.
 +					//TODO: Allow returning a bool to signify if it should save or not.


### PR DESCRIPTION
Basically, for now, if there is an exception in ModifyWorldGenTasks, then the game doesn't show the exception, it just stays permanently on an empty screen and the user doesn't easily see what is causing the issue.
This PR aims to fix that by surrounding the calls with try/catch..