### PR TITLE
Bring itemAnimation counter in line with itemTime and improve usage (item use rework proper impl)

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -78,7 +78,7 @@
  				weaponDrawOrder = WeaponDrawOrder.BehindBackArm;
  
 -			if (GolfHelper.IsPlayerHoldingClub(player) && player.itemAnimation > player.itemAnimationMax)
-+			if (GolfHelper.IsPlayerHoldingClub(player) && player.itemAnimation >= player.itemAnimationMax) // changed > to >= because of itemAnimation adjustment <PR#>.
++			if (GolfHelper.IsPlayerHoldingClub(player) && player.itemAnimation >= player.itemAnimationMax) // changed > to >= because of itemAnimation adjustment #2351
  				weaponDrawOrder = WeaponDrawOrder.OverFrontArm;
  
  			projectileDrawPosition = -1;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -73,7 +73,14 @@
  			seatYOffset = 0f;
  			sittingIndex = 0;
  			Vector2 posOffset = Vector2.Zero;
-@@ -209,10 +_,13 @@
+@@ -203,16 +_,19 @@
+ 			if (heldItem.type == 4952)
+ 				weaponDrawOrder = WeaponDrawOrder.BehindBackArm;
+ 
+-			if (GolfHelper.IsPlayerHoldingClub(player) && player.itemAnimation > player.itemAnimationMax)
++			if (GolfHelper.IsPlayerHoldingClub(player) && player.itemAnimation >= player.itemAnimationMax) // changed > to >= because of itemAnimation adjustment <PR#>.
+ 				weaponDrawOrder = WeaponDrawOrder.OverFrontArm;
+ 
  			projectileDrawPosition = -1;
  			ItemLocation = Position + (drawPlayer.itemLocation - drawPlayer.position);
  			armorAdjust = 0;

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -115,11 +115,14 @@ namespace Terraria
 			=> NewItem(source, (int)position.X, (int)position.Y, 0, 0, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
 		private void ApplyItemAnimationCompensations() {
+			// <PR#>
 			// Compensate for the change of itemAnimation getting reset at 0 instead of vanilla's 1.
-
+			// all items with autoReuse in vanilla are affected, but the animation only has a physical effect for !noMelee items
+			// for those items, we want the faster animation as that governs reuse time as dps is determined by swing speed.
+			// for the others like ranged weapons, it's fine to keep the animation matching the use time, as dps is determined by item use speed
 			currentUseAnimationCompensation = 0;
 
-			if (type < ItemID.Count && !noMelee) {
+			if (type < ItemID.Count && autoReuse && !noMelee) {
 				useAnimation--;
 				currentUseAnimationCompensation--;
 			}

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -115,7 +115,7 @@ namespace Terraria
 			=> NewItem(source, (int)position.X, (int)position.Y, 0, 0, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
 		private void ApplyItemAnimationCompensations() {
-			// <PR#>
+			// #2351
 			// Compensate for the change of itemAnimation getting reset at 0 instead of vanilla's 1.
 			// all items with autoReuse in vanilla are affected, but the animation only has a physical effect for !noMelee items
 			// for those items, we want the faster animation as that governs reuse time as dps is determined by swing speed.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -318,7 +318,7 @@ namespace Terraria.ModLoader
 		/// <br/> Returns whether or not the vanilla logic should be skipped.
 		/// </summary>
 		public static void HoldStyle(Item item, Player player, Rectangle heldItemFrame) {
-			if (item.IsAir || player.pulley || player.itemAnimation > 0)
+			if (item.IsAir || player.pulley || player.ItemAnimationActive)
 				return;
 
 			item.ModItem?.HoldStyle(player, heldItemFrame);
@@ -582,13 +582,6 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		/// <summary>
-		/// If the item is a modded item, ModItem.checkProjOnSwing is true, and the player is not at the beginning of the item's use animation, sets canShoot to false.
-		/// </summary>
-		public static bool CheckProjOnSwing(Player player, Item item) {
-			return item.ModItem == null || !item.ModItem.OnlyShootOnSwing || player.itemAnimation == player.itemAnimationMax - 1;
-		}
-
 		private delegate void DelegatePickAmmo(Item weapon, Item ammo, Player player, ref int type, ref float speed, ref int damage, ref float knockback);
 		private static HookList HookPickAmmo = AddHook<DelegatePickAmmo>(g => g.PickAmmo);
 
@@ -834,7 +827,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static bool? UseItem(Item item, Player player) {
 			if (item.IsAir)
-				return false;
+				return null;
 
 			bool? result = null;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -989,11 +989,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Setting this to true makes it so that this weapon can shoot projectiles only at the beginning of its animation. Set this to true if you want a sword and its projectile creation to be in sync (for example, the Terra Blade). Defaults to false.
-		/// </summary>
-		public virtual bool OnlyShootOnSwing => false;
-
-		/// <summary>
 		/// The type of NPC that drops this boss bag. Used to determine how many coins this boss bag contains. Defaults to 0, which means this isn't a boss bag.
 		/// </summary>
 		public virtual int BossBagNPC => 0;

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -465,12 +465,21 @@ namespace Terraria
 		}
 
 		/// <summary>
-		/// Helper method for modders to check if the player is able to autoswing (auto-reuse) an item.
-		/// <br>This checks item.autoReuse &amp;&amp; !player.noItems, and if Feral Claws effect applies to the item.</br>
-		/// <br>Additionally, any effects applied through the CanAutoReuseItem hooks.</br>
+		/// Returns true if an item animation is currently running.
 		/// </summary>
-		/// <param name="item">The item currently in use</param>
-		/// <returns>true if player can autoswing using the item</returns>
-		public bool ShouldAutoReuseItem(Item item) => TryAllowingItemReuse_Inner(item);
+		public bool ItemAnimationActive => itemAnimation > 0;
+
+		/// <summary>
+		/// Returns true if the item animation is on or after its last frame. Meaning it could (if the player clicks etc) start again next frame. <br/>
+		/// Vanilla uses it to despawn spears, but it's not recommended because it will desync in multiplayer <br/>
+		/// (a remote player could get the packet for a new projectile just as they're finishing a swing). <br/>
+		/// It is recommended to use ai counters for the lifetime of animation bound projectiles instead.
+		/// </summary>
+		public bool ItemAnimationEndingOrEnded => itemAnimation <= 1;
+
+		/// <summary>
+		/// Returns true if the item animation is in its first frame.
+		/// </summary>
+		public bool ItemAnimationJustStarted => itemAnimation == itemAnimationMax;
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3909,7 +3909,7 @@
  			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
  				controlUseItem = true;
  
-+			// <PR#>
++			// #2351
 +			// tML is motivated to bring the itemAnimation and itemTime counters to parity, fixing desync bugs with autoReuse items and providing clearer behaviour
 +			//
 +			// the flow of this method has changed as follows
@@ -4638,7 +4638,7 @@
  		private void ItemCheck_HandleMPItemAnimation(Item sItem) {
 +			// Firstly, in vanilla, autoReuse items go from itemAnimation == 1 to itemAnimationMax-1 here, skipping the frame where itemAnimation == 0
 +			//   this prevents the item flickering out while being auto-reused, and prevents other control inputs that can happen on that 'frame where item is not in use' like useTurn
-+			//   but has the side-effect that autoReuse items are one frame shorter. tML fixes the itemAnimation counter, see the comments near the top of ItemCheck_Inner (<PR#>)
++			//   but has the side-effect that autoReuse items are one frame shorter. tML fixes the itemAnimation counter, see the comments near the top of ItemCheck_Inner (#2351)
 +			//
 +			// Secondly, we don't need to play the shoot-sound and ensure hold-out animation looping for remote players because Shoot logic now runs remote side in tML (#ItemTimeOnAllClients)
 +
@@ -4820,11 +4820,11 @@
  				flag2 = true;
  
 -			if (sItem.type == 434 && itemAnimation < sItem.useAnimation - 2)
-+			// changed to ItemAnimationJustStarted for consistency <PR#>. Also applies to flamethrower and clentaminator below
++			// changed to ItemAnimationJustStarted for consistency #2351. Also applies to flamethrower and clentaminator below
 +			if (sItem.type == 434 && !ItemAnimationJustStarted)
  				flag2 = true;
  
-+			// changed > to >= because of itemAnimation adjustment <PR#>. Uses ammo on last arrow not first
++			// changed > to >= because of itemAnimation adjustment. Uses ammo on last arrow not first
 -			if (sItem.type == 4953 && itemAnimation > sItem.useAnimation - 8)
 +			if (sItem.type == 4953 && itemAnimation >= sItem.useAnimation - 8)
  				flag2 = true;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3905,14 +3905,14 @@
  			if (CCed) {
  				channel = false;
  				itemAnimation = (itemAnimationMax = 0);
-@@ -30216,6 +_,39 @@
+@@ -30216,6 +_,57 @@
  			if (Main.myPlayer == i && PlayerInput.ShouldFastUseItem)
  				controlUseItem = true;
  
-+			// https://github.com/tModLoader/tModLoader/pull/1437
++			// <PR#>
++			// tML is motivated to bring the itemAnimation and itemTime counters to parity, fixing desync bugs with autoReuse items and providing clearer behaviour
 +			//
-+			// Here's a map of vanilla's execution order compared to TML's
-+			//
++			// the flow of this method has changed as follows
 +			// VANILLA:
 +			// 1. Reuse delay is applied
 +			// 2. Item animation is applied if button is pressed
@@ -3920,27 +3920,45 @@
 +			// 4. Hold / Use styles are invoked
 +			// 5. 'releaseUseItem' is set
 +			// 6. Item time is reduced
-+			// 7. Item logic applies item time
-+			//
++			// 7. Item logic applies item time if (itemAnimation > 0 && itemTime == 0)
++			// 8. ItemCheck_GetMeleeHitbox/MeleeDamage/CutTiles if (itemAnimation > 0)
++			// 9. More item logic/and effects (consumables, teleportations) if (itemAnimation > 0)
++			// 
 +			// TML:
 +			// 1. Item animation is reduced
 +			// 2. Item time is reduced
 +			// 3. Reuse delay is applied
 +			// 4. Item animation is applied if button is pressed
-+			// 5. 'releaseUseItem' is set
-+			// 6. Item logic applies item time
-+			// 7. Hold / Use styles are invoked
++			// 5. Hold / Use styles are invoked
++			// 6. 'releaseUseItem' is set
++			// 7. Item logic applies item time if (itemAnimation > 0 && itemTime == 0)
++			// 8. ItemCheck_GetMeleeHitbox/MeleeDamage/CutTiles if (itemAnimation > 0)
++			// 9. More item logic/and effects (consumables, teleportations) if (itemAnimation > 0)
 +			//
-+			// Way more sane and way less confusing!
-+
-+			// Gotos are admittedly not the cleanest way of doing this but they're the most patch-friendly
-+			// TLDR: this moves the blocks responsible for decrementing itemTime and itemAnimation to the start of the method
-+			// This is done so that itemTime and itemAnimation cannot be decremented in the same tick as the one they're set in, which should fix a lot of use time issues
-+			// -- ThomasThePencil
++			// At the end of ItemCheck:
++			//   VANILLA: itemAnimation goes from itemAnimationMax-1 to 0, before it can restart
++			//   TML:     itemAnimation goes from itemAnimationMax to 1, before it can restart
++			//
++			//   VANILLA: If the item has autoReuse, then it can restart at itemAnimation = 1, making the actual animation one frame shorter than expected.
++			//            If a reusuable item has equal itemAnimation and itemTime, the animation will be faster, and they will start to fire at different times
++			//
++			//   TML:     ItemCheck_HandleMPItemAnimation unnecessary. Animation times for modded items as written. See Item.ApplyItemAnimationCompensations
++			//
++			//   VANILLA: All items which don't have autoReuse get 1 frame where itemAnimation == 0, this is often used to despawn projectiles
++			//   TML:     There will be no frame with itemAnimation == 0 if an item is 'reused immediately', via autoReuse, knockbackGlove, or perfect click timing.
++			//            bound projectiles should despawn in the frame of itemAnimation <= 1, after doing damage.
++			//            Player.ItemAnimationEndingOrEnded has been made for this purpose but its use is not recommended due to potential for multiplayer desync.
++			//            Better to have ai counters for projectile lifetime set to itemAnimationMax on spawn
++			//
++			//   VANILLA: hitbox calulation and duration is based on an itemAnimation value between itemAnimationMax-1 and 1, resulting in itemAnimationMax-1 frames of hitbox
++			//   TML:     hitbox lasts the same length as itemAnimation, slightly more backswing (rotation) in the first frame
++			//
++			//   VANILLA: itemTime goes from itemTimeMax to 1, before it can restart, 0 means not using item
++			//   TML:     no change
 +
 +			goto DecrementItemAnimation;
 +
-+			ItemCheckPart1:
++			ReuseDelayAndAnimationStart:
 +
  			ItemCheck_HandleMount();
  			int weaponDamage = GetWeaponDamage(item);
@@ -3978,20 +3996,20 @@
  			if (!controlUseItem)
  				channel = false;
  
-+			goto ItemCheckPart2;
++			goto HoldAndUseStyle;
 +
 +			DecrementItemAnimation:
 +
  			Item item2 = (itemAnimation > 0) ? lastVisualizedSelectedItem : item;
  			Rectangle drawHitbox = Item.GetDrawHitbox(item2.type, this);
  			compositeFrontArm.enabled = false;
-@@ -30289,12 +_,23 @@
+@@ -30289,12 +_,22 @@
  				itemAnimation--;
  			}
  
 +			goto DecrementItemTime;
 +
-+			HandleItemHolding:
++			HoldAndUseStyle:
 +
 +			ItemLoader.HoldItem(item, this);
 +
@@ -4000,25 +4018,21 @@
  			else
  				ItemCheck_ApplyHoldStyle(heightOffsetHitboxCenter, item2, drawHitbox);
  
--			releaseUseItem = !controlUseItem;
-+			//releaseUseItem = !controlUseItem;
-+			return; // This is the end of our spaghetti trip!
+ 			releaseUseItem = !controlUseItem;
++			goto ItemTimeUseItem;
 +
-+			// See the comment at DecrementItemAnimation for explanation
 +			DecrementItemTime:
 +
  			if (itemTime > 0) {
  				itemTime--;
  				if (ItemTimeIsZero && whoAmI == Main.myPlayer) {
-@@ -30308,11 +_,20 @@
+@@ -30308,37 +_,44 @@
  				}
  			}
  
-+			goto ItemCheckPart1;
++			goto ReuseDelayAndAnimationStart;
 +
-+			ItemCheckPart2:
-+
-+			releaseUseItem = !controlUseItem;
++			ItemTimeUseItem:
 +
  			if (!JustDroppedAnItem) {
  				ItemCheck_EmitHeldItemLight(item);
@@ -4031,13 +4045,43 @@
 +				if (true) { 
  					bool flag4 = true;
  					int type2 = item.type;
- 					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)
-@@ -30343,9 +_,13 @@
+-					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && itemAnimation != itemAnimationMax - 1)
++					if ((type2 == 65 || type2 == 676 || type2 == 723 || type2 == 724 || type2 == 757 || type2 == 674 || type2 == 675 || type2 == 989 || type2 == 1226 || type2 == 1227) && !ItemAnimationJustStarted)
+ 						flag4 = false;
+ 
+-					if (type2 == 5097 && itemAnimation == itemAnimationMax - 1)
++					if (type2 == 5097 && ItemAnimationJustStarted)
+ 						_batbatCanHeal = true;
+ 
+-					if (type2 == 5094 && itemAnimation == itemAnimationMax - 1)
++					if (type2 == 5094 && ItemAnimationJustStarted)
+ 						_spawnTentacleSpikes = true;
+ 
+ 					if (type2 == 3852) {
+-						if (itemAnimation < itemAnimationMax - 12)
++						if (itemAnimation <= itemAnimationMax - 12) // tML, change < to <= to account for counter change
+ 							flag4 = false;
+ 
+-						if (altFunctionUse == 2 && itemAnimation != itemAnimationMax - 1)
++						if (altFunctionUse == 2 && !ItemAnimationJustStarted)
+ 							flag4 = false;
+ 					}
+ 
+-					if (type2 == 4956 && itemAnimation < itemAnimationMax - 3 * item.useTime)
++					if (type2 == 4956 && itemAnimation <= itemAnimationMax - 3 * item.useTime) // tML, change < to <= to account for counter change
+ 						flag4 = false;
+ 
+-					if (type2 == 4952 && itemAnimation < itemAnimationMax - 8)
++					if (type2 == 4952 && itemAnimation <= itemAnimationMax - 8) // tML, change < to <= to account for counter change
+ 						flag4 = false;
+ 
+-					if (type2 == 4953 && itemAnimation < itemAnimationMax - 10)
++					if (type2 == 4953 && itemAnimation <= itemAnimationMax - 10) // tML, change < to <= to account for counter change
+ 						flag4 = false;
  
  					ItemCheck_TurretAltFeatureUse(item, flag4);
- 					ItemCheck_MinionAltFeatureUse(item, flag4);
--					if (item.shoot > 0 && itemAnimation > 0 && ItemTimeIsZero && flag4)
-+					if (item.shoot > 0 && itemAnimation > 0 && ItemTimeIsZero && flag4 && ItemLoader.CheckProjOnSwing(this, item))
+@@ -30346,6 +_,10 @@
+ 					if (item.shoot > 0 && itemAnimation > 0 && ItemTimeIsZero && flag4)
  						ItemCheck_Shoot(i, item, weaponDamage);
  
 +					// Added by TML. #ItemTimeOnAllClients - TODO: item time application with these item types
@@ -4187,15 +4231,6 @@
  							if (item.stack > 0)
  								item.stack--;
  
-@@ -30794,6 +_,8 @@
- 
- 			if (itemAnimation == 0)
- 				JustDroppedAnItem = false;
-+
-+			goto HandleItemHolding;
- 		}
- 
- 		private void ItemCheck_EmitFoodParticles(Item sItem) {
 @@ -31056,11 +_,18 @@
  				if (i == whoAmI || !player.active || !player.hostile || player.immune || player.dead || (team != 0 && team == player.team) || !itemRectangle.Intersects(player.Hitbox) || !CanHit(player))
  					continue;
@@ -4334,17 +4369,15 @@
  						if (tile.halfBrick()) {
  							WorldGen.PoundTile(x, y);
  							if (Main.netMode == 1)
-@@ -32586,8 +_,8 @@
- 				cursorItemIconEnabled = true;
- 				Main.ItemIconCacheUpdate(sItem.type);
+@@ -32777,7 +_,7 @@
+ 				}
  			}
--
--			if (!ItemTimeIsZero || itemAnimation <= 0 || !controlUseItem)
-+			// Stack size check added by TML. Works by coincidence in vanilla.
-+			if (!ItemTimeIsZero || itemAnimation <= 0 || !controlUseItem || sItem.stack <= 0)
- 				return;
  
- 			if (sItem.type == 205 || (sItem.type == 3032 && Main.tile[tileTargetX, tileTargetY].liquidType() == 0) || (sItem.type == 4872 && Main.tile[tileTargetX, tileTargetY].lava())) {
+-			if (sItem.type == 4715 && ((Main.mouseLeft && Main.mouseLeftRelease) | (itemAnimation == itemAnimationMax - 1))) {
++			if (sItem.type == 4715 && ((Main.mouseLeft && Main.mouseLeftRelease) | (ItemAnimationJustStarted))) {
+ 				Vector2 vector4 = new Vector2(position.X + (float)width * 0.5f, position.Y + (float)height * 0.5f);
+ 				float num13 = (float)Main.mouseX + Main.screenPosition.X - vector4.X;
+ 				float num14 = (float)Main.mouseY + Main.screenPosition.Y - vector4.Y;
 @@ -32914,7 +_,8 @@
  				}
  
@@ -4432,6 +4465,24 @@
  				KnockBack = GetWeaponKnockback(sItem, KnockBack);
  				IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  				if (projToShoot == 228)
+@@ -33192,7 +_,7 @@
+ 				Vector2 value = Vector2.UnitX.RotatedBy(fullRotation);
+ 				Vector2 vector = Main.MouseWorld - pointPoisition;
+ 				Vector2 v = itemRotation.ToRotationVector2() * direction;
+-				if (sItem.type == 3852 && itemAnimation != itemAnimationMax - 1)
++				if (sItem.type == 3852 && !ItemAnimationJustStarted)
+ 					vector = (v.ToRotation() + fullRotation).ToRotationVector2();
+ 
+ 				if (vector != Vector2.Zero)
+@@ -33241,7 +_,7 @@
+ 
+ 				float num2 = (float)Main.mouseX + Main.screenPosition.X - pointPoisition.X;
+ 				float num3 = (float)Main.mouseY + Main.screenPosition.Y - pointPoisition.Y;
+-				if (sItem.type == 3852 && itemAnimation != itemAnimationMax - 1) {
++				if (sItem.type == 3852 && !ItemAnimationJustStarted) {
+ 					Vector2 vector3 = vector;
+ 					num2 = vector3.X;
+ 					num3 = vector3.Y;
 @@ -33298,6 +_,13 @@
  					num3 = vector4.Y;
  				}
@@ -4554,7 +4605,7 @@
  		}
  
  		private bool ItemCheck_CheckCanUse(Item sItem) {
-+			if(sItem.IsAir || !CombinedHooks.CanUseItem(this, sItem))
++			if (sItem.IsAir || !CombinedHooks.CanUseItem(this, sItem))
 +				return false;
 +
  			int whoAmI = base.whoAmI;
@@ -4581,73 +4632,49 @@
  			if (sItem.type != 3269 && (!spaceGun || (sItem.type != 127 && sItem.type != 4347 && sItem.type != 4348))) {
  				if (statMana >= num) {
  					if (!flag2)
-@@ -36621,9 +_,19 @@
+@@ -36621,6 +_,13 @@
  		}
  
  		private void ItemCheck_HandleMPItemAnimation(Item sItem) {
-+			//return;
++			// Firstly, in vanilla, autoReuse items go from itemAnimation == 1 to itemAnimationMax-1 here, skipping the frame where itemAnimation == 0
++			//   this prevents the item flickering out while being auto-reused, and prevents other control inputs that can happen on that 'frame where item is not in use' like useTurn
++			//   but has the side-effect that autoReuse items are one frame shorter. tML fixes the itemAnimation counter, see the comments near the top of ItemCheck_Inner (<PR#>)
++			//
++			// Secondly, we don't need to play the shoot-sound and ensure hold-out animation looping for remote players because Shoot logic now runs remote side in tML (#ItemTimeOnAllClients)
 +
++			/*
  			if (sItem.autoReuse && !noItems) {
--				releaseUseItem = true;
-+				//releaseUseItem = true; // Now useless as per TryAllowingItemReuse -- direwolf420
-+
-+				// The following lines of code have been removed because of the change in how remote players' items now work in multiplayer.
-+				// Remote players used to simulate using the items by just playing pretty much guessed animations.
-+				// But now they instead run the logic the same way they would run locally, besides for authority-based exceptions.
-+				// -- Mirsario
-+
-+				/*
+ 				releaseUseItem = true;
  				if (itemAnimation == 1 && sItem.stack > 0) {
-+					itemAnimation = 0;
- 					if (sItem.shoot > 0 && whoAmI != Main.myPlayer && controlUseItem && sItem.useStyle == 5 && sItem.reuseDelay == 0) {
- 						ApplyItemAnimation(sItem);
- 						if (sItem.UseSound != null)
-@@ -36633,6 +_,7 @@
- 						itemAnimation = 0;
+@@ -36634,11 +_,14 @@
  					}
  				}
-+				*/
  			}
++			*/
  
  			TryAllowingItemReuse(sItem);
-@@ -36640,19 +_,44 @@
+ 		}
  
++		
  		private void TryAllowingItemReuse(Item sItem) {
++			/*
  			bool flag = false;
-+
-+			flag = TryAllowingItemReuse_Inner(sItem);
-+
-+			// _Inner code changed to utilize conditions from ItemCheck_HandleMPItemAnimation.
-+			// Now the previous assignment inside that method is useless and thus commented out
-+			if (flag)
-+				releaseUseItem = true;
-+		}
-+
-+		private bool TryAllowingItemReuse_Inner(Item sItem) {
-+			// Split into _Inner because it is used by ShouldAutoReuseItem 
-+			bool flag = false;
-+
-+			bool? allow = CombinedHooks.CanAutoReuseItem(this, sItem);
-+			if (allow.HasValue) {
-+				if (allow.Value) {
-+					return !noItems; // Even if forced to true, respect noItems (Cursed debuff)
-+				}
-+
-+				return false;
-+			}
-+
-+			flag |= sItem.autoReuse && !noItems; // Conditions taken from ItemCheck_HandleMPItemAnimation
-+
  			if (autoReuseGlove) {
  				flag |= sItem.melee;
--				flag |= (sItem.summon && ItemID.Sets.SummonerWeaponThatScalesWithAttackSpeed[sItem.type]);
-+				//flag |= (sItem.summon && ItemID.Sets.SummonerWeaponThatScalesWithAttackSpeed[sItem.type]);
-+				flag |= sItem.DamageType == DamageClass.SummonMeleeSpeed;
+@@ -36646,13 +_,23 @@
  			}
  
--			if (flag)
--				releaseUseItem = true;
-+			return flag;
+ 			if (flag)
++			*/
++			if (CanAutoReuseItem(sItem))
+ 				releaseUseItem = true;
++		}
++
++		public bool CanAutoReuseItem(Item sItem) {
++			if (CombinedHooks.CanAutoReuseItem(this, sItem) is bool autoReuse)
++				return autoReuse;
++
++			return sItem.autoReuse || autoReuseGlove && (sItem.DamageType == DamageClass.Melee || sItem.DamageType == DamageClass.SummonMeleeSpeed);
  		}
  
  		private void ItemCheck_HandleMount() {
@@ -4788,39 +4815,35 @@
  			bool flag2 = dontConsume;
  			if (sItem.type == 3475 && Main.rand.Next(3) != 0)
  				flag2 = true;
-@@ -37208,10 +_,15 @@
+@@ -37208,10 +_,12 @@
  			if (sItem.type == 1553 && Main.rand.Next(3) != 0)
  				flag2 = true;
  
-+			// Clockwork Assault Rifle.
-+			// The offset of '-2' doesn't quite matter. The goal is to only use ammo on the first shot.
 -			if (sItem.type == 434 && itemAnimation < sItem.useAnimation - 2)
-+			//if (sItem.type == 434 && itemAnimation < sItem.useAnimation - 2)
-+			if (sItem.type == 434 && itemAnimation < itemAnimationMax)
++			// changed to ItemAnimationJustStarted for consistency <PR#>. Also applies to flamethrower and clentaminator below
++			if (sItem.type == 434 && !ItemAnimationJustStarted)
  				flag2 = true;
  
-+			// Same as above.
++			// changed > to >= because of itemAnimation adjustment <PR#>. Uses ammo on last arrow not first
 -			if (sItem.type == 4953 && itemAnimation > sItem.useAnimation - 8)
-+			//if (sItem.type == 4953 && itemAnimation > sItem.useAnimation - 8)
-+			if (sItem.type == 4953 && itemAnimation < itemAnimationMax)
++			if (sItem.type == 4953 && itemAnimation >= sItem.useAnimation - 8)
  				flag2 = true;
  
  			if (huntressAmmoCost90 && Main.rand.Next(10) == 0)
-@@ -37226,13 +_,20 @@
+@@ -37226,13 +_,17 @@
  			if (ammoCost75 && Main.rand.Next(4) == 0)
  				flag2 = true;
  
-+			// Flamethrower.
-+			// Pre 1.4.3.4: -6 -> -5
-+			// Post 1.4.3.4: -2 -> -2
- 			if (projToShoot == 85 && itemAnimation < itemAnimationMax - 2)
+-			if (projToShoot == 85 && itemAnimation < itemAnimationMax - 2)
++			if (projToShoot == 85 && !ItemAnimationJustStarted)
  				flag2 = true;
  
- 			if ((projToShoot == 145 || projToShoot == 146 || projToShoot == 147 || projToShoot == 148 || projToShoot == 149) && itemAnimation < itemAnimationMax - 5)
+-			if ((projToShoot == 145 || projToShoot == 146 || projToShoot == 147 || projToShoot == 148 || projToShoot == 149) && itemAnimation < itemAnimationMax - 5)
++			if ((projToShoot == 145 || projToShoot == 146 || projToShoot == 147 || projToShoot == 148 || projToShoot == 149) && !ItemAnimationJustStarted)
  				flag2 = true;
- 
-+			flag2 |= !CombinedHooks.CanConsumeAmmo(this, sItem, item);
 +
++			flag2 |= !CombinedHooks.CanConsumeAmmo(this, sItem, item);
+ 
  			if (!flag2 && item.consumable) {
 +				CombinedHooks.OnConsumeAmmo(this, sItem, item);
 +

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -859,6 +859,38 @@
  								int num = damage;
  								position = base.Center;
  								int num2 = 0;
+@@ -29210,7 +_,7 @@
+ 			if (flag2 && player.channel && player.itemAnimation < num)
+ 				player.SetDummyItemTime(num);
+ 
+-			if (player.itemAnimation == 0)
++			if (player.ItemAnimationEndingOrEnded)
+ 				Kill();
+ 
+ 			rotation = (float)Math.Atan2(velocity.Y, velocity.X) + (float)Math.PI / 2f + (float)Math.PI / 4f;
+@@ -29480,7 +_,7 @@
+ 				ai[1] += 1f;
+ 			}
+ 
+-			if (Main.player[owner].itemAnimation == 0)
++			if (Main.player[owner].ItemAnimationEndingOrEnded)
+ 				Kill();
+ 
+ 			rotation = (float)Math.Atan2(velocity.Y, velocity.X) + 2.355f;
+@@ -30381,8 +_,11 @@
+ 			}
+ 
+ 			player.heldProj = whoAmI;
++
++			// causes projectile to be duped with <PR#> because tML makes reuse start at itemAnimation == 1
++			// could fix the calculation to `player.itemAnimationMax - (int)((ai[0] - 1) / MaxUpdates);` but the code doesn't do anything useful (even in vanilla)
+-			player.itemAnimation = player.itemAnimationMax - (int)(ai[0] / (float)MaxUpdates);
++			// player.itemAnimation = player.itemAnimationMax - (int)(ai[0] / MaxUpdates);
+-			player.itemTime = player.itemAnimation;
++			// player.itemTime = player.itemAnimation;
+ 			if (ai[0] == (float)(int)(timeToFlyOut / 2f)) {
+ 				WhipPointsForCollision.Clear();
+ 				FillWhipControlPoints(this, WhipPointsForCollision);
 @@ -33091,6 +_,9 @@
  					if (num3 > (float)num9)
  						ai[0] = 1f;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -882,7 +882,7 @@
  
  			player.heldProj = whoAmI;
 +
-+			// causes projectile to be duped with <PR#> because tML makes reuse start at itemAnimation == 1
++			// causes projectile to be duped with #2351 because tML makes reuse start at itemAnimation == 1
 +			// could fix the calculation to `player.itemAnimationMax - (int)((ai[0] - 1) / MaxUpdates);` but the code doesn't do anything useful (even in vanilla)
 -			player.itemAnimation = player.itemAnimationMax - (int)(ai[0] / (float)MaxUpdates);
 +			// player.itemAnimation = player.itemAnimationMax - (int)(ai[0] / MaxUpdates);


### PR DESCRIPTION
The item use rework (#1437) had noble goals, but lacked research into the full vanilla mechanics and ramifications. This PR is a proper implementation of it, heavy on documentation and bugfixes.

This PR solves or supercedes or reimplements the bugfixes in:
- #2329
- #1821 
- #1774 
- #2126
- #2300 
- #2308 
- #1654
- #1767
- #1721

# What's the goal?
In vanilla, `Player.itemAnimation` runs from `Player.itemAnimationMax - 1` on the first frame (the value from `Item.useAnimation`) down to 0 and then resets. 
During the frame where `itemAnimation == 0` the item is not considered 'in use', it will not be drawn, and will not lock the player out of performing various actions (like turning around).

The `Item.autoReuse` flag causes the '0 frame' to be skipped in vanilla, shortening the animation by 1 frame. This results in a desync between the swing (`itemAnimation`) and use (`itemTime`) when items have `itemAnimation == itemTime`, as well as dps underestimates, and makes animation and use time scaling hooks difficult.

All in all, the behaviour has confusing gotchas and bugs.

# The solution
tML changes `itemAnimation` to count from `itemAnimationMax` down to `1` before it can either go unused (0) or be reused (set back to `itemAnimationMax`. See the table below for an example of a hypothetical item with `useTime = useAnimation = 5`

#### player clicks on frame 1 and 6, item does not have autoReuse
Note in vanilla, the animation is considered 'inactive' in frame 5 and 10, but the duration before reuse is correct (5 frames)
```
                Vanilla                        tML
frame:   itemAnimation   itemTime       itemAnimation   itemTime
1        0->5->4         0->5           0->5            0->5    
2        4->3            5->4           5->4            5->4
3        3->2            4->3           4->3            4->3
4        2->1            3->2           3->2            3->2
5        1->0            2->1           2->1            2->1
6        0->5->4         1->0->5        1->0->5         1->0->5
7        4->3            5->4           5->4            5->4
8        3->2            4->3           4->3            4->3
9        2->1            3->2           3->2            3->2
10       1->0            2->1           2->1            2->1
11       0               1->0           1->0            1->0
```
#### player clicks on frame 1 and holds till frame 10, item does have autoReuse
Note in vanilla, the animation loops every 4 frames. The itemTime (firing of a projectile for eg) desyncs.
```
                Vanilla                        tML
frame:   itemAnimation   itemTime       itemAnimation   itemTime
1        0->5->4         0->5           0->5            0->5    
2        4->3            5->4           5->4            5->4
3        3->2            4->3           4->3            4->3
4        2->1            3->2           3->2            3->2
5        1->0->5->4      2->1           2->1            2->1
6        4->3            1->0->5        1->0->5         1->0->5
7        3->2            5->4           5->4            5->4
8        2->1            4->3           4->3            4->3
9        1->0->5->4      3->2           3->2            3->2
10       4->3            2->1           2->1            2->1
11       3->2            1->0->5        1->0            1->0
12       2->1            5->4           0               0
13       1->0            4->3           0               0
```

## The code-level changes
```
the flow of the ItemCheck method has changed as follows
VANILLA:
1. Reuse delay is applied
2. Item animation is applied if button is pressed
3. Item animation is reduced
4. Hold / Use styles are invoked
5. 'releaseUseItem' is set
6. Item time is reduced
7. Item logic applies item time if (itemAnimation > 0 && itemTime == 0)
8. ItemCheck_GetMeleeHitbox/MeleeDamage/CutTiles if (itemAnimation > 0)
9. More item logic/and effects (consumables, teleportations) if (itemAnimation > 0)

TML:
1. Item animation is reduced
2. Item time is reduced
3. Reuse delay is applied
4. Item animation is applied if button is pressed
5. Hold / Use styles are invoked
6. 'releaseUseItem' is set
7. Item logic applies item time if (itemAnimation > 0 && itemTime == 0)
8. ItemCheck_GetMeleeHitbox/MeleeDamage/CutTiles if (itemAnimation > 0)
9. More item logic/and effects (consumables, teleportations) if (itemAnimation > 0)

At the end of ItemCheck:
  VANILLA: itemAnimation goes from itemAnimationMax-1 to 0, before it can restart
  TML:     itemAnimation goes from itemAnimationMax to 1, before it can restart

  VANILLA: If the item has autoReuse, then it can restart at itemAnimation = 1, making the actual animation one frame shorter than expected.
           If a reusuable item has equal itemAnimation and itemTime, the animation will be faster, and they will start to fire at different times

  TML:     ItemCheck_HandleMPItemAnimation unnecessary. Animation times for modded items as written. See Item.ApplyItemAnimationCompensations

  VANILLA: All items which don't have autoReuse get 1 frame where itemAnimation == 0, this is often used to despawn projectiles
  TML:     There will be no frame with itemAnimation == 0 if an item is 'reused immediately', via autoReuse, knockbackGlove, or perfect click timing.
           bound projectiles should despawn in the frame of itemAnimation <= 1, after doing damage.
           Player.ItemAnimationEndingOrEnded has been made for this purpose but its use is not recommended due to potential for multiplayer desync.
           Better to have ai counters for projectile lifetime set to itemAnimationMax on spawn

  VANILLA: hitbox calulation and duration is based on an itemAnimation value between itemAnimationMax-1 and 1, resulting in itemAnimationMax-1 frames of hitbox
  TML:     hitbox lasts the same length as itemAnimation, slightly more backswing (rotation) in the first frame

  VANILLA: itemTime goes from itemTimeMax to 1, before it can restart, 0 means not using item
  TML:     no change
```

## Other changes
- `ItemLoader.UseItem` now returns `null` instead of `false` if the item is air (because vanilla has decremented the stack in the process of using the item). Cancelling the item time (by returning `null`) led to bucket dupe bug
- Spears AI uses `ItemAnimationEndingOrEnded` to despawn, but read the notes on this method, it's not recommended
- Whip dupe bug fixed by removing some unnecessary logic which was controlling the `itemAnimation` timer
- Items which can only shoot on certain frames (eventide, zenith, Tome of Infinite Wisdom etc adjusted conditions to offset the frame by 1
- Items which shoot multiple times but only consume ammo once adjusted to make sure ammo is consumed at the right time
- auto-reuse logic simplified and made consistent between hook, accessory and `Item.autoReuse`
- No need for `ItemCheck_HandleMPItemAnimation` anymore

## Porting notes
`Player.itemAnimation` counts from `itemAnimationMax` to `1`, take note if you're coming from 1.3
`ModItem.OnlyShootOnSwing` -> unnecessary, just make `item.useAnimation` dividable by `item.useTime`
`Player.ShouldAutoReuseItem` -> `Player.CanAutoReuseItem`
`Player.itemAnimation == 0` -> `ItemAnimationActive` or `ItemAnimationEndingOrEnded` (read the docs on the difference!)
`Player.itemAnimation == itemAnimationMax - 1` -> `Player.ItemAnimationJustStarted`
Check all your `itemAnimation` comparisons if you have frame-sensitive logic like ammo consumption for multi-shot weapons

