### PR TITLE
Better fix for Accidental Upload of Mod Source files

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -71,7 +71,7 @@ namespace Terraria.Social.Steam
 				// Publish by updating the files available on the current published version
 				workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
 
-				if (Directory.Exists(workshopFolderPath + "/bin"))
+				if (Directory.Exists(Path.Combine(workshopFolderPath, "bin")))
 					foreach (var fil in Directory.EnumerateFiles(workshopFolderPath))
 						File.Delete(fil);
 

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -71,9 +71,10 @@ namespace Terraria.Social.Steam
 				// Publish by updating the files available on the current published version
 				workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
 
+				// This eliminates uploaded mod source files that occured prior to the fix of #2263
 				if (Directory.Exists(Path.Combine(workshopFolderPath, "bin")))
-					foreach (var fil in Directory.EnumerateFiles(workshopFolderPath))
-						File.Delete(fil);
+					foreach (var sourceFile in Directory.EnumerateFiles(workshopFolderPath))
+						File.Delete(sourceFile);
 
 				if (new Version(buildData["version"].Replace("v", "")) <= new Version(existing.Version.Replace("v", ""))) {
 					IssueReporter.ReportInstantUploadProblem("tModLoader.ModVersionInfoUnchanged");

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -71,6 +71,10 @@ namespace Terraria.Social.Steam
 				// Publish by updating the files available on the current published version
 				workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
 
+				if (Directory.Exists(workshopFolderPath + "/bin"))
+					foreach (var fil in Directory.EnumerateFiles(workshopFolderPath))
+						File.Delete(fil);
+
 				if (new Version(buildData["version"].Replace("v", "")) <= new Version(existing.Version.Replace("v", ""))) {
 					IssueReporter.ReportInstantUploadProblem("tModLoader.ModVersionInfoUnchanged");
 					return false;


### PR DESCRIPTION
This PR patches WorkshopSocialModule for mod publishing to clean out all files if unexpected Mod Source files are found in the publish directory.

After this is merged, if any mod has the upload issue, they will need to republish on stable & preview accordingly.