### PR TITLE
Add IsSlime, IsBunny, IsSquirrel, IsButterfly and IsBird + example.

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
+++ b/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
@@ -44,6 +44,8 @@ namespace ExampleMod.Content.NPCs
 			// DisplayName.SetDefault("Flutter Slime"); // Automatic from localization files
 			Main.npcFrameCount[NPC.type] = 6; // make sure to set this for your modnpcs.
 
+			NPCID.Sets.IsSlime[Type] = true; // This NPC will be considered a slime.
+			
 			// Specify the debuffs it is immune to
 			NPCID.Sets.DebuffImmunitySets.Add(Type, new NPCDebuffImmunityData {
 				SpecificallyImmuneTo = new int[] {

--- a/ExampleMod/Content/NPCs/PartyZombie.cs
+++ b/ExampleMod/Content/NPCs/PartyZombie.cs
@@ -17,6 +17,8 @@ namespace ExampleMod.Content.NPCs
 
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.Zombie];
 
+			NPCID.Sets.Zombies[Type] = true; // This NPC will be considered a zombie.
+
 			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) { // Influences how the NPC looks in the Bestiary
 				Velocity = 1f // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 			};

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -32,6 +32,36 @@ namespace Terraria.ID
 			/// Whether or not a given NPC can sit on suitable furniture (<see cref="TileID.Sets.CanBeSatOnForNPCs"/>)
 			/// </summary>
 			public static bool[] CannotSitOnFurniture = Factory.CreateBoolSet(638, 656);
+
+			//Default ID is vanilla slimes
+			/// <summary>
+			/// Whether or not a given NPC is considered a slime.
+			/// </summary>
+			public static bool[] IsSlime = Factory.CreateBoolSet(1, 147, 537, 184, 204, 16, 59, 71, 667, 50, 535, 225, 302, 333, 334, 335, 336, 141, 81, 121, 183, 122, 138, 244, 657, 658, 659, 660, 304);
+
+			//Default ID is vanilla bunnies
+			/// <summary>
+			/// Whether or not a given NPC is considered a bunny.
+			/// </summary>
+			public static bool[] IsBunny = Factory.CreateBoolSet(46, 443, 646, 647, 648, 649, 650, 651, 652, 614, 303, 337, 47, 464, 540);
+
+			//Default ID is vanilla squirrels
+			/// <summary>
+			/// Whether or not a given NPC is considered a squirrel.
+			/// </summary>
+			public static bool[] IsSquirrel = Factory.CreateBoolSet(299, 538, 539, 639, 640, 641, 642, 643, 644, 645);
+
+			//Default ID is vanilla butterflies
+			/// <summary>
+			/// Whether or not a given NPC is considered a butterfly.
+			/// </summary>
+			public static bool[] IsButterfly = Factory.CreateBoolSet(356, 444, 653, 661);
+
+			//Default ID is vanilla birds
+			/// <summary>
+			/// Whether or not a given NPC is considered a bird.
+			/// </summary>
+			public static bool[] IsBird = Factory.CreateBoolSet(74, 297, 298, 442);
 		}
 	}
 }


### PR DESCRIPTION
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
### What is the new feature?
Add `IsSlime`, `IsBunny`, `IsSquirrel`, `IsButterfly` and `IsBird` to `NPCID.Sets`.
It is quite similar wiith `NPCID.Sets.IsDragonfly` in vanilla.

### Why should this be part of tModLoader?
For example, if you wanted to make all slimes 2x bigger, you would have to use a long "if" to determine if it was one of the many slimes in vanilla. And it doesn't support another mod that adds slimes at all.
With these new static `NPCID.Sets`, modders can more easily accomplish these functions. It also performs well in cross-mod content if the modder sets the values correctly.

### ExampleMod updates
In ExampleCustomAISlimeNPC.cs: `NPCID.Sets.IsSlime[Type] = true`
PartyZombie also has a fix to make it count as a zombie. In PartyZombie.cs: `NPCID.Sets.Zombies[Type] = true`
<!-- If you also updated ExampleMod for your new feature, let us know here -->