### PR TITLE
[1.4] Added Missing HateCrowded Happiness Quote to Example Person

### DIFF
--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -92,6 +92,7 @@ Mods: {
 				LoveSpace: I love how there is so much space here to code tModLoader mods!
 				FarFromHome: Could you please get me back to my house?
 				DislikeCrowded: There are too many people around, it makes it hard for me to focus on mod making.
+				HateCrowded: I can't test my mod with so many people around!
 				LikeBiome: "{BiomeName} is a very nice place to test mods in."
 				LoveBiome: "I love {BiomeName}."
 				DislikeBiome: "It's way too cold in {BiomeName}, I'm freezing!"


### PR DESCRIPTION
### What are the changes to ExampleMod?

Added the missing `HateCrowded` happiness quote to Example Person in the localization file.

### Do these changes need additional documentation?

No addition documentation necessary. But if you want to know, `DislikeCrowded` is for when there are 4-6 other Town NPCs nearby, `HateCrowded` is for 7+ other Town NPCs nearby.
