### PR TITLE
[1.4] Reimplement two hooks for the new "Color" lighting mode

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -8,24 +8,6 @@
  
  namespace Terraria.Graphics.Light
  {
-@@ -106,7 +_,7 @@
- 		private int _expandedRectTop;
- 		private int _expandedRectRight;
- 		private int _expandedRectBottom;
--		private float _negLight = 0.04f;
-+		internal float _negLight = 0.04f;
- 		private float _negLight2 = 0.16f;
- 		private float _wetLightR = 0.16f;
- 		private float _wetLightG = 0.16f;
-@@ -114,7 +_,7 @@
- 		private float _honeyLightR = 0.16f;
- 		private float _honeyLightG = 0.16f;
- 		private float _honeyLightB = 0.16f;
--		private float _blueWave = 1f;
-+		internal float _blueWave = 1f;
- 		private int _blueDir = 1;
- 		private RectArea _minBoundArea;
- 		private RectArea _requestedArea;
 @@ -575,6 +_,7 @@
  			_tileScanner.ExportTo(new Rectangle(num, num3, num2 - num, num4 - num3), _lightMap);
  			for (int m = num; m < num2; m++) {
@@ -39,7 +21,7 @@
  							break;
  					}
 +
-+					LoaderManager.Get<WaterStylesLoader>().LightColorMultiplier(Main.waterStyle, ref _wetLightR, ref _wetLightG, ref _wetLightB);
++					LoaderManager.Get<WaterStylesLoader>().LightColorMultiplier(Main.waterStyle, _negLight * _blueWave, ref _wetLightR, ref _wetLightG, ref _wetLightB);
  				}
  				else {
  					_negLight = 0.9f;

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -8,6 +8,21 @@
  
  namespace Terraria.Graphics.Light
  {
+@@ -156,6 +_,14 @@
+ 					break;
+ 			}
+ 
++			float factor = 0.91f;
++			// Default values taken from the LightMap contructor, matching the virtual default of the hook
++			float throughWaterR = 0.88f;
++			float throughWaterG = 0.96f;
++			float throughWaterB = 1.015f;
++			LoaderManager.Get<WaterStylesLoader>().LightColorMultiplier(Main.waterStyle, factor, ref throughWaterR, ref throughWaterG, ref throughWaterB);
++			workingLightMap.LightDecayThroughWater = new Vector3(throughWaterR, throughWaterG, throughWaterB);
++
+ 			if (Main.player[Main.myPlayer].nightVision) {
+ 				workingLightMap.LightDecayThroughAir *= 1.03f;
+ 				workingLightMap.LightDecayThroughSolid *= 1.03f;
 @@ -175,6 +_,12 @@
  				workingLightMap.LightDecayThroughAir *= 0.85f;
  				workingLightMap.LightDecayThroughSolid *= 0.85f;

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -1,0 +1,23 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Light/LightingEngine.cs
++++ src/tModLoader/Terraria/Graphics/Light/LightingEngine.cs
+@@ -3,6 +_,7 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Diagnostics;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.Graphics.Light
+ {
+@@ -175,6 +_,12 @@
+ 				workingLightMap.LightDecayThroughAir *= 0.85f;
+ 				workingLightMap.LightDecayThroughSolid *= 0.85f;
+ 			}
++
++			float throughAir = 1f;
++			float throughSolid = 1f;
++			SystemLoader.ModifyLightingBrightness(ref throughAir, ref throughSolid);
++			workingLightMap.LightDecayThroughAir *= throughAir;
++			workingLightMap.LightDecayThroughSolid *= throughSolid;
+ 		}
+ 
+ 		private void ApplyPerFrameLights() {

--- a/patches/tModLoader/Terraria/ModLoader/WaterStyleLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WaterStyleLoader.cs
@@ -95,17 +95,15 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public void LightColorMultiplier(int style, ref float r, ref float g, ref float b) {
+		public void LightColorMultiplier(int style, float factor, ref float r, ref float g, ref float b) {
 			ModWaterStyle waterStyle = Get(style);
 
 			if (waterStyle != null) {
 				waterStyle.LightColorMultiplier(ref r, ref g, ref b);
 
-				r *= Lighting.LegacyEngine._negLight * Lighting.LegacyEngine._blueWave;
-				g *= Lighting.LegacyEngine._negLight * Lighting.LegacyEngine._blueWave;
-				b *= Lighting.LegacyEngine._negLight * Lighting.LegacyEngine._blueWave;
-
-				//TODO: Make this work with the new lighting engine.
+				r *= factor;
+				g *= factor;
+				b *= factor;
 			}
 		}
 	}


### PR DESCRIPTION
### What is the bug?
Two hooks (`ModifyLightingBrightness` and `LightColorMultiplier`) stopped working in 1.4 due to its change to the "Color" lighting mode.

### How did you fix the bug?
This PR reimplements both hooks. It also changes the loader method signature on `LightColorMultiplier` to accept a common factor, since it's now called in two places.

### Are there alternatives to your fix?
You can make an argument to get rid of all patches inside `LegacyLighting.cs.patch` as in vanilla it's not possible to invoke any of that old code anymore. A modder could still force them to get called though.
