### PR TITLE
[1.4] Fix duplicate angler quest rewards

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5449,20 +5449,20 @@
  			Item item = new Item();
  			int num = (questsDone + 50) / 2;
  			num = (int)((float)(num * Main.rand.Next(50, 201)) * 0.015f);
-@@ -39473,6 +_,7 @@
+@@ -39473,6 +_,8 @@
  				item.stack = num;
  			}
  
++			rewardItems.Add(item);
 +			/*
  			item.position = base.Center;
  			Item item2 = GetItem(whoAmI, item, anglerRewardSettings);
  			if (item2.stack > 0) {
-@@ -39480,6 +_,8 @@
+@@ -39480,6 +_,7 @@
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
  			}
 +			*/
-+			rewardItems.Add(item);
  		}
  
  		public bool DropAnglerAccByMissing(List<int> itemIdsOfAccsWeWant, int randomChanceForASingleAcc, out bool botheredRollingForADrop, out int itemIdToDrop) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5341,7 +5341,7 @@
  			Item item = new Item();
  			item.type = 0;
  			switch (questsDone) {
-@@ -39349,34 +_,48 @@
+@@ -39349,6 +_,8 @@
  					}
  			}
  
@@ -5350,11 +5350,9 @@
  			item.position = base.Center;
  			Item item2 = GetItem(whoAmI, item, anglerRewardSettings);
  			if (item2.stack > 0) {
- 				int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
+@@ -39356,11 +_,14 @@
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
-+
-+				rewardItems.Add(item2);
  			}
 +			*/
  
@@ -5367,11 +5365,9 @@
  				item3.position = base.Center;
  				item2 = GetItem(whoAmI, item3, anglerRewardSettings);
  				if (item2.stack > 0) {
- 					int number2 = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
+@@ -39368,15 +_,20 @@
  					if (Main.netMode == 1)
  						NetMessage.SendData(21, -1, -1, null, number2, 1f);
-+
-+					rewardItems.Add(item2);
  				}
 +				*/
  
@@ -5426,7 +5422,7 @@
  			if (Main.rand.Next((int)(100f * rarityReduction)) > 50)
  				return;
  
-@@ -39434,16 +_,21 @@
+@@ -39434,6 +_,8 @@
  			if (Main.rand.Next(250) <= questsDone)
  				item.stack++;
  
@@ -5435,11 +5431,9 @@
  			item.position = base.Center;
  			Item item2 = GetItem(whoAmI, item, GetItemSettings.NPCEntityToPlayerInventorySettings);
  			if (item2.stack > 0) {
- 				int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
+@@ -39441,9 +_,10 @@
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
-+
-+				rewardItems.Add(item2);
  			}
 +			*/
  		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5341,117 +5341,83 @@
  			Item item = new Item();
  			item.type = 0;
  			switch (questsDone) {
-@@ -39349,34 +_,68 @@
+@@ -39349,34 +_,48 @@
  					}
  			}
  
-+			if (!item.IsAir) {
-+				rewardItems.Add(item);
-+			}
-+
++			rewardItems.Add(item);
 +			/*
  			item.position = base.Center;
-+			*/
-+
  			Item item2 = GetItem(whoAmI, item, anglerRewardSettings);
-+
  			if (item2.stack > 0) {
-+				/*
  				int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
-+				*/
 +
 +				rewardItems.Add(item2);
  			}
++			*/
  
  			if (item.type == 2417) {
  				Item item3 = new Item();
  				Item item4 = new Item();
  				item3.SetDefaults(2418);
-+
++				rewardItems.Add(item3);
 +				/*
  				item3.position = base.Center;
-+				*/
-+
  				item2 = GetItem(whoAmI, item3, anglerRewardSettings);
-+
  				if (item2.stack > 0) {
-+					/*
  					int number2 = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  					if (Main.netMode == 1)
  						NetMessage.SendData(21, -1, -1, null, number2, 1f);
-+					*/
 +
 +					rewardItems.Add(item2);
  				}
-+
-+				rewardItems.Add(item3);
++				*/
  
  				item4.SetDefaults(2419);
-+
++				rewardItems.Add(item4);
 +				/*
  				item4.position = base.Center;
-+				*/
-+
  				item2 = GetItem(whoAmI, item4, anglerRewardSettings);
 +
  				if (item2.stack > 0) {
-+					/*
  					int number3 = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  					if (Main.netMode == 1)
  						NetMessage.SendData(21, -1, -1, null, number3, 1f);
-+					*/
-+
-+					rewardItems.Add(item2);
  				}
-+				
-+				rewardItems.Add(item4);
++				*/
  			}
  			else {
  				if (item.type != 2498)
-@@ -39385,26 +_,48 @@
+@@ -39385,26 +_,34 @@
  				Item item5 = new Item();
  				Item item6 = new Item();
  				item5.SetDefaults(2499);
-+
++				rewardItems.Add(item5);
 +				/*
  				item5.position = base.Center;
-+				*/
-+
  				item2 = GetItem(whoAmI, item5, anglerRewardSettings);
 +
  				if (item2.stack > 0) {
-+					/*
  					int number4 = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  					if (Main.netMode == 1)
  						NetMessage.SendData(21, -1, -1, null, number4, 1f);
-+					*/
-+
-+					rewardItems.Add(item2);
  				}
-+
-+				rewardItems.Add(item5);
++				*/
  
  				item6.SetDefaults(2500);
-+
++				rewardItems.Add(item6);
 +				/*
  				item6.position = base.Center;
-+				*/
-+
  				item2 = GetItem(whoAmI, item6, anglerRewardSettings);
 +
  				if (item2.stack > 0) {
-+					/*
  					int number5 = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  					if (Main.netMode == 1)
  						NetMessage.SendData(21, -1, -1, null, number5, 1f);
-+					*/
-+
-+					rewardItems.Add(item2);
  				}
-+
-+				rewardItems.Add(item6);
++				*/
  			}
  		}
  
@@ -5460,29 +5426,22 @@
  			if (Main.rand.Next((int)(100f * rarityReduction)) > 50)
  				return;
  
-@@ -39434,16 +_,28 @@
+@@ -39434,16 +_,21 @@
  			if (Main.rand.Next(250) <= questsDone)
  				item.stack++;
  
-+
-+			if (item.stack > 0)
-+				rewardItems.Add(item);
-+
++			rewardItems.Add(item);
 +			/*
  			item.position = base.Center;
-+			*/
-+
  			Item item2 = GetItem(whoAmI, item, GetItemSettings.NPCEntityToPlayerInventorySettings);
-+
  			if (item2.stack > 0) {
-+				/*
  				int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
-+				*/
 +
 +				rewardItems.Add(item2);
  			}
++			*/
  		}
  
 -		private void GetAnglerReward_Money(IEntitySource source, int questsDone, float rarityReduction, ref GetItemSettings anglerRewardSettings) {
@@ -5490,20 +5449,23 @@
  			Item item = new Item();
  			int num = (questsDone + 50) / 2;
  			num = (int)((float)(num * Main.rand.Next(50, 201)) * 0.015f);
-@@ -39476,9 +_,13 @@
+@@ -39473,6 +_,7 @@
+ 				item.stack = num;
+ 			}
+ 
++			/*
  			item.position = base.Center;
  			Item item2 = GetItem(whoAmI, item, anglerRewardSettings);
  			if (item2.stack > 0) {
-+				/*
- 				int number = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item2.type, item2.stack, noBroadcast: false, 0, noGrabDelay: true);
+@@ -39480,6 +_,8 @@
  				if (Main.netMode == 1)
  					NetMessage.SendData(21, -1, -1, null, number, 1f);
-+				*/
-+
-+				rewardItems.Add(item2);
  			}
++			*/
++			rewardItems.Add(item);
  		}
  
+ 		public bool DropAnglerAccByMissing(List<int> itemIdsOfAccsWeWant, int randomChanceForASingleAcc, out bool botheredRollingForADrop, out int itemIdToDrop) {
 @@ -39603,13 +_,17 @@
  					list.Add(3556);
  				}


### PR DESCRIPTION
### What is the bug?
#2325:
* Unstackable rewards are duplicated but only "shallowly"; interacting with one of them makes the other disappear (as they share the same item instance)
* Stackable rewards are sometimes duplicated or show wrong item text

### How did you fix the bug?
TML rewrote the way quest rewards are given out - instead of spawning every item individually, they are added into a list, which then modders can add their own rewards to, and then TML spawns all those items at the end.
However, this approach was messed up in 98bec3e two months ago, causing many duplicates (`rewardItems.Add`).
The PR fixes those by commenting more code out such that it only follows "instantiate item, then add it to the list". The code that is being commented out is mirrored where `rewardItems` is handled, so no functionality is lost.

It's much clearer to see once you clone this branch and look at the resulting source code instead of the diff (or view the file and search for `rewardItems.Add`):

![Screenshot_3](https://user-images.githubusercontent.com/15894498/165926217-c91c179a-4fec-4fb5-aa1c-aa83428c3a2b.png)

### Are there alternatives to your fix?
No
