### PR TITLE
Fix for Publishing being sometimes Broken after Preview update

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -53,9 +53,6 @@ namespace Terraria
 				if (Directory.Exists(Path.Combine(newPath, subDir)))
 					Directory.Move(Path.Combine(newPath, subDir), Path.Combine(newPath, subDir.Replace(" ", "")));
 			}
-
-			if (Directory.Exists(Path.Combine(newPath, "Workshop")))
-				Directory.Move(Path.Combine(newPath, "Workshop"), Path.Combine(SavePath, "Workshop"));
 				
 			FileUtilities.CopyFolder(newPath, Path.Combine(SavePath, DevFolder));
 			FileUtilities.CopyFolder(newPath, Path.Combine(SavePath, ReleaseFolder));

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -54,16 +54,8 @@ namespace Terraria
 					Directory.Move(Path.Combine(newPath, subDir), Path.Combine(newPath, subDir.Replace(" ", "")));
 			}
 
-			if (Directory.Exists(Path.Combine(newPath, "Workshop"))) {
-				string workshopPath = Path.Combine(newPath, "Workshop", Steamworks.SteamUser.GetSteamID().m_SteamID.ToString());
-				foreach (var repo in Directory.GetDirectories(workshopPath)) {
-					var msNew = Path.Combine(ModLoader.Core.ModCompile.ModSourcePath, Path.GetDirectoryName(repo), "Workshop");
-
-					foreach (var file in Directory.GetFiles(repo)) {
-						File.Copy(file, Path.Combine(msNew, Path.GetFileName(file)));
-					}
-				}
-			}
+			if (Directory.Exists(Path.Combine(newPath, "Workshop")))
+				Directory.Move(Path.Combine(newPath, "Workshop"), Path.Combine(SavePath, "Workshop"));
 				
 			FileUtilities.CopyFolder(newPath, Path.Combine(SavePath, DevFolder));
 			FileUtilities.CopyFolder(newPath, Path.Combine(SavePath, ReleaseFolder));

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -185,7 +185,7 @@ namespace Terraria.Social.Steam
 			/// <summary>
 			/// Updates and/or Downloads the Item specified when generating the ModManager Instance.
 			/// </summary>
-			private bool InnerDownload(UIWorkshopDownload uiProgress, bool mbHasUpdate) {
+			internal bool InnerDownload(UIWorkshopDownload uiProgress, bool mbHasUpdate) {
 				downloadResult = EResult.k_EResultOK;
 
 				if (NeedsUpdate() || mbHasUpdate) {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -171,7 +171,7 @@
  						UpdateItem();
  					}
  					else {
-@@ -205,13 +_,57 @@
+@@ -205,13 +_,56 @@
  				}
  
  				private void CreateItem() {
@@ -213,7 +213,6 @@
 +
 +					_publishedFileID = param.m_nPublishedFileId;
 +					WrappedWriteManifest();
-+					SteamUGC.SubscribeItem(_publishedFileID);
 +
 +					if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
 +						_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
@@ -329,6 +328,15 @@
  						case EResult.k_EResultOK:
  							SteamFriends.ActivateGameOverlayToWebPage("steam://url/CommunityFilePage/" + _publishedFileID.m_PublishedFileId);
  							break;
+@@ -291,6 +_,8 @@
+ 							break;
+ 					}
+ 
++					SteamUGC.SubscribeItem(_publishedFileID);
++
+ 					_endAction(this);
+ 				}
+ 
 @@ -305,6 +_,16 @@
  						_issueReporter.ReportManifestCreationProblem("Workshop.ReportIssue_CouldNotCreateResourcePackManifestFile", exception);
  						return false;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -54,7 +54,9 @@ namespace Terraria.Social.Steam
 			string workshopFolderPath = GetTemporaryFolderPath() + modFile.Name;
 
 			if (existing != null) {
-				ulong existingID = WorkshopHelper.QueryHelper.GetSteamOwner(ulong.Parse(existing.PublishId));
+				currPublishID = ulong.Parse(existing.PublishId);
+
+				ulong existingID = WorkshopHelper.QueryHelper.GetSteamOwner(currPublishID);
 				var currID = Steamworks.SteamUser.GetSteamID();
 
 				if (existingID != currID.m_SteamID) {
@@ -62,13 +64,19 @@ namespace Terraria.Social.Steam
 					return false;
 				}
 
+				// Update the subscribed mod to be the latest version published
+				new WorkshopHelper.ModManager(new Steamworks.PublishedFileId_t(currPublishID)).InnerDownload(null, true);
+
 				// Publish by updating the files available on the current published version
-				string subscribedFolder = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
-				if (Directory.Exists(subscribedFolder))
-					FileUtilities.CopyFolder(subscribedFolder, workshopFolderPath);
+				workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
+
+				if (new Version(buildData["version"].Replace("v", "")) <= new Version(existing.Version.Replace("v", ""))) {
+					IssueReporter.ReportInstantUploadProblem("tModLoader.ModVersionInfoUnchanged");
+					return false;
+				}
 
 				// Use the stable version of the mod for publishing metadata, not the preview version!
-				if (BuildInfo.IsPreview && Directory.Exists(workshopFolderPath)) {
+				if (!BuildInfo.IsStable) {
 					string stable = ModOrganizer.FindOldest(workshopFolderPath);
 					if (!stable.Contains(".tmod"))
 						stable = Directory.GetFiles(stable, "*.tmod")[0];
@@ -82,14 +90,7 @@ namespace Terraria.Social.Steam
 					buildData["version"] = sMod.properties.version.ToString();
 					buildData["modreferences"] = string.Join(", ", sMod.properties.modReferences.Select(x => x.mod));
 					buildData["modside"] = sMod.properties.side.ToFriendlyString();
-				}	
-
-				if (new Version(buildData["version"].Replace("v", "")) <= new Version(existing.Version.Replace("v", ""))) {
-					IssueReporter.ReportInstantUploadProblem("tModLoader.ModVersionInfoUnchanged");
-					return false;
 				}
-
-				currPublishID = uint.Parse(existing.PublishId);
 			}
 
 			string name = buildData["displaynameclean"];

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
@@ -18,3 +18,13 @@
  			_downloader = WorkshopHelper.UGCBased.Downloader.Create();
  			_publishedItems = WorkshopHelper.UGCBased.PublishedItemsFinder.Create();
  			WorkshopIssueReporter workshopIssueReporter = new WorkshopIssueReporter();
+@@ -149,7 +_,8 @@
+ 			resourcePackPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, text, fullPath, settings.PreviewImagePath, settings.Publicity, usedTagsInternalNames);
+ 		}
+ 
+-		private string GetTemporaryFolderPath() => string.Concat(str2: SteamUser.GetSteamID().m_SteamID.ToString(), str0: _contentBaseFolder, str1: Path.DirectorySeparatorChar.ToString(), str3: Path.DirectorySeparatorChar.ToString());
++		//private string GetTemporaryFolderPath() => string.Concat(str2: SteamUser.GetSteamID().m_SteamID.ToString(), str0: _contentBaseFolder, str1: Path.DirectorySeparatorChar.ToString(), str3: Path.DirectorySeparatorChar.ToString());
++		private string GetTemporaryFolderPath() => ModLoader.Core.ModCompile.ModSourcePath + Path.DirectorySeparatorChar;
+ 
+ 		private bool MakeTemporaryFolder(string temporaryFolderPath) {
+ 			bool result = true;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
@@ -9,15 +9,6 @@
  	{
  		private WorkshopHelper.UGCBased.Downloader _downloader;
  		private WorkshopHelper.UGCBased.PublishedItemsFinder _publishedItems;
-@@ -24,7 +_,7 @@
- 			_publisherInstances = new List<WorkshopHelper.UGCBased.APublisherInstance>();
- 			base.ProgressReporter = new WorkshopProgressReporter(_publisherInstances);
- 			base.SupportedTags = new SupportedWorkshopTags();
--			_contentBaseFolder = Main.SavePath + Path.DirectorySeparatorChar + "Workshop";
-+			_contentBaseFolder = Directory.GetParent(Main.SavePath).ToString() + Path.DirectorySeparatorChar + "Workshop";
- 			_downloader = WorkshopHelper.UGCBased.Downloader.Create();
- 			_publishedItems = WorkshopHelper.UGCBased.PublishedItemsFinder.Create();
- 			WorkshopIssueReporter workshopIssueReporter = new WorkshopIssueReporter();
 @@ -149,7 +_,8 @@
  			resourcePackPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, text, fullPath, settings.PreviewImagePath, settings.Publicity, usedTagsInternalNames);
  		}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.cs.patch
@@ -9,3 +9,12 @@
  	{
  		private WorkshopHelper.UGCBased.Downloader _downloader;
  		private WorkshopHelper.UGCBased.PublishedItemsFinder _publishedItems;
+@@ -24,7 +_,7 @@
+ 			_publisherInstances = new List<WorkshopHelper.UGCBased.APublisherInstance>();
+ 			base.ProgressReporter = new WorkshopProgressReporter(_publisherInstances);
+ 			base.SupportedTags = new SupportedWorkshopTags();
+-			_contentBaseFolder = Main.SavePath + Path.DirectorySeparatorChar + "Workshop";
++			_contentBaseFolder = Directory.GetParent(Main.SavePath).ToString() + Path.DirectorySeparatorChar + "Workshop";
+ 			_downloader = WorkshopHelper.UGCBased.Downloader.Create();
+ 			_publishedItems = WorkshopHelper.UGCBased.PublishedItemsFinder.Create();
+ 			WorkshopIssueReporter workshopIssueReporter = new WorkshopIssueReporter();


### PR DESCRIPTION
### What is the bug?
It was found that the recent preview system merge had a bug for select circumstances that prevented publishing mod updates.

This fixes that bug.

### How did you fix the bug?
Reworked the Workshop folder to be indepedent to the development stream, and added missing Directory.Exists() checks for publishing updates that would otherwise fail on nulls.

### Are there alternatives to your fix?
