### PR TITLE
Fix Rarity Count Bleeding + Doc Fixes (resolves #1831)

### DIFF
--- a/patches/tModLoader/Terraria/ID/ItemRarityID.cs
+++ b/patches/tModLoader/Terraria/ID/ItemRarityID.cs
@@ -5,11 +5,11 @@ namespace Terraria.ID
 	/// <summary>Enumerates the values used with Item.rare</summary>
 	public static class ItemRarityID
 	{
-		/// <summary>Minus thirteen (-13)<para/>Master: Fiery Red<para/>Flag: item.master</summary>
+		/// <summary>Minus thirteen (-13)<br/>Master: Fiery Red<br/>Flag: item.master</summary>
 		public const int Master = -13;
-		/// <summary>Minus twelve (-12)<para/>Expert: Rainbow<para/>Flag: item.expert</summary>
+		/// <summary>Minus twelve (-12)<br/>Expert: Rainbow<br/>Flag: item.expert</summary>
 		public const int Expert = -12;
-		/// <summary>Minus eleven (-11)<para/>Quest: Amber<para/>Flag: item.quest</summary>
+		/// <summary>Minus eleven (-11)<br/>Quest: Amber<br/>Flag: item.quest</summary>
 		public const int Quest = -11;
 		/// <summary>Minus one (-1)</summary>
 		public const int Gray = -1;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -302,12 +302,14 @@
  			if ((double)num14 >= 1.2)
  				rare += 2;
  			else if ((double)num14 >= 1.05)
-@@ -1076,17 +_,20 @@
+@@ -1076,17 +_,22 @@
  			else if ((double)num14 <= 0.95)
  				rare--;
  
 +			if (baseRarity >= ItemRarityID.Count)
 +				rare = RarityLoader.GetRarity(baseRarity).GetPrefixedRarity(rare - baseRarity, num14);
++			else if (rare > ItemRarityID.Purple)
++				rare = ItemRarityID.Purple;
 +
  			if (rare > -11) {
  				if (rare < -1)


### PR DESCRIPTION
### What is the bug?
Rarities added by mods (12 and above) are not supposed to show up on reforged vanilla items, but still did. See #1831 for me.

### How did you fix the bug?
I just added a conditional check to cap the rarity, which I/Oli forgot to add previously.

### Are there alternatives to your fix?
No.
