### PR TITLE
Fixed a vanilla bug with OGG audio track looping.

### DIFF
--- a/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
@@ -1,11 +1,31 @@
 --- src/TerrariaNetCore/Terraria/Audio/OGGAudioTrack.cs
 +++ src/tModLoader/Terraria/Audio/OGGAudioTrack.cs
-@@ -57,7 +_,7 @@
+@@ -1,6 +_,7 @@
+ using Microsoft.Xna.Framework.Audio;
+ using NVorbis;
+ using System.IO;
++using System;
+ 
+ namespace Terraria.Audio
+ {
+@@ -57,8 +_,20 @@
  		}
  
  		private void TryGettingVariable(string vorbisComment, string variableWeLookFor, ref int variableValueHolder) {
--			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment, out int result))
-+			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment.Remove(0, variableWeLookFor.Length + 1), out int result))
++			// Vanilla: Code is faulty, tries to parse the whole comment as one integer.
++			/*
+ 			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment, out int result))
  				variableValueHolder = result;
++			*/
++
++			// TML: Fixed parsing
++			if (vorbisComment.Length > variableWeLookFor.Length + 2 && vorbisComment.StartsWith(variableWeLookFor)) {
++				int separatorIndex = vorbisComment.IndexOf('=');
++
++				if (separatorIndex != -1 && int.TryParse(vorbisComment.AsSpan(separatorIndex + 1), out int result)) {
++					variableValueHolder = result;
++				}
++			}
  		}
  
+ 		public override void Dispose() {

--- a/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/Audio/OGGAudioTrack.cs
++++ src/tModLoader/Terraria/Audio/OGGAudioTrack.cs
+@@ -57,7 +_,7 @@
+ 		}
+ 
+ 		private void TryGettingVariable(string vorbisComment, string variableWeLookFor, ref int variableValueHolder) {
+-			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment, out int result))
++			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment.Remove(0, variableWeLookFor.Length + 1), out int result))
+ 				variableValueHolder = result;
+ 		}
+ 

--- a/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/OGGAudioTrack.cs.patch
@@ -8,24 +8,39 @@
  
  namespace Terraria.Audio
  {
-@@ -57,8 +_,20 @@
+@@ -49,17 +_,35 @@
  		}
  
- 		private void TryGettingVariable(string vorbisComment, string variableWeLookFor, ref int variableValueHolder) {
+ 		private void FindLoops() {
 +			// Vanilla: Code is faulty, tries to parse the whole comment as one integer.
 +			/*
- 			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment, out int result))
- 				variableValueHolder = result;
+ 			string[] comments = _vorbisReader.Comments;
+ 			foreach (string vorbisComment in comments) {
+ 				TryGettingVariable(vorbisComment, "LOOPSTART", ref _loopStart);
+ 				TryGettingVariable(vorbisComment, "LOOPEND", ref _loopEnd);
+ 			}
 +			*/
 +
 +			// TML: Fixed parsing
-+			if (vorbisComment.Length > variableWeLookFor.Length + 2 && vorbisComment.StartsWith(variableWeLookFor)) {
-+				int separatorIndex = vorbisComment.IndexOf('=');
-+
-+				if (separatorIndex != -1 && int.TryParse(vorbisComment.AsSpan(separatorIndex + 1), out int result)) {
-+					variableValueHolder = result;
++			var tags = _vorbisReader.Tags.All;
++			
++			void TryReadInteger(string entryName, ref int result) {
++				if (tags.TryGetValue(entryName, out var values) && values.Count > 0 && int.TryParse(values[0], out int potentialResult)) {
++					result = potentialResult;
 +				}
 +			}
++
++			TryReadInteger("LOOPSTART", ref _loopStart);
++			TryReadInteger("LOOPEND", ref _loopEnd);
  		}
  
++		// See the above.
++		/*
+ 		private void TryGettingVariable(string vorbisComment, string variableWeLookFor, ref int variableValueHolder) {
+ 			if (vorbisComment.StartsWith(variableWeLookFor) && int.TryParse(vorbisComment, out int result))
+ 				variableValueHolder = result;
+ 		}
++		*/
+ 
  		public override void Dispose() {
+ 			_soundEffectInstance.Dispose();


### PR DESCRIPTION
### What is the bug?

Terraria 1.4 does not correctly implement the parsing/reading of .OGG file meta tags. In fact, the current code does not find them at all. Using music with loop points is impossible as long as this bug remains unfixed, which is undesirable.

### How did you fix the bug?

I changed one line in `OGGAudioTrack` to ensure meta tags are parsed correctly.

### Are there alternatives to your fix?

I've heard there's an instance of obsolete code inside of the `OGGAudioTrack` class, and changing it gives you the values directly without requiring any modification to the `TryGettingVariable` method. This fix, however, is the only one I found that managed to fix the problem.