### PR TITLE
Player.GetWeaponKnockback improvements

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4473,19 +4473,21 @@
  				grappling[0] = -1;
  				grapCount = 0;
  				for (int j = 0; j < 1000; j++) {
-@@ -33160,6 +_,12 @@
+@@ -33160,7 +_,13 @@
  			}
  
  			if (canShoot) {
+-				KnockBack = GetWeaponKnockback(sItem, KnockBack);
 +				// Added by TML. #ItemTimeOnAllClients
 +				if (whoAmI != Main.myPlayer) {
 +					ApplyItemTime(sItem);
 +					return;
 +				}
 +
- 				KnockBack = GetWeaponKnockback(sItem, KnockBack);
++				//KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: second call removed due to GetWeaponKnockback now working differently
  				IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  				if (projToShoot == 228)
+ 					KnockBack = 0f;
 @@ -33192,7 +_,7 @@
  				Vector2 value = Vector2.UnitX.RotatedBy(fullRotation);
  				Vector2 vector = Main.MouseWorld - pointPoisition;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4465,11 +4465,10 @@
  
  			bool canShoot = false;
  			int Damage = weaponDamage;
--			float KnockBack = sItem.knockBack;
--			if (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331) {
-+			float KnockBack = GetWeaponKnockback(sItem, sItem.knockBack); // sItem.knockBack;
+ 			float KnockBack = sItem.knockBack;
 +
 +			// WhoAmI check added by TML. #ItemTimeOnAllClients
+-			if (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331) {
 +			if (whoAmI == Main.myPlayer && (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331)) {
  				grappling[0] = -1;
  				grapCount = 0;
@@ -4485,7 +4484,7 @@
 +					return;
 +				}
 +
-+				//KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: call moved earlier in method
++				KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: call moved earlier in method
  				IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  				if (projToShoot == 228)
  					KnockBack = 0f;
@@ -4718,10 +4717,15 @@
  					if (buffType[i] == 27 || buffType[i] == 101 || buffType[i] == 102) {
  						DelBuff(i);
  						i--;
-@@ -36974,6 +_,7 @@
+@@ -36973,7 +_,11 @@
+ 			}
  		}
  
- 		public float GetWeaponKnockback(Item sItem, float KnockBack) {
++		// tML-specific overload that exists for consistency with other GetWeaponXYZ methods
++		public float GetWeaponKnockback(Item sItem) => GetWeaponKnockback(sItem, sItem.knockBack);
++
+-		public float GetWeaponKnockback(Item sItem, float KnockBack) {
++		public float GetWeaponKnockback(Item sItem, float baseKnockback) {
 +			/*
  			if (sItem.summon)
  				KnockBack += minionKB;
@@ -4735,7 +4739,7 @@
 -			return KnockBack;
 +			StatModifier modifier = GetTotalKnockback(sItem.DamageType);
 +			CombinedHooks.ModifyWeaponKnockback(this, sItem, ref modifier);
-+			return Math.Max(0f, modifier.ApplyTo(sItem.knockBack));
++			return Math.Max(0f, modifier.ApplyTo(baseKnockback));
  		}
  
  		public int GetWeaponCrit(Item sItem) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4465,10 +4465,11 @@
  
  			bool canShoot = false;
  			int Damage = weaponDamage;
- 			float KnockBack = sItem.knockBack;
+-			float KnockBack = sItem.knockBack;
+-			if (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331) {
++			float KnockBack = GetWeaponKnockback(sItem, sItem.knockBack); // sItem.knockBack;
 +
 +			// WhoAmI check added by TML. #ItemTimeOnAllClients
--			if (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331) {
 +			if (whoAmI == Main.myPlayer && (projToShoot == 13 || projToShoot == 32 || projToShoot == 315 || (projToShoot >= 230 && projToShoot <= 235) || projToShoot == 331)) {
  				grappling[0] = -1;
  				grapCount = 0;
@@ -4484,7 +4485,7 @@
 +					return;
 +				}
 +
-+				//KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: second call removed due to GetWeaponKnockback now working differently
++				//KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: call moved earlier in method
  				IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  				if (projToShoot == 228)
  					KnockBack = 0f;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4473,21 +4473,19 @@
  				grappling[0] = -1;
  				grapCount = 0;
  				for (int j = 0; j < 1000; j++) {
-@@ -33160,7 +_,13 @@
+@@ -33160,6 +_,12 @@
  			}
  
  			if (canShoot) {
--				KnockBack = GetWeaponKnockback(sItem, KnockBack);
 +				// Added by TML. #ItemTimeOnAllClients
 +				if (whoAmI != Main.myPlayer) {
 +					ApplyItemTime(sItem);
 +					return;
 +				}
 +
-+				KnockBack = GetWeaponKnockback(sItem, KnockBack); // tML: call moved earlier in method
+ 				KnockBack = GetWeaponKnockback(sItem, KnockBack);
  				IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  				if (projToShoot == 228)
- 					KnockBack = 0f;
 @@ -33192,7 +_,7 @@
  				Vector2 value = Vector2.UnitX.RotatedBy(fullRotation);
  				Vector2 vector = Main.MouseWorld - pointPoisition;


### PR DESCRIPTION
no fancy title, this is a small PR

### changes
- `Player.GetWeaponKnockback` now has an overload which only takes the item for convenience and consistency purposes. the variant which accepts a custom knockback value is, however, still perfectly available for modders to utilize as they need
- `Player.GetWeaponKnockback` now respects the `baseKnockback` parameter again (which has received its new name to better explain what it does), rather than forcibly usin' the item's base knockback

### fix
- ammo knockback is no longer ignored for ammo-consumin' weapons