### PR TITLE
Fix hardcore characters

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3287,6 +3287,20 @@
  					}
  					else {
  						statLife = 0;
+@@ -27556,6 +_,13 @@
+ 				if (FileUtilities.Exists(Main.playerPathName + ".bak", isCloudSave))
+ 					FileUtilities.Delete(Main.playerPathName + ".bak", isCloudSave);
+ 
++				string moddedPlayerPathName = Path.ChangeExtension(Main.playerPathName, ".tplr");
++				if (FileUtilities.Exists(moddedPlayerPathName, isCloudSave))
++					FileUtilities.Delete(moddedPlayerPathName, isCloudSave);
++
++				if (FileUtilities.Exists(moddedPlayerPathName + ".bak", isCloudSave))
++					FileUtilities.Delete(moddedPlayerPathName + ".bak", isCloudSave);
++
+ 				Main.ActivePlayerFileData = new PlayerFileData();
+ 			}
+ 		}
 @@ -27565,6 +_,11 @@
  				return;
  


### PR DESCRIPTION
### What is the bug?
When an hardcore character dies, the tplr and the tplr.bak stay there. 

### How did you fix the bug?
By extending the way the vanilla player files are deleted

### Are there alternatives to your fix?
PlayerIO.ErasePlayer(Main.playerPathName, isCloudSave); would also work but it doesn't check the existence of tplr files, it used a try/catch instead

A method could also be added to ModPlayer so that mods that store info about the player can delete theirs, but it would only make sense if the normal deletion of a character also used it (an hook on kill isn't enough btw, as a player could be delete due to an accessory instead of just the difficulty)