### PR TITLE
Create BirthdayParty.cs.patch

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Events/BirthdayParty.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Events/BirthdayParty.cs.patch
@@ -1,0 +1,10 @@
+--- src/Terraria/Terraria/GameContent/Events/BirthdayParty.cs
++++ src/tModLoader/Terraria/GameContent/Events/BirthdayParty.cs
+@@ -138,7 +_,6 @@
+ 			GenuineParty = false;
+ 			PartyDaysOnCooldown = 0;
+ 			CelebratingNPCs.Clear();
+-			_wasCelebrating = false;
+ 		}
+ 
+ 		public static void UpdateTime() {


### PR DESCRIPTION
### What is the bug?
Calling BirthdayParty.WorldClear() wouldn't deactivate the party custom sky (i.e. balloons in background).

### How did you fix the bug?
Removing the change to the _wasCelebrating variable ensures the appropriate path is followed on the next call of UpdateTime.

### Are there alternatives to your fix?
A call to the SkyManager could be introduced directly in the WorldClear method. This would require additional logic to ensure it not be called when the custom sky is not active or the net mode inappropriate.  This logic already exists in BirthdayParty.UpdateTime() so duplication seems unnecessary.

