### PR TITLE
[1.4] fixed targeting reticule being absent for whips

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -66,6 +66,8 @@ namespace Terraria.ModLoader
 			return StatInheritanceData.None;
 		}
 
+		public override bool GetEffectInheritance(DamageClass damageClass) => damageClass == Summon;
+
 		public override bool UseStandardCritCalcs => false;
 
 		public override bool ShowStatTooltipLine(Player player, string lineName) => lineName != "CritChance";
@@ -81,6 +83,8 @@ namespace Terraria.ModLoader
 
 			return StatInheritanceData.None;
 		}
+
+		public override bool GetEffectInheritance(DamageClass damageClass) => damageClass == Magic || damageClass == Summon;
 	}
 
 	public class ThrowingDamageClass : VanillaDamageClass


### PR DESCRIPTION
**hi**
I didn't expect to touch damage classes again, but apparently, I overlooked some stuff in the initial go-arounds

**the bug:** the targetin' reticule used for whips doesn't currently show up due to `SummonMeleeSpeed` not benefitin' from summon effects
**the fix:** `SummonMeleeSpeed` now triggers summon effects accordingly, allowin' the targetin' reticule to show up again
**are there alternative fixes?** technically, this could be done with a manual check for `thing.DamageType == DamageClass.SummonMeleeSpeed`, but, and hear me out here: that's fuckin' dumb

also, while I'm here, I took the liberty of fixin' MagicSummonHybrid (used solely for Forbidden armor's set bonus) not bein' able to proc magic or summon effects