### PR TITLE
[1.4] Fix TileEntity deletion when entering world without it's mod enabled

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedTileEntity.cs
@@ -19,7 +19,7 @@ namespace Terraria.ModLoader.Default
 
 		public override bool IsTileValidForEntity(int i, int j) {
 			Tile tile = Main.tile[i, j];
-			return tile.active() && TileLoader.GetTile(type) is UnloadedTile;
+			return tile.HasTile && TileLoader.GetTile(tile.TileType) is UnloadedTile;
 		}
 
 		public override void SaveData(TagCompound tag) {
@@ -35,7 +35,9 @@ namespace Terraria.ModLoader.Default
 			SetData(tag);
 		}
 
-		internal void TryRestore(ref ModTileEntity newEntity) {
+		internal bool TryRestore(out ModTileEntity newEntity) {
+			newEntity = null;
+
 			if (ModContent.TryFind(modName, tileEntityName, out ModTileEntity tileEntity)) {
 				newEntity = ModTileEntity.ConstructFromBase(tileEntity);
 				newEntity.type = (byte)tileEntity.Type;
@@ -45,6 +47,8 @@ namespace Terraria.ModLoader.Default
 					newEntity.LoadData(data);
 				}
 			}
+
+			return newEntity != null;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
@@ -45,12 +45,14 @@ namespace Terraria.ModLoader.IO
 				var point = new Point16(tag.GetShort("X"), tag.GetShort("Y"));
 
 				ModTileEntity baseModTileEntity = null;
-				TileEntity tileEntity = null;
+				TileEntity tileEntity;
+				bool foundTE = true;
 
 				//If the TE is modded
 				if (modName != "Terraria") {
 					//Find its type, defaulting to pending.
 					if (!ModContent.TryFind(modName, name, out baseModTileEntity)) {
+						foundTE = false;
 						baseModTileEntity = ModContent.GetInstance<UnloadedTileEntity>();
 					}
 
@@ -58,7 +60,9 @@ namespace Terraria.ModLoader.IO
 					tileEntity.type = (byte)baseModTileEntity.Type;
 					tileEntity.Position = point;
 
-					(tileEntity as UnloadedTileEntity)?.SetData(tag);
+					if (!foundTE) {
+						(tileEntity as UnloadedTileEntity)?.SetData(tag);
+					}
 				}
 				//Otherwise, if the TE is vanilla, try to find its existing instance for the current coordinate.
 				else if (!TileEntity.ByPosition.TryGetValue(point, out tileEntity)) {
@@ -69,12 +73,11 @@ namespace Terraria.ModLoader.IO
 				//Load TE data.
 				if (tag.ContainsKey("data")) {
 					try {
-						tileEntity.LoadData(tag.GetCompound("data"));
-
-						if (tileEntity is ModTileEntity modTileEntity) {
-							(tileEntity as UnloadedTileEntity)?.TryRestore(ref modTileEntity);
-
-							tileEntity = modTileEntity;
+						if (foundTE) {
+							tileEntity.LoadData(tag.GetCompound("data"));
+						}
+						if (tileEntity is UnloadedTileEntity unloadedTE && unloadedTE.TryRestore(out var restoredTE)) {
+							tileEntity = restoredTE;
 						}
 					}
 					catch (Exception e) {
@@ -83,7 +86,7 @@ namespace Terraria.ModLoader.IO
 				}
 
 				//Check mods' TEs for being valid. If they are, register them to TE collections.
-				if (baseModTileEntity != null && baseModTileEntity.IsTileValidForEntity(tileEntity.Position.X, tileEntity.Position.Y)) {
+				if (baseModTileEntity != null && tileEntity.IsTileValidForEntity(tileEntity.Position.X, tileEntity.Position.Y)) {
 					tileEntity.ID = TileEntity.AssignNewID();
 					TileEntity.ByID[tileEntity.ID] = tileEntity;
 


### PR DESCRIPTION
### What is the bug?
Fixes #2151 

### How did you fix the bug?
Fix placement of `UnloadedTileEntity`
Fix unloaded TE data overwriting
Fix unloaded TE data nesting
Fix which TE is used to check `IsTileValidForEntity`

### Are there alternatives to your fix?

