### PR TITLE
[1.4] Fix credit roll crashing at the end when trying to draw player

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -214,15 +214,6 @@
  		public static Preferences Configuration = new Preferences(SavePath + Path.DirectorySeparatorChar + "config.json");
  		public static Preferences InputProfiles = new Preferences(SavePath + Path.DirectorySeparatorChar + "input profiles.json");
  		public static KeyboardState inputText;
-@@ -1864,7 +_,7 @@
- 		public static float exitScale = 0.8f;
- 		public static bool mouseReforge;
- 		public static float reforgeScale = 0.8f;
--		public static Player clientPlayer = new Player();
-+		public static Player clientPlayer = new Player(); // setup inventory is unnecessary
- 		public static string getIP = defaultIP;
- 		public static string getPort = Convert.ToString(Netplay.ListenPort);
- 		public static bool menuMultiplayer;
 @@ -1972,7 +_,7 @@
  		public static bool _shouldUseWindyDayMusic = false;
  		public static bool _shouldUseStormMusic = false;
@@ -885,15 +876,6 @@
  
  			musicFade[50] = 1f;
  			for (int i = 0; i < 10; i++) {
-@@ -5117,7 +_,7 @@
- 			}
- 
- 			for (int m = 0; m < 256; m++) {
--				player[m] = new Player();
-+				player[m] = new Player(); // setup inventory is unnecessary
- 			}
- 
- 			for (int n = 0; n < 1001; n++) {
 @@ -8372,11 +_,17 @@
  		public static void LoadTestLog(string logname) {
  		}

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -526,7 +526,8 @@ namespace Terraria.ModLoader
 			}
 
 			// TML: Due to Segments.PlayerSegment._player being initialized way before any mods are loaded, calling methods on this player (which vanilla does) will crash since no ModPlayers are set up for it, so reinitialize it
-			SkyManager.Instance["CreditsRoll"] = new CreditsRollSky();
+			if (!Main.dedServ)
+				SkyManager.Instance["CreditsRoll"] = new CreditsRollSky();
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -25,6 +25,8 @@ using Terraria.ModLoader.Utilities;
 using Terraria.Initializers;
 using Terraria.Map;
 using Terraria.GameContent.Creative;
+using Terraria.Graphics.Effects;
+using Terraria.GameContent.Skies;
 
 namespace Terraria.ModLoader
 {
@@ -522,6 +524,9 @@ namespace Terraria.ModLoader
 			foreach (LocalizedText text in LanguageManager.Instance._localizedTexts.Values) {
 				text.Override = null;
 			}
+
+			// TML: Due to Segments.PlayerSegment._player being initialized way before any mods are loaded, calling methods on this player (which vanilla does) will crash since no ModPlayers are set up for it, so reinitialize it
+			SkyManager.Instance["CreditsRoll"] = new CreditsRollSky();
 		}
 
 		/// <summary>


### PR DESCRIPTION
### What is the bug?
#2250:
Due to `Segments.PlayerSegment._player` being initialized way before any mods are loaded, calling methods on this player (which vanilla does) will crash since no `ModPlayer`s are set up for it.

### How did you fix the bug?
Reinitialize the entire `CreditsRollSky` object in `ModContent.ResizeArrays` (running on load and unload) which contains the `Segments.PlayerSegment` constructor, reinitializing the player aswell, and making sure `Player.modPlayers` is populated.

Also removed outdated/redundant comments from 1.3 (where `Player` ctor had an optional parameter) to reduce patch count.

### Are there alternatives to your fix?
Making `_player` static, essentially a "shared" rendering dummy. Problem is the fact that vanilla uses this object to bind it to cutscene actions, reinitializing this object afterwards will disconnect it.
