### PR TITLE
[1.4] Fix certain music boxes not recording

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1813,16 +1813,15 @@
  				SoundEngine.PlaySound(SoundID.Item166, base.Center);
  				int num3 = -1;
  				if (Main.curMusic == 1)
-@@ -10917,10 +_,14 @@
+@@ -10917,10 +_,12 @@
  					currentItem.SetDefaults(5044);
  				else if (Main.curMusic == 90)
  					currentItem.SetDefaults(5112);
 -				else if (Main.curMusic > 13)
 +				else if (Main.curMusic > 13 && Main.curMusic < Main.maxMusic)
  					currentItem.SetDefaults(1596 + Main.curMusic - 14);
- 				else if (num3 != -1)
-+					; // Silence.
-+				else if (Main.curMusic < Main.maxMusic)
+-				else if (num3 != -1)
++				else if (num3 != -1 && Main.curMusic < Main.maxMusic)
  					currentItem.SetDefaults(num3 + 562);
 +				else if (MusicLoader.musicToItem.TryGetValue(Main.curMusic, out int modMusicBoxType))
 +					currentItem.SetDefaults(modMusicBoxType);


### PR DESCRIPTION
### What is the bug?
#2204: Musics associated with the music boxes with IDs 562 to 574 (13 in total) are never recorded when a music box is equipped.

### How did you fix the bug?
These 13 musics were purposefully skipped by tml in [this commit](https://github.com/tModLoader/tModLoader/commit/dc7013d5140f0837cb92e73d4bc1fde49e7bb78e#diff-85ab89e76e315ab17504ba97049ea5eb55d2d1bd90f7f52fc36bcb0d4f36f588R1291), meaning they never enter their intended code `SetDefaults(num3 + 562);`. I changed that by combining the two conditions together to closer resemble vanilla code. Now all music boxes get recorded properly (including modded):
* Musics `> 13` are handled on the first if condition
* Musics `<= 13` (flagged before the patch) are handled in the second if condition
* Musics `>= Main.maxMusic` (modded) are handled last

### Are there alternatives to your fix?
No
