### PR TITLE
[1.4] Remove bashism from dotnet version detection logic

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/InstallNetFramework.sh
+++ b/patches/tModLoader/Terraria/release_extras/InstallNetFramework.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #Author: covers1624
 # Provided for use in tModLoader deployment. 
 

--- a/patches/tModLoader/Terraria/release_extras/start-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoaderServer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd "$(dirname "$0")"
 script_dir="$(pwd -P)"
 launch_args="-server -config serverconfig.txt"


### PR DESCRIPTION
### What is the bug?
If `/bin/sh` is provided by [dash](http://gondor.apana.org.au/~herbert/dash/) instead of [bash](https://www.gnu.org/software/bash/) the path to dotnet will be `dotnet/6.0.0\r/dotnet` (if the filesystem uses the bag-of-bytes approach to filenames (like Ext4); if it doesn't, then dotnet-install.sh probably fails to create the directory and bails.)

### How did you fix the bug?
I replaced the bash expression in the version detection logic with a call to [tr](https://en.wikipedia.org/wiki/Tr_(Unix)).

### Are there alternatives to your fix?
Replacing the `#!/bin/sh` shebang with `#!/bin/bash`. Bash is a dependency for Steam on Linux, but I don't know if it is installed by default on all Linux distributions.