### PR TITLE
Fix #1881 (boulder issue)

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -649,7 +649,7 @@
  				}
  
  				if (minion && numUpdates == -1 && type != 625 && type != 628) {
-@@ -12121,8 +_,20 @@
+@@ -12121,8 +_,21 @@
  					overrideHeight = 4;
  				}
  
@@ -662,7 +662,8 @@
 -				if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
 +				else if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
 +					// base.center isn't correct, we have to use position to get a right value
-+					Vector2 vector2 = base.position - new Vector2(num, num2) * (hitboxCenterFrac - new Vector2(0.5f));
++					Vector2 center = base.position + new Vector2(base.width, base.height) * 0.5f;
++					Vector2 vector2 = center - new Vector2(num, num2) * hitboxCenterFrac;
  					if (aiStyle == 10) {
 +						base.velocity = Collision.TileCollision(vector2, base.velocity, num, num2, flag6, flag6);
 +						if (type >= ProjectileID.CopperCoinsFalling && type <= ProjectileID.PlatinumCoinsFalling)

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -528,10 +528,10 @@
  
 +						//Patch context: ^ flag18, to be used below multiple times.
  						int num45 = Main.DamageVar((int)((float)damage * num5), Main.player[owner].luck);
-+						
++
 +						ProjectileLoader.ModifyHitPvp(this, player2, ref num45, ref flag18);
 +						PlayerLoader.ModifyHitPvpWithProj(this, player2, ref num45, ref flag18);
-+						
++
  						if (!player2.immune)
  							StatusPvP(m);
  
@@ -649,7 +649,7 @@
  				}
  
  				if (minion && numUpdates == -1 && type != 625 && type != 628) {
-@@ -12121,8 +_,19 @@
+@@ -12121,8 +_,20 @@
  					overrideHeight = 4;
  				}
  
@@ -661,7 +661,8 @@
 +				}
 -				if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
 +				else if (((type != 440 && type != 449 && type != 606) || ai[1] != 1f) && (type != 466 || localAI[1] != 1f) && (type != 580 || !(localAI[1] > 0f)) && (type != 640 || !(localAI[1] > 0f))) {
-+					Vector2 vector2 = base.Center - new Vector2(num, num2) * hitboxCenterFrac;
++					// base.center isn't correct, we have to use position to get a right value
++					Vector2 vector2 = base.position - new Vector2(num, num2) * (hitboxCenterFrac - new Vector2(0.5f));
  					if (aiStyle == 10) {
 +						base.velocity = Collision.TileCollision(vector2, base.velocity, num, num2, flag6, flag6);
 +						if (type >= ProjectileID.CopperCoinsFalling && type <= ProjectileID.PlatinumCoinsFalling)


### PR DESCRIPTION
### What is the bug?
Boulders are buggy because center is miscalculated (center.x = topLeft.x + width / 2) for example, so with its width of 31, the center is computed 15 pixels away from the top left instead of 15.5, so the previous use of the center was computing the top left as if the center was well computed and removed the 15.5 to get the top left

### How did you fix the bug?
I switched the calculation by starting from the top left and adding half the size of the projectile does make it work

### Are there alternatives to your fix?
An other way would be to make entity.center make a correct calculation.
Both width and height could also be rounded down to the nearest even integer, also fixing the issue.