### PR TITLE
1.4 migrate files v3

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -51,7 +51,7 @@ namespace Terraria.ModLoader.Core
 			}
 		}
 
-		public static readonly string ModSourcePath = Path.Combine(Program.SavePath, "ModSources");
+		public static readonly string ModSourcePath = Path.Combine(Program.SavePathShared, "ModSources");
 
 		internal static string[] FindModSources()
 		{

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -48,7 +48,9 @@ namespace Terraria.ModLoader
 			Utils.TryCreatingDirectory(LogDir);
 
 			ConfigureAppenders(dedServ);
+		}
 
+		internal static void LogStartup(bool dedServ) {
 			tML.InfoFormat("Starting tModLoader {0} {1} built {2}", dedServ ? "server" : "client", BuildInfo.BuildIdentifier, $"{BuildInfo.BuildDate:g}");
 			tML.InfoFormat("Log date: {0}", DateTime.Now.ToString("d"));
 			tML.InfoFormat("Running on {0} {1} {2} {3}", ReLogic.OS.Platform.Current.Type, System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture, FrameworkVersion.Framework, FrameworkVersion.Version);

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -14,6 +14,7 @@ namespace Terraria
 	public static partial class Program
 	{
 		public static string SavePath { get; private set; } // Moved from Main to avoid triggering the Main static constructor before logging initializes
+		public static string SavePathShared { get; private set; } // Points to the Stable tModLoader save folder, used for Mod Sources only currently
 
 		private static IEnumerable<MethodInfo> GetAllMethods(Type type) {
 			return type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
@@ -106,7 +107,9 @@ namespace Terraria
 			if (LaunchParameters.ContainsKey("-tmlsavedirectory"))
 				SavePath = LaunchParameters["-tmlsavedirectory"];
 
-			Logging.tML.Info($"Save Are Located At: {SavePath}");
+			SavePathShared = Path.Combine(SavePath, "..", ReleaseFolder);
+			
+			Logging.tML.Info($"Save Are Located At: {Path.GetFullPath(SavePath)}");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,72 @@
+@@ -138,32 +_,73 @@
  			}
  		}
  
@@ -105,15 +105,6 @@
  
 +			LaunchParameters = Utils.ParseArguements(args);
 +
-+			try {
-+				SetSavePath(); // Needs to run before Logging.Init due to DeveloperMode check in ModCompile
-+			}
-+			catch (Exception e) {
-+				Logging.Terraria.Fatal("Failed to Handle Save Data", e);
-+				DisplayException(e);
-+				return;
-+			}
-+
 +			bool isServer = LaunchParameters.ContainsKey("-server");
 +			try {
 +				Logging.Init(isServer);
@@ -122,6 +113,16 @@
 +			}
 +			catch (Exception e) {
 +				Logging.Terraria.Fatal("Main engine crash", e);
++				DisplayException(e);
++				return;
++			}
++
++			try {
++				SetSavePath(); // Needs to run before Logging.LogStartup due to DeveloperMode check in ModCompile
++				Logging.LogStartup(isServer);
++			}
++			catch (Exception e) {
++				Logging.Terraria.Fatal("Failed to Handle Save Data", e);
 +				DisplayException(e);
 +				return;
 +			}


### PR DESCRIPTION
Fixes Concerns regarding the Directory Split introduced in the Preview System PR.

Improves Logging regarding the movement of files.

Mod Sources now pulls from a single folder in Terraria/tModLoader instead of looking at each of the branches.