### PR TITLE
[1.4, quickfix] Stop projectiles from sending an extra byte if extra AI is empty

### DIFF
--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -163,7 +163,7 @@
  							if (bb22[7])
  								writer.Write((short)projectile.projUUID);
  
-+							if (extraAI != null) {
++							if (bb22[2]) {
 +								ProjectileLoader.SendExtraAI(writer, extraAI);
 +							}
 +

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -141,7 +141,7 @@
  							break;
  						}
  					case 24:
-@@ -624,12 +_,16 @@
+@@ -624,12 +_,17 @@
  							if (projectile.knockBack != 0f)
  								bb22[5] = true;
  
@@ -153,8 +153,9 @@
  								bb22[6] = true;
  
 +							byte[] extraAI = !ModNet.AllowVanillaClients ? ProjectileLoader.WriteExtraAI(projectile) : null;
++							ref bool hasExtraAI = ref bb22[2]; // This bit is unused by vanilla.
 +
-+							bb22[2] = extraAI?.Length > 0; // This bit is unused by vanilla.
++							hasExtraAI = extraAI?.Length > 0; 
 +
  							writer.Write(bb22);
  							for (int num21 = 0; num21 < Projectile.maxAI; num21++) {
@@ -163,7 +164,7 @@
  							if (bb22[7])
  								writer.Write((short)projectile.projUUID);
  
-+							if (bb22[2]) {
++							if (hasExtraAI) {
 +								ProjectileLoader.SendExtraAI(writer, extraAI);
 +							}
 +


### PR DESCRIPTION
### What is the bug?

ProjectileLoader.SendExtraAI currently sends an extra unread byte which usually marks the number of elements in the array that is unread when bb22[2] is false. This removes the sent byte.

### How did you fix the bug?

Made NetMessage.SendData check for bb22[2] before sending the byte.

### Are there alternatives to your fix?

No.