### PR TITLE
[1.4] Allow UTF-8-BOM for localization files

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -12,6 +12,13 @@ namespace Terraria.ModLoader
 {
 	public static class LocalizationLoader
 	{
+		/// <summary>
+		/// UTF8 Byte-order-mask encoding used to load manually created localization files
+		/// </summary>
+		private static readonly Encoding UTF8BOMEncoding = new UTF8Encoding(true);
+
+		private static readonly byte[] UTF8BOMPreamble = new byte[] { 0xEF, 0xBB, 0xBF };
+
 		private static readonly Dictionary<string, ModTranslation> translations = new();
 
 		/// <summary>
@@ -210,7 +217,28 @@ namespace Terraria.ModLoader
 
 		private static void AutoloadTranslations(Mod mod, Dictionary<string, ModTranslation> modTranslationDictionary) {
 			foreach (var translationFile in mod.File.Where(entry => Path.GetExtension(entry.Name) == ".hjson")) {
-				string translationFileContents = Encoding.UTF8.GetString(mod.File.GetBytes(translationFile));
+				byte[] bytes = mod.File.GetBytes(translationFile);
+
+				// Read using suitable encoding
+				Encoding encoding = Encoding.UTF8;
+				int index = 0;
+
+				int preambleLength = UTF8BOMPreamble.Length;
+				if (bytes.Length >= preambleLength) {
+					// If the files are created manually by the user, they tend to be UTF-8-BOM encoded. tML uses UTF-8
+					bool canUseUTF8BOM = true;
+					for (int i = 0; i < preambleLength; i++) {
+						if (canUseUTF8BOM && bytes[i] != UTF8BOMPreamble[i])
+							canUseUTF8BOM = false;
+					}
+
+					if (canUseUTF8BOM) {
+						encoding = UTF8BOMEncoding;
+						index = preambleLength;
+					}
+				}
+
+				string translationFileContents = encoding.GetString(bytes, index, bytes.Length - index);
 				var culture = GameCulture.FromName(Path.GetFileNameWithoutExtension(translationFile.Name));
 
 				// Parse HJSON and convert to standard JSON


### PR DESCRIPTION
### What is the bug?
`.hjson` files using `UTF-8-BOM` encoding (the default when creating files on windows for example) fail to retreive the values from the localization system due to keys not conforming to the default UTF-8 encoding.

### Reproduction
1. In a mod, make a suitable `.hjson` file with `UTF-8-BOM` encoding and add a single key/value pair to it.
2. Add `Language.GetTextValue("my.full.key")` somewhere (I.e. `ModPlayer.OnEnterWorld`)
3. Breakpoint it, write code for the dict used in `Language.GetTextValue` to find the key you registered (i.e. matching by the mod name using `System.Linq.IEnumerable.Where`), then "copy value" on inspect, and paste it in the file, then save. It would prompt VS to change the encoding of the entire file to accomodate for this new string.

### How did you fix the bug?
Introduce reading the UTF-8-BOM preamble (https://www.unicode.org/faq/utf_bom.html#bom1) of the bytes to pick and read using correct encoding during localization loading.

### Are there alternatives to your fix?
* A more broad detection of encodings, such as ASCII, Windows-1251 (used by russians).
* Hardcode encoding support for localization files: Throw on load when an invalid encoding is detected

