### PR TITLE
[1.4] Fix display name of patreon and dev items

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader.Default.Developer
 
 		public override void SetStaticDefaults() {
 			string displayName = Name.Replace('_', ' ');
-			displayName.Insert(displayName.IndexOf(' '), SetSuffix);
+			displayName = displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 			DisplayName.SetDefault(displayName);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
@@ -12,7 +12,7 @@ namespace Terraria.ModLoader.Default.Patreon
 
 		public override void SetStaticDefaults() {
 			var displayName = Name.Replace('_', ' ');
-			displayName.Insert(displayName.IndexOf(' '), SetSuffix);
+			displayName = displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 			DisplayName.SetDefault(displayName);
 		}
 


### PR DESCRIPTION
### What is the bug?
Someone forgot to use the return value of `string.Insert` causing dev and patreon items to be missing the `'s` suffix after the name

### How did you fix the bug?
Assign the return value to `displayName`

### Are there alternatives to your fix?
No

