### PR TITLE
Fixes #2194 fully. Part 2 of High DPI to fix windows detection

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -374,16 +374,6 @@
  					break;
  				case GraphicsProfile.Reach:
  					maxScreenW = 1920;
-@@ -2861,6 +_,9 @@
- 					break;
- 			}
- 
-+			maxScreenW = Math.Min(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Width, maxScreenW);
-+			maxScreenH = Math.Min(graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height, maxScreenH);
-+
- 			try {
- 				graphics.ApplyChanges();
- 			}
 @@ -2870,8 +_,8 @@
  					SetGraphicsProfileInternal();
  				}

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -129,6 +129,13 @@ namespace Terraria
 			if (isServer)
 				return;
 
+			if (Platform.IsWindows) {
+				[System.Runtime.InteropServices.DllImport("user32.dll")]
+				static extern bool SetProcessDPIAware();
+
+				SetProcessDPIAware();
+			}
+
 			SDL2.SDL.SDL_VideoInit(null);
 			SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
 			if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold)


### PR DESCRIPTION
The second part of the High DPI fix series, 

This PR fixes windows detection of high dpi coming from DPI Scaling Level in display settings.
This is a windows bug, so the fix involves windows only code.