### PR TITLE
[1.4] Fixed Traveling Merchant instantly spawning when time is frozen

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4588,21 +4588,23 @@
  						if (!NPC.downedSlimeKing)
  							num3 /= 2;
  
-@@ -50141,9 +_,14 @@
+@@ -50140,12 +_,14 @@
+ 					if (!dayTime || time > 48600.0)
  						WorldGen.UnspawnTravelNPC();
  				}
- 				else if (!fastForwardTime && dayTime && time < 27000.0) {
+-				else if (!fastForwardTime && dayTime && time < 27000.0) {
++				else if (!fastForwardTime && dayRate > 0 && dayTime && time < 27000.0) {
 +					/*
  					int num6 = dayRate;
  					if (num6 < 1)
  						num6 = 1;
 +					*/
-+					double num6 = dayRate;
-+					if (num6 < 0)
-+						num6 = 0;
  
- 					int num7 = (int)(27000.0 / (double)num6);
+-					int num7 = (int)(27000.0 / (double)num6);
++					int num7 = (int)(27000.0 / dayRate);
  					num7 *= 4;
+ 					if (rand.Next(num7) == 0) {
+ 						int num8 = 0;
 @@ -50505,6 +_,11 @@
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4588,23 +4588,25 @@
  						if (!NPC.downedSlimeKing)
  							num3 /= 2;
  
-@@ -50140,12 +_,14 @@
- 					if (!dayTime || time > 48600.0)
+@@ -50141,13 +_,17 @@
  						WorldGen.UnspawnTravelNPC();
  				}
--				else if (!fastForwardTime && dayTime && time < 27000.0) {
-+				else if (!fastForwardTime && dayRate > 0 && dayTime && time < 27000.0) {
+ 				else if (!fastForwardTime && dayTime && time < 27000.0) {
 +					/*
  					int num6 = dayRate;
  					if (num6 < 1)
  						num6 = 1;
-+					*/
  
 -					int num7 = (int)(27000.0 / (double)num6);
 +					int num7 = (int)(27000.0 / dayRate);
  					num7 *= 4;
  					if (rand.Next(num7) == 0) {
++					*/
++
++					if (rand.NextDouble() < dayRate / (27000.0 * 4))
  						int num8 = 0;
+ 						for (int j = 0; j < 200; j++) {
+ 							if (npc[j].active && npc[j].townNPC && npc[j].type != 37 && npc[j].type != 453)
 @@ -50505,6 +_,11 @@
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4602,7 +4602,7 @@
  					if (rand.Next(num7) == 0) {
 +					*/
 +
-+					if (rand.NextDouble() < dayRate / (27000.0 * 4))
++					if (rand.NextDouble() < dayRate / (27000.0 * 4)) {
  						int num8 = 0;
  						for (int j = 0; j < 200; j++) {
  							if (npc[j].active && npc[j].townNPC && npc[j].type != 37 && npc[j].type != 453)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4588,7 +4588,7 @@
  						if (!NPC.downedSlimeKing)
  							num3 /= 2;
  
-@@ -50141,13 +_,17 @@
+@@ -50141,6 +_,7 @@
  						WorldGen.UnspawnTravelNPC();
  				}
  				else if (!fastForwardTime && dayTime && time < 27000.0) {
@@ -4596,9 +4596,8 @@
  					int num6 = dayRate;
  					if (num6 < 1)
  						num6 = 1;
- 
--					int num7 = (int)(27000.0 / (double)num6);
-+					int num7 = (int)(27000.0 / dayRate);
+@@ -50148,6 +_,9 @@
+ 					int num7 = (int)(27000.0 / (double)num6);
  					num7 *= 4;
  					if (rand.Next(num7) == 0) {
 +					*/


### PR DESCRIPTION
This was originally an issue present in vanilla Terraria that got fixed, but said fix was commented out in a patch.

Now, when time is frozen, the Traveling Merchant can not spawn at all. This is not consistent with vanilla, but it was discussed that this would otherwise lead to unreasonable situations (e.g. Traveling Merchant being more likely to spawn when time is frozen than when time is slowed down). 