### PR TITLE
Improved extensibility of config UI by making the relevant classes mostly public

### DIFF
--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ArrayElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ArrayElement.cs
@@ -2,7 +2,7 @@
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal class ArrayElement : CollectionElement
+	public class ArrayElement : CollectionElement
 	{
 		Type itemType;
 

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/BooleanElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/BooleanElement.cs
@@ -8,7 +8,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal class BooleanElement : ConfigElement<bool>
+	public class BooleanElement : ConfigElement<bool>
 	{
 		private Texture2D _toggleTexture;
 

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/CollectionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/CollectionElement.cs
@@ -11,7 +11,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	abstract class CollectionElement : ConfigElement
+	public abstract class CollectionElement : ConfigElement
 	{
 		protected object data;
 		protected UIElement dataListElement;

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ConfigElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ConfigElement.cs
@@ -164,7 +164,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class HeaderElement : UIElement
+	public class HeaderElement : UIElement
 	{
 		string header;
 		public HeaderElement(string header) {

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/DefinitionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/DefinitionElement.cs
@@ -11,7 +11,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	abstract class DefinitionElement<T> : ConfigElement<T> where T : EntityDefinition
+	public abstract class DefinitionElement<T> : ConfigElement<T> where T : EntityDefinition
 	{
 		protected bool updateNeeded;
 		protected bool selectionExpanded;
@@ -139,12 +139,12 @@ namespace Terraria.ModLoader.Config.UI
 		protected virtual void TweakDefinitionOptionElement(DefinitionOptionElement<T> optionElement) { }
 	}
 
-	class DefinitionOptionElement<T> : UIElement where T : EntityDefinition
+	public class DefinitionOptionElement<T> : UIElement where T : EntityDefinition
 	{
 		public static Texture2D defaultBackgroundTexture = Main.inventoryBack9Texture;
 		public Texture2D backgroundTexture = defaultBackgroundTexture;
 		public string tooltip;
-		internal float scale = .75f;
+		protected internal float scale = .75f;
 		protected bool unloaded;
 		public int type;
 		public T definition;

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/DictionaryElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/DictionaryElement.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal abstract class IDictionaryElementWrapper
+	public abstract class IDictionaryElementWrapper
 	{
 		//public UIModConfigDictionaryElementWrapper() { }
 		internal virtual object Key => null;
@@ -23,7 +23,7 @@ namespace Terraria.ModLoader.Config.UI
 		//}
 	}
 
-	internal class DictionaryElementWrapper<K, V> : IDictionaryElementWrapper
+	public class DictionaryElementWrapper<K, V> : IDictionaryElementWrapper
 	{
 		private IDictionary dictionary;
 		//private object _key;
@@ -63,8 +63,8 @@ namespace Terraria.ModLoader.Config.UI
 
 		//public K key;
 		//public V value;
-		internal override object Key => key;
-		internal override object Value => value;
+		public override object Key => key;
+		public override object Value => value;
 		//internal UIModConfigDictionaryItem parent;
 		public DictionaryElementWrapper(K key, V value, IDictionary dictionary) //, UIModConfigDictionaryItem parent)
 		{
@@ -84,11 +84,11 @@ namespace Terraria.ModLoader.Config.UI
 	//	}
 	//}
 
-	internal class DictionaryElement : CollectionElement
+	public class DictionaryElement : CollectionElement
 	{
-		internal Type keyType;
-		internal Type valueType;
-		internal UIText save;
+		protected internal Type keyType;
+		protected internal Type valueType;
+		protected internal UIText save;
 		public List<IDictionaryElementWrapper> dataWrapperList;
 
 		// These 2 hold the default value of the dictionary value, hence ValueValue

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/EnumElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/EnumElement.cs
@@ -4,12 +4,12 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class EnumElement : RangeElement
+	public class EnumElement : RangeElement
 	{
-		private Func<object> _GetValue;
-		private Func<object> _GetValueString;
-		private Func<int> _GetIndex;
-		private Action<int> _SetValue;
+		protected Func<object> _GetValue;
+		protected Func<object> _GetValueString;
+		protected Func<int> _GetIndex;
+		protected Action<int> _SetValue;
 		int max;
 		string[] valueStrings;
 

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/IntegerElements.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/IntegerElements.cs
@@ -9,7 +9,7 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal class IntInputElement : ConfigElement
+	public class IntInputElement : ConfigElement
 	{
 		public IList<int> intList;
 		public int min = 0;
@@ -81,7 +81,7 @@ namespace Terraria.ModLoader.Config.UI
 		protected virtual void SetValue(int value) => SetObject(Utils.Clamp(value, min, max));
 	}
 
-	internal class IntRangeElement : PrimitiveRangeElement<int>
+	public class IntRangeElement : PrimitiveRangeElement<int>
 	{
 		public override int NumberTicks => ((max - min) / increment) + 1;
 		public override float TickIncrement => (float)(increment) / (max - min);
@@ -98,7 +98,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class UIntElement : PrimitiveRangeElement<uint>
+	public class UIntElement : PrimitiveRangeElement<uint>
 	{
 		public override int NumberTicks => (int)((max - min) / increment) + 1;
 		public override float TickIncrement => (float)(increment) / (max - min);
@@ -115,7 +115,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class ByteElement : PrimitiveRangeElement<byte>
+	public class ByteElement : PrimitiveRangeElement<byte>
 	{
 		public override int NumberTicks => (int)((max - min) / increment) + 1;
 		public override float TickIncrement => (float)(increment) / (max - min);

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ItemDefinitionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ItemDefinitionElement.cs
@@ -10,7 +10,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class ItemDefinitionElement : DefinitionElement<ItemDefinition>
+	public class ItemDefinitionElement : DefinitionElement<ItemDefinition>
 	{
 		protected override DefinitionOptionElement<ItemDefinition> CreateDefinitionOptionElement() => new ItemDefinitionOptionElement(Value, 0.5f);
 
@@ -48,7 +48,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class ItemDefinitionOptionElement : DefinitionOptionElement<ItemDefinition>
+	public class ItemDefinitionOptionElement : DefinitionOptionElement<ItemDefinition>
 	{
 		public Item item;
 

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ListElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ListElement.cs
@@ -8,9 +8,9 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal class ListElement : CollectionElement
+	public class ListElement : CollectionElement
 	{
-		private Type listType;
+		protected Type listType;
 
 		protected override void PrepareTypes() {
 			listType = memberInfo.Type.GetGenericArguments()[0];
@@ -51,7 +51,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	class NestedUIList : UIList
+	public class NestedUIList : UIList
 	{
 		public NestedUIList() {
 			//OverflowHidden = false;

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/NPCDefinitionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/NPCDefinitionElement.cs
@@ -9,7 +9,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class NPCDefinitionElement : DefinitionElement<NPCDefinition>
+	public class NPCDefinitionElement : DefinitionElement<NPCDefinition>
 	{
 		protected override DefinitionOptionElement<NPCDefinition> CreateDefinitionOptionElement() => new NPCDefinitionOptionElement(Value, 0.5f);
 
@@ -46,7 +46,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class NPCDefinitionOptionElement : DefinitionOptionElement<NPCDefinition>
+	public class NPCDefinitionOptionElement : DefinitionOptionElement<NPCDefinition>
 	{
 		public NPCDefinitionOptionElement(NPCDefinition definition, float scale = .75f) : base(definition, scale) {
 		}

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ObjectElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ObjectElement.cs
@@ -10,7 +10,7 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class ObjectElement : ConfigElement<object>
+	public class ObjectElement : ConfigElement<object>
 	{
 		protected Func<string> AbridgedTextDisplayFunction;
 
@@ -265,9 +265,9 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class UIModConfigHoverImage : UIImage
+	public class UIModConfigHoverImage : UIImage
 	{
-		internal string HoverText;
+		protected internal string HoverText;
 
 		public UIModConfigHoverImage(Texture2D texture, string hoverText) : base(texture) {
 			HoverText = hoverText;
@@ -281,10 +281,10 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class UIModConfigHoverImageSplit : UIImage
+	public class UIModConfigHoverImageSplit : UIImage
 	{
-		internal string HoverTextUp;
-		internal string HoverTextDown;
+		protected internal string HoverTextUp;
+		protected internal string HoverTextDown;
 
 		public UIModConfigHoverImageSplit(Texture2D texture, string hoverTextUp, string hoverTextDown) : base(texture) {
 			HoverTextUp = hoverTextUp;
@@ -305,7 +305,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	class FuncStringWrapper {
+	public class FuncStringWrapper {
 		public Func<string> func;
 		public override string ToString() {
 			return func();

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/PrefixDefinitionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/PrefixDefinitionElement.cs
@@ -10,7 +10,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class PrefixDefinitionElement : DefinitionElement<PrefixDefinition>
+	public class PrefixDefinitionElement : DefinitionElement<PrefixDefinition>
 	{
 		protected override DefinitionOptionElement<PrefixDefinition> CreateDefinitionOptionElement() => new PrefixDefinitionOptionElement(Value, .8f);
 
@@ -56,7 +56,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class PrefixDefinitionOptionElement : DefinitionOptionElement<PrefixDefinition>
+	public class PrefixDefinitionOptionElement : DefinitionOptionElement<PrefixDefinition>
 	{
 		UIAutoScaleTextTextPanel<string> text;
 		public PrefixDefinitionOptionElement(PrefixDefinition definition, float scale = .75f) : base(definition, scale) {

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/ProjectileDefinitionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/ProjectileDefinitionElement.cs
@@ -9,7 +9,7 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class ProjectileDefinitionElement : DefinitionElement<ProjectileDefinition>
+	public class ProjectileDefinitionElement : DefinitionElement<ProjectileDefinition>
 	{
 		protected override DefinitionOptionElement<ProjectileDefinition> CreateDefinitionOptionElement() => new ProjectileDefinitionOptionElement(Value, 0.5f);
 
@@ -45,7 +45,7 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class ProjectileDefinitionOptionElement : DefinitionOptionElement<ProjectileDefinition>
+	public class ProjectileDefinitionOptionElement : DefinitionOptionElement<ProjectileDefinition>
 	{
 		public ProjectileDefinitionOptionElement(ProjectileDefinition definition, float scale = .75f) : base(definition, scale) {
 		}

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/RangeElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/RangeElement.cs
@@ -49,7 +49,7 @@ namespace Terraria.ModLoader.Config.UI
 	{
 		protected Color sliderColor = Color.White;
 		protected Utils.ColorLerpMethod colorMethod;
-		internal bool drawTicks;
+		protected internal bool drawTicks;
 		public abstract int NumberTicks { get; }
 		public abstract float TickIncrement { get; }
 
@@ -128,8 +128,8 @@ namespace Terraria.ModLoader.Config.UI
 			return 1f;
 		}
 
-		private static RangeElement rightLock;
-		private static RangeElement rightHover;
+		protected static RangeElement rightLock;
+		protected static RangeElement rightHover;
 		protected override void DrawSelf(SpriteBatch spriteBatch)
 		{
 			base.DrawSelf(spriteBatch);

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/SetElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/SetElement.cs
@@ -6,13 +6,13 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal abstract class ISetElementWrapper
+	public abstract class ISetElementWrapper
 	{
-		internal virtual object Value => null;
+		protected internal virtual object Value => null;
 	}
 
 	// TODO: Somehow prevent this class from displaying?
-	internal class SetElementWrapper<V> : ISetElementWrapper
+	public class SetElementWrapper<V> : ISetElementWrapper
 	{
 		private object set;
 
@@ -43,7 +43,7 @@ namespace Terraria.ModLoader.Config.UI
 				//}
 			}
 		}
-		internal override object Value => value;
+		protected internal override object Value => value;
 
 		public SetElementWrapper(V value, object set) {
 			this.set = set;
@@ -51,9 +51,9 @@ namespace Terraria.ModLoader.Config.UI
 		}
 	}
 
-	internal class SetElement : CollectionElement
+	public class SetElement : CollectionElement
 	{
-		private Type setType;
+		protected Type setType;
 		public List<ISetElementWrapper> dataWrapperList;
 
 		protected override void PrepareTypes() {

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/StringInputElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/StringInputElement.cs
@@ -6,7 +6,7 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	internal class StringInputElement : ConfigElement<string>
+	public class StringInputElement : ConfigElement<string>
 	{
 		public override void OnBind() {
 			base.OnBind();

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/StringOptionElement.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/StringOptionElement.cs
@@ -5,11 +5,11 @@ using Terraria.ModLoader.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class StringOptionElement : RangeElement
+	public class StringOptionElement : RangeElement
 	{
-		private Func<string> _GetValue;
-		private Func<int> _GetIndex;
-		private Action<int> _SetValue;
+		protected Func<string> _GetValue;
+		protected Func<int> _GetIndex;
+		protected Action<int> _SetValue;
 		string[] options;
 		public IList<string> stringList;
 

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/UIModConfig.cs
@@ -18,7 +18,7 @@ namespace Terraria.ModLoader.Config.UI
 	// TODO: Revert individual button.	
 	// TODO: Collapse All button, or default to collapsed?
 	// TODO: Localization support
-	internal class UIModConfig : UIState
+	public class UIModConfig : UIState
 	{
 		private UIElement uIElement;
 		private UITextPanel<string> headerTextPanel;
@@ -581,7 +581,7 @@ namespace Terraria.ModLoader.Config.UI
 			return null;
 		}
 
-		internal static UIElement GetContainer(UIElement containee, int sortid) {
+		public static UIElement GetContainer(UIElement containee, int sortid) {
 			UIElement container = new UISortableElement(sortid);
 			container.Width.Set(0f, 1f);
 			container.Height.Set(30f, 0f);
@@ -707,7 +707,7 @@ namespace Terraria.ModLoader.Config.UI
 			return uIPanel;
 		}
 
-		internal static void SwitchToSubConfig(UIPanel separateListPanel) {
+		public static void SwitchToSubConfig(UIPanel separateListPanel) {
 			Interface.modConfig.uIElement.RemoveChild(Interface.modConfig.configPanelStack.Peek());
 			Interface.modConfig.uIElement.Append(separateListPanel);
 			Interface.modConfig.configPanelStack.Push(separateListPanel);

--- a/patches/tModLoader/Terraria.ModLoader.Config.UI/Vector2Element.cs
+++ b/patches/tModLoader/Terraria.ModLoader.Config.UI/Vector2Element.cs
@@ -8,11 +8,11 @@ using Terraria.UI;
 
 namespace Terraria.ModLoader.Config.UI
 {
-	class Vector2Element : ConfigElement
+	public class Vector2Element : ConfigElement
 	{
-		class Vector2Object
+		public class Vector2Object
 		{
-			internal Vector2 current;
+			protected internal Vector2 current;
 			PropertyFieldWrapper memberInfo;
 			object item;
 			IList<Vector2> array;
@@ -34,7 +34,7 @@ namespace Terraria.ModLoader.Config.UI
 					Update();
 				}
 			}
-			private void Update() {
+			protected void Update() {
 				if (array == null)
 					memberInfo.SetValue(item, current);
 				else


### PR DESCRIPTION
### What is the new feature?
Improved extensibility of config UI by making the relevant classes mostly public

### Why should this be part of tModLoader?
Currently making a config UI element type with functionality similar but not identical to a pre-existing type requires entirely reimplementing the other type with whatever changes are desired

### Are there alternative designs?
I am not aware of any better way to accomplish this than reducing access limitations

### Sample usage for the new feature
Custom collection UI elements for custom collection types