### PR TITLE
Accept dots in hjson

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -224,22 +224,26 @@ namespace Terraria.ModLoader
 				var jsonObject = JObject.Parse(jsonString);
 				// Flatten JSON into dot seperated key and value
 				var flattened = new Dictionary<string, string>();
-				foreach (JToken t in jsonObject.SelectTokens("$..*")) {
-					if (!t.HasValues) {
-						// Custom implementation of Path to allow "x.y" keys
-						string path = "";
-						JToken current = t;
-						for (JToken parent = t.Parent; parent != null; parent = parent.Parent) {
-							path = parent switch {
-								JProperty property => property.Name + (path == "" ? "" : "." + path),
-								JArray array => array.IndexOf(current) + (path == "" ? "" : "." + path),
-								_ => path
-							};
-							current = parent;
-						}
 
-						flattened.Add(path, t.ToString());
+				foreach (JToken t in jsonObject.SelectTokens("$..*")) {
+					if (t.HasValues) {
+						continue;
 					}
+
+					// Custom implementation of Path to allow "x.y" keys
+					string path = "";
+					JToken current = t;
+
+					for (JToken parent = t.Parent; parent != null; parent = parent.Parent) {
+						path = parent switch {
+							JProperty property => property.Name + (path == string.Empty ? string.Empty : "." + path),
+							JArray array => array.IndexOf(current) + (path == string.Empty ? string.Empty : "." + path),
+							_ => path
+						};
+						current = parent;
+					}
+
+					flattened.Add(path, t.ToString());
 				}
 
 				foreach (var (key, value) in flattened) {


### PR DESCRIPTION
Currently the hjson translation file doesn't handle dots in keys, because the jToken.Path tries to be clever by transforming "x.y" to "['x.y']". This PR solves this issue by recreating the Path method.
I did an handling of the arrays so that random message can be handled well, but didn't implement for the constructors because I didn't know what they were
This PR can also be considered as a way to have prefixes in hjson files as you can easily write it as the first line