### PR TITLE
Port '-SkipSelect' to include 1.4 addition of Journey Mode world entry restriction

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UIWorldListItem.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.cs
-@@ -2,11 +_,14 @@
+@@ -2,11 +_,15 @@
  using Microsoft.Xna.Framework.Graphics;
  using ReLogic.Content;
  using ReLogic.OS;
@@ -11,6 +11,7 @@
  using Terraria.IO;
  using Terraria.Localization;
 +using Terraria.Utilities;
++using Terraria.ModLoader;
 +using Terraria.ModLoader.Config;
  using Terraria.Social;
  using Terraria.UI;
@@ -131,6 +132,30 @@
  		}
  
  		private bool TryMovingToRejectionMenuIfNeeded(int worldGameMode) {
+@@ -283,6 +_,9 @@
+ 				return true;
+ 			}
+ 
++			if (_canBePlayed)
++				return false;
++
+ 			bool flag = Main.ActivePlayerFileData.Player.difficulty == 3;
+ 			bool isJourneyMode = value.IsJourneyMode;
+ 			if (flag && !isJourneyMode) {
+@@ -299,6 +_,13 @@
+ 				return true;
+ 			}
+ 
++			if (!SystemLoader.CanWorldBePlayed(Main.ActivePlayerFileData, _data, out var rejector)) {
++				SoundEngine.PlaySound(10);
++				Main.statusText = rejector.WorldCanBePlayedRejectionMessage(Main.ActivePlayerFileData, _data);
++				Main.menuMode = 1000000;
++				return true;
++			}
++
+ 			return false;
+ 		}
+ 
 @@ -342,10 +_,16 @@
  			_buttonLabel.SetText(Language.GetTextValue("UI.SeedCopied"));
  		}

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
@@ -28,7 +28,7 @@
  
  		public override void OnInitialize() {
  			UIElement uIElement = new UIElement();
-@@ -133,9 +_,166 @@
+@@ -133,12 +_,169 @@
  			foreach (WorldFileData item in orderedEnumerable) {
  				_worldList.Add(new UIWorldListItem(item, num++, CanWorldBePlayed(item)));
  			}
@@ -195,4 +195,8 @@
 +		internal static bool CanWorldBePlayed(WorldFileData file) {
  			bool num = Main.ActivePlayerFileData.Player.difficulty == 3;
  			bool flag = file.GameMode == 3;
- 			return num == flag;
+-			return num == flag;
++			return (num == flag) && SystemLoader.CanWorldBePlayed(Main.ActivePlayerFileData, file, out var _);
+ 		}
+ 
+ 		public override void Draw(SpriteBatch spriteBatch) {

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
@@ -28,11 +28,10 @@
  
  		public override void OnInitialize() {
  			UIElement uIElement = new UIElement();
-@@ -132,6 +_,163 @@
- 			int num = 0;
+@@ -133,9 +_,166 @@
  			foreach (WorldFileData item in orderedEnumerable) {
  				_worldList.Add(new UIWorldListItem(item, num++, CanWorldBePlayed(item)));
-+			}
+ 			}
 +
 +			AddIndividualWorldMigrationButtons();
 +
@@ -189,6 +188,11 @@
 +						}
 +					}
 +				}
- 			}
++			}
  		}
  
+-		private bool CanWorldBePlayed(WorldFileData file) {
++		internal static bool CanWorldBePlayed(WorldFileData file) {
+ 			bool num = Main.ActivePlayerFileData.Player.difficulty == 3;
+ 			bool flag = file.GameMode == 3;
+ 			return num == flag;

--- a/patches/tModLoader/Terraria/Initializers/LaunchInitializer.cs.patch
+++ b/patches/tModLoader/Terraria/Initializers/LaunchInitializer.cs.patch
@@ -21,7 +21,7 @@
  		}
  
  		private static void LoadClientParameters(Main game) {
-@@ -38,6 +_,33 @@
+@@ -38,6 +_,34 @@
  
  			if (HasParameter("-host"))
  				game.AutoHost();
@@ -47,7 +47,8 @@
 +					(Main.WorldList.FirstOrDefault(x => x.Name == worldName) ?? Main.WorldList[0]).SetAsActive();
 +					if (!GameContent.UI.States.UIWorldSelect.CanWorldBePlayed(Main.ActiveWorldFileData))
 +						throw new Exception($"The selected character {playerName} can not be used with the selected world {worldName}.\n" +
-+							$"This could be due to mismatched Journey Mode or other mod specific changes.");
++							$"This could be due to mismatched Journey Mode or other mod specific changes." +
++							$"Check in Game Menus for more information.");
 +
 +					WorldGen.playWorld();
 +				};

--- a/patches/tModLoader/Terraria/Initializers/LaunchInitializer.cs.patch
+++ b/patches/tModLoader/Terraria/Initializers/LaunchInitializer.cs.patch
@@ -21,7 +21,7 @@
  		}
  
  		private static void LoadClientParameters(Main game) {
-@@ -38,6 +_,29 @@
+@@ -38,6 +_,33 @@
  
  			if (HasParameter("-host"))
  				game.AutoHost();
@@ -45,6 +45,10 @@
 +					(Main.PlayerList.FirstOrDefault(x => x.Name == playerName) ?? Main.PlayerList[0]).SetAsActive();
 +					Main.LoadWorlds();
 +					(Main.WorldList.FirstOrDefault(x => x.Name == worldName) ?? Main.WorldList[0]).SetAsActive();
++					if (!GameContent.UI.States.UIWorldSelect.CanWorldBePlayed(Main.ActiveWorldFileData))
++						throw new Exception($"The selected character {playerName} can not be used with the selected world {worldName}.\n" +
++							$"This could be due to mismatched Journey Mode or other mod specific changes.");
++
 +					WorldGen.playWorld();
 +				};
 +			}

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
 using Terraria.ID;
+using Terraria.IO;
 using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader.Core;
@@ -268,6 +269,18 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="tag"> The TagCompound to load data from. </param>
 		public virtual void LoadWorldData(TagCompound tag) { }
+
+		/// <summary>
+		/// Allows you to prevent the world and player from being loaded/selected as a valid combination, similar to Journey Mode pairing.
+		/// </summary>
+		public virtual bool CanWorldBePlayed(PlayerFileData playerData, WorldFileData worldFileData) {
+			return true;
+		}
+
+		public virtual string WorldCanBePlayedRejectionMessage(PlayerFileData playerData, WorldFileData worldData) {
+			return $"The selected character {playerData.Name} can not be used with the selected world {worldData.Name}.\n" +
+							$"This could be due to mismatched Journey Mode or other mod specific changes.";
+		}
 
 		/// <summary>
 		/// Allows you to send custom data between clients and server, which will be handled in <see cref="NetReceive"/>. This is useful for syncing information such as bosses that have been defeated.

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
 using Terraria.Graphics;
+using Terraria.IO;
 using Terraria.Localization;
 using Terraria.Map;
 using Terraria.UI;
@@ -75,6 +76,8 @@ namespace Terraria.ModLoader
 		private static HookList HookOnWorldLoad = AddHook<Action>(s => s.OnWorldLoad);
 
 		private static HookList HookOnWorldUnload = AddHook<Action>(s => s.OnWorldUnload);
+
+		private static HookList HookCanWorldBePlayed = AddHook<Func<PlayerFileData, WorldFileData, bool>>(s => s.CanWorldBePlayed);
 
 		private static HookList HookModifyScreenPosition = AddHook<Action>(s => s.ModifyScreenPosition);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Terraria.Graphics;
+using Terraria.IO;
 using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader.UI;
@@ -111,6 +112,18 @@ namespace Terraria.ModLoader
 			foreach (var system in HookOnWorldUnload.arr) {
 				system.OnWorldUnload();
 			}
+		}
+
+		public static bool CanWorldBePlayed(PlayerFileData playerData, WorldFileData worldData, out ModSystem rejector) {
+			foreach (var system in HookCanWorldBePlayed.arr) {
+				if (!system.CanWorldBePlayed(playerData, worldData)) {
+					rejector = system;
+					return false;
+				}
+			}
+
+			rejector = null;
+			return true;
 		}
 
 		public static void ModifyScreenPosition() {


### PR DESCRIPTION
This PR ports Journey Mode restrictions to the '-skipselect' developer launch parameter.

This reinstates consistent behaviour with vanilla - non-journey mode characters by default can't enter journey mode worlds, and vice versa.

This also adds simple hooks related to that behaviour in case modders have a need for it, as inevitably somebody will.
