### PR TITLE
Improved scripts

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/InstallNetFramework.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/InstallNetFramework.sh
@@ -68,7 +68,12 @@ if [[ ! -f "$install_dir/dotnet" && ! -f "$install_dir/dotnet.exe" ]]; then
 			# Neither of Win7_32 or Win7_Arm are expected, so we just keep this as is
 			file_download dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
 			
-			powershell.exe -NoProfile -ExecutionPolicy unrestricted -File dotnet-install.ps1 -Channel "$channel" -InstallDir "$install_dir" -Runtime "dotnet" -Version "$dotnet_version"
+			if [ ! -f dotnet-install.ps1 ]; then
+				echo "Failed to download dotnet-install.ps1. Relying on Powershell to work"
+				powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -Channel $channel -InstallDir \"$install_dir\" -Version $dotnet_version -Runtime dotnet"
+			else
+				powershell.exe -NoProfile -ExecutionPolicy unrestricted -File dotnet-install.ps1 -Channel "$channel" -InstallDir "$install_dir" -Runtime "dotnet" -Version "$dotnet_version"
+			fi
 	else
 		# *nix binaries are various and not worth detecting the required one here, always use "on-the-fly" script install
 		file_download dotnet-install.sh https://dot.net/v1/dotnet-install.sh

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -68,7 +68,6 @@ echo "Success!"
 run_script ./InstallNetFramework.sh
 
 echo "Attempting Launch..."
-exec 1>&3 3>&-
 
 # Actually run tML with the passed arguments
 # Move to the root folder
@@ -81,10 +80,10 @@ if [[ "$_uname" == *"_NT"* ]]; then
 fi
 
 if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
-	echo "Launched Using Local Dotnet" | tee -a "$LogFile"
+	echo "Launched Using Local Dotnet"
 	chmod a+x "$install_dir/dotnet"
 	exec "$install_dir/dotnet" tModLoader.dll "$@"
 else
-	echo "Launched Using System Dotnet" | tee -a "$LogFile"
+	echo "Launched Using System Dotnet"
 	exec dotnet tModLoader.dll "$@"
 fi


### PR DESCRIPTION
### What is the bug?
Add additional redundancy to the launch scripts since curl/wget has been not fetching the files and keeping a local copy.
IF the two attempts to download using those fail, than we will fallback to relying on PowerShell to fetch the files.

Hopefully this knocks off even more of the launch failed reports as that appears to be all that is left.

Also make the launch log carry through to launch of the actual game so that it has less of a gap between client.log beginning and launch.log ending

