### PR TITLE
Draw mod accessory slot textures from centre (support non 32x32 textures)

### DIFF
--- a/ExampleMod/Common/Players/ExampleAccessorySlot.cs
+++ b/ExampleMod/Common/Players/ExampleAccessorySlot.cs
@@ -15,16 +15,16 @@ namespace ExampleMod.Common.Players
 		// We will place the slot to be at the center of the map, making the decision not to follow the internal UI handling
 		public override Vector2? CustomLocation => new Vector2(Main.screenWidth / 2, 3 * Main.screenHeight / 4);
 
-		// We will disable drawing the vanity slot
-		public override bool DrawVanitySlot => false;
+		// We will draw the vanity slot when there's a dye
+		public override bool DrawVanitySlot => !DyeItem.IsAir;
 
 		//     We will use our 'custom' textures
 		// Background Textures -> In general, you can use most of the existing vanilla ones to get different colours
 		public override string VanityBackgroundTexture => "Terraria/Images/Inventory_Back14"; // yellow
 		public override string FunctionalBackgroundTexture => "Terraria/Images/Inventory_Back7"; // pale blue
 
-		// Icon textures. Expects 32x32 images if you want it to look proper.
-		public override string VanityTexture => "Terraria/Images/Item_" + ItemID.PiggyBank; // The piggy bank is 16x24, so we expect it to look funny. Is a fun funny tho :)
+		// Icon textures. Nominal image size is 32x32. Piggy bank is 16x24 but it still works as it's drawn centered.
+		public override string VanityTexture => "Terraria/Images/Item_" + ItemID.PiggyBank;
 
 		// We will keep it hidden most of the time so that it isn't an intrusive example
 		public override bool IsHidden() {
@@ -61,7 +61,7 @@ namespace ExampleMod.Common.Players
 			return false; // We set to false to just not display if not Enabled. NOTE: this does not affect behavour when mod is unloaded!
 		}
 
-		// Icon textures. Expects 32x32 images if you want it to look proper.
+		// Icon textures. Nominal image size is 32x32. Will be centered on the slot.
 		public override string FunctionalTexture => "Terraria/Images/Item_" + ItemID.CreativeWings;
 
 		// Can be used to modify stuff while the Mouse is hovering over the slot.

--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -401,10 +401,13 @@ namespace Terraria.ModLoader
 					break;
 			}
 
-			if (texture == null)
+			if (texture == null) {
 				texture = value6;
-			else
-				rectangle = new Rectangle(0, 0, 32, 32);
+			}
+			else {
+				rectangle = new Rectangle(0, 0, texture.Width, texture.Height);
+				origin = rectangle.Size() / 2;
+			}
 
 			Main.spriteBatch.Draw(texture, position, rectangle, color, rotation, origin, scale, effects, layerDepth);
 		}


### PR DESCRIPTION
### What is the bug?

Accessory slot background textures which aren't 32x32 get drawn offset from their top left corner as if they were 32x32.
Sure modders can custom draw, but there's no reason for this not to work.

### How did you fix the bug?

Recalculate the origin for drawing based on texture size.

### Are there alternatives to your fix?

Actually return origin, source rectangle and scale from texture properties, allowing for easy animations and scaling, or provide a more granular draw override for the `SpriteBatch.Draw` call.