### PR TITLE
[1.4] ModMenu background implementation

### DIFF
--- a/ExampleMod/Content/ExampleModMenu.cs
+++ b/ExampleMod/Content/ExampleModMenu.cs
@@ -19,7 +19,7 @@ namespace ExampleMod.Content
 
 		public override Asset<Texture2D> MoonTexture => ModContent.Request<Texture2D>($"{menuAssetPath}/ExampliumMoon");
 
-		/*public override int Music => Mod.GetSoundSlot(SoundType.Music, ""); TODO: Reimplement music loading */
+		public override int Music => MusicLoader.GetMusicSlot(Mod, "Assets/Music/MysteriousMystery");
 
 		public override ModSurfaceBackgroundStyle MenuBackgroundStyle => ModContent.GetInstance<ExampleSurfaceBackgroundStyle>();
 

--- a/ExampleMod/Content/ExampleModMenu.cs
+++ b/ExampleMod/Content/ExampleModMenu.cs
@@ -5,6 +5,7 @@ using ReLogic.Content;
 using Terraria.ModLoader;
 using Terraria.Audio;
 using Terraria.ID;
+using ExampleMod.Backgrounds;
 
 namespace ExampleMod.Content
 {
@@ -20,7 +21,7 @@ namespace ExampleMod.Content
 
 		/*public override int Music => Mod.GetSoundSlot(SoundType.Music, ""); TODO: Reimplement music loading */
 
-		/*public override ModSurfaceBackgroundStyle MenuBackgroundStyle => Mod.GetSurfaceBackgroundStyle(""); TODO: Reimplement backgrounds */
+		public override ModSurfaceBackgroundStyle MenuBackgroundStyle => ModContent.GetInstance<ExampleSurfaceBackgroundStyle>();
 
 		public override string DisplayName => "Example ModMenu";
 

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1022,7 +1022,7 @@
 -					}
 -					else if (!audioSystem.IsTrackPlaying(50)) {
 +					else {
-+						newMusic = MenuLoader.CurrentMenu.Music; // TODO: Music loader to make music function properly.
++						newMusic = MenuLoader.CurrentMenu.Music;
 +					}
 +
 +					if (_isAsyncLoadComplete && newMusic == 50 && !audioSystem.IsTrackPlaying(50)) {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4132,6 +4132,17 @@
  		}
  
  		private static void UpdateAtmosphereTransparencyToSkyColor() {
+@@ -49322,6 +_,10 @@
+ 				preferredBGStyleForPlayer = bgStyle;
+ 				if (WorldGen.drunkWorldGen)
+ 					bgStyle = 9;
++
++				var menuBackgroundStyle = MenuLoader.CurrentMenu.MenuBackgroundStyle;
++				if (menuBackgroundStyle != null)
++					bgStyle = menuBackgroundStyle.Slot;
+ 			}
+ 
+ 			if (instantBGTransitionCounter > 0) {
 @@ -49332,6 +_,8 @@
  
  			UpdateBGVisibility_BackLayer(null, null);

--- a/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBackgroundStyle.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader
 		public sealed override void SetupContent() => SetStaticDefaults();
 
 		/// <summary>
-		/// Allows you to determine which textures make up the background by assigning their background slots/IDs to the given array. Mod.GetBackgroundSlot may be useful here. Index 0 is the texture on the border of the ground and sky layers. Index 1 is the texture drawn between rock and ground layers. Index 2 is the texture on the border of ground and rock layers. Index 3 is the texture drawn in the rock layer. The border images are 160x16 pixels, and the others are 160x96, but it seems like the right 32 pixels of each is a duplicate of the far left 32 pixels.
+		/// Allows you to determine which textures make up the background by assigning their background slots/IDs to the given array. BackgroundTextureLoader.GetBackgroundSlot may be useful here. Index 0 is the texture on the border of the ground and sky layers. Index 1 is the texture drawn between rock and ground layers. Index 2 is the texture on the border of ground and rock layers. Index 3 is the texture drawn in the rock layer. The border images are 160x16 pixels, and the others are 160x96, but it seems like the right 32 pixels of each is a duplicate of the far left 32 pixels.
 		/// </summary>
 		public abstract void FillTextureArray(int[] textureSlots);
 	}
@@ -44,7 +44,7 @@ namespace Terraria.ModLoader
 		public abstract void ModifyFarFades(float[] fades, float transitionSpeed);
 
 		/// <summary>
-		/// Allows you to determine which texture is drawn in the very back of the background. Mod.GetBackgroundSlot may be useful here, as well as for the other texture-choosing hooks.
+		/// Allows you to determine which texture is drawn in the very back of the background. BackgroundTextureLoader.GetBackgroundSlot may be useful here, as well as for the other texture-choosing hooks.
 		/// </summary>
 		public virtual int ChooseFarTexture() {
 			return -1;


### PR DESCRIPTION
### Description
1. `ModMenu.MenuBackgroundStyle` was never used. **Fixed** by adding code to where vanilla decides the background in the main menu. (Sadly, adding patch context via a single line wasn't possible as the gameMenu check was too far away)
2. Some docs in `ModBackgroundStyle.cs` were referencing old code for retrieving backgrounds. **Fixed** by using new 1.4 code.
3. `ExampleModMenu.Music` wasn't overridden. **Fixed** by overriding it, the implementation was already there.
