### PR TITLE
Fix bucket duplication bugs

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3969,6 +3969,18 @@
  						if (tile.halfBrick()) {
  							WorldGen.PoundTile(x, y);
  							if (Main.netMode == 1)
+@@ -32713,6 +_,11 @@
+ 						NetMessage.sendWater(tileTargetX, tileTargetY);
+ 				}
+ 			}
++
++			if (sItem.stack <= 0) {
++				sItem.TurnToAir();
++				Main.blockMouse = true;
++			}
+ 		}
+ 
+ 		private void ItemCheck_PlayInstruments(Item sItem) {
 @@ -32922,7 +_,8 @@
  				}
  


### PR DESCRIPTION
### What is the bug?

This fixes #2077 and #1932. The bug in general is that there is no check for the stack being empty after decrementing stack size while using buckets, so if you held the mouse down you would continue to "use" the empty stack (decrementing `item.stack` to negative numbers).

### How did you fix the bug?

I added a small check at the end of `ItemCheck_UseBuckets` which simply clears the item if the stack is empty. This is only reached after a bucket has been used somehow, so it should be largely harmless. To stop the item animation from playing I also set `Main.blockMouse`.

### Are there alternatives to your fix?

To me this smells like a symptom of some deeper issue, but I do not know enough about the codebase to be sure what, or how to solve it. If a similar duplication glitch happens with other stackable but not `consumable` items, it is likely to be a similar issue caused by the same underlying lack of a check somewhere.