### PR TITLE
[1,4] fixed parent sources not affectin' crit chance and armor pen as they should

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -57,12 +57,18 @@ namespace Terraria
 		- thomas
 		*/
 		private static void HandlePlayerStatModifiers(IEntitySource spawnSource, Projectile projectile) {
-			if (spawnSource is EntitySource_ItemUse itemUseSource && itemUseSource.Entity is Player player) {
+			// to-do: make this less ugly and more easily extensible to modded sources
+			// (requires substantial changes, at minimum, to how entity sources are handled)
+			if (spawnSource is EntitySource_ItemUse itemUseSource && itemUseSource.Entity is Player) {
+				Player player = itemUseSource.Entity as Player;
 				projectile.CritChance += player.GetWeaponCrit(itemUseSource.Item);
 				projectile.ArmorPenetration += player.GetWeaponArmorPenetration(itemUseSource.Item);
 			}
-
-			// TODO: what about other spawn sources which are from a player, but not an item use (accessories, set effects). Should be able to use projectile DamageType to get modifiers
+			else if (spawnSource is EntitySource_Parent parentSource && parentSource.Entity is Projectile) {
+				Projectile parentProjectile = parentSource.Entity as Projectile;
+				projectile.CritChance += parentProjectile.CritChance;
+				projectile.ArmorPenetration += parentProjectile.ArmorPenetration;
+			}
 		}
 
 		/// <summary> Gets the instance of the specified GlobalProjectile type. This will throw exceptions on failure. </summary>

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -59,13 +59,11 @@ namespace Terraria
 		private static void HandlePlayerStatModifiers(IEntitySource spawnSource, Projectile projectile) {
 			// to-do: make this less ugly and more easily extensible to modded sources
 			// (requires substantial changes, at minimum, to how entity sources are handled)
-			if (spawnSource is EntitySource_ItemUse itemUseSource && itemUseSource.Entity is Player) {
-				Player player = itemUseSource.Entity as Player;
+			if (spawnSource is EntitySource_ItemUse itemUseSource && itemUseSource.Entity is Player player) {
 				projectile.CritChance += player.GetWeaponCrit(itemUseSource.Item);
 				projectile.ArmorPenetration += player.GetWeaponArmorPenetration(itemUseSource.Item);
 			}
-			else if (spawnSource is EntitySource_Parent parentSource && parentSource.Entity is Projectile) {
-				Projectile parentProjectile = parentSource.Entity as Projectile;
+			else if (spawnSource is EntitySource_Parent parentSource && parentSource.Entity is Projectile parentProjectile) {
 				projectile.CritChance += parentProjectile.CritChance;
 				projectile.ArmorPenetration += parentProjectile.ArmorPenetration;
 			}


### PR DESCRIPTION
**hi**
this is self-explanatory

**the bug:** parent sources weren't included in `Projectile.HandlePlayerStatModifiers`, causin' things like Last Prism and Vortex Beater to fail to set crit chance or armor pen correctly
**the fix:** parent sources are now included in `Projectile.HandlePlayerStatModifiers`
**are there alternative fixes?** there is one, but it'd take far too much time