### PR TITLE
[1.4] Fix Yoyo drop rules not appearing in ModifyGlobalLoot

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -24,10 +24,12 @@
  			if (!_entriesByNpcNetId.ContainsKey(npcNetId))
  				_entriesByNpcNetId[npcNetId] = new List<IItemDropRule>();
  
-@@ -114,6 +_,11 @@
+@@ -114,6 +_,13 @@
  			RegisterMimic();
  			RegisterEclipse();
  			RegisterBloodMoonFishing();
++
++			NPCLoader.ModifyGlobalLoot(new GlobalLoot(this));
 +
 +			foreach (KeyValuePair<int, NPC> pair in ContentSamples.NpcsByNetId) {
 +				NPCLoader.ModifyNPCLoot(pair.Value, new NPCLoot(pair.Key, this));
@@ -36,11 +38,3 @@
  			TrimDuplicateRulesForNegativeIDs();
  		}
  
-@@ -607,6 +_,7 @@
- 			RegisterToGlobal(new ItemDropWithConditionRule(520, 5, 1, 1, new Conditions.SoulOfLight()));
- 			RegisterToGlobal(new ItemDropWithConditionRule(521, 5, 1, 1, new Conditions.SoulOfNight()));
- 			RegisterToGlobal(ItemDropRule.ByCondition(new Conditions.PirateMap(), 1315, 100));
-+			NPCLoader.ModifyGlobalLoot(new GlobalLoot(this));
- 		}
- 
- 		private void RegisterFoodDrops() {


### PR DESCRIPTION
### What is the bug?
Yoyo drop rules don't appear in `ModifyGlobalLoot` due to vanilla registering them separately outside the regular global loot context.

### How did you fix the bug?
The lowest maintenance solution was simply moving `ModifyGlobalLoot` to the end of the population chain, where `ModifyNPCLoot` is also called. This also gets rid of 1 patch.

### Are there alternatives to your fix?
Move the method for Yoyo drop rules into the regular global loot context. This is more maintenance heavy, as it also creates 2 new patches.
