### PR TITLE
[1.4] dedicated server fix for town NPC profiles

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/TownNPCProfiles.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/TownNPCProfiles.cs.patch
@@ -30,7 +30,7 @@
  			{ 229, new Profiles.LegacyNPCProfile("Images/TownNPCs/Pirate", 19) },
  			{ 142, new Profiles.LegacyNPCProfile("Images/TownNPCs/Santa", 11) },
  			{ 453, new Profiles.LegacyNPCProfile("Images/TownNPCs/SkeletonMerchant", -1) },
-@@ -48,13 +_,27 @@
+@@ -48,13 +_,28 @@
  			{ 353, new Profiles.LegacyNPCProfile("Images/TownNPCs/Stylist", 20) },
  			{ 441, new Profiles.LegacyNPCProfile("Images/TownNPCs/TaxCollector", 23) },
  			{ 368, new Profiles.LegacyNPCProfile("Images/TownNPCs/TravelingMerchant", 21) },
@@ -48,7 +48,8 @@
 +		public bool GetProfile(NPC npc, out ITownNPCProfile profile) {
 +			_townNPCProfiles.TryGetValue(npc.type, out profile);
 +			NPCLoader.ModifyTownNPCProfile(npc, ref profile);
-+			profile?.GetTextureNPCShouldUse(npc).Wait?.Invoke();
++			if (!Main.dedServ)
++				profile?.GetTextureNPCShouldUse(npc).Wait?.Invoke();
 +			return profile != null;
 +		}
 +


### PR DESCRIPTION
**hi**
are you expectin' anything? too bad

**the bug:** dedicated servers currently silently throw an exception, and fail to spawn NPCs properly, due to the NPCs' textures bein' erroneously invoked on them
**the fix:** the invocation of `GetTextureNPCShouldUse` is now properly prefaced by a `Main.dedServ` check
**are there alternative fixes?** no