### PR TITLE
[1.4] Fix full inventory stacking bug

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3372,7 +3372,7 @@
  
 -			if (theSlot.stack < theSlot.maxStack && theItemToAccept.IsTheSameAs(theSlot))
 +			//if (theSlot.stack < theSlot.maxStack && theItemToAccept.IsTheSameAs(theSlot))
-+			if (theSlot.stack < theSlot.maxStack && theItemToAccept.IsTheSameAs(theSlot) && !ItemLoader.CanStack(theSlot, theItemToAccept))
++			if (theSlot.stack < theSlot.maxStack && theItemToAccept.IsTheSameAs(theSlot) && ItemLoader.CanStack(theSlot, theItemToAccept))
  				return true;
  
  			return false;


### PR DESCRIPTION
### What is the bug?
Video: [here](https://cdn.discordapp.com/attachments/871289059396448337/959796457723019314/full_inv.webm)

"when you have item A and no vacancy in your inventory, you cannot move other item A from a chest to your inventory using left shift"

### How did you fix the bug?
Remove a bad `!` 

### Are there alternatives to your fix?
No, this is likely just a typo (I wrote that original code, and it was just a matter of time for such an issue to be discovered)
