### PR TITLE
Fix ScriptCaller.sh never checking for system dotnet

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -64,7 +64,6 @@ dotnet_version=${dotnet_version%$'\r'} # remove trailing carriage return that se
 echo "Success!"  2>&1 | tee -a "$LogFile"
 
 compareversions() {
-	echo sysver is $1 neededver is $2
 	if [[ $1 == $2 ]]
 	then
 		return 1
@@ -102,8 +101,6 @@ then
 else
 	installdotnet
 fi
-
-installdotnet
 
 echo "Attempting Launch..."
 


### PR DESCRIPTION
### What is the bug?
ScriptCaller.sh never actually checks for a system install of dotnet.

### How did you fix the bug?
Check dotnet exists on the system on the path, then compare the version string with the one in runtimeconfig.json

### Are there alternatives to your fix?
Someone could probably write it cleaner
