### PR TITLE
[1.4] WorldUIAnchor projectile sync fix (for EmoteBubble)

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
@@ -21,10 +21,10 @@
 +				// TML: #WorldUIAnchorProjectileSyncFix: Explanation below
 +				// Vanilla never uses Projectile as a WorldUIAnchor, but if mods do, it is very likely to desync.
 +				// As whoAmI is not enough to match a projectile between sides, TML rewrites it to use identity + owner instead.
-+				// It does so by packing the anchor entity type together with the ownerif it's a projectile.
++				// It does so by packing the anchor entity type together with the owner if it's a projectile.
 +				// Chosen because both variables can never go above 255 (whoAmI can go above that for projectiles), allowing for easier masking.
 +				// Methods (including the IO protocol) accessing this packed owner/type pair handle it properly.
-+				// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in case of Projectile
++				// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in case of Projectile.
 +				// tl;dr: byte type -> ushort packedOwnerType [owner << 8 | type] (only if it's a projectile)
 +				int whoAmI = anch.entity.whoAmI;
 +				if (!ModNet.AllowVanillaClients) {

--- a/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
@@ -14,26 +14,24 @@
  		public static Dictionary<int, EmoteBubble> byID = new Dictionary<int, EmoteBubble>();
  		private static List<int> toClean = new List<int>();
  		public static int NextID;
-@@ -61,19 +_,58 @@
+@@ -61,19 +_,55 @@
  				else if (anch.entity is Projectile)
  					item = 2;
  
 +				// TML: #WorldUIAnchorProjectileSyncFix: Explanation below
 +				// Vanilla never uses Projectile as a WorldUIAnchor, but if mods do, it is very likely to desync.
 +				// As whoAmI is not enough to match a projectile between sides, TML rewrites it to use identity + owner instead.
-+				// It does so by packing the anchor entity type together with the owner (which is irrelevant for anything but projectiles).
-+				// Chosen because both variables can never go above 255 (whoAmI can go above that for projectiles), making them suitable for combining them into one.
-+				// Methods (including the IO protocol) accessing this packed type/owner pair handle it properly.
-+				// byte type -> ushort packedTypeOwner [type << 8 | owner]
-+				// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in all cases
++				// It does so by packing the anchor entity type together with the ownerif it's a projectile.
++				// Chosen because both variables can never go above 255 (whoAmI can go above that for projectiles), allowing for easier masking.
++				// Methods (including the IO protocol) accessing this packed owner/type pair handle it properly.
++				// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in case of Projectile
++				// tl;dr: byte type -> ushort packedOwnerType [owner << 8 | type] (only if it's a projectile)
 +				int whoAmI = anch.entity.whoAmI;
 +				if (!ModNet.AllowVanillaClients) {
-+					int owner = 0;
 +					if (anch.entity is Projectile projectile) {
 +						whoAmI = projectile.identity; // This is the meta parameter in DeserializeNetAnchor
-+						owner = projectile.owner;
++						item = projectile.owner << 8 | item;
 +					}
-+					item = item << 8 | owner;
 +				}
 -				return Tuple.Create(item, anch.entity.whoAmI);
 +				return Tuple.Create(item, whoAmI);
@@ -45,9 +43,8 @@
  		public static WorldUIAnchor DeserializeNetAnchor(int type, int meta) {
 +			// TML: #WorldUIAnchorProjectileSyncFix
 +			// Unpack type for the switch case evaluation, use the owner in the Projectile case
-+			int packedTypeOwner = type;
-+			if (!ModNet.AllowVanillaClients)
-+				type = packedTypeOwner >> 8;
++			int packedOwnerType = type;
++			type = packedOwnerType & 0xFF; // Masking has no effect on vanilla value
 +
  			switch (type) {
  				case 0:
@@ -57,7 +54,7 @@
  				case 2:
 +					if (!ModNet.AllowVanillaClients) {
 +						// meta represents the identity here
-+						int owner = packedTypeOwner & 0xFF;
++						int owner = packedOwnerType >> 8;
 +
 +						// identity matching code taken from MessageBuffer.GetData case 27
 +						int whoAmI = Main.maxProjectiles;

--- a/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
@@ -14,6 +14,66 @@
  		public static Dictionary<int, EmoteBubble> byID = new Dictionary<int, EmoteBubble>();
  		private static List<int> toClean = new List<int>();
  		public static int NextID;
+@@ -61,19 +_,58 @@
+ 				else if (anch.entity is Projectile)
+ 					item = 2;
+ 
++				// TML: #WorldUIAnchorProjectileSyncFix: Explanation below
++				// Vanilla never uses Projectile as a WorldUIAnchor, but if mods do, it is very likely to desync.
++				// As whoAmI is not enough to match a projectile between sides, TML rewrites it to use identity + owner instead.
++				// It does so by packing the anchor entity type together with the owner (which is irrelevant for anything but projectiles).
++				// Chosen because both variables can never go above 255 (whoAmI can go above that for projectiles), making them suitable for combining them into one.
++				// Methods (including the IO protocol) accessing this packed type/owner pair handle it properly.
++				// byte type -> ushort packedTypeOwner [type << 8 | owner]
++				// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in all cases
++				int whoAmI = anch.entity.whoAmI;
++				if (!ModNet.AllowVanillaClients) {
++					int owner = 0;
++					if (anch.entity is Projectile projectile) {
++						whoAmI = projectile.identity; // This is the meta parameter in DeserializeNetAnchor
++						owner = projectile.owner;
++					}
++					item = item << 8 | owner;
++				}
+-				return Tuple.Create(item, anch.entity.whoAmI);
++				return Tuple.Create(item, whoAmI);
+ 			}
+ 
+ 			return Tuple.Create(0, 0);
+ 		}
+ 
+ 		public static WorldUIAnchor DeserializeNetAnchor(int type, int meta) {
++			// TML: #WorldUIAnchorProjectileSyncFix
++			// Unpack type for the switch case evaluation, use the owner in the Projectile case
++			int packedTypeOwner = type;
++			if (!ModNet.AllowVanillaClients)
++				type = packedTypeOwner >> 8;
++
+ 			switch (type) {
+ 				case 0:
+ 					return new WorldUIAnchor(Main.npc[meta]);
+ 				case 1:
+ 					return new WorldUIAnchor(Main.player[meta]);
+ 				case 2:
++					if (!ModNet.AllowVanillaClients) {
++						// meta represents the identity here
++						int owner = packedTypeOwner & 0xFF;
++
++						// identity matching code taken from MessageBuffer.GetData case 27
++						int whoAmI = Main.maxProjectiles;
++						for (int i = 0; i < Main.maxProjectiles; i++) {
++							Projectile projectile = Main.projectile[i];
++							if (projectile.owner == owner && projectile.identity == meta && projectile.active) {
++								whoAmI = i;
++								break;
++							}
++						}
++
++						return new WorldUIAnchor(Main.projectile[whoAmI]);
++					}
+ 					return new WorldUIAnchor(Main.projectile[meta]);
+ 				default:
+ 					throw new Exception("How did you end up getting this?");
 @@ -347,7 +_,7 @@
  		}
  

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -543,26 +543,20 @@
  					}
  					break;
  				case 91: {
-@@ -2687,8 +_,22 @@
+@@ -2687,8 +_,17 @@
  							break;
  
  						int num201 = reader.ReadInt32();
--						int num202 = reader.ReadByte();
--						if (num202 == 255) {
 +						// TML: #WorldUIAnchorProjectileSyncFix
-+						// Read ushort which contains type and owner, split it where necessary
-+						int num202;
-+						int type;
-+						if (ModNet.AllowVanillaClients) {
-+							num202 = reader.ReadByte();
-+							type = num202;
+ 						int num202 = reader.ReadByte();
+-						if (num202 == 255) {
++						bool delete = num202 == 255;
++						bool playerAnchor = num202 == 1;
++						// If type corresponds to projectile (magic number 2), read another byte for owner
++						if (!ModNet.AllowVanillaClients && num202 == 2) {
++							int owner = reader.ReadByte();
++							num202 = owner << 8 | num202; // Reassign num202 for use in DeserializeNetAnchor - this is now "packedOwnerType"
 +						}
-+						else {
-+							num202 = reader.ReadUInt16();
-+							type = num202 >> 8;
-+						}
-+						bool delete = type == 255;
-+						bool playerAnchor = type == 1;
 +
 +						if (delete) {
  							if (EmoteBubble.byID.ContainsKey(num201))

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -543,6 +543,40 @@
  					}
  					break;
  				case 91: {
+@@ -2687,8 +_,22 @@
+ 							break;
+ 
+ 						int num201 = reader.ReadInt32();
+-						int num202 = reader.ReadByte();
+-						if (num202 == 255) {
++						// TML: #WorldUIAnchorProjectileSyncFix
++						// Read ushort which contains type and owner, split it where necessary
++						int num202;
++						int type;
++						if (ModNet.AllowVanillaClients) {
++							num202 = reader.ReadByte();
++							type = num202;
++						}
++						else {
++							num202 = reader.ReadUInt16();
++							type = num202 >> 8;
++						}
++						bool delete = type == 255;
++						bool playerAnchor = type == 1;
++
++						if (delete) {
+ 							if (EmoteBubble.byID.ContainsKey(num201))
+ 								EmoteBubble.byID.Remove(num201);
+ 
+@@ -2703,7 +_,7 @@
+ 							metadata = reader.ReadInt16();
+ 
+ 						WorldUIAnchor worldUIAnchor = EmoteBubble.DeserializeNetAnchor(num202, num203);
+-						if (num202 == 1)
++						if (playerAnchor)
+ 							Main.player[num203].emoteTime = 360;
+ 
+ 						lock (EmoteBubble.byID) {
 @@ -3155,10 +_,28 @@
  					if (Main.netMode == 2) {
  						short x9 = reader.ReadInt16();

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -242,7 +242,7 @@
  
  							break;
  						}
-@@ -1060,15 +_,31 @@
+@@ -1060,14 +_,28 @@
  							writer.Write((short)number);
  							writer.Write((short)number2);
  							Item item3 = Main.player[(int)number4].inventory[(int)number3];
@@ -263,22 +263,17 @@
  						}
  					case 91:
  						writer.Write(number);
--						writer.Write((byte)number2);
--						if (number2 != 255f) {
 +						// TML: #WorldUIAnchorProjectileSyncFix
-+						// Send packed type and owner as ushort
-+						bool noDelete = number2 != 255f;
-+						if (ModNet.AllowVanillaClients)
-+							writer.Write((byte)number2);
-+						else {
-+							int packedTypeOwner = (int)number2;
-+							noDelete = (packedTypeOwner >> 8) != 255;
-+							writer.Write((ushort)packedTypeOwner);
-+						}
-+						if (noDelete) {
++						// number2 is packed with owner and type
++						int packedOwnerType = (int)number2;
++						number2 = (int)number2 & 0xFF; // Reassign for patch reduction - this is now "type" (Masking has no effect on vanilla value)
+ 						writer.Write((byte)number2);
++						// Send byte for owner if type corresponds to projectile (magic number 2)
++						if (!ModNet.AllowVanillaClients && number2 == 2)
++							writer.Write((byte)(packedOwnerType >> 8));
+ 						if (number2 != 255f) {
  							writer.Write((ushort)number3);
  							writer.Write((ushort)number4);
- 							writer.Write((byte)number5);
 @@ -1230,9 +_,17 @@
  							writer.Write((short)number);
  							writer.Write((short)number2);

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -242,7 +242,7 @@
  
  							break;
  						}
-@@ -1060,9 +_,16 @@
+@@ -1060,15 +_,31 @@
  							writer.Write((short)number);
  							writer.Write((short)number2);
  							Item item3 = Main.player[(int)number4].inventory[(int)number3];
@@ -262,6 +262,23 @@
  							break;
  						}
  					case 91:
+ 						writer.Write(number);
+-						writer.Write((byte)number2);
+-						if (number2 != 255f) {
++						// TML: #WorldUIAnchorProjectileSyncFix
++						// Send packed type and owner as ushort
++						bool noDelete = number2 != 255f;
++						if (ModNet.AllowVanillaClients)
++							writer.Write((byte)number2);
++						else {
++							int packedTypeOwner = (int)number2;
++							noDelete = (packedTypeOwner >> 8) != 255;
++							writer.Write((ushort)packedTypeOwner);
++						}
++						if (noDelete) {
+ 							writer.Write((ushort)number3);
+ 							writer.Write((ushort)number4);
+ 							writer.Write((byte)number5);
 @@ -1230,9 +_,17 @@
  							writer.Write((short)number);
  							writer.Write((short)number2);


### PR DESCRIPTION
### What is the bug?
Currently, `EmoteBubble` does not sync it's `WorldUIAnchor` correctly if it's a projectile, which makes desyncs very likely. Vanilla never uses projectiles as anchors, but mods might, so fixing this is important for proper functionality.

### How did you fix the bug?
As `whoAmI` is not enough to match a projectile between sides, I rewrote it to use `identity + owner` instead.
It does so by packing the anchor entity type together with the `owner` if it's a projectile.
Chosen because both variables can never go above 255 (`whoAmI` can go above that for projectiles), allowing for easier masking.
Methods (including the IO protocol) accessing this packed owner/type pair handle it properly.
This adds an overhead of a byte to the message 91 (`SyncEmoteBubble`) in case of `Projectile`.
tl;dr: `byte type -> ushort packedOwnerType [owner << 8 | type]` (only if it's a projectile)

### Are there alternatives to your fix?
Most likely. My solution aims to reduce patch size and net overhead.