### PR TITLE
[1.4] Netsend/Receive doc expansion and unification

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/TileEntity.TML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntity.TML.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Terraria.ID;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.DataStructures
@@ -22,13 +23,17 @@ namespace Terraria.DataStructures
 		public virtual void LoadData(TagCompound tag) { }
 
 		/// <summary>
-		/// Allows you to send custom data for this tile entity between client and server. This is called on the server while sending tile data (!lightSend) and when a MessageID.TileEntitySharing message is sent (lightSend)
+		/// Allows you to send custom data for this tile entity between client and server, which will be handled in <see cref="NetReceive"/>.
+		/// <br/>Called while sending tile data (!lightSend) and when <see cref="MessageID.TileEntitySharing"/> is sent (lightSend).
+		/// <br/>Only called on the server.
 		/// </summary>
 		/// <param name="writer">The writer.</param>
 		public virtual void NetSend(BinaryWriter writer) => WriteExtraData(writer, true);
 
 		/// <summary>
-		/// Receives the data sent in the NetSend hook. Called on MP Client when receiving tile data (!lightReceive) and when a MessageID.TileEntitySharing message is sent (lightReceive)
+		/// Receives custom data sent in the <see cref="NetSend"/> hook.
+		/// <br/>Called while receiving tile data (!lightReceive) and when <see cref="MessageID.TileEntitySharing"/> is received (lightReceive).
+		/// <br/>Only called on the client.
 		/// </summary>
 		/// <param name="reader">The reader.</param>
 		public virtual void NetReceive(BinaryReader reader) => ReadExtraData(reader, true);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -912,15 +912,11 @@ namespace Terraria.ModLoader
 		/// <param name="tag"> The TagCompound to load data from. </param>
 		public virtual void LoadData(Item item, TagCompound tag) { }
 
-		/// <summary>
-		/// Allows you to send custom data for the given item between client and server.
-		/// </summary>
+		/// <inheritdoc cref="ModItem.NetSend"/>
 		public virtual void NetSend(Item item, BinaryWriter writer) {
 		}
 
-		/// <summary>
-		///
-		/// </summary>
+		/// <inheritdoc cref="ModItem.NetReceive"/>
 		public virtual void NetReceive(Item item, BinaryReader reader) {
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -120,7 +120,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Return true or false to specify if the projectile can cut tiles, like vines. Return null for vanilla decision.
+		/// Return true or false to specify if the projectile can cut tiles like vines, pots, and Queen Bee larva. Return null for vanilla decision.
 		/// </summary>
 		/// <param name="projectile"></param>
 		/// <returns></returns>

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -1014,15 +1014,21 @@ namespace Terraria.ModLoader
 		/// <param name="tag"> The TagCompound to load data from. </param>
 		public virtual void LoadData(TagCompound tag) { }
 
+		//Does not use <see cref="NetReceive"> because of inheritdoc on the equivalent GlobalItem hook
 		/// <summary>
-		/// Allows you to send custom data for this item between client and server.
+		/// Allows you to send custom data for this item between client and server, which will be handled in NetReceive.
+		/// <br/>Called whenever an item container syncs its contents (various MessageIDs and sources), or <see cref="MessageID.SyncItem"/> and <see cref="MessageID.InstancedItem"/> are successfully sent, for example when the item is dropped into the world.
+		/// <br/>Can be called on both server and client.
 		/// </summary>
 		/// <param name="writer">The writer.</param>
 		public virtual void NetSend(BinaryWriter writer) {
 		}
 
+		//Does not use <see cref="NetSend"> because of inheritdoc on the equivalent GlobalItem hook
 		/// <summary>
-		/// Receives the custom data sent in the NetSend hook.
+		/// Receives the custom data sent in NetSend.
+		/// <br/>Called whenever an item container syncs its contents (various MessageIDs and sources), or <see cref="MessageID.SyncItem"/> and <see cref="MessageID.InstancedItem"/> are successfully received.
+		/// <br/>Can be called on both server and client.
 		/// </summary>
 		/// <param name="reader">The reader.</param>
 		public virtual void NetReceive(BinaryReader reader) {

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -29,7 +29,7 @@ namespace Terraria.ModLoader
 		public Item Item { get; internal set; }
 
 		/// <summary>
-		/// Shorthand for item.type;
+		/// Shorthand for Item.type;
 		/// </summary>
 		public int Type => Item.type;
 
@@ -704,7 +704,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Returns if the normal reforge pricing is applied.
 		/// If true or false is returned and the price is altered, the price will equal the altered price.
-		/// The passed reforge price equals the item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.
+		/// The passed reforge price equals the Item.value. Vanilla pricing will apply 20% discount if applicable and then price the reforge at a third of that value.
 		/// </summary>
 		public virtual bool ReforgePrice(ref int reforgePrice, ref bool canApplyDiscount) {
 			return true;

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader
 		/// <summary> The NPC object that this ModNPC controls. </summary>
 		public NPC NPC { get; internal set; }
 
-		/// <summary> Shorthand for npc.type; </summary>
+		/// <summary> Shorthand for NPC.type; </summary>
 		public int Type => NPC.type;
 
 		/// <summary> The translations for the display name of this NPC. </summary>
@@ -189,7 +189,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// If you are storing AI information outside of the npc.ai array, use this to send that AI information between clients and servers.
+		/// If you are storing AI information outside of the NPC.ai array, use this to send that AI information between clients and servers.
 		/// </summary>
 		/// <param name="writer"></param>
 		public virtual void SendExtraAI(BinaryWriter writer) {
@@ -211,13 +211,13 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to make things happen whenever this NPC is hit, such as creating dust or gores.
-		/// <br/> This hook is client side. Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for `if (npc.life &lt;= 0)` to do client-side death effects, such as spawning dust, gore, or death sounds.
+		/// <br/> This hook is client side. Usually when something happens when an NPC dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for `if (NPC.life &lt;= 0)` to do client-side death effects, such as spawning dust, gore, or death sounds.
 		/// </summary>
 		public virtual void HitEffect(int hitDirection, double damage) {
 		}
 
 		/// <summary>
-		/// Allows you to make the NPC either regenerate health or take damage over time by setting npc.lifeRegen. Regeneration or damage will occur at a rate of half of npc.lifeRegen per second. The damage parameter is the number that appears above the NPC's head if it takes damage over time.
+		/// Allows you to make the NPC either regenerate health or take damage over time by setting NPC.lifeRegen. Regeneration or damage will occur at a rate of half of NPC.lifeRegen per second. The damage parameter is the number that appears above the NPC's head if it takes damage over time.
 		/// </summary>
 		/// <param name="damage"></param>
 		public virtual void UpdateLifeRegen(ref int damage) {
@@ -279,7 +279,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to add and modify NPC loot tables to drop on death and to appear in the Bestiary.<br/>
-		/// The <see href="https://github.com/tModLoader/tModLoader/wiki/Basic-NPC-Drops-and-Loot-1.4">Basic NPC Drops and Loot 1.4 Guide</see> explains how to use this hook to modify npc loot.
+		/// The <see href="https://github.com/tModLoader/tModLoader/wiki/Basic-NPC-Drops-and-Loot-1.4">Basic NPC Drops and Loot 1.4 Guide</see> explains how to use this hook to modify NPC loot.
 		/// </summary>
 		/// <param name="npcLoot"></param>
 		public virtual void ModifyNPCLoot(NPCLoot npcLoot) {
@@ -483,7 +483,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// When used in conjunction with "npc.hide = true", allows you to specify that this npc should be drawn behind certain elements. Add the index to one of Main.DrawCacheNPCsMoonMoon, DrawCacheNPCsOverPlayers, DrawCacheNPCProjectiles, or DrawCacheNPCsBehindNonSolidTiles.
+		/// When used in conjunction with "NPC.hide = true", allows you to specify that this NPC should be drawn behind certain elements. Add the index to one of Main.DrawCacheNPCsMoonMoon, DrawCacheNPCsOverPlayers, DrawCacheNPCProjectiles, or DrawCacheNPCsBehindNonSolidTiles.
 		/// </summary>
 		/// <param name="index"></param>
 		public virtual void DrawBehind(int index)
@@ -533,11 +533,11 @@ namespace Terraria.ModLoader
 
 		/* Disabled until #2083 is addressed. Originally introduced in #1323, but was refactored and now would be for additional features outside PR scope.
 		/// <summary>
-		/// Allows you to set an NPC's biome preferences and nearby npc preferences for the NPC happiness system. Recommended to only be used with NPCs that have shops.
+		/// Allows you to set an NPC's biome preferences and nearby NPC preferences for the NPC happiness system. Recommended to only be used with NPCs that have shops.
 		/// </summary>
 		/// <param name="shopHelperInstance">The vanilla shop modifier instance to invoke methods such as LikeNPC and HateBiome on</param>
-		/// <param name="primaryPlayerBiome">The current biome the player is in for purposes of npc happiness, referred by PrimaryBiomeID </param>
-		/// <param name="nearbyNPCsByType">The boolean array of if each type of npc is nearby</param>
+		/// <param name="primaryPlayerBiome">The current biome the player is in for purposes of NPC happiness, referred by PrimaryBiomeID </param>
+		/// <param name="nearbyNPCsByType">The boolean array of if each type of NPC is nearby</param>
 		public virtual void ModifyNPCHappiness(int primaryPlayerBiome, ShopHelper shopHelperInstance, bool[] nearbyNPCsByType) {
 		}
 		*/

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -189,16 +189,20 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// If you are storing AI information outside of the NPC.ai array, use this to send that AI information between clients and servers.
+		/// If you are storing AI information outside of the NPC.ai array, use this to send that AI information between clients and servers, which will be handled in <see cref="ReceiveExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncNPC"/> is successfully sent, for example on NPC creation, on player join, or whenever NPC.netUpdate is set to true in the update loop for that tick.
+		/// <br/>Only called on the server.
 		/// </summary>
-		/// <param name="writer"></param>
+		/// <param name="writer">The writer.</param>
 		public virtual void SendExtraAI(BinaryWriter writer) {
 		}
 
 		/// <summary>
-		/// Use this to receive information that was sent in SendExtraAI.
+		/// Use this to receive information that was sent in <see cref="SendExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncNPC"/> is successfully received.
+		/// <br/>Only called on the client.
 		/// </summary>
-		/// <param name="reader"></param>
+		/// <param name="reader">The reader.</param>
 		public virtual void ReceiveExtraAI(BinaryReader reader) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -133,13 +133,13 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to give the player a negative life regeneration based on its state (for example, the "On Fire!" debuff makes the player take damage-over-time). This is typically done by setting player.lifeRegen to 0 if it is positive, setting player.lifeRegenTime to 0, and subtracting a number from player.lifeRegen. The player will take damage at a rate of half the number you subtract per second.
+		/// Allows you to give the player a negative life regeneration based on its state (for example, the "On Fire!" debuff makes the player take damage-over-time). This is typically done by setting Player.lifeRegen to 0 if it is positive, setting Player.lifeRegenTime to 0, and subtracting a number from Player.lifeRegen. The player will take damage at a rate of half the number you subtract per second.
 		/// </summary>
 		public virtual void UpdateBadLifeRegen() {
 		}
 
 		/// <summary>
-		/// Allows you to increase the player's life regeneration based on its state. This can be done by incrementing player.lifeRegen by a certain number. The player will recover life at a rate of half the number you add per second. You can also increment player.lifeRegenTime to increase the speed at which the player reaches its maximum natural life regeneration.
+		/// Allows you to increase the player's life regeneration based on its state. This can be done by incrementing Player.lifeRegen by a certain number. The player will recover life at a rate of half the number you add per second. You can also increment Player.lifeRegenTime to increase the speed at which the player reaches its maximum natural life regeneration.
 		/// </summary>
 		public virtual void UpdateLifeRegen() {
 		}
@@ -172,7 +172,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Use this to modify the control inputs that the player receives. For example, the Confused debuff swaps the values of player.controlLeft and player.controlRight. This is called sometime after PreUpdate is called.
+		/// Use this to modify the control inputs that the player receives. For example, the Confused debuff swaps the values of Player.controlLeft and Player.controlRight. This is called sometime after PreUpdate is called.
 		/// </summary>
 		public virtual void SetControls() {
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -127,14 +127,20 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// If you are storing AI information outside of the Projectile.ai array, use this to send that AI information between clients and servers.
+		/// If you are storing AI information outside of the Projectile.ai array, use this to send that AI information between clients and servers, which will be handled in <see cref="ReceiveExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncProjectile"/> is successfully sent, for example on projectile creation, or whenever Projectile.netUpdate is set to true in the update loop for that tick.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
 		/// </summary>
+		/// <param name="writer">The writer.</param>
 		public virtual void SendExtraAI(BinaryWriter writer) {
 		}
 
 		/// <summary>
-		/// Use this to receive information that was sent in SendExtraAI.
+		/// Use this to receive information that was sent in <see cref="SendExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncProjectile"/> is successfully received.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
 		/// </summary>
+		/// <param name="reader">The reader.</param>
 		public virtual void ReceiveExtraAI(BinaryReader reader) {
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -43,7 +43,7 @@ namespace Terraria.ModLoader
 		/// <summary> The file name of this projectile's glow texture file in the mod loader's file space. If it does not exist it is ignored. </summary>
 		public virtual string GlowTexture => Texture + "_Glow"; //TODO: this is wasteful. We should consider AutoStaticDefaults or something... requesting assets regularly is bad perf
 
-		/// <summary>  Shorthand for projectile.type; </summary>
+		/// <summary>  Shorthand for Projectile.type; </summary>
 		public int Type => Projectile.type;
 
 		public ModProjectile() {
@@ -127,7 +127,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// If you are storing AI information outside of the projectile.ai array, use this to send that AI information between clients and servers.
+		/// If you are storing AI information outside of the Projectile.ai array, use this to send that AI information between clients and servers.
 		/// </summary>
 		public virtual void SendExtraAI(BinaryWriter writer) {
 		}
@@ -148,8 +148,8 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Allows you to determine how this projectile interacts with tiles. Return false if you completely override or cancel this projectile's tile collision behavior. Returns true by default.
 		/// </summary>
-		/// <param name="width"> The width of the hitbox this projectile will use for tile collision. If vanilla doesn't modify it, defaults to projectile.width. </param>
-		/// <param name="height"> The height of the hitbox this projectile will use for tile collision. If vanilla doesn't modify it, defaults to projectile.height. </param>
+		/// <param name="width"> The width of the hitbox this projectile will use for tile collision. If vanilla doesn't modify it, defaults to Projectile.width. </param>
+		/// <param name="height"> The height of the hitbox this projectile will use for tile collision. If vanilla doesn't modify it, defaults to Projectile.height. </param>
 		/// <param name="fallThrough"> Whether or not this projectile falls through platforms and similar tiles. </param>
 		/// <param name="hitboxCenterFrac"> Determines by how much the tile collision hitbox's position (top left corner) will be offset from this projectile's real center. If vanilla doesn't modify it, defaults to half the hitbox size (new Vector2(0.5f, 0.5f)). </param>
 		/// <returns></returns>
@@ -158,7 +158,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to determine what happens when this projectile collides with a tile. OldVelocity is the velocity before tile collision. The velocity that takes tile collision into account can be found with projectile.velocity. Return true to allow the vanilla tile collision code to take place (which normally kills the projectile). Returns true by default.
+		/// Allows you to determine what happens when this projectile collides with a tile. OldVelocity is the velocity before tile collision. The velocity that takes tile collision into account can be found with Projectile.velocity. Return true to allow the vanilla tile collision code to take place (which normally kills the projectile). Returns true by default.
 		/// </summary>
 		/// <param name="oldVelocity">The velocity of the projectile upon collision.</param>
 		public virtual bool OnTileCollide(Vector2 oldVelocity) {
@@ -166,7 +166,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Return true or false to specify if the projectile can cut tiles, like vines. Return null for vanilla decision.
+		/// Return true or false to specify if the projectile can cut tiles like vines, pots, and Queen Bee larva. Return null for vanilla decision.
 		/// </summary>
 		public virtual bool? CanCutTiles() {
 			return null;
@@ -186,7 +186,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to control what happens when this projectile is killed (for example, creating dust or making sounds). Also useful for creating retrievable ammo. Called on all clients and the server in multiplayer, so be sure to use `if (projectile.owner == Main.myPlayer)` if you are spawning retrievable ammo. (As seen in ExampleJavelinProjectile)
+		/// Allows you to control what happens when this projectile is killed (for example, creating dust or making sounds). Also useful for creating retrievable ammo. Called on all clients and the server in multiplayer, so be sure to use `if (Projectile.owner == Main.myPlayer)` if you are spawning retrievable ammo. (As seen in ExampleJavelinProjectile)
 		/// </summary>
 		public virtual void Kill(int timeLeft) {
 		}
@@ -395,7 +395,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// When used in conjunction with "projectile.hide = true", allows you to specify that this projectile should be drawn behind certain elements. Add the index to one and only one of the lists. For example, the Nebula Arcanum projectile draws behind NPCs and tiles.
+		/// When used in conjunction with "Projectile.hide = true", allows you to specify that this projectile should be drawn behind certain elements. Add the index to one and only one of the lists. For example, the Nebula Arcanum projectile draws behind NPCs and tiles.
 		/// </summary>
 		public virtual void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI) {
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader.Core;
@@ -269,13 +270,19 @@ namespace Terraria.ModLoader
 		public virtual void LoadWorldData(TagCompound tag) { }
 
 		/// <summary>
-		/// Allows you to send custom data between clients and server. This is useful for syncing information such as bosses that have been defeated.
+		/// Allows you to send custom data between clients and server, which will be handled in <see cref="NetReceive"/>. This is useful for syncing information such as bosses that have been defeated.
+		/// <br/>Called whenever <see cref="MessageID.WorldData"/> is successfully sent, for example after a boss is defeated, a new day starts, or a player joins the server.
+		/// <br/>Only called on the server.
 		/// </summary>
+		/// <param name="writer">The writer.</param>
 		public virtual void NetSend(BinaryWriter writer) { }
 
 		/// <summary>
-		/// Allows you to do things with custom data that is received between clients and server.
+		/// Use this to receive information that was sent in <see cref="NetSend"/>.
+		/// <br/>Called whenever <see cref="MessageID.WorldData"/> is successfully received.
+		/// <br/>Only called on the client.
 		/// </summary>
+		/// <param name="reader">The reader.</param>
 		public virtual void NetReceive(BinaryReader reader) { }
 
 		/// <summary>


### PR DESCRIPTION
### Description
1. Expands `Mod/GlobalProjectile.CanCutTiles` docs with some commonly asked tiles it affects.
2. Fixes `ModItem/NPC/Player/Projectile` docs still referencing the lowercase property of the associated entity (changed early on in 1.4 tml), and just a general npc -> NPC conversion as it's an acronym. Motivation: I saw a handful of people do what the docs say literally and get errors due to capitalization (ModProjectile.DrawBehind for example).
3. Unifies `Netsend/Receive` and `Send/ReceiveExtraAI` docs and expands them with examples of when they are called and on what side.

The format I decided upon is the following:
```xml
/// <summary>
/// *generic description*, *corresponding other hook*
/// *when it is called*, *examples on send*
/// *on what side it can be called*
/// </summary>
```
