### PR TITLE
Added missing localization + localized UIMemoryBar 

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -370,13 +370,14 @@
 		"DefaultNurseCantHealChat": "Ich weiß nicht warum, aber ich kann dich nicht Heilen. Anscheinend hat der Modder vergessen, mir einen Dialog zu geben.",
 
 		// Memory bar
-		"LastLoadRamUsage": "Geschätzte RAM-Nutzung beim letzten Laden",
-		"AvailableMemory": "Verfügbarer Arbeitsspeicher",
-		"Managed": "Verwaltet",
-		"Code": "Code",
-		"Sounds": "Geräusche",
-		"Textures": "Texturen",
-		"Total": "Gesamt",
+		"LastLoadRamUsage": "Geschätzte RAM-Nutzung beim letzten Laden: {0}",
+		"AvailableMemory": "Verfügbarer Arbeitsspeicher: {0}",
+		"TerrariaMemory": "Terraria + Verschiedenes: {0}",
+		"ManagedMemory": "Verwaltet: {0}",
+		"CodeMemory": "Code: {0}",
+		"SoundMemory": "Geräusche: {0}",
+		"TextureMemory": "Texturen: {0}",
+		"TotalMemory": "Gesamt: {0}",
 
 		// Extra mouse buttons
 		"MouseMiddle": "Mittlere Maus",

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -369,6 +369,15 @@
 		"DefaultTownNPCChat": "Mein Modder hat vergessen mir einen Dialog zu geben.",
 		"DefaultNurseCantHealChat": "Ich weiß nicht warum, aber ich kann dich nicht Heilen. Anscheinend hat der Modder vergessen, mir einen Dialog zu geben.",
 
+		// Memory bar
+		"LastLoadRamUsage": "Geschätzte RAM-Nutzung beim letzten Laden",
+		"AvailableMemory": "Verfügbarer Arbeitsspeicher",
+		"Managed": "Verwaltet",
+		"Code": "Code",
+		"Sounds": "Geräusche",
+		"Textures": "Texturen",
+		"Total": "Gesamt",
+
 		// Extra mouse buttons
 		"MouseMiddle": "Mittlere Maus",
 		"MouseXButton1": "Maus 4",

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -144,6 +144,7 @@
 		"ModInfoNoDescriptionAvailable": "Keine Beschreibung verfügbar",
 		"ModInfoProblemTryAgain": "Es gab ein Problem, versuch es nochmal",
 		"ModInfoDisableModToDelete": "Mod zum Löschen deaktivieren",
+		"ModInfoVisitSteampage": "Besuche die Steam-Workshop Seite der Mod",
 
 		// Mod Packs
 		"ModPacksHeader": "Modpakete",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -144,6 +144,7 @@
 		"ModInfoNoDescriptionAvailable": "No description available",
 		"ModInfoProblemTryAgain": "There was a problem, try again",
 		"ModInfoDisableModToDelete": "Disable Mod to Delete",
+		"ModInfoVisitSteampage": "Visit the Mod's Steam Workshop page",
 
 		// Mod Packs
 		"ModPacksHeader": "Mod Packs",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -370,13 +370,14 @@
 		"DefaultNurseCantHealChat": "I don't know why I can't heal you, the modder forgot to give me a chat message.",
 
 		// Memory bar
-		"LastLoadRamUsage": "Estimated last load RAM usage",
-		"AvailableMemory": "Available Memory",
-		"Managed": "Managed",
-		"Code": "Code",
-		"Sounds": "Sounds",
-		"Textures": "Textures",
-		"Total": "Total",
+		"LastLoadRamUsage": "Estimated last load RAM usage: {0}",
+		"AvailableMemory": "Available Memory: {0}",
+		"TerrariaMemory": "Terraria + misc: {0}",
+		"ManagedMemory": "Managed: {0}",
+		"CodeMemory": "Code: {0}",
+		"SoundMemory": "Sounds: {0}",
+		"TextureMemory": "Textures: {0}",
+		"TotalMemory": "Total: {0}",
 
 		// Extra mouse buttons
 		"MouseMiddle": "Middle Mouse",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -369,6 +369,15 @@
 		"DefaultTownNPCChat": "My modder forgot to give me a chat message.",
 		"DefaultNurseCantHealChat": "I don't know why I can't heal you, the modder forgot to give me a chat message.",
 
+		// Memory bar
+		"LastLoadRamUsage": "Estimated last load RAM usage",
+		"AvailableMemory": "Available Memory",
+		"Managed": "Managed",
+		"Code": "Code",
+		"Sounds": "Sounds",
+		"Textures": "Textures",
+		"Total": "Total",
+
 		// Extra mouse buttons
 		"MouseMiddle": "Middle Mouse",
 		"MouseXButton1": "Mouse 4",

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.Localization;
 using Terraria.ModLoader.Core;
 using Terraria.UI;
 
@@ -127,27 +128,27 @@ namespace Terraria.ModLoader.UI
 				totalModMemory += usage.total;
 				var sb = new StringBuilder();
 				sb.Append(ModLoader.GetMod(modName).DisplayName);
-				sb.Append($"\nEstimate last load RAM usage: {SizeSuffix(usage.total)}");
+				sb.Append($"\n{Language.GetTextValue("tModLoader.LastLoadRamUsage")}: {SizeSuffix(usage.total)}");
 				if (usage.managed > 0)
-					sb.Append($"\n Managed: {SizeSuffix(usage.managed)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.Managed")}: {SizeSuffix(usage.managed)}");
 				if (usage.managed > 0)
-					sb.Append($"\n Code: {SizeSuffix(usage.code)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.Code")}: {SizeSuffix(usage.code)}");
 				if (usage.sounds > 0)
-					sb.Append($"\n Sounds: {SizeSuffix(usage.sounds)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.Sounds")}: {SizeSuffix(usage.sounds)}");
 				if (usage.textures > 0)
-					sb.Append($"\n Textures: {SizeSuffix(usage.textures)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.Textures")}: {SizeSuffix(usage.textures)}");
 				_memoryBarItems.Add(new MemoryBarItem(sb.ToString(), usage.total, _colors[i++ % _colors.Length]));
 			}
 
 			long allocatedMemory = Process.GetCurrentProcess().WorkingSet64;
 			var nonModMemory = allocatedMemory - totalModMemory;
 			_memoryBarItems.Add(new MemoryBarItem(
-				$"Terraria + misc: {SizeSuffix(nonModMemory)}\n Total: {SizeSuffix(allocatedMemory)}",
+				$"Terraria + misc: {SizeSuffix(nonModMemory)}\n {Language.GetTextValue("tModLoader.Total")}: {SizeSuffix(allocatedMemory)}",
 				nonModMemory, Color.DeepSkyBlue));
 
 			var remainingMemory = availableMemory - allocatedMemory;
 			_memoryBarItems.Add(new MemoryBarItem(
-				$"Available Memory: {SizeSuffix(remainingMemory)}\n Total: {SizeSuffix(availableMemory)}",
+				$"{Language.GetTextValue("tModLoader.AvailableMemory")}: {SizeSuffix(remainingMemory)}\n {Language.GetTextValue("tModLoader.Total")}: {SizeSuffix(availableMemory)}",
 				remainingMemory, Color.Gray));
 
 			//portion = (maxMemory - availableMemory - meminuse) / (float)maxMemory;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMemoryBar.cs
@@ -128,27 +128,27 @@ namespace Terraria.ModLoader.UI
 				totalModMemory += usage.total;
 				var sb = new StringBuilder();
 				sb.Append(ModLoader.GetMod(modName).DisplayName);
-				sb.Append($"\n{Language.GetTextValue("tModLoader.LastLoadRamUsage")}: {SizeSuffix(usage.total)}");
+				sb.Append($"\n{Language.GetTextValue("tModLoader.LastLoadRamUsage", SizeSuffix(usage.total))}");
 				if (usage.managed > 0)
-					sb.Append($"\n {Language.GetTextValue("tModLoader.Managed")}: {SizeSuffix(usage.managed)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.ManagedMemory", SizeSuffix(usage.managed))}");
 				if (usage.managed > 0)
-					sb.Append($"\n {Language.GetTextValue("tModLoader.Code")}: {SizeSuffix(usage.code)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.CodeMemory", SizeSuffix(usage.code))}");
 				if (usage.sounds > 0)
-					sb.Append($"\n {Language.GetTextValue("tModLoader.Sounds")}: {SizeSuffix(usage.sounds)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.SoundMemory", SizeSuffix(usage.sounds))}");
 				if (usage.textures > 0)
-					sb.Append($"\n {Language.GetTextValue("tModLoader.Textures")}: {SizeSuffix(usage.textures)}");
+					sb.Append($"\n {Language.GetTextValue("tModLoader.TextureMemory", SizeSuffix(usage.textures))}");
 				_memoryBarItems.Add(new MemoryBarItem(sb.ToString(), usage.total, _colors[i++ % _colors.Length]));
 			}
 
 			long allocatedMemory = Process.GetCurrentProcess().WorkingSet64;
 			var nonModMemory = allocatedMemory - totalModMemory;
 			_memoryBarItems.Add(new MemoryBarItem(
-				$"Terraria + misc: {SizeSuffix(nonModMemory)}\n {Language.GetTextValue("tModLoader.Total")}: {SizeSuffix(allocatedMemory)}",
+				$"{Language.GetTextValue("tModLoader.TerrariaMemory", SizeSuffix(nonModMemory))}\n {Language.GetTextValue("tModLoader.TotalMemory", SizeSuffix(allocatedMemory))}",
 				nonModMemory, Color.DeepSkyBlue));
 
 			var remainingMemory = availableMemory - allocatedMemory;
 			_memoryBarItems.Add(new MemoryBarItem(
-				$"{Language.GetTextValue("tModLoader.AvailableMemory")}: {SizeSuffix(remainingMemory)}\n {Language.GetTextValue("tModLoader.Total")}: {SizeSuffix(availableMemory)}",
+				$"{Language.GetTextValue("tModLoader.AvailableMemory", SizeSuffix(remainingMemory))}\n {Language.GetTextValue("tModLoader.TotalMemory", SizeSuffix(availableMemory))}",
 				remainingMemory, Color.Gray));
 
 			//portion = (maxMemory - availableMemory - meminuse) / (float)maxMemory;


### PR DESCRIPTION
## What Changed?
I added the missing "Visit Steampage" localization text:
##### Before:
![image](https://user-images.githubusercontent.com/26361108/152691095-21be1093-7cc1-4464-8703-70a49a419aa4.png)

##### After:
![image](https://user-images.githubusercontent.com/26361108/152691071-982239db-968c-4bf2-92f1-a9b13ebe6adb.png)
--- 
In addition to that, I localized the Memory bar, which previously had hardcoded strings. 

![image](https://user-images.githubusercontent.com/26361108/152691234-4d2d6271-78b6-4bd6-82e8-6602895ce10a.png)
###### (german translation)