### PR TITLE
GetDrawHitbox Accounting for Item Animations

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -594,6 +594,15 @@
  					position = (position + item.position) / 2f;
  					velocity = (velocity + item.velocity) / 2f;
  					int num3 = item.stack;
+@@ -46276,6 +_,8 @@
+ 				case 4070:
+ 					return TextureAssets.Item[type].Frame(1, 4);
+ 				default:
++					if (Main.itemAnimationsRegistered.Contains(type))
++					return TextureAssets.Item[type].Frame(verticalFrames: Main.itemAnimations[type].FrameCount);
+ 					return TextureAssets.Item[type].Frame();
+ 			}
+ 		}
 @@ -46290,6 +_,9 @@
  			if (Main.rand == null)
  				Main.rand = new UnifiedRandom();


### PR DESCRIPTION
### What is the bug?
Mouse text displaying item names did not account for modded animated items
See: https://cdn.discordapp.com/attachments/941876757022277673/947559840811745290/unknown.png
For an example of what I meant

### How did you fix the bug?
Patched GetDrawHitbox to include a check for registered item animations

### Are there alternatives to your fix?
No.