### PR TITLE
[1.4] Add public Mod.NetID property

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -82,6 +82,7 @@ namespace Terraria.ModLoader
 		public IContentSource RootContentSource { get; private set; }
 
 		internal short netID = -1;
+		public short NetID => netID;
 		public bool IsNetSynced => netID >= 0;
 
 		private IDisposable fileHandle;


### PR DESCRIPTION
### What is the new feature?
`public short NetID => netID;`

### Why should this be part of tModLoader?
1. `ModLoader.GetMod(int netID)` is already public, but has no use for modders at all because netIDs are unavailable.
2. Mod netcode for efficiently transferring mod identity which is valid within the current session instead of having to use a string.

### Are there alternative designs?
Change `netID` to `NetID` public get/internal set. Decided to go with just an additional property instead to complement `public bool IsNetSynced => netID >= 0;`

### Sample usage for the new feature
`packet.Write(mod.NetID);`

### ExampleMod updates
Nothing.

