### PR TITLE
[1.4] Potion Sickness duration hook

### DIFF
--- a/ExampleMod/Content/Items/Consumables/ExampleHealingPotion.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleHealingPotion.cs
@@ -34,17 +34,27 @@ namespace ExampleMod.Content.Items.Consumables
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
 			// Find the tooltip line that corresponds to 'Heals ... life'
 			// See https://tmodloader.github.io/tModLoader/html/class_terraria_1_1_mod_loader_1_1_tooltip_line.html for a list of vanilla tooltip line names
-			TooltipLine line = tooltips.FirstOrDefault(x => x.Mod == "Terraria" && x.Name == "HealLife");
+			int lineIndex = tooltips.FindIndex(x => x.Mod == "Terraria" && x.Name == "HealLife");
 
-			if (line != null) {
+			if (lineIndex >= 0) {
+				TooltipLine line = tooltips[lineIndex];
 				// Change the text to 'Heals max/2 (max/4 when quick healing) life'
 				line.Text = Language.GetTextValue("CommonItemTooltip.RestoresLife", $"{Main.LocalPlayer.statLifeMax2 / 2} ({Main.LocalPlayer.statLifeMax2 / 4} when quick healing)");
+
+				TooltipLine sicknessLine = new(Mod, "ExampleMod.HealingPotionSickness", "Potion sickness lasts half as long if used manually");
+				tooltips.Insert(lineIndex + 1, sicknessLine);
 			}
 		}
 
 		public override void GetHealLife(Player player, bool quickHeal, ref int healValue) {
 			// Make the item heal half the player's max health normally, or one fourth if used with quick heal
 			healValue = player.statLifeMax2 / (quickHeal ? 4 : 2);
+		}
+
+		public override void ApplyPotionDelay(Player player, bool quickHeal, ref int potionDelay) {
+			// Make the potion sickness duration half as long if used normally
+			if (!quickHeal)
+				potionDelay /= 2;
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/Consumables/ExampleHealingPotion.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleHealingPotion.cs
@@ -53,8 +53,9 @@ namespace ExampleMod.Content.Items.Consumables
 
 		public override void ApplyPotionDelay(Player player, bool quickHeal, ref int potionDelay) {
 			// Make the potion sickness duration half as long if used normally
-			if (!quickHeal)
+			if (!quickHeal) {
 				potionDelay /= 2;
+			}
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -21,6 +21,11 @@ namespace Terraria.ModLoader
 			PlayerLoader.ModifyWeaponKnockback(player, item, ref knockback);
 		}
 
+		public static void ApplyPotionDelay(Player player, Item item, bool quickHeal, ref int potionDelay) {
+			ItemLoader.ApplyPotionDelay(item, player, false, ref potionDelay);
+			PlayerLoader.ApplyPotionDelay(player, item, false, ref potionDelay);
+		}
+
 		public static void ModifyManaCost(Player player, Item item, ref float reduce, ref float mult) {
 			ItemLoader.ModifyManaCost(item, player, ref reduce, ref mult);
 			PlayerLoader.ModifyManaCost(player, item, ref reduce, ref mult);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -148,6 +148,9 @@ namespace Terraria.ModLoader
 		public virtual void GetHealLife(Item item, Player player, bool quickHeal, ref int healValue) {
 		}
 
+		public virtual void ApplyPotionDelay(Item item, Player player, bool quickHeal, ref int potionDelay) {
+		}
+
 		/// <summary>
 		/// Allows you to temporarily modify the amount of mana a mana healing item will heal for, based on player buffs, accessories, etc. This is only called for items with a healMana value.
 		/// </summary>
@@ -225,7 +228,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to create custom behaviour when an item is accepted by the Research function 
+		/// Allows you to create custom behaviour when an item is accepted by the Research function
 		/// </summary>
 		/// <param name="item">The item being researched</param>
 		/// <param name="fullyResearched">True if the item was completely researched, and is ready to be duplicated, false if only partially researched.</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -4,11 +4,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using Terraria.DataStructures;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
-using Terraria.ID;
-using Terraria.ModLoader.Core;
-using static Terraria.GameContent.Creative.CreativeUI;
 
 namespace Terraria.ModLoader
 {
@@ -148,6 +146,13 @@ namespace Terraria.ModLoader
 		public virtual void GetHealLife(Item item, Player player, bool quickHeal, ref int healValue) {
 		}
 
+		/// <summary>
+		/// Allows you to temporarily modify the duration of potion sickness, based on player buffs, accessories, etc. This is only called for items with <see cref="Item.potion"/> set to true.
+		/// </summary>
+		/// <param name="item">The item being used.</param>
+		/// <param name="player">The player using the item.</param>
+		/// <param name="quickHeal">Whether the item is being used through quick heal or not.</param>
+		/// <param name="potionDelay">Duration of the <see cref="BuffID.PotionSickness"/> debuff.</param>
 		public virtual void ApplyPotionDelay(Item item, Player player, bool quickHeal, ref int potionDelay) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -406,6 +406,23 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateApplyPotionDelay(Item item, Player player, bool quickHeal, ref int potionDelay);
+		private static HookList HookApplyPotionDelay = AddHook<DelegateApplyPotionDelay>(g => g.ApplyPotionDelay);
+
+		/// <summary>
+		/// Calls ModItem.ApplyPotionDelay, then all GlobalItem.ApplyPotionDelay hooks.
+		/// </summary>
+		public static void ApplyPotionDelay(Item item, Player player, bool quickHeal, ref int potionDelay) {
+			if (item.IsAir)
+				return;
+
+			item.ModItem?.ApplyPotionDelay(player, quickHeal, ref potionDelay);
+
+			foreach (var g in HookApplyPotionDelay.Enumerate(item.globalItems)) {
+				g.ApplyPotionDelay(item, player, quickHeal, ref potionDelay);
+			}
+		}
+
 		private delegate void DelegateGetHealMana(Item item, Player player, bool quickHeal, ref int healValue);
 		private static HookList HookGetHealMana = AddHook<DelegateGetHealMana>(g => g.GetHealMana);
 
@@ -482,7 +499,7 @@ namespace Terraria.ModLoader
 				if (g.CanConsumeBait(player, bait) is bool b)
 					ret = (ret ?? true) && b;
 			}
-			
+
 			return ret;
 		}
 
@@ -504,7 +521,7 @@ namespace Terraria.ModLoader
 		private static HookList HookCanResearch = AddHook<DelegateCanResearch>(g => g.CanResearch);
 
 		/// <summary>
-		/// Hook that determines if an item will be prevented from being consumed by the research function. 
+		/// Hook that determines if an item will be prevented from being consumed by the research function.
 		/// </summary>
 		/// <param name="item">The item to be consumed or not</param>
 		public static bool CanResearch(Item item) {
@@ -529,7 +546,7 @@ namespace Terraria.ModLoader
 			foreach (var g in HookOnResearched.Enumerate(item.globalItems))
 				g.Instance(item).OnResearched(item, fullyResearched);
 		}
-    
+
 		private delegate void DelegateModifyWeaponDamage(Item item, Player player, ref StatModifier damage);
 		private static HookList HookModifyWeaponDamage = AddHook<DelegateModifyWeaponDamage>(g => g.ModifyWeaponDamage);
 
@@ -1199,7 +1216,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPreOpenVanillaBag = AddHook<Func<string, Player, int, bool>>(g => g.PreOpenVanillaBag);
-		
+
 		/// <summary>
 		/// Calls each GlobalItem.PreOpenVanillaBag hook until one of them returns false. Returns true if all of them returned true.
 		/// </summary>
@@ -1218,7 +1235,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookOpenVanillaBag = AddHook<Action<string, Player, int>>(g => g.OpenVanillaBag);
-		
+
 		/// <summary>
 		/// Calls all GlobalItem.OpenVanillaBag hooks.
 		/// </summary>
@@ -1247,7 +1264,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanStackInWorld = AddHook<Func<Item, Item, bool>>(g => g.CanStackInWorld);
-		
+
 		/// <summary>
 		/// Calls all GlobalItem.CanStackInWorld hooks until one returns false then ModItem.CanStackInWorld. Returns whether any of the hooks returned false.
 		/// </summary>
@@ -1370,7 +1387,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateVerticalWingSpeeds(Item item, Player player, ref float ascentWhenFalling, ref float ascentWhenRising, ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend);
 		private static HookList HookVerticalWingSpeeds = AddHook<DelegateVerticalWingSpeeds>(g => g.VerticalWingSpeeds);
-		
+
 		/// <summary>
 		/// If the player is using wings, this uses the result of GetWing, and calls ModItem.VerticalWingSpeeds then all GlobalItem.VerticalWingSpeeds hooks.
 		/// </summary>
@@ -1396,7 +1413,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateHorizontalWingSpeeds(Item item, Player player, ref float speed, ref float acceleration);
 		private static HookList HookHorizontalWingSpeeds = AddHook<DelegateHorizontalWingSpeeds>(g => g.HorizontalWingSpeeds);
-		
+
 		/// <summary>
 		/// If the player is using wings, this uses the result of GetWing, and calls ModItem.HorizontalWingSpeeds then all GlobalItem.HorizontalWingSpeeds hooks.
 		/// </summary>
@@ -1436,7 +1453,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateUpdate(Item item, ref float gravity, ref float maxFallSpeed);
 		private static HookList HookUpdate = AddHook<DelegateUpdate>(g => g.Update);
-		
+
 		/// <summary>
 		/// Calls ModItem.Update, then all GlobalItem.Update hooks.
 		/// </summary>
@@ -1486,7 +1503,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateGrabRange(Item item, Player player, ref int grabRange);
 		private static HookList HookGrabRange = AddHook<DelegateGrabRange>(g => g.GrabRange);
-		
+
 		/// <summary>
 		/// Calls ModItem.GrabRange, then all GlobalItem.GrabRange hooks.
 		/// </summary>
@@ -1499,7 +1516,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookGrabStyle = AddHook<Func<Item, Player, bool>>(g => g.GrabStyle);
-		
+
 		/// <summary>
 		/// Calls all GlobalItem.GrabStyle hooks then ModItem.GrabStyle, until one of them returns true. Returns whether any of the hooks returned true.
 		/// </summary>
@@ -1513,7 +1530,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanPickup = AddHook<Func<Item, Player, bool>>(g => g.CanPickup);
-		
+
 		public static bool CanPickup(Item item, Player player) {
 			foreach (var g in HookCanPickup.Enumerate(item.globalItems)) {
 				if (!g.CanPickup(item, player))
@@ -1524,7 +1541,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookOnPickup = AddHook<Func<Item, Player, bool>>(g => g.OnPickup);
-		
+
 		/// <summary>
 		/// Calls all GlobalItem.OnPickup hooks then ModItem.OnPickup, until one of the returns false. Returns true if all of the hooks return true.
 		/// </summary>
@@ -1538,7 +1555,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookItemSpace = AddHook<Func<Item, Player, bool>>(g => g.ItemSpace);
-		
+
 		public static bool ItemSpace(Item item, Player player) {
 			foreach (var g in HookItemSpace.Enumerate(item.globalItems)) {
 				if (g.ItemSpace(item, player))
@@ -1549,7 +1566,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookGetAlpha = AddHook<Func<Item, Color, Color?>>(g => g.GetAlpha);
-		
+
 		/// <summary>
 		/// Calls all GlobalItem.GetAlpha hooks then ModItem.GetAlpha, until one of them returns a color, and returns that color. Returns null if all of the hooks return null.
 		/// </summary>
@@ -1585,7 +1602,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPostDrawInWorld = AddHook<Action<Item, SpriteBatch, Color, Color, float, float, int>>(g => g.PostDrawInWorld);
-		
+
 		/// <summary>
 		/// Calls ModItem.PostDrawInWorld, then all GlobalItem.PostDrawInWorld hooks.
 		/// </summary>
@@ -1598,7 +1615,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPreDrawInInventory = AddHook<Func<Item, SpriteBatch, Vector2, Rectangle, Color, Color, Vector2, float, bool>>(g => g.PreDrawInInventory);
-		
+
 		/// <summary>
 		/// Returns the "and" operator on the results of all GlobalItem.PreDrawInInventory hooks and ModItem.PreDrawInInventory.
 		/// </summary>
@@ -1676,7 +1693,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanEquipAccessory = AddHook<Func<Item, Player, int, bool, bool>>(g => g.CanEquipAccessory);
-		
+
 		public static bool CanEquipAccessory(Item item, int slot, bool modded) {
 			Player player = Main.player[Main.myPlayer];
 			if (item.ModItem != null && !item.ModItem.CanEquipAccessory(player, slot, modded))

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -421,6 +421,9 @@ namespace Terraria.ModLoader
 			foreach (var g in HookApplyPotionDelay.Enumerate(item.globalItems)) {
 				g.ApplyPotionDelay(item, player, quickHeal, ref potionDelay);
 			}
+
+			if (potionDelay < 0)
+				potionDelay = 0;
 		}
 
 		private delegate void DelegateGetHealMana(Item item, Player player, bool quickHeal, ref int healValue);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -499,7 +499,7 @@ namespace Terraria.ModLoader
 				if (g.CanConsumeBait(player, bait) is bool b)
 					ret = (ret ?? true) && b;
 			}
-
+			
 			return ret;
 		}
 
@@ -521,7 +521,7 @@ namespace Terraria.ModLoader
 		private static HookList HookCanResearch = AddHook<DelegateCanResearch>(g => g.CanResearch);
 
 		/// <summary>
-		/// Hook that determines if an item will be prevented from being consumed by the research function.
+		/// Hook that determines if an item will be prevented from being consumed by the research function. 
 		/// </summary>
 		/// <param name="item">The item to be consumed or not</param>
 		public static bool CanResearch(Item item) {
@@ -546,7 +546,7 @@ namespace Terraria.ModLoader
 			foreach (var g in HookOnResearched.Enumerate(item.globalItems))
 				g.Instance(item).OnResearched(item, fullyResearched);
 		}
-
+    
 		private delegate void DelegateModifyWeaponDamage(Item item, Player player, ref StatModifier damage);
 		private static HookList HookModifyWeaponDamage = AddHook<DelegateModifyWeaponDamage>(g => g.ModifyWeaponDamage);
 
@@ -1216,7 +1216,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPreOpenVanillaBag = AddHook<Func<string, Player, int, bool>>(g => g.PreOpenVanillaBag);
-
+		
 		/// <summary>
 		/// Calls each GlobalItem.PreOpenVanillaBag hook until one of them returns false. Returns true if all of them returned true.
 		/// </summary>
@@ -1235,7 +1235,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookOpenVanillaBag = AddHook<Action<string, Player, int>>(g => g.OpenVanillaBag);
-
+		
 		/// <summary>
 		/// Calls all GlobalItem.OpenVanillaBag hooks.
 		/// </summary>
@@ -1264,7 +1264,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanStackInWorld = AddHook<Func<Item, Item, bool>>(g => g.CanStackInWorld);
-
+		
 		/// <summary>
 		/// Calls all GlobalItem.CanStackInWorld hooks until one returns false then ModItem.CanStackInWorld. Returns whether any of the hooks returned false.
 		/// </summary>
@@ -1387,7 +1387,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateVerticalWingSpeeds(Item item, Player player, ref float ascentWhenFalling, ref float ascentWhenRising, ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend);
 		private static HookList HookVerticalWingSpeeds = AddHook<DelegateVerticalWingSpeeds>(g => g.VerticalWingSpeeds);
-
+		
 		/// <summary>
 		/// If the player is using wings, this uses the result of GetWing, and calls ModItem.VerticalWingSpeeds then all GlobalItem.VerticalWingSpeeds hooks.
 		/// </summary>
@@ -1413,7 +1413,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateHorizontalWingSpeeds(Item item, Player player, ref float speed, ref float acceleration);
 		private static HookList HookHorizontalWingSpeeds = AddHook<DelegateHorizontalWingSpeeds>(g => g.HorizontalWingSpeeds);
-
+		
 		/// <summary>
 		/// If the player is using wings, this uses the result of GetWing, and calls ModItem.HorizontalWingSpeeds then all GlobalItem.HorizontalWingSpeeds hooks.
 		/// </summary>
@@ -1453,7 +1453,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateUpdate(Item item, ref float gravity, ref float maxFallSpeed);
 		private static HookList HookUpdate = AddHook<DelegateUpdate>(g => g.Update);
-
+		
 		/// <summary>
 		/// Calls ModItem.Update, then all GlobalItem.Update hooks.
 		/// </summary>
@@ -1503,7 +1503,7 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateGrabRange(Item item, Player player, ref int grabRange);
 		private static HookList HookGrabRange = AddHook<DelegateGrabRange>(g => g.GrabRange);
-
+		
 		/// <summary>
 		/// Calls ModItem.GrabRange, then all GlobalItem.GrabRange hooks.
 		/// </summary>
@@ -1516,7 +1516,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookGrabStyle = AddHook<Func<Item, Player, bool>>(g => g.GrabStyle);
-
+		
 		/// <summary>
 		/// Calls all GlobalItem.GrabStyle hooks then ModItem.GrabStyle, until one of them returns true. Returns whether any of the hooks returned true.
 		/// </summary>
@@ -1530,7 +1530,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanPickup = AddHook<Func<Item, Player, bool>>(g => g.CanPickup);
-
+		
 		public static bool CanPickup(Item item, Player player) {
 			foreach (var g in HookCanPickup.Enumerate(item.globalItems)) {
 				if (!g.CanPickup(item, player))
@@ -1541,7 +1541,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookOnPickup = AddHook<Func<Item, Player, bool>>(g => g.OnPickup);
-
+		
 		/// <summary>
 		/// Calls all GlobalItem.OnPickup hooks then ModItem.OnPickup, until one of the returns false. Returns true if all of the hooks return true.
 		/// </summary>
@@ -1555,7 +1555,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookItemSpace = AddHook<Func<Item, Player, bool>>(g => g.ItemSpace);
-
+		
 		public static bool ItemSpace(Item item, Player player) {
 			foreach (var g in HookItemSpace.Enumerate(item.globalItems)) {
 				if (g.ItemSpace(item, player))
@@ -1566,7 +1566,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookGetAlpha = AddHook<Func<Item, Color, Color?>>(g => g.GetAlpha);
-
+		
 		/// <summary>
 		/// Calls all GlobalItem.GetAlpha hooks then ModItem.GetAlpha, until one of them returns a color, and returns that color. Returns null if all of the hooks return null.
 		/// </summary>
@@ -1602,7 +1602,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPostDrawInWorld = AddHook<Action<Item, SpriteBatch, Color, Color, float, float, int>>(g => g.PostDrawInWorld);
-
+		
 		/// <summary>
 		/// Calls ModItem.PostDrawInWorld, then all GlobalItem.PostDrawInWorld hooks.
 		/// </summary>
@@ -1615,7 +1615,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookPreDrawInInventory = AddHook<Func<Item, SpriteBatch, Vector2, Rectangle, Color, Color, Vector2, float, bool>>(g => g.PreDrawInInventory);
-
+		
 		/// <summary>
 		/// Returns the "and" operator on the results of all GlobalItem.PreDrawInInventory hooks and ModItem.PreDrawInInventory.
 		/// </summary>
@@ -1693,7 +1693,7 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookCanEquipAccessory = AddHook<Func<Item, Player, int, bool, bool>>(g => g.CanEquipAccessory);
-
+		
 		public static bool CanEquipAccessory(Item item, int slot, bool modded) {
 			Player player = Main.player[Main.myPlayer];
 			if (item.ModItem != null && !item.ModItem.CanEquipAccessory(player, slot, modded))

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -9,11 +9,9 @@ using System.Text.RegularExpressions;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
-using Terraria.Localization;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
-using static Terraria.GameContent.Creative.CreativeUI;
 
 namespace Terraria.ModLoader
 {
@@ -231,6 +229,12 @@ namespace Terraria.ModLoader
 		public virtual void GetHealLife(Player player, bool quickHeal, ref int healValue) {
 		}
 
+		/// <summary>
+		/// Allows you to temporarily modify the duration of potion sickness, based on player buffs, accessories, etc. This is only called for items with <see cref="Item.potion"/> set to true.
+		/// </summary>
+		/// <param name="player">The player using the item.</param>
+		/// <param name="quickHeal">Whether the item is being used through quick heal or not.</param>
+		/// <param name="potionDelay">Duration of the <see cref="BuffID.PotionSickness"/> debuff.</param>
 		public virtual void ApplyPotionDelay(Player player, bool quickHeal, ref int potionDelay) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -106,7 +106,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public virtual void SetDefaults() {
 		}
-		
+
 		/// <summary>
 		/// Gets called when your item spawns in world
 		/// </summary>
@@ -231,6 +231,9 @@ namespace Terraria.ModLoader
 		public virtual void GetHealLife(Player player, bool quickHeal, ref int healValue) {
 		}
 
+		public virtual void ApplyPotionDelay(Player player, bool quickHeal, ref int potionDelay) {
+		}
+
 		/// <summary>
 		/// Allows you to temporarily modify the amount of mana a mana healing item will heal for, based on player buffs, accessories, etc. This is only called for items with a healMana value.
 		/// </summary>
@@ -299,7 +302,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to create custom behaviour when an item is accepted by the Research function 
+		/// Allows you to create custom behaviour when an item is accepted by the Research function
 		/// </summary>
 		/// <param name="fullyResearched">True if the item was completely researched, and is ready to be duplicated, false if only partially researched.</param>
 		public virtual void OnResearched(bool fullyResearched) {

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -373,6 +373,9 @@ namespace Terraria.ModLoader
 		public virtual void GetHealLife(Item item, bool quickHeal, ref int healValue) {
 		}
 
+		public virtual void ApplyPotionDelay(Item item, bool quickHeal, ref int potionDelay) {
+		}
+
 		/// <summary>
 		/// Allows you to temporarily modify the amount of mana a mana healing item will heal for, based on player buffs, accessories, etc. This is only called for items with a healMana value.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -2,10 +2,10 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.GameInput;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
@@ -367,12 +367,18 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to temporarily modify the amount of life a life healing item will heal for, based on player buffs, accessories, etc. This is only called for items with a healLife value.
 		/// </summary>
-		/// <param name="item">The item.</param>
+		/// <param name="item">The item being used.</param>
 		/// <param name="quickHeal">Whether the item is being used through quick heal or not.</param>
 		/// <param name="healValue">The amount of life being healed.</param>
 		public virtual void GetHealLife(Item item, bool quickHeal, ref int healValue) {
 		}
 
+		/// <summary>
+		/// Allows you to temporarily modify the duration of potion sickness, based on player buffs, accessories, etc. This is only called for items with <see cref="Item.potion"/> set to true.
+		/// </summary>
+		/// <param name="item">The item being used.</param>
+		/// <param name="quickHeal">Whether the item is being used through quick heal or not.</param>
+		/// <param name="potionDelay">Duration of the <see cref="BuffID.PotionSickness"/> debuff.</param>
 		public virtual void ApplyPotionDelay(Item item, bool quickHeal, ref int potionDelay) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -458,6 +458,9 @@ namespace Terraria.ModLoader
 			foreach (int index in HookApplyPotionDelay.arr) {
 				player.modPlayers[index].ApplyPotionDelay(item, quickHeal, ref healValue);
 			}
+
+			if (potionDelay < 0)
+				potionDelay = 0;
 		}
 
 		private delegate void DelegateGetHealMana(Item item, bool quickHeal, ref int healValue);

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -448,15 +448,15 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private delegate void DelegateApplyPotionDelay(Item item, bool quickHeal, ref int healValue);
+		private delegate void DelegateApplyPotionDelay(Item item, bool quickHeal, ref int potionDelay);
 		private static HookList HookApplyPotionDelay = AddHook<DelegateApplyPotionDelay>(p => p.ApplyPotionDelay);
 
-		public static void ApplyPotionDelay(Player player, Item item, bool quickHeal, ref int healValue) {
+		public static void ApplyPotionDelay(Player player, Item item, bool quickHeal, ref int potionDelay) {
 			if (item.IsAir)
 				return;
 
 			foreach (int index in HookApplyPotionDelay.arr) {
-				player.modPlayers[index].ApplyPotionDelay(item, quickHeal, ref healValue);
+				player.modPlayers[index].ApplyPotionDelay(item, quickHeal, ref potionDelay);
 			}
 
 			if (potionDelay < 0)

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -448,6 +448,18 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateApplyPotionDelay(Item item, bool quickHeal, ref int healValue);
+		private static HookList HookApplyPotionDelay = AddHook<DelegateApplyPotionDelay>(p => p.ApplyPotionDelay);
+
+		public static void ApplyPotionDelay(Player player, Item item, bool quickHeal, ref int healValue) {
+			if (item.IsAir)
+				return;
+
+			foreach (int index in HookApplyPotionDelay.arr) {
+				player.modPlayers[index].ApplyPotionDelay(item, quickHeal, ref healValue);
+			}
+		}
+
 		private delegate void DelegateGetHealMana(Item item, bool quickHeal, ref int healValue);
 		private static HookList HookGetHealMana = AddHook<DelegateGetHealMana>(p => p.GetHealMana);
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4568,24 +4568,27 @@
  			if (Main.dedServ)
  				return;
  
-@@ -36070,22 +_,26 @@
+@@ -36070,7 +_,8 @@
  			}
  		}
  
 -		private void ApplyPotionDelay(Item sItem) {
 +		private void ApplyPotionDelay(Item sItem, bool quickHeal = false) {
++			/*
  			if (sItem.type == 227) {
  				potionDelay = restorationDelayTime;
--				AddBuff(21, potionDelay);
- 			}
- 			else if (sItem.type == 5) {
- 				potionDelay = mushroomDelayTime;
--				AddBuff(21, potionDelay);
- 			}
- 			else {
+ 				AddBuff(21, potionDelay);
+@@ -36083,9 +_,23 @@
  				potionDelay = potionDelayTime;
--				AddBuff(21, potionDelay);
+ 				AddBuff(21, potionDelay);
  			}
++			*/
++
++			potionDelay = sItem.type switch {
++				ItemID.RestorationPotion => restorationDelayTime,
++				ItemID.Mushroom          => mushroomDelayTime,
++				_                        => potionDelayTime,
++			};
 +
 +			CombinedHooks.ApplyPotionDelay(this, sItem, quickHeal, ref potionDelay);
 +

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -455,8 +455,20 @@
  				if (buffType[num] > 0)
  					num++;
  			}
-@@ -2812,24 +_,29 @@
+@@ -2798,6 +_,8 @@
+ 
+ 			SoundEngine.PlaySound(item.UseSound, position);
+ 			if (item.potion) {
++				ApplyPotionDelay(item, true);
++				/*
+ 				if (item.type == 227) {
+ 					potionDelay = restorationDelayTime;
+ 					AddBuff(21, potionDelay);
+@@ -2810,26 +_,32 @@
+ 					potionDelay = potionDelayTime;
+ 					AddBuff(21, potionDelay);
  				}
++				*/
  			}
  
 +			ItemLoader.UseItem(item, this);
@@ -513,8 +525,20 @@
  						break;
  
  					num++;
-@@ -2900,24 +_,29 @@
+@@ -2886,6 +_,8 @@
+ 
+ 			SoundEngine.PlaySound(inventory[num].UseSound, position);
+ 			if (inventory[num].potion) {
++				ApplyPotionDelay(inventory[num], true);
++				/*
+ 				if (inventory[num].type == 227) {
+ 					potionDelay = restorationDelayTime;
+ 					AddBuff(21, potionDelay);
+@@ -2898,26 +_,32 @@
+ 					potionDelay = potionDelayTime;
+ 					AddBuff(21, potionDelay);
  				}
++				*/
  			}
  
 -			statLife += inventory[num].healLife;
@@ -1058,7 +1082,7 @@
  				cWings = dyeItem.dye;
  
  			if (armorItem.type == 934)
-@@ -6598,11 +_,13 @@
+@@ -6598,6 +_,8 @@
  			}
  		}
  
@@ -1067,12 +1091,6 @@
  		public IEntitySource GetProjectileSource_Buff(int buffIndex) {
  			int buffId = buffType[buffIndex];
  			return new EntitySource_Buff(this, buffId, buffIndex);
- 		}
--
-+		
- 		public IEntitySource GetProjectileSource_Item(Item item) => new EntitySource_ItemUse(this, item);
- 		public IEntitySource GetItemSource_OpenItem(int itemType) => new EntitySource_ItemOpen(this, itemType);
- 		public IEntitySource GetItemSource_Death() => new EntitySource_ByItemSourceId(this, 3);
 @@ -6617,21 +_,51 @@
  		public IEntitySource GetItemSource_TileInteraction(int tileCoordsX, int tileCoordsY) => new EntitySource_TileInteraction(this, tileCoordsX, tileCoordsY);
  		public IEntitySource GetNPCSource_TileInteraction(int tileCoordsX, int tileCoordsY) => new EntitySource_TileInteraction(this, tileCoordsX, tileCoordsY);
@@ -4028,7 +4046,7 @@
 +				// TML attempts to make ApplyItemTime calls run on remote players, so this check is removed. #ItemTimeOnAllClients
 -				if (whoAmI == Main.myPlayer) {
 +				// if (whoAmI == Main.myPlayer) {
-+				if (true) { 
++				if (true) {
  					bool flag4 = true;
  					int type2 = item.type;
  					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)
@@ -4535,7 +4553,7 @@
  
  		private void ItemCheck_ApplyManaRegenDelay(Item sItem) {
 -			if (!spaceGun || (sItem.type != 127 && sItem.type != 4347 && sItem.type != 4348))
-+ 			if (GetManaCost(sItem) > 0)
++			if (GetManaCost(sItem) > 0)
  				manaRegenDelay = (int)maxRegenDelay;
  		}
  
@@ -4550,7 +4568,28 @@
  			if (Main.dedServ)
  				return;
  
-@@ -36086,6 +_,9 @@
+@@ -36070,22 +_,26 @@
+ 			}
+ 		}
+ 
+-		private void ApplyPotionDelay(Item sItem) {
++		private void ApplyPotionDelay(Item sItem, bool quickHeal = false) {
+ 			if (sItem.type == 227) {
+ 				potionDelay = restorationDelayTime;
+-				AddBuff(21, potionDelay);
+ 			}
+ 			else if (sItem.type == 5) {
+ 				potionDelay = mushroomDelayTime;
+-				AddBuff(21, potionDelay);
+ 			}
+ 			else {
+ 				potionDelay = potionDelayTime;
+-				AddBuff(21, potionDelay);
+ 			}
++
++			CombinedHooks.ApplyPotionDelay(this, sItem, quickHeal, ref potionDelay);
++
++			AddBuff(BuffID.PotionSickness, potionDelay);
  		}
  
  		private bool ItemCheck_CheckCanUse(Item sItem) {
@@ -4624,7 +4663,7 @@
 +		}
 +
 +		private bool TryAllowingItemReuse_Inner(Item sItem) {
-+			// Split into _Inner because it is used by ShouldAutoReuseItem 
++			// Split into _Inner because it is used by ShouldAutoReuseItem
 +			bool flag = false;
 +
 +			bool? allow = CombinedHooks.CanAutoReuseItem(this, sItem);
@@ -5309,9 +5348,9 @@
  			num2 = ((num <= 50) ? (num2 - (float)num * 0.01f) : ((num <= 100) ? (0.5f - (float)(num - 50) * 0.005f) : ((num > 150) ? 0.15f : (0.25f - (float)(num - 100) * 0.002f))));
  			num2 *= 0.9f;
  			num2 *= (float)(currentShoppingSettings.PriceAdjustment + 1.0) / 2f;
-+			
++
 +			List<Item> rewardItems = new List<Item>();
-+			
++
  			GetItemSettings anglerRewardSettings = GetItemSettings.NPCEntityToPlayerInventorySettings;
 -			GetAnglerReward_MainReward(source, num, num2, ref anglerRewardSettings);
 +			GetAnglerReward_MainReward(rewardItems, source, num, num2, ref anglerRewardSettings);
@@ -5319,17 +5358,17 @@
 +			GetAnglerReward_Money(rewardItems, source, num, num2, ref anglerRewardSettings);
 -			GetAnglerReward_Bait(source, num, num2, ref anglerRewardSettings);
 +			GetAnglerReward_Bait(rewardItems, source, num, num2, ref anglerRewardSettings);
-+			
++
 +			PlayerLoader.AnglerQuestReward(this, num2, rewardItems);
 +
 +			foreach (Item rewardItem in rewardItems) {
 +				rewardItem.position = Center;
-+				
++
 +				Item getItem = GetItem(whoAmI, rewardItem, GetItemSettings.NPCEntityToPlayerInventorySettings);
-+				
++
 +				if (getItem.stack > 0) {
 +					int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, getItem.type, getItem.stack, noBroadcast: false, 0, noGrabDelay: true);
-+					
++
 +					if (Main.netMode == 1)
 +						NetMessage.SendData(21, -1, -1, null, number, 1f);
 +				}
@@ -5405,7 +5444,7 @@
 +
 +					rewardItems.Add(item2);
  				}
-+				
++
 +				rewardItems.Add(item4);
  			}
  			else {


### PR DESCRIPTION
### What is the new feature?
`ApplyPotionDelay` hook in `ModItem`, `GlobalItem` and `ModPlayer` which allows modifying the duration of the potion sickness debuff

### Why should this be part of tModLoader?
Allows creation of items with functionality similar to that of Terraria's `Philosopher's Stone`

### Are there alternative designs?
None that I can think of

### Sample usage for the new feature
```cs
// ModItem
public override void ApplyPotionDelay(Player player, bool quickHeal, ref int potionDelay)
{
	if (!quickHeal)
	{
		potionDelay = 300; // 5 seconds
	}
}

// ModPlayer
public override void ApplyPotionDelay(Item item, bool quickHeal, ref int potionDelay)
{
	if (someBool)
	{
		potionDelay /= 2; // Half as long
	}
}
```

### ExampleMod updates
`ExampleHealingPotion` uses the new hook

