### PR TITLE
Fix bucket duplication glitches

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3969,6 +3969,17 @@
  						if (tile.halfBrick()) {
  							WorldGen.PoundTile(x, y);
  							if (Main.netMode == 1)
+@@ -32594,8 +_,8 @@
+ 				cursorItemIconEnabled = true;
+ 				Main.ItemIconCacheUpdate(sItem.type);
+ 			}
+-
+-			if (!ItemTimeIsZero || itemAnimation <= 0 || !controlUseItem)
++			// Stack size check added by TML. Works by coincidence in vanilla.
++			if (!ItemTimeIsZero || itemAnimation <= 0 || !controlUseItem || sItem.stack <= 0)
+ 				return;
+ 
+ 			if (sItem.type == 205 || (sItem.type == 3032 && Main.tile[tileTargetX, tileTargetY].liquidType() == 0) || (sItem.type == 4872 && Main.tile[tileTargetX, tileTargetY].lava())) {
 @@ -32922,7 +_,8 @@
  				}
  
@@ -4174,7 +4185,7 @@
  		}
  
  		private bool ItemCheck_CheckCanUse(Item sItem) {
-+			if(!CombinedHooks.CanUseItem(this, sItem))
++			if(sItem.IsAir || !CombinedHooks.CanUseItem(this, sItem))
 +				return false;
 +
  			int whoAmI = base.whoAmI;


### PR DESCRIPTION
### What is the bug?

This fixes #2077 and fixes #1932. The issue is discussed at length in PR #2122. There are actually two bugs fixed with this PR.

In general, the item use rework broke animation checking for items which are _not_ consumable, but are consumed manually, like buckets. This happened because the check for removing an empty stack of items (and stopping the animation), requires that `itemAnimation` is 0, (so that animations play out even after using the last of an item), and in the rework, resetting `itemAnimation` while the mouse was held down happened _after_ decrementing `itemAnimation`, but _before_ checking this, so empty stacks would never be cleared (unless they were consumable, in which case the logic handles this).

The second bug was that buckets never checked for stack size before they were used. The only reason why this didn't cause the same bug in vanilla was because of a series of weird coincidences outlined in #2122.

### How did you fix the bug?

For the first issue I added a check to `ItemCheck_CheckCanUse` for stack size. My argument is essentially that it makes zero sense to "use" (i.e. reset animation timer for) an item that has stack size zero. This check was implicit before, but making it explicit should have no real consequences.

For the second I just added a check to the beginning of `ItemCheck_UseBuckets`.

### Are there alternatives to your fix?

I guess reverting the whole thing.

The first change is an actual bug. It can be fixed with good conscience, I think. The second change is the type that would have been required when allowing modders to modify item use times in general. The reason it worked in vanilla was because a series of coincidences, that allowing modders to touch use time would trigger anyway. In practice this means that if we want to modify use time for buckets, this change must be made.