### PR TITLE
Use bash to run scripts that source scripts that contain bashisms

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd "$(dirname "$0")"
 script_dir="$(pwd -P)"


### PR DESCRIPTION
### What is the bug?
If tModLoader is launched via start-tModLoader.sh then InstallNetFramework.sh is run by `/bin/sh` instead of `/bin/bash`, and if `/bin/sh` is provided by [dash](http://gondor.apana.org.au/~herbert/dash/) instead of [bash](https://www.gnu.org/software/bash/) then this line fails to remove the carriage return:
https://github.com/tModLoader/tModLoader/blob/18ed9d7f4cd4efe00f3e1a48f71ba911efbbb2a4/patches/tModLoader/Terraria/release_extras/InstallNetFramework.sh#L37
### How did you fix the bug?
I fixed the bug by replacing the `#!/bin/sh` shebang with `#!/bin/bash`.
### Are there alternatives to your fix?
Converting the Bash scripts to Posix shell.