### PR TITLE
Fix Auto Publishing for Preview/Stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,12 +414,10 @@ jobs:
         working-directory: artifacts/Build
         
       - name: Setup steamcmd
-        if: steps.changed-files-examplemod.outputs.any_modified == 'true' || steps.changed-files-patches.outputs.any_modified == 'true'
         id: setupsteam
         uses: CyberAndrii/setup-steamcmd@v1
         
       - name: Setup Authentication Files
-        if: steps.changed-files-examplemod.outputs.any_modified == 'true' || steps.changed-files-patches.outputs.any_modified == 'true'
         shell: bash
         run: |
           echo Decrypting Authentication Files
@@ -429,7 +427,6 @@ jobs:
           STEAMCMDDIR: ${{ steps.setupsteam.outputs.directory }}
           
       - name: Attempt run_app_build_http 
-        if: steps.changed-files-patches.outputs.any_modified == 'true'
         shell: bash
         run: |
           mkdir artifacts/shared
@@ -451,7 +448,6 @@ jobs:
           cat BuildOutput/*.log
           
       - name: Download ExampleMod build artifact from build job
-        if: steps.changed-files-examplemod.outputs.any_modified == 'true'
         # This should hopefully always work since this job shouldn't even run if the build job failed due to ExampleMod not compiling.
         uses: actions/download-artifact@v2
         with:
@@ -459,14 +455,12 @@ jobs:
           path: artifacts/ExampleMod
           
       - name: View ExampleMod build artifact files
-        if: steps.changed-files-examplemod.outputs.any_modified == 'true'
         run: |
           echo pwd is: ${PWD}
           ls -alhR
         working-directory: artifacts/ExampleMod
         
       - name: Attempt workshop_build_item 
-        if: steps.changed-files-examplemod.outputs.any_modified == 'true'
         shell: bash
         run: |
           echo Changes detected in ExampleMod folder, attempting to publish ExampleMod to workshop
@@ -483,3 +477,12 @@ jobs:
           cat publish.vdf
           echo Done
         working-directory: artifacts/ExampleMod
+      
+      - name: Make a release
+        if: github.ref == 'refs/heads/1.4-stable'
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/ExampleMod,artifacts/Build"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: "Monthly Github Auto-release for 1.4-stable"
+            


### PR DESCRIPTION
Removes the 'Changed Files' checks so that we ALWAYS publish both ExampleMod & tML when Preview & Stable get updated.

Adds auto deployment of the 'release' when building on Stable.