### PR TITLE
[1.4] xID.TML IDs to names

### DIFF
--- a/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
@@ -13,18 +13,18 @@ namespace Terraria.ID
 			partial class Sets
 			{
 				// Created based on 'fullHair' definition in 'Player.GetHairSettings'.
-				public static bool[] DrawFullHair = Factory.CreateBoolSet(10, 12, 28, 42, 62, 97, 106, 113, 116, 119, 133, 138, 139, 163, 178, 181, 191, 198, 217, 218, 220, 222, 224, 225, 228, 229, 230, 232, 235, 238, 242, 243, 244, 245, 272);
+				public static bool[] DrawFullHair = Factory.CreateBoolSet(Goggles, Sunglasses, MimeMask, HallowedHeadgear, Tiara, EyePatch, CenxsTiara, NurseHat, SteampunkGoggles, CatMask, CatEars, GiantBow, ReindeerAntlers, SeashellHairpin, HiTekSunglasses, LazuresValkyrieCirclet, Yoraiz0rsRecoloredGoggles, _0x33sAviators, Maid, MaidAlt, GolfVisor, StarPrincessCrown, BunnyEars, DevilHorns, StarHairpin, HeartHairpin, SuperHeroMask, PrettyPinkRibbon, GhostarSkullPin, SafemanSunHair, DogEars, FoxEars, LizardEars, PandaEars, RoyalTiara);
 				// Created based on 'hatHair' definition in 'Player.GetHairSettings'.
-				public static bool[] DrawHatHair = Factory.CreateBoolSet(13, 14, 15, 16, 18, 21, 24, 25, 26, 29, 40, 44, 51, 56, 59, 60, 63, 64, 65, 67, 68, 69, 81, 92, 94, 95, 100, 114, 121, 126, 130, 136, 140, 143, 145, 158, 159, 161, 182, 184, 190, 195, 215, 216, 219, 223, 226, 227, 231, 233, 234, 262, 263, 264, 265, 267);
+				public static bool[] DrawHatHair = Factory.CreateBoolSet(EmptyBucket, WizardHat, TopHat, SummerHat, PlumbersHat, ArchaeologistsHat, RedHat, RobotHat, GoldCrown, CobaltHat, ClownHat, SantaHat, PlatinumCrown, RuneHat, SteampunkHat, BeeHat, GreenCap, MushroomCap, TamOShanter, CowboyHat, PirateHat, VikingHelmet, RainHat, UmbrellaHat, BallaHat, GangstaHat, Beanie, WizardsHat, PumpkinMask, LeprechaunHat, ScarecrowHat, WolfMask, MrsClausHat, SnowHat, Fez, PeddlersHat, MagicHat, AnglerHat, TaxCollectorsHat, BuccaneerBandana, WeddingVeil, PartyHat, LeinforsHat, UltraBrightHelmet, GolfHat, DemonHorns, Fedora, ChefHat, UndertakerHat, FuneralHat, VictorianGothHat, GraduationCapBlue, GraduationCapMaroon, GraduationCapBlack, BadgersHat, RoninHat);
 				// Created based on 'backHairDraw' definition in 'Player.GetHairSettings'.
 				/// <summary>
 				/// Index using Player.hair
 				/// </summary>
-				public static bool[] DrawBackHair = Factory.CreateBoolSet(51, 52, 53, 54, 55, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 101, 102, 103, 105, 106, 107, 108, 109, 110, 111, 113, 114, 115);
+				public static bool[] DrawBackHair = Factory.CreateBoolSet(PlatinumCrown, WoodHelmet, EbonwoodHelmet, RichMahoganyHelmet, PearlwoodHelmet, MushroomCap, TamOShanter, MummyMask, CowboyHat, PirateHat, VikingHelmet, CactusHelmet, ShadewoodHelmet, AncientIronHelmet, AncientGoldHelmet, ChlorophyteMask, ChlorophyteHelmet, ChlorophyteHeadgear, RainHat, TikiMask, PalladiumMask, PalladiumHelmet, PalladiumHeadgear, OrichalcumMask, OrichalcumHelmet, TitaniumHelmet, TitaniumHeadgear, UmbrellaHat, Skull, BallaHat, GangstaHat, SailorHat, EyePatch, SkeletronMask, TurtleHelmet, SpectreHood, SWATHelmet, ShroomiteHeadgear, ShroomiteHelmet, CenxsTiara, CrownosMask, WillsHelmet, JimsHelmet, AaronsHelmet, DTownsHelmet, NurseHat, WizardsHat, GuyFawkesMask);
 				// Created based on 'drawsBackHairWithoutHeadgear' definition in 'Player.GetHairSettings'.
-				public static bool[] DrawsBackHairWithoutHeadgear = Factory.CreateBoolSet(0, 23, 259);
+				public static bool[] DrawsBackHairWithoutHeadgear = Factory.CreateBoolSet(FamiliarWig, JungleRose, RabbitOrder);
 				// Created based on 'PlayerDrawLayers.DrawPlayer_21_Head_TheFace'.
-				public static bool[] DrawHead = Factory.CreateBoolSet(true, 38, 135, 269);
+				public static bool[] DrawHead = Factory.CreateBoolSet(true, Werewolf, SpaceCreatureMask, FloretProtectorHelmet);
 			}
 		}
 
@@ -33,16 +33,16 @@ namespace Terraria.ID
 			partial class Sets
 			{
 				// Created based on 'hidesTopSkin' definition in 'PlayerDrawSet.BoringSetup'.
-				public static bool[] HidesTopSkin = Factory.CreateBoolSet(21, 22, 82, 83, 93);
+				public static bool[] HidesTopSkin = Factory.CreateBoolSet(Werewolf, Merfolk, PumpkinShirt, RobotShirt, ReaperRobe);
 				// Created based on 'hidesBottomSkin' definition in 'PlayerDrawSet.BoringSetup'.
-				public static bool[] HidesBottomSkin = Factory.CreateBoolSet(93);
+				public static bool[] HidesBottomSkin = Factory.CreateBoolSet(ReaperRobe);
 				// Created based on 'missingHand' definition in 'PlayerDrawSet.BoringSetup'.
-				public static bool[] HidesHands = Factory.CreateBoolSet(true, 77, 103, 41, 100, 10, 11, 12, 13, 14, 43, 15, 16, 20, 39, 50, 38, 40, 57, 44, 52, 53, 68, 81, 85, 88, 98, 86, 87, 99, 165, 166, 167, 171, 45, 168, 169, 42, 180, 181, 183, 186, 187, 188, 64, 189, 191, 192, 198, 199, 202, 203, 58, 59, 60, 61, 62, 63, 36, 104, 184, 74, 78, 185, 196, 197, 182, 87, 76, 209, 168, 210, 211, 213);
+				public static bool[] HidesHands = Factory.CreateBoolSet(true, TuxedoShirt, PlumbersShirt, HerosShirt, ArchaeologistsJacket, NinjaShirt, Robe, TheDoctorsShirt, MiningShirt, RuneRobe, EskimoCoat, SteampunkShirt, BeeShirt, PrincessCostume, PharaohsRobe, MummyShirt, CowboyJacket, PirateShirt, PinkEskimoCoat, RainCoat, TikiShirt, SailorShirt, AmethystRobe, TopazRobe, SapphireRobe, EmeraldRobe, RubyRobe, DiamondRobe, WhiteTuxedoShirt, CenxsBreastplate, CenxsDress, NurseShirt, DyeTraderRobe, CyborgShirt, GhostShirt, VampireShirt, LeprechaunShirt, PixieShirt, PrincessDress, TreasureHunterShirt, DryadCoverings, MrsClausShirt, UglySweater, ElfShirt, Gi, Kimono, GypsyRobe, BeeBreastplate, AnglerVest, MermaidAdornment, SolarCultistRobe, LunarCultistRobe, GladiatorBreastplate, LazuresValkyrieCloak, TaxCollectorsSuit, ClothiersJacket, BuccaneerTunic, ObsidianLongcoat, FallenTuxedoShirt, FossilPlate, WeddingDress, Yoraiz0rsUniform, PedguinsJacket, AncientArmor, AncientBattleArmor, Lamia, HuntressJerkin, MonkShirt, LeinforsShirt, Maid, MaidAlt, AmberRobe);
 				// Created based on 'missingArm' definition in 'PlayerDrawSet.BoringSetup'.
 				/// <summary>
 				/// Hiding arms also hides hands
 				/// </summary>
-				public static bool[] HidesArms = Factory.CreateBoolSet(83);
+				public static bool[] HidesArms = Factory.CreateBoolSet(RobotShirt);
 			}
 		}
 
@@ -51,7 +51,7 @@ namespace Terraria.ID
 			partial class Sets
 			{
 				// Created based on 'PlayerDrawLayers.ShouldOverrideLegs_CheckPants'.
-				public static bool[] OverridesLegs = Factory.CreateBoolSet(67, 106, 138, 140, 143, 217, 222, 226, 228);
+				public static bool[] OverridesLegs = Factory.CreateBoolSet(CreeperPants, MermaidTail, SillySunflowerBottoms, DjinnsCurse, Lamia, MoonLordLegs, TimelessTravelerBottom, CapricornTail, RoyalDressBottom);
 				// Created based on 'hidesTopSkin' definition in 'PlayerDrawSet.BoringSetup'.
 				public static bool[] HidesTopSkin = Factory.CreateBoolSet();
 				// Created based on 'hidesBottomSkin' definition in 'PlayerDrawSet.BoringSetup'.
@@ -64,7 +64,7 @@ namespace Terraria.ID
 			partial class Sets
 			{
 				// Created based on 'PlayerDrawLayers.ShouldOverrideLegs_CheckShoes'.
-				public static bool[] OverridesLegs = Factory.CreateBoolSet(15);
+				public static bool[] OverridesLegs = Factory.CreateBoolSet(FrogLeg);
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/ID/BuffID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/BuffID.TML.cs
@@ -8,6 +8,6 @@ public partial class BuffID
 		/// Set for debuffs.
 		/// Causes debuffs to last twice as long on players in expert mode. Defaults to false.
 		/// </summary>
-		public static bool[] LongerExpertDebuff = Factory.CreateBoolSet(20, 22, 23, 24, 30, 31, 32, 33, 35, 36, 39, 44, 46, 47, 69, 70, 80);
+		public static bool[] LongerExpertDebuff = Factory.CreateBoolSet(Poisoned, Darkness, Cursed, OnFire, Bleeding, Confused, Slow, Weak, Silenced, BrokenArmor, CursedInferno, Frostburn, Chilled, Frozen, Ichor, Venom, Blackout);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/GoreID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/GoreID.TML.cs
@@ -4,6 +4,6 @@ public static partial class GoreID
 {
 	public static partial class Sets
 	{
-		public static bool[] DrawBehind = Factory.CreateBoolSet(706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 943, 1147, 1160, 1161, 1162);
+		public static bool[] DrawBehind = Factory.CreateBoolSet(WaterDrip, WaterDripCorrupt, WaterDripJungle, WaterDripHallow, WaterDripIce, WaterDripDesert, WaterDripUnderground, WaterDripCavern, WaterDripBlood, WaterDripCrimson, LavaDrip, HoneyDrip, SandDrip, WaterDripDesert2, EbonsandDrip, CrimsandDrip, PearlsandDrip);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -4,7 +4,7 @@
 	{
 		partial class Sets
 		{
-			public static bool[] Glowsticks = Factory.CreateBoolSet(282, 286, 3002, 3112, 4776);
+			public static bool[] Glowsticks = Factory.CreateBoolSet(Glowstick, StickyGlowstick, SpelunkerGlowstick, BouncyGlowstick, FairyGlowstick);
 
 			/// <summary>
 			/// Set for all boss bags. Causes bags to drop dev armor.

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -11,27 +11,27 @@ namespace Terraria.ID
 			/// Whether or not the spawned NPC will start looking for a suitable slot from the end of <seealso cref="Main.npc"/>, ignoring the Start parameter of <see cref="NPC.NewNPC"/>.
 			/// Useful if you have a multi-segmented boss and want its parts to draw over the main body (body will be in this set).
 			/// </summary>
-			public static bool[] SpawnFromLastEmptySlot = Factory.CreateBoolSet(222, 245);
+			public static bool[] SpawnFromLastEmptySlot = Factory.CreateBoolSet(QueenBee, Golem);
 
 			//Default ID is the skeleton merchant
 			/// <summary>
 			/// Whether or not a given NPC will act like a town NPC in terms of AI, animations, and attacks, but not in other regards, such as having a happiness button or appearing
 			/// on the minimap, like the bone merchant in vanilla.
 			/// </summary>
-			public static bool[] ActsLikeTownNPC = Factory.CreateBoolSet(453);
+			public static bool[] ActsLikeTownNPC = Factory.CreateBoolSet(SkeletonMerchant);
 
 			//Default ID is the skeleton merchant
 			/// <summary>
 			/// Whether or not a given NPC will spawn with a custom name like a town NPC. In order to determine what name will be selected, override the TownNPCName hook.
 			/// True will force a name to be rolled regardless of vanilla behavior. False will have vanilla handle the naming.
 			/// </summary>
-			public static bool[] SpawnsWithCustomName = Factory.CreateBoolSet(453);
+			public static bool[] SpawnsWithCustomName = Factory.CreateBoolSet(SkeletonMerchant);
 
 			// IDs taken from NPC.AI_007_TryForcingSitting
 			/// <summary>
 			/// Whether or not a given NPC can sit on suitable furniture (<see cref="TileID.Sets.CanBeSatOnForNPCs"/>)
 			/// </summary>
-			public static bool[] CannotSitOnFurniture = Factory.CreateBoolSet(638, 656);
+			public static bool[] CannotSitOnFurniture = Factory.CreateBoolSet(TownDog, TownBunny);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -4,29 +4,29 @@
 	{
 		partial class Sets
 		{
-			public static bool[] CanDropFromRightClick = Factory.CreateBoolSet(4);
-			public static bool[] Stone = Factory.CreateBoolSet(1, 117, 25, 203);
-			public static bool[] Grass = Factory.CreateBoolSet(2, 23, 109, 199, 477, 492);
-			public static bool[] CanBeClearedDuringOreRunner = Factory.CreateBoolSet(0, 1, 23, 25, 40, 53, 57, 59, 60, 70, 109, 112, 116, 117, 147, 161, 163, 164, 199, 200, 203, 234);
+			public static bool[] CanDropFromRightClick = Factory.CreateBoolSet(Torches);
+			public static bool[] Stone = Factory.CreateBoolSet(TileID.Stone, Pearlstone, Ebonstone, Crimstone);
+			public static bool[] Grass = Factory.CreateBoolSet(TileID.Grass, CorruptGrass, HallowedGrass, CrimsonGrass, GolfGrass, GolfGrassHallowed);
+			public static bool[] CanBeClearedDuringOreRunner = Factory.CreateBoolSet(Dirt, TileID.Stone, CorruptGrass, Ebonstone, ClayBlock, Sand, Ash, TileID.Mud, JungleGrass, MushroomGrass, HallowedGrass, Ebonsand, Pearlsand, Pearlstone, SnowBlock, IceBlock, CorruptIce, HallowedIce, CrimsonGrass, FleshIce, Crimstone, Crimsand);
 
 			/// <summary>
 			/// Whether or not the tile will be ignored for automatic step up regarding town NPC collision.
 			/// <br>Only checked when <see cref="Collision.StepUp"/> with specialChecksMode set to 1 is called</br>
 			/// </summary>
-			public static bool[] IgnoredByNpcStepUp = Factory.CreateBoolSet(14, 16, 18, 134, 469);
+			public static bool[] IgnoredByNpcStepUp = Factory.CreateBoolSet(Tables, Anvils, WorkBenches, MythrilAnvil, Tables2);
 
 			/// <summary> Whether or not the smart cursor function is disabled when the cursor hovers above this tile. </summary>
 			// Maybe this should be a hook instead?
-			public static bool[] DisableSmartCursor = Factory.CreateBoolSet(4, 10, 11, 13, 21, 29, 33, 49, 50, 55, 79, 85, 88, 97, 104, 125, 132, 136, 139, 144, 174, 207, 209, 212, 216, 219, 237, 287, 334, 335, 338, 354, 386, 387, 388, 389, 411, 425, 441, 463, 467, 468, 491, 494, 510, 511, 573, 621);
+			public static bool[] DisableSmartCursor = Factory.CreateBoolSet(Torches, ClosedDoor, OpenDoor, Bottles, Containers, PiggyBank, Candles, WaterCandle, Books, Signs, Beds, Tombstones, Dressers, Safes, GrandfatherClocks, CrystalBall, Lever, Switches, MusicBoxes, Timers, PlatinumCandle, WaterFountain, Cannon, SnowballLauncher, Firework, Extractinator, LihzahrdAltar, AmmoBox, WeaponsRack, FireworksBox, FireworkFountain, BewitchingTable, TrapdoorOpen, TrapdoorClosed, TallGateClosed, TallGateOpen, Detonator, AnnouncementBox, FakeContainers, DefendersForge, Containers2, FakeContainers2, VoidVault, GolfTee, ArrowSign, PaintedArrowSign, TatteredWoodSign, SliceOfCake);
 
 			/// <summary> Whether or not the smart tile interaction function is disabled when the cursor hovers above this tile. </summary>
-			public static bool[] DisableSmartInteract = Factory.CreateBoolSet(4, 33, 334, 395, 410, 455, 471, 480, 509, 520);
+			public static bool[] DisableSmartInteract = Factory.CreateBoolSet(Torches, Candles, WeaponsRack, ItemFrame, LunarMonolith, PartyMonolith, WeaponsRack2, BloodMoonMonolith, VoidMonolith, FoodPlatter);
 
 			/// <summary> Whether or not this tile is a valid spawn point. </summary>
 			public static bool[] IsValidSpawnPoint = Factory.CreateBoolSet(Beds);
 
 			/// <summary> Whether or not this tile behaves like a torch. If you are making a torch tile, then setting this to true is necessary in order for tile placement, tile framing, and the item's smart selection to work properly. </summary>
-			public static bool[] Torch = Factory.CreateBoolSet(TileID.Torches);
+			public static bool[] Torch = Factory.CreateBoolSet(Torches);
 
 			/// <summary> Whether or not this tile is a clock. </summary>
 			public static bool[] Clock = Factory.CreateBoolSet(GrandfatherClocks);
@@ -35,7 +35,7 @@
 			public static bool[] TreeSapling = Factory.CreateBoolSet(Saplings);
 
 			/// <summary> Whether or not this tile counts as a water source for crafting purposes. </summary>
-			public static bool[] CountsAsWaterSource = Factory.CreateBoolSet(172);
+			public static bool[] CountsAsWaterSource = Factory.CreateBoolSet(Sinks);
 
 			/// <summary> Whether or not this tile counts as a honey source for crafting purposes. </summary>
 			public static bool[] CountsAsHoneySource = Factory.CreateBoolSet();
@@ -44,7 +44,7 @@
 			public static bool[] CountsAsLavaSource = Factory.CreateBoolSet();
 
 			/// <summary> Whether or not saplings count this tile as empty when trying to grow. </summary>
-			public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 201, 233, 352, 485, 529, 530);
+			public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(Plants, CorruptPlants, CorruptThorns, JunglePlants, JungleVines, JungleThorns, MushroomPlants, Plants2, JunglePlants2, ImmatureHerbs, MatureHerbs, BloomingHerbs, HallowedPlants, HallowedPlants2, CrimsonPlants, PlantDetritus, CrimsonThorns, AntlionLarva, SeaOats, OasisPlants);
 		}
 	}
 }


### PR DESCRIPTION
### What is the new feature?
Changes most of the constants in the xID(.TML).Sets classes to use their appropriate IDs.
One set (`ArmorIDs(.TML).Legs.Sets.HidesBottomSkin`) is not changed because the two values in the set have no names in ArmorIDs.Legs.
Some `TileID` sets explicitly prefix some constants with "`TileID.`" because a set shares a name with the constant and not prefixing causes the set to be used (Ex: `TileID.Sets.Stone` and `TileID.Stone`).

### Why should this be part of tModLoader?
So the xID.TML.cs files are slightly more readable.

### Are there alternative designs?
Do the same thing for the normal xID file Sets. Didn't do in this PR since it would patch the entirety of every `Sets` class, which I didn't think would be appreciated.
If it's wanted, I can also run through the non-TML ID files and apply the same changes I've already done to the TML ones.

### Sample usage for the new feature
N/A

### ExampleMod updates
N/A
<!-- If you also updated ExampleMod for your new feature, let us know here -->

