### PR TITLE
[1.4] Fix issue with drawing tooltip lines

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1536,7 +1536,7 @@
  			int num12 = 0;
  			for (int j = 0; j < numLines; j++) {
  				Vector2 stringSize = ChatManager.GetStringSize(FontAssets.MouseText.Value, array[j], Vector2.One);
-@@ -15120,11 +_,17 @@
+@@ -15120,14 +_,20 @@
  				Utils.DrawInvBG(spriteBatch, new Microsoft.Xna.Framework.Rectangle(X - num17, Y - num18, (int)zero.X + num17 * 2, (int)zero.Y + num18 + num18 / 2), new Microsoft.Xna.Framework.Color(23, 25, 81, 255) * 0.925f);
  			}
  
@@ -1547,7 +1547,7 @@
 -					int num20 = (int)((float)(int)mouseTextColor * num19);
 -					Microsoft.Xna.Framework.Color color2 = Microsoft.Xna.Framework.Color.Black;
 +				drawableLines[k].OriginalX = X;
-+				drawableLines[k].OriginalY = Y;
++				drawableLines[k].OriginalY = Y + num16;
 +				if (drawableLines[k].mod == "Terraria" && drawableLines[k].Name == "OneDropLogo") {
 +					int num20 = (int)((float)(int)mouseTextColor * 1f);
 +					Color color2 = Color.Black;
@@ -1556,8 +1556,13 @@
 +						goto PostDraw;
 +
  					for (int l = 0; l < 5; l++) {
- 						int num21 = X;
- 						int num22 = Y + num16;
+-						int num21 = X;
+-						int num22 = Y + num16;
++						int num21 = drawableLines[k].X;
++						int num22 = drawableLines[k].Y;
+ 						if (l == 4)
+ 							color2 = new Microsoft.Xna.Framework.Color(num20, num20, num20, num20);
+ 
 @@ -15145,17 +_,14 @@
  								num22++;
  								break;
@@ -1613,6 +1618,7 @@
 +					if (drawableLines[k].mod == "Terraria" && drawableLines[k].Name == "JourneyResearch")
  						black = Colors.JourneyMode;
  
+-					ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, array[k], new Vector2(X, Y + num16), black, 0f, Vector2.Zero, Vector2.One);
 +					drawableLines[k].Color = black;
 +					Color realLineColor = black;
 +
@@ -1624,14 +1630,14 @@
 +					if (!ItemLoader.PreDrawTooltipLine(HoverItem, drawableLines[k], ref num12) || !globalCanDraw)
 +						goto PostDraw;
 +
--					ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, array[k], new Vector2(X, Y + num16), black, 0f, Vector2.Zero, Vector2.One);
-+					ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, array[k], new Vector2(X, Y + num16), realLineColor, 0f, Vector2.Zero, Vector2.One);
++					ChatManager.DrawColorCodedStringWithShadow(spriteBatch, drawableLines[k].font, drawableLines[k].text, new Vector2(drawableLines[k].X, drawableLines[k].Y), realLineColor, drawableLines[k].rotation, drawableLines[k].origin, drawableLines[k].baseScale, drawableLines[k].maxWidth, drawableLines[k].spread);
  				}
-+
+ 
 +				PostDraw:
 +				ItemLoader.PostDrawTooltipLine(HoverItem, drawableLines[k]);
- 
- 				num16 += (int)(FontAssets.MouseText.Value.MeasureString(array[k]).Y + (float)num12);
++
+-				num16 += (int)(FontAssets.MouseText.Value.MeasureString(array[k]).Y + (float)num12);
++				num16 += (int)(FontAssets.MouseText.Value.MeasureString(drawableLines[k].text).Y + (float)num12);
  			}
 +
 +			ItemLoader.PostDrawTooltip(HoverItem, drawableLines.AsReadOnly());


### PR DESCRIPTION
### What is the bug?

> Attempt to change the tooltip line has no effect on the drawing result. Also, all lines have draw position of the first line. Below is an example:
>
> Code:
> ```
> public override bool PreDrawTooltipLine(Item item, DrawableTooltipLine line, ref int yOffset)
> {
>        switch (line.Name)
>        {
>                case "ItemName":
>                        line.X += 10;
>                        break;
>                case "CritChance":
>                        ChatManager.DrawColorCodedStringWithShadow(Main.spriteBatch, line.font, line.text, new Vector2(line.X, line.Y),
>                        Color.Cyan, line.rotation, line.origin, line.baseScale, line.maxWidth, line.spread);
>                        return false;
>                default:
>                        break;
>        }
>        return true;
> }
> ```
>
> Current result:
> ![image](https://user-images.githubusercontent.com/36926642/154394980-5c1344a8-6a2d-4a37-8354-5aec19417aac.png)
> Corrected version:
> ![image](https://user-images.githubusercontent.com/36926642/154394995-719d1a39-13d6-4e33-b678-c61d32a68f2d.png)

### How did you fix the bug?
> I made a couple of changes that are in 1.3, but for some reason are missing in 1.4