### PR TITLE
Design for High DPI auto support

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -1,6 +1,3 @@
-using MonoMod.RuntimeDetour;
-using MonoMod.Cil;
-using Mono.Cecil.Cil;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,6 +9,8 @@ namespace Terraria
 {
 	public static partial class Program
 	{
+		const int HighDpiThreshold = 96;
+
 		public static string SavePath { get; private set; } // Moved from Main to avoid triggering the Main static constructor before logging initializes
 
 		private static IEnumerable<MethodInfo> GetAllMethods(Type type) {
@@ -35,6 +34,17 @@ namespace Terraria
 				if (!type.IsGenericType)
 					RuntimeHelpers.RunClassConstructor(type.TypeHandle);
 			}
+		}
+
+		// Add Support for High DPI displays, such as Mac M1 laptops. Must run before Game constructor.
+		private static void AttemptSupportHighDPI(bool isServer) {
+			if (isServer)
+				return;
+
+			SDL2.SDL.SDL_VideoInit(null);
+			SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
+			if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold)
+				Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,66 @@
+@@ -138,32 +_,67 @@
  			}
  		}
  
@@ -120,6 +120,7 @@
 +				return;
 +			}
 +
++			AttemptSupportHighDPI(isServer);
 +			LaunchGame_(isServer);
 +		}
 +


### PR DESCRIPTION
### What is the bug?
Closes #2078 .

Might improve #1699 , maybe even close.

### How did you fix the bug?
Used SDL2 to obtain primary monitor DPI values, and added checks against the threshold value of 96.
If higher, we enable the environment variable for FNA.

I am unable to test the fix, as my (only) monitor is exactly 96 DPI, so there is no difference either way.

### Are there alternatives to your fix?