### PR TITLE
[1.4] fix right clicking unloaded items in dye slots, missing CanStack

### DIFF
--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -457,6 +457,20 @@
  				case 12:
  				case 25:
  				case 27: {
+@@ -1274,10 +_,11 @@
+ 							break;
+ 
+ 						bool flag = false;
+-						if (!flag && ((Main.mouseItem.stack < Main.mouseItem.maxStack && Main.mouseItem.type > 0) || Main.mouseItem.IsAir) && inv[slot].type > 0 && (Main.mouseItem.type == inv[slot].type || Main.mouseItem.IsAir)) {
++						//if (!flag && ((Main.mouseItem.stack < Main.mouseItem.maxStack && Main.mouseItem.type > 0) || Main.mouseItem.IsAir) && inv[slot].type > 0 && (Main.mouseItem.type == inv[slot].type || Main.mouseItem.IsAir)) {
++						if (!flag && ((Main.mouseItem.stack < Main.mouseItem.maxStack && Main.mouseItem.type > 0 && ItemLoader.CanStack(Main.mouseItem, inv[slot])) || Main.mouseItem.IsAir) && inv[slot].type > 0 && (Main.mouseItem.type == inv[slot].type || Main.mouseItem.IsAir)) {
+ 							flag = true;
+ 							if (Main.mouseItem.IsAir)
+-								Main.mouseItem.SetDefaults(inv[slot].type);
++								Main.mouseItem = inv[slot].Clone();
+ 							else
+ 								Main.mouseItem.stack++;
+ 
 @@ -1310,12 +_,15 @@
  
  			_ = Main.instance.shop[Main.npcShop];


### PR DESCRIPTION
### What is the bug?
#2268, also falls under "Right Click to/from Equipment" in #265

### How did you fix the bug?
`SetDefaults` -> `Clone`, to preserve modded data.
And added another `ItemLoader.CanStack` invocation next to it as in 1.4 dyes can be stacked on the mouse (was not possible in 1.3, thank god for that change)

### Are there alternatives to your fix?
No.
