### PR TITLE
[1.4] Re-init sacrifices on reload

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -24,6 +24,7 @@ using Terraria.UI;
 using Terraria.ModLoader.Utilities;
 using Terraria.Initializers;
 using Terraria.Map;
+using Terraria.GameContent.Creative;
 
 namespace Terraria.ModLoader
 {
@@ -484,6 +485,7 @@ namespace Terraria.ModLoader
 			// WallID.Search = IdDictionary.Create<WallID, ushort>();
 			// BuffID.Search = IdDictionary.Create<BuffID, int>();
 
+			CreativeItemSacrificesCatalog.Instance.Initialize();
 			ContentSamples.Initialize();
 			SetupBestiary();
 


### PR DESCRIPTION
### What is the bug?
`CreativeItemSacrificesCatalog._sacrificeCountNeededByItemId` does not reduce it's size when mods with researchable items get disabled. This proves problematic if you want to display current vs total research progress by checking `.Count` on it when mods were loaded/reloaded during this session.

### How did you fix the bug?
Re-initialize it.

### Are there alternatives to your fix?
No. Done like most things.
