### PR TITLE
[1.4] various post-item use rework fixes

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2382,15 +2382,6 @@
  			}
  			else {
  				if (jumpBoost) {
-@@ -14215,7 +_,7 @@
- 						direction = -1;
- 				}
- 				else if ((itemAnimation == 0 || inventory[selectedItem].useTurn) && mount.AllowDirectionChange) {
--					direction = -1;
-+					direction = -1 ;
- 				}
- 
- 				if (velocity.Y == 0f || wingsLogic > 0 || mount.CanFly()) {
 @@ -14330,7 +_,7 @@
  				if (flag4)
  					num5 = 30;
@@ -3985,19 +3976,20 @@
  			Item item2 = (itemAnimation > 0) ? lastVisualizedSelectedItem : item;
  			Rectangle drawHitbox = Item.GetDrawHitbox(item2.type, this);
  			compositeFrontArm.enabled = false;
-@@ -30289,12 +_,23 @@
+@@ -30289,12 +_,21 @@
  				itemAnimation--;
  			}
  
+-			if (itemAnimation > 0)
+-				ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
+-			else
 +			goto DecrementItemTime;
 +
 +			HandleItemHolding:
 +
 +			ItemLoader.HoldItem(item, this);
 +
- 			if (itemAnimation > 0)
- 				ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
- 			else
++			if (itemAnimation == 0)
  				ItemCheck_ApplyHoldStyle(heightOffsetHitboxCenter, item2, drawHitbox);
  
 -			releaseUseItem = !controlUseItem;
@@ -4032,7 +4024,7 @@
  					bool flag4 = true;
  					int type2 = item.type;
  					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)
-@@ -30343,9 +_,13 @@
+@@ -30343,9 +_,16 @@
  
  					ItemCheck_TurretAltFeatureUse(item, flag4);
  					ItemCheck_MinionAltFeatureUse(item, flag4);
@@ -4040,6 +4032,9 @@
 +					if (item.shoot > 0 && itemAnimation > 0 && ItemTimeIsZero && flag4 && ItemLoader.CheckProjOnSwing(this, item))
  						ItemCheck_Shoot(i, item, weaponDamage);
  
++					if (itemAnimation > 0)
++						ItemCheck_ApplyUseStyle(heightOffsetHitboxCenter, item2, drawHitbox);
++
 +					// Added by TML. #ItemTimeOnAllClients - TODO: item time application with these item types
 +					if (whoAmI != Main.myPlayer)
 +						goto endItemChecks;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -859,6 +859,35 @@
  								int num = damage;
  								position = base.Center;
  								int num2 = 0;
+@@ -29210,7 +_,12 @@
+ 			if (flag2 && player.channel && player.itemAnimation < num)
+ 				player.SetDummyItemTime(num);
+ 
+-			if (player.itemAnimation == 0)
++			/*
++			tML:
++			the reason this checks against itemAnimation == 1 + auto-reuse is because of the logic execution order and how auto-reuse now behaves with regard to itemAnimation
++			if reset every time a new usage starts, the spear's main projectile will just die instantly on use. the kill condition is checked manually to avoid this issue
++			*/
++			if (player.itemAnimation == 0 || (player.itemAnimation == 1 && player.ShouldAutoReuseItem(player.HeldItem)))
+ 				Kill();
+ 
+ 			rotation = (float)Math.Atan2(velocity.Y, velocity.X) + (float)Math.PI / 2f + (float)Math.PI / 4f;
+@@ -30375,7 +_,13 @@
+ 			GetWhipSettings(this, out float timeToFlyOut, out int _, out float _);
+ 			base.Center = Main.GetPlayerArmPosition(this) + velocity * (ai[0] - 1f);
+ 			spriteDirection = ((!(Vector2.Dot(velocity, Vector2.UnitX) < 0f)) ? 1 : (-1));
+-			if (ai[0] >= timeToFlyOut || player.itemAnimation == 0) {
++
++			/*
++			tML:
++			the reason this checks against itemAnimation == 1 + auto-reuse is because of the logic execution order and how auto-reuse now behaves with regard to itemAnimation
++			if reset every time a new usage starts, the spear's main projectile will just die instantly on use. the kill condition is checked manually to avoid this issue
++			*/
++			if (ai[0] >= timeToFlyOut || player.itemAnimation == 0 || (player.itemAnimation == 1 && player.ShouldAutoReuseItem(player.HeldItem))) {
+ 				Kill();
+ 				return;
+ 			}
 @@ -33091,6 +_,9 @@
  					if (num3 > (float)num9)
  						ai[0] = 1f;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -882,7 +882,7 @@
 +			/*
 +			tML:
 +			the reason this checks against itemAnimation == 1 + auto-reuse is because of the logic execution order and how auto-reuse now behaves with regard to itemAnimation
-+			if reset every time a new usage starts, the spear's main projectile will just die instantly on use. the kill condition is checked manually to avoid this issue
++			if reset every time a new usage starts, the whip's main projectile will just die instantly on use. the kill condition is checked manually to avoid this issue
 +			*/
 +			if (ai[0] >= timeToFlyOut || player.itemAnimation == 0 || (player.itemAnimation == 1 && player.ShouldAutoReuseItem(player.HeldItem))) {
  				Kill();


### PR DESCRIPTION
# IN WHICH
I fix a number of issues related to the great item use rework of...how long ago was it, again?

either way, this is meant as a long-needed follow-up PR to #1437 

## it's all tML bug fixes, ladies and gents
- whips no longer start to duplicate themselves after autoswingin' for a short amount of time
(solves #1654)
- spears no longer build up more hitbox as they're used when in possession of autoswing
(solves #1767)
- melee weapons no longer have their hitbox linger weirdly near an enemy for a single frame
(solves #1721)

## and now, I'll address the Beholster in the room: Feral Claws interactions
(and conditional auto-reuse overall)
this solves #1770 --- by provin' that it's not an issue in the first place, but rather a fix to an issue that was already there

assume I have an Iron Broadsword and a Lead Broadsword. the Iron one has `autoReuse` set to true, while the Lead one has `autoReuse` set to false. 

### vanilla behavior
**Iron, no Feral:** locked into initial swing direction
**Iron w/ Feral:** locked into initial swing direction
**Lead, no Feral:** swing direction decided per-swing
**Lead w/ Feral:** swing direction decided per-swing despite havin' autoswing; inconsistent with pre-established broadsword autoswing mechanics

### stock tML behavior, post-item use rework
**Iron, no Feral:** locked into initial swing direction
**Iron w/ Feral:** locked into initial swing direction
**Lead, no Feral:** swing direction decided per-swing
**Lead w/ Feral:** locked into initial swing direction

notice that in both cases, the Iron Broadsword locks you into your initial swing direction regardless of whether or not you have Feral Claws equipped. this is how broadswords without `useTurn` set to true have always behaved with autoswing, both in vanilla and in tML --- it's only with 1.4's honestly wonky implementation of conditional autoswing bonuses that a third option became plausible in the first place. the item use rework essentially silently fixed this issue, only for some to mistakenly view it as a fully intended feature and cry out for its return. the case demonstrated with vanilla Lead w/ Feral has never been how these sorts of cases are supposed to be handled, which means tML has actually made this more consistent and thus increased intuitivity for modders and players alike --- and, as such, the issue here isn't actually an issue at all. on top of that, returnin' the behavior described here as an actual feature would require enough work, and would fly in the face of vanilla's established rules enough, to where it's genuinely better if a mod takes on that task. I rest my case

## what about alternate fixes for the stuff that's actually fixed?
the spear and whip fixes are tentative; **ideally, they'd be done with a more notable fundamental change to how they're handled on reuse**, but that's not what I came here to do and other people are likely to have better ideas on how to do that which I can't think of off of the top of my head. I simply aim to fix these issues well enough that we stop gettin' bug reports about things that can be tentatively fixed now and properly fixed later