### PR TITLE
[1.4] Example Chest Opening Sound Fix

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -168,12 +168,12 @@ namespace ExampleMod.Content.Tiles.Furniture
 							SoundEngine.PlaySound(SoundID.MenuClose);
 						}
 						else {
+							SoundEngine.PlaySound(player.chest < 0 ? SoundID.MenuOpen : SoundID.MenuTick);
 							player.chest = chest;
 							Main.playerInventory = true;
 							Main.recBigList = false;
 							player.chestX = left;
 							player.chestY = top;
-							SoundEngine.PlaySound(player.chest < 0 ? SoundID.MenuOpen : SoundID.MenuTick);
 						}
 
 						Recipe.FindRecipes();


### PR DESCRIPTION
Back again with a 1 line PR (or is this 0 lines?).

### What are the changes to ExampleMod?

Currently, the Example Chest never plays the MenuOpen sound and always plays the MenuTick sound, even if the player isn't currently looking in a chest. The MenuTick sound should only be played if the player is already looking in a chest.

Here is a video demonstrating the bug. On the left is a vanilla chest, on the right is the Example Chest. Notice how the MenuOpen sound is never played when opening the Example Chest.

https://user-images.githubusercontent.com/11262234/167707626-da1df0fd-0da7-4c3a-b079-ac8912ac9ebf.mp4



This PR fixes the Example Chest opening sound by moving the `Playsound` line to before the `player.chest`. The `Playsound` needs to happen before the `player.chest` is assigned. Otherwise, `player.chest` will never be -1.

### Do these changes need additional documentation?
No



