### PR TITLE
[1.4] misc. post-freeze fixes for April

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -107,7 +107,7 @@ namespace Terraria
 					spriteBatch.Draw(TextureAssets.InfoIcon[13].Value, buttonPosition - Vector2.One * 2f, null, OurFavoriteColor, 0f, default, 1f, SpriteEffects.None, 0f);
 
 				hovering = false;
-				GetInfoAccIconPosition(0, startX, out X, out Y);
+				GetInfoAccIconPosition(0, startX, out X, out int _);
 				buttonPosition = new Vector2(X, Y + 20);
 
 				if ((float)mouseX >= buttonPosition.X && (float)mouseY >= buttonPosition.Y && (float)mouseX <= buttonPosition.X + (float)buttonTexture.Width && (float)mouseY <= buttonPosition.Y + (float)buttonTexture.Height && !PlayerInput.IgnoreMouseInterface) {

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -448,7 +448,8 @@ namespace Terraria.ModLoader
 
 			NPCLoader.Unload();
 			NPCHeadLoader.Unload();
-			TownNPCProfiles.Instance.ResetTexturesAccordingToVanillaProfiles();
+			if (!Main.dedServ) // dedicated servers implode with texture swaps and I've never understood why, so here's a fix for that     -thomas
+				TownNPCProfiles.Instance.ResetTexturesAccordingToVanillaProfiles();
 
 			BossBarLoader.Unload();
 			PlayerLoader.Unload();


### PR DESCRIPTION
**hi**
it's me again, and on today's episode of "Thomas goes out of his way to solve problems he inadvertently caused"...

**bugs in question:**
- the left arrow for info display page controls, on lower resolutions that cause the buttons to be re-organized, currently overtakes the Moon Phase button
- dedicated servers are currently dead in the water due to the texture reset that occurs on mod unload

**how I fixed them:**
- the left arrow for info display page controls now scales its Y position with the *last* button on the "page", rather than the first
- added a `Main.dedServ` check for the `TownNPCProfiles.Instance.ResetTexturesAccordingToVanillaProfiles` call in `NPCLoader.Unload`

**are there alternative fixes?**
no