### PR TITLE
[1.4] Fixed The Bee's Knees double-firing 

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -373,6 +373,15 @@
  		}
  
  		public bool FitsAmmoSlot() {
+@@ -29993,7 +_,7 @@
+ 							case 2888:
+ 								useStyle = 5;
+ 								useAnimation = 24;
+-								useTime = 23;
++								useTime = 24;
+ 								width = 12;
+ 								height = 28;
+ 								shoot = 469;
 @@ -44343,7 +_,8 @@
  			shoot = projectileId;
  			UseSound = SoundID.Item152;


### PR DESCRIPTION
### What is the bug?
This PR fixes the bug in #2120, where The Bee's Knees would fire 2 shots after 1 click. This likely came up due to the weapon's use time getting increased in 1.4.0.1 from 23 to 24, and while the useAnimation got changed to 24, the useTime was untouched. 

Below is a gif of what this would look like in game. When I would only click once, my character could rapidly turn another direction in 1 frame to fire the second shot before putting down the bow.
![The Bee's Knees before](https://user-images.githubusercontent.com/29829542/164345230-23a17a4b-82f7-4168-b9c9-85b10bcfa1d3.gif)

### How did you fix the bug?
I edited the item's use time to be 24 instead of 23 like it is supposed to be according to the wiki. Below is a gif of the what this looks like in game now.
![The Bee's Knees after](https://user-images.githubusercontent.com/29829542/164345237-d7f0f420-858f-4254-9440-0eb3b4489cf8.gif)

### Are there alternatives to your fix?
Outside of fundamentally changing how useTime and useAnimations work, not really. All the fix needs is this small number change.