### PR TITLE
Fix Modded Droplet Gores (resolves #2049)

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -99,6 +99,15 @@
  			_specialTileX[_specialTilesCount] = x;
  			_specialTileY[_specialTilesCount] = y;
  			_specialTilesCount++;
+@@ -5094,6 +_,8 @@
+ 
+ 			Vector2 position = new Vector2(i * 16, j * 16);
+ 			int type = 706;
++			if (Main.waterStyle >= Main.maxLiquidTypes)
++				type = LoaderManager.Get<WaterStylesLoader>().Get(Main.waterStyle).GetDropletGore();
+ 			if (Main.waterStyle == 12)
+ 				type = 1147;
+ 			else if (Main.waterStyle > 1)
 @@ -5423,6 +_,8 @@
  
  					Main.spriteBatch.Draw(value9, vector, value10, new Color(255, 255, 255, 0) * 0.1f, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -99,15 +99,15 @@
  			_specialTileX[_specialTilesCount] = x;
  			_specialTileY[_specialTilesCount] = y;
  			_specialTilesCount++;
-@@ -5094,6 +_,8 @@
- 
- 			Vector2 position = new Vector2(i * 16, j * 16);
+@@ -5096,6 +_,8 @@
  			int type = 706;
-+			if (Main.waterStyle >= Main.maxLiquidTypes)
-+				type = LoaderManager.Get<WaterStylesLoader>().Get(Main.waterStyle).GetDropletGore();
  			if (Main.waterStyle == 12)
  				type = 1147;
++			else if (Main.waterStyle >= Main.maxLiquidTypes)
++				type = LoaderManager.Get<WaterStylesLoader>().Get(Main.waterStyle).GetDropletGore();
  			else if (Main.waterStyle > 1)
+ 				type = 706 + Main.waterStyle - 1;
+ 
 @@ -5423,6 +_,8 @@
  
  					Main.spriteBatch.Draw(value9, vector, value10, new Color(255, 255, 255, 0) * 0.1f, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);


### PR DESCRIPTION
### What is the bug?
#2049

### How did you fix the bug?
Added a simple conditional for checking if the water style is that of a modded type, and instead use `GetDropletGore` instead of vanilla's hardcoded calculations.

### Are there alternatives to your fix?
No.

Resolves #2049.
