### PR TITLE
[1.4] Fix held item animations

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -364,21 +364,29 @@
  					drawinfo.DrawDataCache.Add(item);
  					if (num == 3870) {
  						item = new DrawData(TextureAssets.GlowMask[238].Value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + origin5.X + num10), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + num11)), sourceRect, new Color(255, 255, 255, 127), num9, origin5, adjustedItemScale, drawinfo.itemEffect, 0);
-@@ -2407,13 +_,15 @@
+@@ -2407,13 +_,23 @@
  				}
  
  				int num12 = 10;
-+				int width = sourceRect.Value.Width;
-+				int height = sourceRect.Value.Height;
++				// If the item is animated, its texture is larger than the item because it contains multiple animation frames.
++				// Because of this, we can't trust the dimensions of the item's texture.
++				// Thankfully, `sourceRect` contains the width and height of the item.
++				// Specifically, it contains either the dimensions of the item's texture or the dimensions of a single frame of the item's animation if it is animated.
++				var frame = sourceRect.Value;
++				int width = frame.Width;
++				int height = frame.Height;
 -				Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
++				// Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
 +				Vector2 vector5 = new Vector2(width / 2, height / 2);
  				Vector2 vector6 = Main.DrawPlayerItemPos(drawinfo.drawPlayer.gravDir, num);
  				num12 = (int)vector6.X;
  				vector5.Y = vector6.Y;
 -				Vector2 origin7 = new Vector2(-num12, value.Height / 2);
++				// Vector2 origin7 = new Vector2(-num12, value.Height / 2);
 +				Vector2 origin7 = new Vector2(-num12, height / 2);
  				if (drawinfo.drawPlayer.direction == -1)
 -					origin7 = new Vector2(value.Width + num12, value.Height / 2);
++					// origin7 = new Vector2(value.Width + num12, value.Height / 2);
 +					origin7 = new Vector2(width + num12, height / 2);
  
  				item = new DrawData(value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + vector5.X), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + vector5.Y)), sourceRect, heldItem.GetAlpha(drawinfo.itemColor), drawinfo.drawPlayer.itemRotation, origin7, adjustedItemScale, drawinfo.itemEffect, 0);

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -364,10 +364,11 @@
  					drawinfo.DrawDataCache.Add(item);
  					if (num == 3870) {
  						item = new DrawData(TextureAssets.GlowMask[238].Value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + origin5.X + num10), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + num11)), sourceRect, new Color(255, 255, 255, 127), num9, origin5, adjustedItemScale, drawinfo.itemEffect, 0);
-@@ -2407,13 +_,23 @@
+@@ -2407,13 +_,34 @@
  				}
  
  				int num12 = 10;
++
 +				// If the item is animated, its texture is larger than the item because it contains multiple animation frames.
 +				// Because of this, we can't trust the dimensions of the item's texture.
 +				// Thankfully, `sourceRect` contains the width and height of the item.
@@ -375,18 +376,25 @@
 +				var frame = sourceRect.Value;
 +				int width = frame.Width;
 +				int height = frame.Height;
--				Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
-+				// Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
++
++				/*
+ 				Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
++				*/
 +				Vector2 vector5 = new Vector2(width / 2, height / 2);
++
  				Vector2 vector6 = Main.DrawPlayerItemPos(drawinfo.drawPlayer.gravDir, num);
  				num12 = (int)vector6.X;
  				vector5.Y = vector6.Y;
--				Vector2 origin7 = new Vector2(-num12, value.Height / 2);
-+				// Vector2 origin7 = new Vector2(-num12, value.Height / 2);
++
++				/*
+ 				Vector2 origin7 = new Vector2(-num12, value.Height / 2);
++				*/
 +				Vector2 origin7 = new Vector2(-num12, height / 2);
++
  				if (drawinfo.drawPlayer.direction == -1)
--					origin7 = new Vector2(value.Width + num12, value.Height / 2);
-+					// origin7 = new Vector2(value.Width + num12, value.Height / 2);
++					/*
+ 					origin7 = new Vector2(value.Width + num12, value.Height / 2);
++					*/
 +					origin7 = new Vector2(width + num12, height / 2);
  
  				item = new DrawData(value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + vector5.X), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + vector5.Y)), sourceRect, heldItem.GetAlpha(drawinfo.itemColor), drawinfo.drawPlayer.itemRotation, origin7, adjustedItemScale, drawinfo.itemEffect, 0);

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.cs.patch
@@ -364,6 +364,25 @@
  					drawinfo.DrawDataCache.Add(item);
  					if (num == 3870) {
  						item = new DrawData(TextureAssets.GlowMask[238].Value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + origin5.X + num10), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + num11)), sourceRect, new Color(255, 255, 255, 127), num9, origin5, adjustedItemScale, drawinfo.itemEffect, 0);
+@@ -2407,13 +_,15 @@
+ 				}
+ 
+ 				int num12 = 10;
++				int width = sourceRect.Value.Width;
++				int height = sourceRect.Value.Height;
+-				Vector2 vector5 = new Vector2(value.Width / 2, value.Height / 2);
++				Vector2 vector5 = new Vector2(width / 2, height / 2);
+ 				Vector2 vector6 = Main.DrawPlayerItemPos(drawinfo.drawPlayer.gravDir, num);
+ 				num12 = (int)vector6.X;
+ 				vector5.Y = vector6.Y;
+-				Vector2 origin7 = new Vector2(-num12, value.Height / 2);
++				Vector2 origin7 = new Vector2(-num12, height / 2);
+ 				if (drawinfo.drawPlayer.direction == -1)
+-					origin7 = new Vector2(value.Width + num12, value.Height / 2);
++					origin7 = new Vector2(width + num12, height / 2);
+ 
+ 				item = new DrawData(value, new Vector2((int)(drawinfo.ItemLocation.X - Main.screenPosition.X + vector5.X), (int)(drawinfo.ItemLocation.Y - Main.screenPosition.Y + vector5.Y)), sourceRect, heldItem.GetAlpha(drawinfo.itemColor), drawinfo.drawPlayer.itemRotation, origin7, adjustedItemScale, drawinfo.itemEffect, 0);
+ 				drawinfo.DrawDataCache.Add(item);
 @@ -2505,7 +_,7 @@
  			if (drawinfo.usesCompositeTorso) {
  				DrawPlayer_28_ArmOverItemComposite(ref drawinfo);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -308,10 +308,11 @@
  		}
  
  		public static string playerPathName => ActivePlayerFileData.Path;
-@@ -2461,6 +_,9 @@
+@@ -2461,6 +_,10 @@
  			float num = 10f;
  			instance.LoadItem(itemtype);
  			Vector2 result = new Vector2(TextureAssets.Item[itemtype].Width() / 2, TextureAssets.Item[itemtype].Height() / 2);
++			// TML: If the item is animated, use the dimensions of a single frame of animation
 +			if (Main.itemAnimations[itemtype]?.GetFrame(TextureAssets.Item[itemtype].Value) is { } frame) {
 +				result = new Vector2(frame.Width / 2, frame.Height / 2);
 +			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -308,6 +308,16 @@
  		}
  
  		public static string playerPathName => ActivePlayerFileData.Path;
+@@ -2461,6 +_,9 @@
+ 			float num = 10f;
+ 			instance.LoadItem(itemtype);
+ 			Vector2 result = new Vector2(TextureAssets.Item[itemtype].Width() / 2, TextureAssets.Item[itemtype].Height() / 2);
++			if (Main.itemAnimations[itemtype]?.GetFrame(TextureAssets.Item[itemtype].Value) is { } frame) {
++				result = new Vector2(frame.Width / 2, frame.Height / 2);
++			}
+ 			switch (itemtype) {
+ 				case 95:
+ 					num = 6f;
 @@ -2775,6 +_,7 @@
  			}
  
@@ -3038,16 +3048,16 @@
 +			Rectangle sourceRectangle = new Rectangle(0, 0, width, height);
 +			Rectangle mouseRectangle = new Rectangle(x, y, width, height);
 +			Color drawColor = color;
-+			
++
 +			BuffDrawParams drawParams = new BuffDrawParams(texture, drawPosition, textPosition, sourceRectangle, mouseRectangle, drawColor);
 +
 +			bool skipped = !BuffLoader.PreDraw(spriteBatch, num, buffSlotOnPlayer, ref drawParams);
 +
 +			(texture, drawPosition, textPosition, sourceRectangle, mouseRectangle, drawColor) = drawParams;
-+		
++
 +			if (!skipped)
 +				spriteBatch.Draw(texture, drawPosition, sourceRectangle, drawColor, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
-+		
++
 +			BuffLoader.PostDraw(spriteBatch, num, buffSlotOnPlayer, drawParams);
 +
  			if (TryGetBuffTime(buffSlotOnPlayer, out int buffTimeValue) && buffTimeValue > 2) {
@@ -3375,9 +3385,9 @@
  
  		private static void TryDisposingEverything() {
  			ChromaInitializer.DisableAllDeviceGroups();
-+			
++
 +			WorkshopHelper.OnGameExitCleanup(); // Added by TML.
-+			
++
  			CaptureManager.Instance.Dispose();
  			audioSystem.Dispose();
  		}


### PR DESCRIPTION
### What is the bug?
Animated items use full texture dimensions when drawing while held causing incorrect offsets
Caused by: #2209 

Before:
![image](https://user-images.githubusercontent.com/16169502/162640223-4a230a8a-136b-406a-adeb-f2736d3c0709.png)
After:
![image](https://user-images.githubusercontent.com/16169502/162640417-343010f8-92cd-43f6-9c9e-1786cab8a290.png)

### How did you fix the bug?
Use dimensions of a single frame

### Are there alternatives to your fix?
No

