### PR TITLE
[1.4] Fix Bone Helm Not Rendering on Minimap

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
@@ -102,7 +102,7 @@ namespace Terraria.DataStructures
 		public static readonly PlayerDrawLayer FinchNest = new VanillaPlayerDrawLayer(nameof(FinchNest), DrawPlayer_21_2_FinchNest, TorsoGroup, isHeadLayer: false);
 
 		/// <summary> Draws the player's face accessory. </summary>
-		public static readonly PlayerDrawLayer FaceAcc = new VanillaPlayerDrawLayer(nameof(FaceAcc), DrawPlayer_22_FaceAcc, TorsoGroup);
+		public static readonly PlayerDrawLayer FaceAcc = new VanillaPlayerDrawLayer(nameof(FaceAcc), DrawPlayer_22_FaceAcc, TorsoGroup, isHeadLayer: true);
 
 		/// <summary> Draws the front textures of the player's mount. </summary>
 		public static readonly PlayerDrawLayer MountFront = new VanillaPlayerDrawLayer(nameof(MountFront), DrawPlayer_23_MountFront, TorsoGroup);


### PR DESCRIPTION
### What is the bug?
`DrawPlayer_22_FaceAcc` layer was not classified as a head layer, and this causes a handful of accessories (bone helm, fake unicorn horn, angel halo etc) not rendering on the map in tModLoader, while they are in vanilla.

### How did you fix the bug?
classify `DrawPlayer_22_FaceAcc` as a head layer

### Are there alternatives to your fix?
No
