### PR TITLE
Fix Server Crash on Reload Mods Being Due to tMod

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -36,26 +36,29 @@ if [ ! -d "$LaunchLogs" ]; then
 	mkdir -p "$LaunchLogs"
 fi
 LogFile="$LaunchLogs/Launch.log"
+NativeLog="$LaunchLogs/Natives.log"
 if [ -f "$LogFile" ]; then
 	rm "$LogFile"
 fi
-touch "$LogFile"
+touch "$NativeLog"
+if [ -f "$NativeLog" ]; then
+	rm "$NativeLog"
+fi
+touch "$NativeLog"
 
 echo "Verifying .NET...."
 echo "This may take a few moments."
-echo "Logging to $LogFile"
-
-exec 3>&1 > >(tee "$LogFile") 2>&1
+echo "Logging to $LogFile" 2>&1 | tee -a "$LogFile"
 
 if [[ "$_uname" == *"_NT"* ]]; then
-	run_script ./Remove13_64Bit.sh
+	run_script ./Remove13_64Bit.sh 2>&1 | tee -a "$LogFile"
 fi
 
 . ./UnixLinkerFix.sh
-run_script ./PlatformLibsDeploy.sh
+run_script ./PlatformLibsDeploy.sh 2>&1 | tee -a "$LogFile"
 
 #Parse version from runtimeconfig, jq would be a better solution here, but its not installed by default on all distros.
-echo "Parsing .NET version requirements from runtimeconfig.json"
+echo "Parsing .NET version requirements from runtimeconfig.json"  2>&1 | tee -a "$LogFile"
 dotnet_version=$(sed -n 's/^.*"version": "\(.*\)"/\1/p' <../tModLoader.runtimeconfig.json) #sed, go die plskthx
 export dotnet_version=${dotnet_version%$'\r'} # remove trailing carriage return that sed may leave in variable, producing a bad folder name
 #echo $version
@@ -63,9 +66,9 @@ export dotnet_version=${dotnet_version%$'\r'} # remove trailing carriage return 
 # echo $(hexdump -C <<< "$version")
 export dotnet_dir="$root_dir/dotnet"
 export install_dir="$dotnet_dir/$dotnet_version"
-echo "Success!"
+echo "Success!"  2>&1 | tee -a "$LogFile"
 
-run_script ./InstallNetFramework.sh
+run_script ./InstallNetFramework.sh 2>&1 | tee -a "$LogFile"
 
 echo "Attempting Launch..."
 
@@ -80,10 +83,10 @@ if [[ "$_uname" == *"_NT"* ]]; then
 fi
 
 if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
-	echo "Launched Using Local Dotnet"
+	echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
 	chmod a+x "$install_dir/dotnet"
-	exec "$install_dir/dotnet" tModLoader.dll "$@"
+	exec "$install_dir/dotnet" tModLoader.dll "$@" 2>"$NativeLog"
 else
-	echo "Launched Using System Dotnet"
-	exec dotnet tModLoader.dll "$@"
+	echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
+	exec dotnet tModLoader.dll "$@" 2>"$NativeLog"
 fi

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -85,8 +85,10 @@ fi
 if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
 	echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
 	chmod a+x "$install_dir/dotnet"
+	clear
 	exec "$install_dir/dotnet" tModLoader.dll "$@" 2>"$NativeLog"
 else
 	echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
+	clear
 	exec dotnet tModLoader.dll "$@" 2>"$NativeLog"
 fi

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -82,13 +82,12 @@ if [[ "$_uname" == *"_NT"* ]]; then
 	export WINDIR=${WINDIR////\\}
 fi
 
+clear
 if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
 	echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
 	chmod a+x "$install_dir/dotnet"
-	clear
 	exec "$install_dir/dotnet" tModLoader.dll "$@" 2>"$NativeLog"
 else
 	echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
-	clear
 	exec dotnet tModLoader.dll "$@" 2>"$NativeLog"
 fi


### PR DESCRIPTION
Fixes Server StdOut IO Stream hijacking resulting in server reload errors blaming tMod.

Does not intentionally fix Linux steam InstallNetFramework.sh conflict, nor does this fix the server console not clearing properly at the end of mod loading.


