### PR TITLE
[1.4, quickfix] fixed modded NPCs not settin' their name list correctly

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -921,13 +921,15 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookModifyNPCNameList = AddHook<Action<NPC, List<string>>>(g => g.ModifyNPCNameList);
-		public static void ModifyNPCNameList(NPC npc, List<string> nameList) {
+		public static List<string> ModifyNPCNameList(NPC npc, List<string> nameList) {
 			if (npc.ModNPC != null)
 				nameList = npc.ModNPC.SetNPCNameList();
 
 			foreach (GlobalNPC g in HookModifyNPCNameList.Enumerate(npc.globalNPCs)) {
 				g.ModifyNPCNameList(npc, nameList);
 			}
+
+			return nameList;
 		}
 
 		public static bool UsesPartyHat(NPC npc) {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -171,7 +171,7 @@
 +			List<string> NPCNameList = new List<string>();
 +			if (NPCNameCategoryKey != null)
 +				NPCNameList = LanguageManager.Instance.GetLocalizedEntriesInCategory(NPCNameCategoryKey);
-+			NPCLoader.ModifyNPCNameList(this, NPCNameList);
++			NPCNameList = NPCLoader.ModifyNPCNameList(this, NPCNameList);
 +			if (NPCNameList != null && NPCNameList.Count > 0)
 +				return NPCNameList[WorldGen.genRand.Next(NPCNameList.Count)];
 +			else


### PR DESCRIPTION
pretty self-explanatory

**bug:** modded NPCs don't currently set their name list correctly due to an oversight of mine with how `NPCLoader.ModifyNPCNameList` works
**the fix:** simply made `NPCLoader.ModifyNPCNameList` return a `List<string>` and set NPCNameList to that string accordingly
**are there alternatives:** who cares? it's a four-line fix