### PR TITLE
[1.4] Fix tile placing wands draining inventory

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4102,7 +4102,7 @@
  
  				if (i == Main.myPlayer) {
 -					if (!dontConsumeWand && itemTime == (int)((float)item.useTime * tileSpeed) && item.tileWand > 0) {
-+					if (item.tileWand > 0 && !dontConsumeWand && itemTime == itemTimeMax) {
++					if (itemTimeMax != 0 && item.tileWand > 0 && !dontConsumeWand && itemTime == itemTimeMax) {
  						int tileWand = item.tileWand;
  						for (int num15 = 0; num15 < 58; num15++) {
  							if (tileWand == inventory[num15].type && inventory[num15].stack > 0) {


### PR DESCRIPTION
### What is the bug?

This PR fixes the bug in #2239, #1863, tile placing wands rapidly drains your inventory if you have not yet used anything when entering a world and select the wand.

### How did you fix the bug?

I added the condition `itemTimeMax != 0` to the check for removing items from wands.

This feels a little like a patch, but I don't really think it is. Every other comparison `itemTime == itemTimeMax` also checks `itemTimeMax != 0`. This particular line was changed in the item use rework to refer to `itemTimeMax`, so the logic here is not vanilla original.

### Are there alternatives to your fix?

Maybe? I don't know entirely why this was changed in the first place. The change seems reasonable, but it is clear to me that if you compare `itemTime` with `itemTimeMax` you also need to check `itemTimeMax != 0`.



As an aside, `dontConsumeWand` does nothing at all in vanilla. It is checked a few places, and repeatedly set to false, but the only place it is set to true is behind `if (0 == 0)`, no TML changes involved.
