### PR TITLE
1.4 mod map layer

### DIFF
--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent;
@@ -8,7 +9,7 @@ using Terraria.Map;
 using Terraria.ModLoader;
 using Terraria.UI;
 
-namespace ExampleMod.Common.Systems
+namespace ExampleMod.Systems
 {
 	// ModMapLayers are used to draw icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. This example adds an icon over the dungeon.
 	public class ExampleMapLayer : ModMapLayer

--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -1,15 +1,13 @@
 ﻿using Microsoft.Xna.Framework;
-using System.Collections.Generic;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.GameContent;
-using Terraria.ID;
 using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader;
 using Terraria.UI;
 
-namespace ExampleMod.Systems
+namespace ExampleMod.Common
 {
 	// ModMapLayers are used to draw icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. This example adds an icon over the dungeon.
 	public class ExampleMapLayer : ModMapLayer

--- a/ExampleMod/Common/Systems/ExampleMapLayer.cs
+++ b/ExampleMod/Common/Systems/ExampleMapLayer.cs
@@ -16,7 +16,7 @@ namespace ExampleMod.Common.Systems
 			const float scaleIfNotSelected = 1f;
 			const float scaleIfSelected = scaleIfNotSelected * 2f;
 			Main.instance.LoadItem(ItemID.BoneKey);
-			var dungeonTexture = TextureAssets.Item[ItemID.BoneKey].Value;
+			var dungeonTexture = TextureAssets.NpcHeadBoss[19].Value;
 			if (context.Draw(dungeonTexture, new Vector2(Main.dungeonX, Main.dungeonY), Color.White, new SpriteFrame(1, 1, 0, 0), scaleIfNotSelected, scaleIfSelected, Alignment.Center).IsMouseOver) {
 				text = Language.GetTextValue("Bestiary_Biomes.TheDungeon");
 			}

--- a/ExampleMod/Common/Systems/ExampleMapLayer.cs
+++ b/ExampleMod/Common/Systems/ExampleMapLayer.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.Map;
+using Terraria.ModLoader;
+using Terraria.UI;
+
+namespace ExampleMod.Common.Systems
+{
+	public class ExampleMapLayer : ModMapLayer
+	{
+		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
+			const float scaleIfNotSelected = 1f;
+			const float scaleIfSelected = scaleIfNotSelected * 2f;
+			Main.instance.LoadItem(ItemID.BoneKey);
+			var dungeonTexture = TextureAssets.Item[ItemID.BoneKey].Value;
+			if (context.Draw(dungeonTexture, new Vector2(Main.dungeonX, Main.dungeonY), Color.White, new SpriteFrame(1, 1, 0, 0), scaleIfNotSelected, scaleIfSelected, Alignment.Center).IsMouseOver) {
+				text = Language.GetTextValue("Bestiary_Biomes.TheDungeon");
+			}
+		}
+	}
+}

--- a/ExampleMod/Common/Systems/ExampleMapLayer.cs
+++ b/ExampleMod/Common/Systems/ExampleMapLayer.cs
@@ -10,14 +10,23 @@ using Terraria.UI;
 
 namespace ExampleMod.Common.Systems
 {
+	// ModMapLayers are used to draw icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. This example adds an icon over the dungeon.
 	public class ExampleMapLayer : ModMapLayer
 	{
+		// In the Draw method, we draw everything. Consulting vanilla examples in the source code is a good resource for properly using this Draw method.
 		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
+			// Here we define the scale that we wish to draw the icon when hovered and not hovered.
 			const float scaleIfNotSelected = 1f;
 			const float scaleIfSelected = scaleIfNotSelected * 2f;
-			Main.instance.LoadItem(ItemID.BoneKey);
+
+			// Here we retrieve the texture of the Skeletron boss head so that we can draw it. Remember that not all textures are loaded by default, so you might need to do something like `Main.instance.LoadItem(ItemID.BoneKey);` in your code to ensure the texture is loaded.
 			var dungeonTexture = TextureAssets.NpcHeadBoss[19].Value;
+
+			// The MapOverlayDrawContext.Draw method used here handles many of the small details for drawing an icon and should be used if possible. It'll handle scaling, alignment, culling, framing, and accounting for map zoom. Handling these manually is a lot of work.
+			// Note that the `position` argument expects tile coordinates expressed as a Vector2. Don't scale tile coordinates to world coordinates by multiplying by 16.
+			// The return of MapOverlayDrawContext.Draw has a field that indicates if the mouse is currently over our icon.
 			if (context.Draw(dungeonTexture, new Vector2(Main.dungeonX, Main.dungeonY), Color.White, new SpriteFrame(1, 1, 0, 0), scaleIfNotSelected, scaleIfSelected, Alignment.Center).IsMouseOver) {
+				// When the icon is being hovered by the users mouse, we set the mouse text to the localized text for "The Dungeon"
 				text = Language.GetTextValue("Bestiary_Biomes.TheDungeon");
 			}
 		}

--- a/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
@@ -1,0 +1,12 @@
+--- src/Terraria/Terraria/Map/IMapLayer.cs
++++ src/tModLoader/Terraria/Map/IMapLayer.cs
+@@ -3,5 +_,9 @@
+ 	public interface IMapLayer
+ 	{
+ 		void Draw(ref MapOverlayDrawContext context, ref string text);
++
++		bool Visible { get; set; }
++
++		void Hide();
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
@@ -5,8 +5,8 @@
  	{
  		void Draw(ref MapOverlayDrawContext context, ref string text);
 +
-+		bool Visible { get; set; }
++		bool Visible { get; internal set; }
 +
-+		void Hide();
++		void Hide() => Visible = false;
  	}
  }

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -1,12 +1,15 @@
 --- src/Terraria/Terraria/Map/MapIconOverlay.cs
 +++ src/tModLoader/Terraria/Map/MapIconOverlay.cs
-@@ -7,15 +_,20 @@
+@@ -6,16 +_,23 @@
+ 	public class MapIconOverlay
  	{
  		private readonly List<IMapLayer> _layers = new List<IMapLayer>();
++		private IReadOnlyList<IMapLayer> _readOnlyLayers;
  
 -		public MapIconOverlay AddLayer(IMapLayer layer) {
 +		internal MapIconOverlay AddLayer(IMapLayer layer) {
  			_layers.Add(layer);
++			_readOnlyLayers = _layers.AsReadOnly();
  			return this;
  		}
  
@@ -15,7 +18,7 @@
 +			foreach (var layer in _layers) {
 +				layer.Visible = true;
 +			}
-+			ModLoader.SystemLoader.PreDrawMapIconOverlay(_layers, context);
++			ModLoader.SystemLoader.PreDrawMapIconOverlay(_readOnlyLayers, context);
  			foreach (IMapLayer layer in _layers) {
 +				if (layer.Visible)
 -				layer.Draw(ref context, ref text);

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -17,7 +17,7 @@
 +			}
 +			ModLoader.SystemLoader.PreDrawMapIconOverlay(_layers, context);
  			foreach (IMapLayer layer in _layers) {
-+				if(layer.Visible)
++				if (layer.Visible)
 -				layer.Draw(ref context, ref text);
 +					layer.Draw(ref context, ref text);
  			}

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -1,0 +1,12 @@
+--- src/Terraria/Terraria/Map/MapIconOverlay.cs
++++ src/tModLoader/Terraria/Map/MapIconOverlay.cs
+@@ -18,5 +_,9 @@
+ 				layer.Draw(ref context, ref text);
+ 			}
+ 		}
++
++		internal void ClearModded() {
++			_layers.RemoveAll(x => x is ModLoader.ModMapLayer);
++		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -1,12 +1,22 @@
 --- src/Terraria/Terraria/Map/MapIconOverlay.cs
 +++ src/tModLoader/Terraria/Map/MapIconOverlay.cs
-@@ -18,5 +_,9 @@
- 				layer.Draw(ref context, ref text);
+@@ -14,9 +_,18 @@
+ 
+ 		public void Draw(Vector2 mapPosition, Vector2 mapOffset, Rectangle? clippingRect, float mapScale, float drawScale, ref string text) {
+ 			MapOverlayDrawContext context = new MapOverlayDrawContext(mapPosition, mapOffset, clippingRect, mapScale, drawScale);
++			foreach (var layer in _layers) {
++				layer.Visible = true;
++			}
++			ModLoader.SystemLoader.PreDrawMapIconOverlay(_layers, context);
+ 			foreach (IMapLayer layer in _layers) {
++				if(layer.Visible)
+-				layer.Draw(ref context, ref text);
++					layer.Draw(ref context, ref text);
  			}
- 		}
++		}
 +
 +		internal void ClearModded() {
 +			_layers.RemoveAll(x => x is ModLoader.ModMapLayer);
-+		}
+ 		}
  	}
  }

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -1,6 +1,14 @@
 --- src/Terraria/Terraria/Map/MapIconOverlay.cs
 +++ src/tModLoader/Terraria/Map/MapIconOverlay.cs
-@@ -14,9 +_,18 @@
+@@ -7,15 +_,20 @@
+ 	{
+ 		private readonly List<IMapLayer> _layers = new List<IMapLayer>();
+ 
+-		public MapIconOverlay AddLayer(IMapLayer layer) {
++		internal MapIconOverlay AddLayer(IMapLayer layer) {
+ 			_layers.Add(layer);
+ 			return this;
+ 		}
  
  		public void Draw(Vector2 mapPosition, Vector2 mapOffset, Rectangle? clippingRect, float mapScale, float drawScale, ref string text) {
  			MapOverlayDrawContext context = new MapOverlayDrawContext(mapPosition, mapOffset, clippingRect, mapScale, drawScale);
@@ -13,10 +21,5 @@
 -				layer.Draw(ref context, ref text);
 +					layer.Draw(ref context, ref text);
  			}
-+		}
-+
-+		internal void ClearModded() {
-+			_layers.RemoveAll(x => x is ModLoader.ModMapLayer);
  		}
  	}
- }

--- a/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapIconOverlay.cs.patch
@@ -1,15 +1,18 @@
 --- src/Terraria/Terraria/Map/MapIconOverlay.cs
 +++ src/tModLoader/Terraria/Map/MapIconOverlay.cs
-@@ -6,16 +_,23 @@
+@@ -6,16 +_,26 @@
  	public class MapIconOverlay
  	{
  		private readonly List<IMapLayer> _layers = new List<IMapLayer>();
 +		private IReadOnlyList<IMapLayer> _readOnlyLayers;
++
++		public MapIconOverlay() {
++			_readOnlyLayers = _layers.AsReadOnly();
++		}
  
 -		public MapIconOverlay AddLayer(IMapLayer layer) {
 +		internal MapIconOverlay AddLayer(IMapLayer layer) {
  			_layers.Add(layer);
-+			_readOnlyLayers = _layers.AsReadOnly();
  			return this;
  		}
  

--- a/patches/tModLoader/Terraria/Map/PingMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/PingMapLayer.cs.patch
@@ -1,0 +1,20 @@
+--- src/Terraria/Terraria/Map/PingMapLayer.cs
++++ src/tModLoader/Terraria/Map/PingMapLayer.cs
+@@ -10,6 +_,9 @@
+ {
+ 	public class PingMapLayer : IMapLayer
+ 	{
++		public bool Visible { get; set; } = true;
++		public void Hide() => Visible = false;
++
+ 		private struct Ping
+ 		{
+ 			public readonly Vector2 Position;
+@@ -25,6 +_,7 @@
+ 		private const double PING_FRAME_RATE = 10.0;
+ 		private readonly SlotVector<Ping> _pings = new SlotVector<Ping>(100);
+ 
++		
+ 		public void Draw(ref MapOverlayDrawContext context, ref string text) {
+ 			SpriteFrame frame = new SpriteFrame(1, 5);
+ 			DateTime now = DateTime.Now;

--- a/patches/tModLoader/Terraria/Map/PingMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/PingMapLayer.cs.patch
@@ -1,20 +1,11 @@
 --- src/Terraria/Terraria/Map/PingMapLayer.cs
 +++ src/tModLoader/Terraria/Map/PingMapLayer.cs
-@@ -10,6 +_,9 @@
+@@ -10,6 +_,8 @@
  {
  	public class PingMapLayer : IMapLayer
  	{
 +		public bool Visible { get; set; } = true;
-+		public void Hide() => Visible = false;
 +
  		private struct Ping
  		{
  			public readonly Vector2 Position;
-@@ -25,6 +_,7 @@
- 		private const double PING_FRAME_RATE = 10.0;
- 		private readonly SlotVector<Ping> _pings = new SlotVector<Ping>(100);
- 
-+		
- 		public void Draw(ref MapOverlayDrawContext context, ref string text) {
- 			SpriteFrame frame = new SpriteFrame(1, 5);
- 			DateTime now = DateTime.Now;

--- a/patches/tModLoader/Terraria/Map/SpawnMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/SpawnMapLayer.cs.patch
@@ -1,0 +1,12 @@
+--- src/Terraria/Terraria/Map/SpawnMapLayer.cs
++++ src/tModLoader/Terraria/Map/SpawnMapLayer.cs
+@@ -7,6 +_,9 @@
+ {
+ 	public class SpawnMapLayer : IMapLayer
+ 	{
++		public bool Visible { get; set; } = true;
++		public void Hide() => Visible = false;
++
+ 		public void Draw(ref MapOverlayDrawContext context, ref string text) {
+ 			Player localPlayer = Main.LocalPlayer;
+ 			Vector2 position = new Vector2(localPlayer.SpawnX, localPlayer.SpawnY);

--- a/patches/tModLoader/Terraria/Map/SpawnMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/SpawnMapLayer.cs.patch
@@ -1,11 +1,10 @@
 --- src/Terraria/Terraria/Map/SpawnMapLayer.cs
 +++ src/tModLoader/Terraria/Map/SpawnMapLayer.cs
-@@ -7,6 +_,9 @@
+@@ -7,6 +_,8 @@
  {
  	public class SpawnMapLayer : IMapLayer
  	{
 +		public bool Visible { get; set; } = true;
-+		public void Hide() => Visible = false;
 +
  		public void Draw(ref MapOverlayDrawContext context, ref string text) {
  			Player localPlayer = Main.LocalPlayer;

--- a/patches/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs.patch
@@ -1,0 +1,12 @@
+--- src/Terraria/Terraria/Map/TeleportPylonsMapLayer.cs
++++ src/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs
+@@ -11,6 +_,9 @@
+ {
+ 	public class TeleportPylonsMapLayer : IMapLayer
+ 	{
++		public bool Visible { get; set; } = true;
++		public void Hide() => Visible = false;
++
+ 		public void Draw(ref MapOverlayDrawContext context, ref string text) {
+ 			List<TeleportPylonInfo> pylons = Main.PylonSystem.Pylons;
+ 			float num = 1f;

--- a/patches/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs.patch
@@ -1,11 +1,10 @@
 --- src/Terraria/Terraria/Map/TeleportPylonsMapLayer.cs
 +++ src/tModLoader/Terraria/Map/TeleportPylonsMapLayer.cs
-@@ -11,6 +_,9 @@
+@@ -11,6 +_,8 @@
  {
  	public class TeleportPylonsMapLayer : IMapLayer
  	{
 +		public bool Visible { get; set; } = true;
-+		public void Hide() => Visible = false;
 +
  		public void Draw(ref MapOverlayDrawContext context, ref string text) {
  			List<TeleportPylonInfo> pylons = Main.PylonSystem.Pylons;

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -23,6 +23,7 @@ using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.ModLoader.Utilities;
 using Terraria.Initializers;
+using Terraria.Map;
 
 namespace Terraria.ModLoader
 {
@@ -474,7 +475,7 @@ namespace Terraria.ModLoader
 			Config.ConfigManager.Unload();
 			CustomCurrencyManager.Initialize();
 			EffectsTracker.RemoveModEffects();
-			Main.MapIcons.ClearModded();
+			Main.MapIcons = new MapIconOverlay().AddLayer(new SpawnMapLayer()).AddLayer(new TeleportPylonsMapLayer()).AddLayer(Main.Pings);
 
 			// ItemID.Search = IdDictionary.Create<ItemID, short>();
 			// NPCID.Search = IdDictionary.Create<NPCID, short>();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -474,6 +474,7 @@ namespace Terraria.ModLoader
 			Config.ConfigManager.Unload();
 			CustomCurrencyManager.Initialize();
 			EffectsTracker.RemoveModEffects();
+			Main.MapIcons.ClearModded();
 
 			// ItemID.Search = IdDictionary.Create<ItemID, short>();
 			// NPCID.Search = IdDictionary.Create<NPCID, short>();

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -8,6 +8,9 @@ namespace Terraria.ModLoader
 {
 	public abstract class ModMapLayer : ModType, IMapLayer
 	{
+		public bool Visible { get; set; } = true;
+		public void Hide() => Visible = false;
+
 		public abstract void Draw(ref MapOverlayDrawContext context, ref string text);
 
 		protected sealed override void Register() {

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -2,10 +2,18 @@
 
 namespace Terraria.ModLoader
 {
+	/// <summary>
+	/// This class is used to facilitate easily drawing icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. Use <see cref="ModSystem.PreDrawMapIconOverlay(System.Collections.Generic.List{IMapLayer}, MapOverlayDrawContext)"/> to selectively hide vanilla layers if needed.
+	/// </summary>
 	public abstract class ModMapLayer : ModType, IMapLayer
 	{
 		public bool Visible { get; set; } = true;
 
+		/// <summary>
+		/// This method is called when this MapLayer is to be drawn. Map layers are drawn after the map itself is drawn. Use <see cref="MapOverlayDrawContext.Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Color, DataStructures.SpriteFrame, float, float, Terraria.UI.Alignment)"/> as described in ExampleMod and in vanilla examples for full compatibility and simplicity of code.
+		/// </summary>
+		/// <param name="context">Contains the scaling and positional data of the map being drawn. You should use the MapOverlayDrawContext.Draw method for all drawing</param>
+		/// <param name="text">The mouse hover text. Assign a value typically if the user is hovering over something you draw</param>
 		public abstract void Draw(ref MapOverlayDrawContext context, ref string text);
 
 		protected sealed override void Register() {

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using Terraria.Chat;
+using Terraria.Localization;
+using Terraria.Map;
+
+namespace Terraria.ModLoader
+{
+	public abstract class ModMapLayer : ModType, IMapLayer
+	{
+		public abstract void Draw(ref MapOverlayDrawContext context, ref string text);
+
+		protected sealed override void Register() {
+			ModTypeLookup<ModMapLayer>.Register(this);
+			Main.MapIcons.AddLayer(this);
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -1,15 +1,10 @@
-﻿using Microsoft.Xna.Framework;
-using System;
-using Terraria.Chat;
-using Terraria.Localization;
-using Terraria.Map;
+﻿using Terraria.Map;
 
 namespace Terraria.ModLoader
 {
 	public abstract class ModMapLayer : ModType, IMapLayer
 	{
 		public bool Visible { get; set; } = true;
-		public void Hide() => Visible = false;
 
 		public abstract void Draw(ref MapOverlayDrawContext context, ref string text);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -218,7 +218,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="layers"></param>
 		/// <param name="mapOverlayDrawContext"></param>
-		public virtual void PreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) { }
+		public virtual void PreDrawMapIconOverlay(IReadOnlyList<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) { }
 
 		/// <summary>
 		/// Called while the fullscreen map is active. Allows custom drawing to the map. Using <see cref="ModMapLayer"/> is more compatible and allows drawing on the minimap and fullscreen maps.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
 using Terraria.Localization;
+using Terraria.Map;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.UI;
@@ -211,6 +212,13 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="spriteBatch">The sprite batch.</param>
 		public virtual void PostDrawInterface(SpriteBatch spriteBatch) { }
+
+		/// <summary>
+		/// Called right before map icon overlays are drawn. Use this hook to selectively hide existing IMapLayer or ModMapLayer
+		/// </summary>
+		/// <param name="layers"></param>
+		/// <param name="mapOverlayDrawContext"></param>
+		public virtual void PreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) { }
 
 		/// <summary>
 		/// Called while the fullscreen map is active. Allows custom drawing to the map.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -214,14 +214,14 @@ namespace Terraria.ModLoader
 		public virtual void PostDrawInterface(SpriteBatch spriteBatch) { }
 
 		/// <summary>
-		/// Called right before map icon overlays are drawn. Use this hook to selectively hide existing IMapLayer or ModMapLayer
+		/// Called right before map icon overlays are drawn. Use this hook to selectively hide existing <see cref="IMapLayer"/> or <see cref="ModMapLayer"/>
 		/// </summary>
 		/// <param name="layers"></param>
 		/// <param name="mapOverlayDrawContext"></param>
 		public virtual void PreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) { }
 
 		/// <summary>
-		/// Called while the fullscreen map is active. Allows custom drawing to the map.
+		/// Called while the fullscreen map is active. Allows custom drawing to the map. Using <see cref="ModMapLayer"/> is more compatible and allows drawing on the minimap and fullscreen maps.
 		/// </summary>
 		/// <param name="mouseText">The mouse text.</param>
 		public virtual void PostDrawFullscreenMap(ref string mouseText) { }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -52,7 +52,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateModifyLightingBrightness(ref float scale);
 
-		private delegate void DelegatePreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext);
+		private delegate void DelegatePreDrawMapIconOverlay(IReadOnlyList<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext);
 
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Terraria.Graphics;
 using Terraria.Localization;
+using Terraria.Map;
 using Terraria.UI;
 using Terraria.WorldBuilding;
 
@@ -51,6 +52,8 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateModifyLightingBrightness(ref float scale);
 
+		private delegate void DelegatePreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext);
+
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
 
 		private delegate void DelegateModifyTimeRate(ref double timeRate, ref double tileUpdateRate, ref double eventUpdateRate);
@@ -80,6 +83,8 @@ namespace Terraria.ModLoader
 		private static HookList HookModifySunLightColor = AddHook<DelegateModifySunLightColor>(s => s.ModifySunLightColor);
 
 		private static HookList HookModifyLightingBrightness = AddHook<DelegateModifyLightingBrightness>(s => s.ModifyLightingBrightness);
+
+		private static HookList HookPreDrawMapIconOverlay = AddHook<DelegatePreDrawMapIconOverlay>(s => s.PreDrawMapIconOverlay);
 
 		private static HookList HookPostDrawFullscreenMap = AddHook<DelegatePostDrawFullscreenMap>(s => s.PostDrawFullscreenMap);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
 using Terraria.Localization;
+using Terraria.Map;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.WorldBuilding;
@@ -151,6 +152,12 @@ namespace Terraria.ModLoader
 
 			negLight = Math.Max(negLight, 0.001f);
 			negLight2 = Math.Max(negLight2, 0.001f);
+		}
+
+		public static void PreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) {
+			foreach (var system in HookPreDrawMapIconOverlay.arr) {
+				system.PreDrawMapIconOverlay(layers, mapOverlayDrawContext);
+			}
 		}
 
 		public static void PostDrawFullscreenMap(ref string mouseText) {

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -154,7 +154,7 @@ namespace Terraria.ModLoader
 			negLight2 = Math.Max(negLight2, 0.001f);
 		}
 
-		public static void PreDrawMapIconOverlay(List<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) {
+		public static void PreDrawMapIconOverlay(IReadOnlyList<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext) {
 			foreach (var system in HookPreDrawMapIconOverlay.arr) {
 				system.PreDrawMapIconOverlay(layers, mapOverlayDrawContext);
 			}


### PR DESCRIPTION
ModMapLayer allows usage of IMapLayer, which is how most icons are now drawn on the maps. Without ModMapLayer, the modder would have to manually unregister their layer, which is annoying. ModSystem.PreDrawMapIconOverlay can be used for hiding layers.