### PR TITLE
Fixed transparent inventory slots caused by expert and master mode accessory slots in non-expert/master worlds

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -220,6 +220,7 @@ namespace Terraria.ModLoader
 				DrawSlot(Player.armor, 11, slot + Player.dye.Length, flag3, xLoc, yLoc);
 				DrawSlot(Player.dye, 12, slot, flag3, xLoc, yLoc);
 			}
+			Main.inventoryBack = color;
 
 			return !customLoc;
 		}


### PR DESCRIPTION
### What is the bug?

#2057

### How did you fix the bug?

The color of the slot background was changed to be transparent, but this change was never reverted.
After the transparent slot was rendered I changed the color back to the default solid color.