### PR TITLE
[1.4] Fix modded music boxes crashing when clicked on

### DIFF
--- a/patches/tModLoader/Terraria/SceneMetrics.cs.patch
+++ b/patches/tModLoader/Terraria/SceneMetrics.cs.patch
@@ -155,12 +155,13 @@
  							HasClock = true;
  
  						switch (tile2.type) {
-@@ -323,6 +_,11 @@
+@@ -323,6 +_,12 @@
  									BloodMoonMonolith = true;
  								break;
  						}
 +
-+						if (TileLoader.IsModMusicBox(tile2) && tile2.frameX == 36)
++						// This does not use TileLoader.IsModMusicBox because it needs the *exact* frameY for the second dict lookup
++						if (MusicLoader.tileToMusic.ContainsKey(tile2.type) && MusicLoader.tileToMusic[tile2.type].ContainsKey(tile2.frameY) && tile2.frameX == 36)
 +							ActiveMusicBox = MusicLoader.tileToMusic[tile2.type][tile2.frameY];
 +
 +						TileLoader.NearbyEffects(k, l, tile2.type, true);


### PR DESCRIPTION
### What is the bug?
Modded music boxes crash when clicked on to enable them

### How did you fix the bug?
This reverts a refactoring change which was added in b8b1ee2
A faulty call to `TileLoader.IsModMusicBox` was causing this as ActiveMusicBox is assigned to by the raw frameY, but that method floors it by dividing and then multiplying by 36, turning a value of i.e. 18 into 0, returning true, but then causing a `KeyNotFoundException`.

### Are there alternatives to your fix?
No, this is just a revert. The alternative would alter IsModMusicBox, causing logic issues in other places.
