### PR TITLE
[1.4] Switch from preprocessor to runtime os checking for file deletion

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -487,7 +487,26 @@
  			try {
  				string text = PlayerList[i].Path.Substring(0, PlayerList[i].Path.Length - 4);
  				if (text.Substring(text.Length - 1) != "." && text.Substring(text.Length - 1) != "\\" && Directory.Exists(text))
-@@ -3735,6 +_,7 @@
+@@ -3720,21 +_,23 @@
+ 		private static void EraseWorld(int i) {
+ 			try {
+ 				if (!WorldList[i].IsCloudSave) {
+-#if WINDOWS
++					if (OperatingSystem.IsWindows()) {
+ 					FileOperationAPIWrapper.MoveToRecycleBin(WorldList[i].Path);
+ 					FileOperationAPIWrapper.MoveToRecycleBin(WorldList[i].Path + ".bak");
+ 					for (int j = 2; j <= 9; j++) {
+ 						FileOperationAPIWrapper.MoveToRecycleBin(WorldList[i].Path + ".bak" + j);
+ 					}
+-#else
++					}
++					else {
+ 					File.Delete(Main.WorldList[i].Path);
+ 					File.Delete(Main.WorldList[i].Path + ".bak");
+-#endif
++					}
+ 				}
+ 				else if (SocialAPI.Cloud != null) {
  					SocialAPI.Cloud.Delete(WorldList[i].Path);
  				}
  

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -488,13 +488,14 @@ namespace Terraria.ModLoader.IO
 		internal static void EraseWorld(string path, bool cloudSave) {
 			path = Path.ChangeExtension(path, ".twld");
 			if (!cloudSave) {
-#if WINDOWS
-				FileOperationAPIWrapper.MoveToRecycleBin(path);
-				FileOperationAPIWrapper.MoveToRecycleBin(path + ".bak");
-#else
-				File.Delete(path);
-				File.Delete(path + ".bak");
-#endif
+				if (OperatingSystem.IsWindows()) {
+					FileOperationAPIWrapper.MoveToRecycleBin(path);
+					FileOperationAPIWrapper.MoveToRecycleBin(path + ".bak");
+				}
+				else {
+					File.Delete(path);
+					File.Delete(path + ".bak");
+				}
 			}
 			else if (SocialAPI.Cloud != null) {
 				SocialAPI.Cloud.Delete(path);

--- a/patches/tModLoader/Terraria/Utilities/FileOperationAPIWrapper.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileOperationAPIWrapper.cs.patch
@@ -1,0 +1,28 @@
+--- src/TerrariaNetCore/Terraria/Utilities/FileOperationAPIWrapper.cs
++++ src/tModLoader/Terraria/Utilities/FileOperationAPIWrapper.cs
+@@ -1,9 +_,10 @@
+-#if WINDOWS
+ using System;
+ using System.Runtime.InteropServices;
++using System.Runtime.Versioning;
+ 
+ namespace Terraria.Utilities
+ {
++	[SupportedOSPlatform("windows")]
+ 	public static class FileOperationAPIWrapper
+ 	{
+ 		[Flags]
+@@ -25,7 +_,7 @@
+ 			FO_RENAME
+ 		}
+ 
+-		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 1)]
++		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+ 		private struct SHFILEOPSTRUCT
+ 		{
+ 			public IntPtr hwnd;
+@@ -79,4 +_,3 @@
+ 		private static bool DeleteCompletelySilent(string path) => DeleteFile(path, FileOperationFlags.FOF_SILENT | FileOperationFlags.FOF_NOCONFIRMATION | FileOperationFlags.FOF_NOERRORUI);
+ 	}
+ }
+-#endif

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -1,0 +1,19 @@
+--- src/TerrariaNetCore/Terraria/Utilities/FileUtilities.cs
++++ src/tModLoader/Terraria/Utilities/FileUtilities.cs
+@@ -20,14 +_,10 @@
+ 		public static void Delete(string path, bool cloud, bool forceDeleteFile = false) {
+ 			if (cloud && SocialAPI.Cloud != null)
+ 				SocialAPI.Cloud.Delete(path);
+-			else if (forceDeleteFile)
+-				File.Delete(path);
+-			else
+-#if WINDOWS
++			else if (!forceDeleteFile && OperatingSystem.IsWindows())
+ 				FileOperationAPIWrapper.MoveToRecycleBin(path);
+-#else
++			else
+ 				File.Delete(path);
+-#endif
+ 		}
+ 
+ 		public static string GetFullPath(string path, bool cloud) {


### PR DESCRIPTION
### What is the bug?

#2313 : Hardmode Players no longer end up in recycle bin

### How did you fix the bug?

Switch from using preprocessor `#if WINDOWS` to runtime OS checks. Doing so also revealed a `System.AccessViolationException` when attempting to delete the files. According to https://stackoverflow.com/a/17648641, the struct should be aligned but not packed. Removing `Pack = 1` allowed deletion to work properly.

### Are there alternatives to your fix?

Not many. Specifically since we want to delete to the recycle bin without showing a dialog, we can't rely on the .NET function `FileSystem.DeleteFile` as it _will_ show error dialogs. We need to rely on the existing `FileOperationAPIWrapper.cs` for this behavior. `SHFILEOperation` is deprecated as of Windows Vista, but there's no need to expand this PR by updating it.