### PR TITLE
Re-implement the High DPI 

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -374,6 +374,16 @@
  					break;
  				case GraphicsProfile.Reach:
  					maxScreenW = 1920;
+@@ -2861,6 +_,9 @@
+ 					break;
+ 			}
+ 
++			maxScreenW = Math.Min(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Width, maxScreenW);
++			maxScreenH = Math.Min(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height, maxScreenH);
++
+ 			try {
+ 				graphics.ApplyChanges();
+ 			}
 @@ -2870,8 +_,8 @@
  					SetGraphicsProfileInternal();
  				}

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -121,5 +121,18 @@ namespace Terraria
 			
 			Logging.tML.Info($"Save Are Located At: {Path.GetFullPath(SavePath)}");
 		}
+
+		private const int HighDpiThreshold = 96; // Rando internet value that Solxan couldn't refind the sauce for.
+
+		// Add Support for High DPI displays, such as Mac M1 laptops. Must run before Game constructor.
+		private static void AttemptSupportHighDPI(bool isServer) {
+			if (isServer)
+				return;
+
+			SDL2.SDL.SDL_VideoInit(null);
+			SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
+			if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold)
+				Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -87,7 +87,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,32 +_,73 @@
+@@ -138,32 +_,74 @@
  			}
  		}
  
@@ -127,6 +127,7 @@
 +				return;
 +			}
 +
++			AttemptSupportHighDPI(isServer);
 +			LaunchGame_(isServer);
 +		}
 +


### PR DESCRIPTION
### What is the bug?
Closes #2078 .

Might improve #1699 , maybe even close.

### How did you fix the bug?
Used SDL2 to obtain primary monitor DPI values, and added checks against the threshold value of 96.
If higher, we enable the environment variable for FNA.

I am unable to test the fix, as my (only) monitor is exactly 96 DPI, so there is no difference either way.

### Are there alternatives to your fix?