### PR TITLE
[1.4] Fix water lighting in color mode, clarify hook defaults

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -8,15 +8,14 @@
  
  namespace Terraria.Graphics.Light
  {
-@@ -156,6 +_,14 @@
+@@ -156,6 +_,13 @@
  					break;
  			}
  
 +			float factor = 0.91f;
-+			// Default values taken from the LightMap contructor, matching the virtual default of the hook
-+			float throughWaterR = 0.88f;
-+			float throughWaterG = 0.96f;
-+			float throughWaterB = 1.015f;
++			float throughWaterR = workingLightMap.LightDecayThroughWater.X;
++			float throughWaterG = workingLightMap.LightDecayThroughWater.Y;
++			float throughWaterB = workingLightMap.LightDecayThroughWater.Z;
 +			LoaderManager.Get<WaterStylesLoader>().LightColorMultiplier(Main.waterStyle, factor, ref throughWaterR, ref throughWaterG, ref throughWaterB);
 +			workingLightMap.LightDecayThroughWater = new Vector3(throughWaterR, throughWaterG, throughWaterB);
 +

--- a/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWaterStyle.cs
@@ -50,6 +50,7 @@ namespace Terraria.ModLoader
 		/// Allows you to modify the light levels of the tiles behind the water. The light color components will be multiplied by the parameters.
 		/// </summary>
 		public virtual void LightColorMultiplier(ref float r, ref float g, ref float b) {
+			// Default values taken from the LightMap contructor
 			r = 0.88f;
 			g = 0.96f;
 			b = 1.015f;
@@ -59,6 +60,7 @@ namespace Terraria.ModLoader
 		/// Allows you to change the hair color resulting from the biome hair dye when this water style is in use.
 		/// </summary>
 		public virtual Color BiomeHairColor() {
+			// Default value taken from DyeInitializer.LoadLegacyHairdyes on 1983 default case
 			return new Color(28, 216, 94);
 		}
 


### PR DESCRIPTION
### What is the bug?
with "Color" lighting mode, water is very bright when a light source is affecting it. 
[Image](https://cdn.discordapp.com/attachments/848886153817620530/960056136030126140/unknown.png)

### How did you fix the bug?
The code was ignoring the vanilla values assigned to water styles AND the factor multiplication, causing this "too bright" behavior. I changed it to use its previous values instead, this way vanilla is not affected, modded will continue to work as before.

Also added/moved the comments about how these numbers come together into the hooks.

### Are there alternatives to your fix?
No, just an oversight from the commit that made the hook work in the first place.
