### PR TITLE
[1.4] Add CanFallThroughPlatforms NPC hook

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
+++ b/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
@@ -41,7 +41,7 @@ namespace ExampleMod.Content.NPCs
 		public ref float AI_FlutterTime => ref NPC.ai[2];
 
 		public override void SetStaticDefaults() {
-			// DisplayName.SetDefault("Flutter Slime"); // Automatic from .lang files
+			// DisplayName.SetDefault("Flutter Slime"); // Automatic from localization files
 			Main.npcFrameCount[NPC.type] = 6; // make sure to set this for your modnpcs.
 
 			// Specify the debuffs it is immune to
@@ -143,6 +143,17 @@ namespace ExampleMod.Content.NPCs
 					NPC.frame.Y = (int)Frame.Falling * frameHeight;
 					break;
 			}
+		}
+
+		// Here, because we use custom AI (aiStyle not set to a suitable vanilla value), we should manually decide when Flutter Slime can fall through platforms
+		public override bool? CanFallThroughPlatforms() {
+			if (AI_State == (float)ActionState.Fall && NPC.HasValidTarget && Main.player[NPC.target].Top.Y > NPC.Bottom.Y) {
+				// If Flutter Slime is currently falling, we want it to keep falling through platforms as long as it's above the player
+				return true;
+			}
+
+			return false;
+			// You could also return null here to apply vanilla behavior (which is the same as false for custom AI)
 		}
 
 		private void FallAsleep() {

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -23,12 +23,12 @@ using Terraria.DataStructures;
 
 namespace ExampleMod.Content.NPCs
 {
-	// [AutoloadHead] and npc.townNPC are extremely important and absolutely both necessary for any Town NPC to work at all.
+	// [AutoloadHead] and NPC.townNPC are extremely important and absolutely both necessary for any Town NPC to work at all.
 	[AutoloadHead]
 	public class ExamplePerson : ModNPC
 	{
 		public override void SetStaticDefaults() {
-			// DisplayName automatically assigned from .lang files, but the commented line below is the normal approach.
+			// DisplayName automatically assigned from localization files, but the commented line below is the normal approach.
 			// DisplayName.SetDefault("Example Person");
 			Main.npcFrameCount[Type] = 25; // The amount of frames the NPC has
 

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -29,7 +29,7 @@ Mods: {
 		}
 		
 		NPCName: {
-			FlutterSlime: Flutter Slime
+			ExampleCustomAISlimeNPC: Flutter Slime
 			# Here we see that spaces in translation keys are not allowed. Any space will be replaced with an underscore.
 			Example_Person: Example Person
 		}

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -8,7 +8,7 @@ Mods: {
 		}
 		
 		NPCName: {
-			FlutterSlime: Порхающий слизень
+			ExampleCustomAISlimeNPC: Порхающий слизень
 			Example_Person: Пример человека
 		}
 		

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -180,6 +180,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine how and when an NPC can fall through platforms and similar tiles.
+		/// <br/>Return true to allow an NPC to fall through platforms, false to prevent it. Returns null by default, applying vanilla behaviors (based on aiStyle and type).
+		/// </summary>
+		public virtual bool? CanFallThroughPlatforms(NPC npc) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to make things happen when an NPC is caught. Ran Serverside.
 		/// </summary>
 		/// <param name="npc">The caught NPC</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -284,6 +284,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine how and when this NPC can fall through platforms and similar tiles.
+		/// <br/>Return true to allow this NPC to fall through platforms, false to prevent it. Returns null by default, applying vanilla behaviors (based on aiStyle and type).
+		/// </summary>
+		public virtual bool? CanFallThroughPlatforms() {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to make things happen when this NPC is caught. Ran Serverside
 		/// </summary>
 		/// <param name="player">The player catching this NPC</param>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -438,6 +438,30 @@ namespace Terraria.ModLoader
 			npc.ModNPC?.BossLoot(ref name, ref potionType);
 		}
 
+		private static HookList HookCanFallThroughPlatforms = AddHook<Func<NPC, bool?>>(g => g.CanFallThroughPlatforms);
+
+		public static bool? CanFallThroughPlatforms(NPC npc) {
+			bool? ret = npc.ModNPC?.CanFallThroughPlatforms() ?? null;
+			if (ret.HasValue) {
+				if (!ret.Value) {
+					return false;
+				}
+				ret = true;
+			}
+
+			foreach (GlobalNPC g in HookCanFallThroughPlatforms.Enumerate(npc.globalNPCs)) {
+				bool? globalRet = g.CanFallThroughPlatforms(npc);
+				if (globalRet.HasValue) {
+					if (!globalRet.Value) {
+						return false;
+					}
+					ret = true;
+				}
+			}
+
+			return ret;
+		}
+
 		private static HookList HookOnCatchNPC = AddHook<Action<NPC, Player, Item>>(g => g.OnCatchNPC);
 
 		public static void OnCatchNPC(NPC npc, Player player, Item item) {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -911,6 +911,17 @@
  			if (dryadWard) {
  				num2 = (int)num5 / 3;
  				num3 = 6;
+@@ -70586,6 +_,10 @@
+ 		}
+ 
+ 		private bool Collision_DecideFallThroughPlatforms() {
++			bool? modResult = NPCLoader.CanFallThroughPlatforms(this);
++			if (modResult.HasValue)
++				return modResult.Value;
++
+ 			bool result = false;
+ 			if (type == 2 || type == -43 || type == 190 || type == 191 || type == 192 || type == 193 || type == 194 || type == 317 || type == 318 || type == 133)
+ 				result = true;
 @@ -70871,6 +_,10 @@
  			if (IsABestiaryIconDummy)
  				newColor = Color.White;


### PR DESCRIPTION
This PR adds a `CanFallThroughPlatforms` NPC hook + example, and fixes localization for the NPC used as an example.
Implements #2178.

### What is the new feature?
A hook for `GlobalNPC` and `ModNPC` which is called during tile collision code for NPCs, allowing modders to mimick the code used by vanilla for their own NPCs or to override vanilla NPC behavior regarding interactions with platforms.
The hook shortcirquits whenever something wants the NPC to **not** fall through platforms.

### Why should this be part of tModLoader?
Requires detouring otherwise. Similar hook exists for projectiles already.

### Are there alternative designs?
Yes. 1.4 added two fields for projectiles (`shouldFallThrough` and `decidesManualFallThrough`, the latter set as an "enable" in `SetDefaults`), it would be possible to mirror this design for NPCs. Vanilla only uses it for the Pirate minion.
The downside of this design is that `shouldFallThrough` is not synced, so modders would have to take special care to make sure whatever leads up to the variable being set is also synced (and preferably runs every tick).
It's also two fields and not one, but this can be changed by just turning it into `bool?` instead.

A hook on the other hand brings it closer to the already existing implementation for projectiles, reinforcing design familiarity for modders.

### Sample usage for the new feature
```cs
//Falls through platforms if above the player and is not in any possible idle state
public override bool? CanFallThroughPlatforms() {
	if (notIdle && NPC.HasValidTarget && Main.player[NPC.target].Top.Y > NPC.Bottom.Y) {
		return true;
	}

	return false;
}
```

### ExampleMod updates
`ExampleCustomAISlimeNPC` ("Flutter Slime") was updated to use this new hook in a natural way.
Some outdated localization bugs/comments were fixed aswell.
A localization oddity is still open and should be addressed: What is up with `Example_Person` being used as the key instead of `ExamplePerson`?
