### PR TITLE
[1.4] dynamic item scalin' hook

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -113,6 +113,11 @@ namespace Terraria.ModLoader
 			return result;
 		}
 
+		public static void ModifyItemScale(Player player, Item item, ref float scale) {
+			ItemLoader.ModifyItemScale(item, player, ref scale);
+			PlayerLoader.ModifyItemScale(player, item, ref scale);
+		}
+
 		public static float TotalUseSpeedMultiplier(Player player, Item item) {
 			return PlayerLoader.UseSpeedMultiplier(player, item) * ItemLoader.UseSpeedMultiplier(item, player) * player.GetWeaponAttackSpeed(item);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -356,6 +356,18 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to dynamically modify the given item's size for the given player, similarly to the effect of the Titan Glove.
+		/// </summary>
+		/// <param name="item">The item to modify the scale of.</param>
+		/// <param name="player">The player wielding the given item.</param>
+		/// <param name="scale">
+		/// The scale multiplier to be applied to the given item.<br></br>
+		/// Will be 1.1 if the Titan Glove is equipped, and 1 otherwise.
+		/// </param>
+		public virtual void ModifyItemScale(Item item, Player player, ref float scale) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether a melee weapon can hit the given NPC when swung. Return true to allow hitting the target, return false to block the weapon from hitting the target, and return null to use the vanilla code for whether the target can be hit. Returns null by default.
 		/// </summary>
 		public virtual bool? CanHitNPC(Item item, Player player, NPC target) {

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -717,6 +717,20 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateModifyItemScale(Item item, Player player, ref float scale);
+		private static HookList HookModifyItemScale = AddHook<DelegateModifyItemScale>(g => g.ModifyItemScale);
+
+		/// <summary>
+		/// Calls <see cref="ModItem.ModifyItemScale"/> if applicable, then all applicable <see cref="GlobalItem.ModifyItemScale"/> instances.
+		/// </summary>
+		public static void ModifyItemScale(Item item, Player player, ref float scale) {
+			item.ModItem?.ModifyItemScale(player, ref scale);
+
+			foreach (var g in HookModifyItemScale.Enumerate(item.globalItems)) {
+				g.ModifyItemScale(item, player, ref scale);
+			}
+		}
+
 		private static HookList HookCanHitNPC = AddHook<Func<Item, Player, NPC, bool?>>(g => g.CanHitNPC);
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -425,6 +425,17 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to dynamically modify this item's size for the given player, similarly to the effect of the Titan Glove.
+		/// </summary>
+		/// <param name="player">The player wielding this item.</param>
+		/// <param name="scale">
+		/// The scale multiplier to be applied to this item.<br></br>
+		/// Will be 1.1 if the Titan Glove is equipped, and 1 otherwise.
+		/// </param>
+		public virtual void ModifyItemScale(Player player, ref float scale) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether this melee weapon can hit the given NPC when swung. Return true to allow hitting the target, return false to block this weapon from hitting the target, and return null to use the vanilla code for whether the target can be hit. Returns null by default.
 		/// </summary>
 		/// <param name="player">The player.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -501,6 +501,17 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to dynamically modify the given item's size for this player, similarly to the effect of the Titan Glove.
+		/// </summary>
+		/// <param name="item">The item to modify the scale of.</param>
+		/// <param name="scale">
+		/// The scale multiplier to be applied to the given item.<br></br>
+		/// Will be 1.1 if the Titan Glove is equipped, and 1 otherwise.
+		/// </param>
+		public virtual void ModifyItemScale(Item item, ref float scale) {
+		}
+
+		/// <summary>
 		/// This hook is called when a player damages anything, whether it be an NPC or another player, using anything, whether it be a melee weapon or a projectile. The x and y parameters are the coordinates of the victim parameter's center.
 		/// </summary>
 		/// <param name="x"></param>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -596,6 +596,15 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateModifyItemScale(Item item, ref float scale);
+		private static HookList HookModifyItemScale = AddHook<DelegateModifyItemScale>(p => p.ModifyItemScale);
+
+		public static void ModifyItemScale(Player player, Item item, ref float scale) {
+			foreach (int index in HookModifyItemScale.arr) {
+				player.modPlayers[index].ModifyItemScale(item, ref scale);
+			}
+		}
+
 		private static HookList HookOnHitAnything = AddHook<Action<float, float, Entity>>(p => p.OnHitAnything);
 
 		public static void OnHitAnything(Player player, float x, float y, Entity victim) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3892,6 +3892,15 @@
  			Main.instance.LoadItem(type);
  			if (type == 75)
  				return TextureAssets.Item[type].Frame(1, 8);
+@@ -30188,7 +_,7 @@
+ 			float num = item.scale;
+ 			if (item.melee && meleeScaleGlove)
+ 				num *= 1.1f;
+-
++			CombinedHooks.ModifyItemScale(this, item, ref num);
+ 			return num;
+ 		}
+ 
 @@ -30204,6 +_,12 @@
  		}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3892,7 +3892,7 @@
  			Main.instance.LoadItem(type);
  			if (type == 75)
  				return TextureAssets.Item[type].Frame(1, 8);
-@@ -30184,11 +_,19 @@
+@@ -30184,11 +_,20 @@
  			return TextureAssets.Item[type].Frame();
  		}
  
@@ -3908,7 +3908,7 @@
  			float num = item.scale;
  			if (item.melee && meleeScaleGlove)
  				num *= 1.1f;
--
+ 
 +			CombinedHooks.ModifyItemScale(this, item, ref num);
  			return num;
  		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3892,7 +3892,19 @@
  			Main.instance.LoadItem(type);
  			if (type == 75)
  				return TextureAssets.Item[type].Frame(1, 8);
-@@ -30188,7 +_,7 @@
+@@ -30184,11 +_,19 @@
+ 			return TextureAssets.Item[type].Frame();
+ 		}
+ 
++		/// <summary>
++		/// Used to determine what the overall scale of an item should be.<br></br>
++		/// <see cref="CombinedHooks.ModifyItemScale"/> is called here.
++		/// </summary>
++		/// <param name="item">The item to fetch the adjusted scale of.</param>
++		/// <returns>
++		/// The final scale of the item, after the Titan Glove effect and all modded calculations.
++		/// </returns>
+ 		public float GetAdjustedItemScale(Item item) {
  			float num = item.scale;
  			if (item.melee && meleeScaleGlove)
  				num *= 1.1f;


### PR DESCRIPTION
# IN WHICH
I allow the Titan Glove to be ripped off, because it's what the people want

## why does this exist?
a number of people (includin' myself in the future, quite frankly) have immediate use cases for bein' able to dynamically modify item scale, a feature for which tML currently has no support, and which has been demonstrated in vanilla by the Titan Glove

## changelog
- added the `ModifyItemScale` hook to `ModPlayer`, `GlobalItem`, and `ModItem`

that's it
that's the whole changelog
bye