### PR TITLE
Remove weird .Remove()  line

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3271,7 +3271,7 @@
  				num5 = 2;
  				array9[0] = statusText;
  				array[0] = true;
-@@ -36836,17 +_,22 @@
+@@ -36836,17 +_,21 @@
  					Netplay.ServerPassword = "";
  				}
  				else if (selectedMenu == 2 || inputTextEnter || autoPass) {
@@ -3292,8 +3292,7 @@
 +					tServer.StartInfo.FileName = "tModLoaderServer.exe";
  #else
 -					tServer.StartInfo.FileName = "TerrariaServer";
-+					var fileName = Process.GetCurrentProcess().MainModule.FileName;
-+					tServer.StartInfo.FileName = fileName.Remove(fileName.LastIndexOf("."));
++					tServer.StartInfo.FileName = Process.GetCurrentProcess().MainModule.FileName;
  #endif
  					tServer.StartInfo.Arguments = str;
  					if (libPath != "") {


### PR DESCRIPTION
### What is the bug?
#1595  - this should fix a bug with Unix Host & Play. 
Whether or not its the only bug remains to be seen, but baby steps.

### How did you fix the bug?
Removed a "Remove()" string line that made no sense.

### Are there alternatives to your fix?
