### PR TITLE
[1.4 EM] Decouple RandomBuffKeybind from ExampleMod class

### DIFF
--- a/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
@@ -2,13 +2,15 @@ using Terraria;
 using Terraria.ID;
 using Terraria.GameInput;
 using Terraria.ModLoader;
+using ExampleMod.Common.Systems;
 
 namespace ExampleMod.Common.Players
 {
+	// See Common/Systems/KeybindSystem for keybind registration.
 	public class ExampleKeybindPlayer : ModPlayer
 	{
 		public override void ProcessTriggers(TriggersSet triggersSet) {
-			if (ExampleMod.RandomBuffKeybind.JustPressed) {
+			if (KeybindSystem.RandomBuffKeybind.JustPressed) {
 				int buff = Main.rand.Next(BuffID.Count);
 				Player.AddBuff(buff, 600);
 				Main.NewText($"ExampleMod's ModKeybind was just pressed. The {Lang.GetBuffName(buff)} buff was given to the player.");

--- a/ExampleMod/Common/Systems/KeybindSystem.cs
+++ b/ExampleMod/Common/Systems/KeybindSystem.cs
@@ -6,7 +6,7 @@ namespace ExampleMod.Common.Systems
 	// See Common/Players/ExampleKeybindPlayer for usage.
 	public class KeybindSystem : ModSystem
 	{
-		public static ModKeybind RandomBuffKeybind;
+		public static ModKeybind RandomBuffKeybind { get; private set; }
 
 		public override void Load() {
 			// Registers a new keybind

--- a/ExampleMod/Common/Systems/KeybindSystem.cs
+++ b/ExampleMod/Common/Systems/KeybindSystem.cs
@@ -1,0 +1,22 @@
+﻿using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Systems
+{
+	// Acts as a container for keybinds registered by this mod.
+	// See Common/Players/ExampleKeybindPlayer for usage.
+	public class KeybindSystem : ModSystem
+	{
+		public static ModKeybind RandomBuffKeybind;
+
+		public override void Load() {
+			// Registers a new keybind
+			RandomBuffKeybind = KeybindLoader.RegisterKeybind(Mod, "Random Buff", "P");
+		}
+
+		// Please see ExampleMod.cs' Unload() method for a detailed explanation of the unloading process.
+		public override void Unload() {
+			// Not required if your AssemblyLoadContext is unloading properly, but nulling out static fields can help you figure out what's keeping it loaded.
+			RandomBuffKeybind = null;
+		}
+	}
+}

--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -8,13 +8,9 @@ namespace ExampleMod
 	{
 		public const string AssetPath = $"{nameof(ExampleMod)}/Assets/";
 
-		public static ModKeybind RandomBuffKeybind;
 		public static int ExampleCustomCurrencyId;
 
 		public override void Load() {
-			// Registers a new keybind
-			RandomBuffKeybind = KeybindLoader.RegisterKeybind(this, "Random Buff", "P");
-
 			// Registers a new custom currency
 			ExampleCustomCurrencyId = CustomCurrencyManager.RegisterCurrency(new Content.Currencies.ExampleCustomCurrency(ModContent.ItemType<Content.Items.ExampleItem>(), 999L, "Mods.ExampleMod.Currencies.ExampleCustomCurrency"));
 		}
@@ -27,9 +23,6 @@ namespace ExampleMod
 
 			// NOTE: When writing unload code - be sure use 'defensive programming'. Or, in other words, you should always assume that everything in the mod you're unloading might've not even been initialized yet.
 			// NOTE: There is rarely a need to null-out values of static fields, since TML aims to completely dispose mod assemblies in-between mod reloads.
-
-			// Not required if your AssemblyLoadContext is unloading properly, but nulling out static fields can help you figure out what's keeping it loaded.
-			RandomBuffKeybind = null;
 		}
 	}
 }


### PR DESCRIPTION
### What are the changes to ExampleMod?
`RandomBuffKeybind` currently lives in the `ExampleMod` class, which is 1.3 legacy, since in 1.4 `ModSystem`s (and all `ModType`s) are able to load/unload things, encouraging contextual separation of code. With this change, there is now a `KeybindSystem` that takes care of the registering instead.

Added helpful comments for where the modder has to look to find all the required code.

