### PR TITLE
Add GlobalProjectile Send/ReceiveExtraAI

### DIFF
--- a/ExampleMod/Common/GlobalProjectiles/ExampleProjectileNetSync.cs
+++ b/ExampleMod/Common/GlobalProjectiles/ExampleProjectileNetSync.cs
@@ -57,12 +57,17 @@ namespace ExampleMod.Common.GlobalProjectiles
 		public override void AI(Projectile projectile) {
 			if (differentBehaviour) {
 				int p = Player.FindClosest(projectile.position, projectile.width, projectile.height);
-				int dustType;
+				float currentDistance = p == -1 ? 0 : projectile.Distance(Main.player[p].Center);
+				int dustType = DustID.GemSapphire;
 
-				// Normal behaviour when in close range
-				if (p != -1 && projectile.Distance(Main.player[p].Center) < distance / 2) {
+				// Ends behaviour when in very close range
+				if (currentDistance < distance / 4) {
+					differentBehaviour = false;
+					projectile.netUpdate = true;
+				}
+				// Move at normal speed but can speed back up
+				else if (currentDistance < distance / 2) {
 					projectile.extraUpdates = 0;
-					dustType = DustID.GemSapphire;
 				}
 				// Becomes faster when out of range
 				else {
@@ -73,15 +78,6 @@ namespace ExampleMod.Common.GlobalProjectiles
 				// Visually indicates this typhoon has special behaviour and which mode it is in
 				int d = Dust.NewDust(projectile.position, projectile.width, projectile.height, dustType, Scale: 5f);
 				Main.dust[d].noGravity = true;
-
-				if (projectile.Distance(Main.player[p].Center) < distance / 3) {
-					//differentBehaviour = false;
-					//projectile.netUpdate = true;
-
-					// Do not do this!
-					// Anything your Send/ReceiveExtraAI relies on should always be the same between client and server
-					// Ignoring this risks desync, read overflows, or unread packets that can even affect other mods' behaviour
-				}
 			}
 		}
 	}

--- a/ExampleMod/Common/GlobalProjectiles/ExampleProjectileNetSync.cs
+++ b/ExampleMod/Common/GlobalProjectiles/ExampleProjectileNetSync.cs
@@ -1,0 +1,88 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Microsoft.Xna.Framework;
+using Terraria.DataStructures;
+using Terraria.ModLoader.IO;
+using System.IO;
+
+namespace ExampleMod.Common.GlobalProjectiles
+{
+	// Here is a class dedicated to showcasing Send/ReceiveExtraAI()
+	public class ExampleProjectileNetSync : GlobalProjectile
+	{
+		public override bool InstancePerEntity => true;
+		private bool differentBehaviour;
+		private float distance;
+
+		// This reduces how many projectiles actually have this GlobalProjectile
+		public override bool AppliesToEntity(Projectile entity, bool lateInstantiation) {
+			return entity.type == ProjectileID.SharknadoBolt;
+		}
+
+		// Although this runs on both client and server, only the session that spawned the projectile knows its source
+		// As such, the check demonstrated below will always be false client-side and the code will never run!
+		public override void OnSpawn(Projectile projectile, IEntitySource source) {
+
+			// When spawned by Duke Fishron during a Blood Moon
+			if (source is EntitySource_Parent parent
+				&& parent.Entity is NPC npc
+				&& npc.type == NPCID.DukeFishron
+				&& Main.bloodMoon) {
+
+				differentBehaviour = true;
+				distance = projectile.Distance(Main.player[npc.target].Center);
+			}
+		}
+
+		// Because this GlobalProjectile only applies to typhoons, this data is not attached to all projectile sync packets
+		public override void SendExtraAI(Projectile projectile, BitWriter bitWriter, BinaryWriter binaryWriter) {
+			bitWriter.WriteBit(differentBehaviour);
+
+			// This check further avoids sending distance when it wouldn't be necessary
+			if (differentBehaviour) {
+				binaryWriter.Write(distance);
+			}
+		}
+
+		// Make sure you always read exactly as much data as you sent!
+		public override void ReceiveExtraAI(Projectile projectile, BitReader bitReader, BinaryReader binaryReader) {
+			differentBehaviour = bitReader.ReadBit();
+
+			if (differentBehaviour) {
+				distance = binaryReader.ReadSingle();
+			}
+		}
+
+		public override void AI(Projectile projectile) {
+			if (differentBehaviour) {
+				int p = Player.FindClosest(projectile.position, projectile.width, projectile.height);
+				int dustType;
+
+				// Normal behaviour when in close range
+				if (p != -1 && projectile.Distance(Main.player[p].Center) < distance / 2) {
+					projectile.extraUpdates = 0;
+					dustType = DustID.GemSapphire;
+				}
+				// Becomes faster when out of range
+				else {
+					projectile.extraUpdates = 1;
+					dustType = DustID.GemRuby;
+				}
+
+				// Visually indicates this typhoon has special behaviour and which mode it is in
+				int d = Dust.NewDust(projectile.position, projectile.width, projectile.height, dustType, Scale: 5f);
+				Main.dust[d].noGravity = true;
+
+				if (projectile.Distance(Main.player[p].Center) < distance / 3) {
+					//differentBehaviour = false;
+					//projectile.netUpdate = true;
+
+					// Do not do this!
+					// Anything your Send/ReceiveExtraAI relies on should always be the same between client and server
+					// Ignoring this risks desync, read overflows, or unread packets that can even affect other mods' behaviour
+				}
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Terraria.DataStructures;
 using Terraria.ModLoader.Core;
 
@@ -67,6 +68,27 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="projectile"></param>
 		public virtual void PostAI(Projectile projectile) {
+		}
+
+		/// <summary>
+		/// Use this judiciously to avoid straining the network.
+		/// <br/>If you are storing AI information outside of the Projectile.ai array, use this to send that AI information between clients and servers, which will be handled in <see cref="ReceiveExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncProjectile"/> is successfully sent, for example on projectile creation, or whenever Projectile.netUpdate is set to true in the update loop for that tick.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
+		/// </summary>
+		/// <param name="projectile">The projectile.</param>
+		/// <param name="writer">The writer.</param>
+		public virtual void SendExtraAI(Projectile projectile, BinaryWriter writer) {
+		}
+
+		/// <summary>
+		/// Use this to receive information that was sent in <see cref="SendExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncProjectile"/> is successfully received.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
+		/// </summary>
+		/// <param name="projectile">The projectile.</param>
+		/// <param name="reader">The reader.</param>
+		public virtual void ReceiveExtraAI(Projectile projectile, BinaryReader reader) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.DataStructures;
 using Terraria.ModLoader.Core;
+using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {
@@ -72,13 +73,14 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Use this judiciously to avoid straining the network.
-		/// <br/>If you are storing AI information outside of the Projectile.ai array, use this to send that AI information between clients and servers, which will be handled in <see cref="ReceiveExtraAI"/>.
+		/// <br/>Checks and methods such as <see cref="AppliesToEntity"/> can reduce how much data must be sent for how many projectiles.
 		/// <br/>Called whenever <see cref="MessageID.SyncProjectile"/> is successfully sent, for example on projectile creation, or whenever Projectile.netUpdate is set to true in the update loop for that tick.
 		/// <br/>Can be called on both server and client, depending on who owns the projectile.
 		/// </summary>
 		/// <param name="projectile">The projectile.</param>
-		/// <param name="writer">The writer.</param>
-		public virtual void SendExtraAI(Projectile projectile, BinaryWriter writer) {
+		/// <param name="bitWriter">The compressible bit writer. Booleans written via this are compressed across all mods to improve multiplayer performance.</param>
+		/// <param name="binaryWriter">The writer.</param>
+		public virtual void SendExtraAI(Projectile projectile, BitWriter bitWriter, BinaryWriter binaryWriter) {
 		}
 
 		/// <summary>
@@ -87,8 +89,9 @@ namespace Terraria.ModLoader
 		/// <br/>Can be called on both server and client, depending on who owns the projectile.
 		/// </summary>
 		/// <param name="projectile">The projectile.</param>
-		/// <param name="reader">The reader.</param>
-		public virtual void ReceiveExtraAI(Projectile projectile, BinaryReader reader) {
+		/// <param name="bitReader">The compressible bit reader.</param>
+		/// <param name="binaryReader">The reader.</param>
+		public virtual void ReceiveExtraAI(Projectile projectile, BitReader bitReader, BinaryReader binaryReader) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader.IO
 
 		public bool ReadBit() {
 			if (BitsRead >= MaxBits) {
-				throw new IOException("Read overflow while reading compressed bits");
+				throw new IOException("Read overflow while reading compressed bits, more info below");
 			}
 
 			return (bytes[BitsRead / 8] & (1 << BitsRead++ % 8)) != 0;

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
@@ -7,14 +7,25 @@ namespace Terraria.ModLoader.IO
 	public class BitReader
 	{
 		private byte[] bytes;
-		private int i;
+		public int MaxBits { get; private set; }
+		public int BitsRead { get; private set; }
 
 		public BitReader(BinaryReader reader) {
-			bytes = reader.ReadBytes(reader.ReadVarInt());
+			MaxBits = reader.ReadVarInt();
+
+			int byteCount = MaxBits / 8;
+			if (MaxBits % 8 != 0)
+				byteCount++;
+
+			bytes = reader.ReadBytes(byteCount);
 		}
 
 		public bool ReadBit() {
-			return (bytes[i / 8] & (1 << i++ % 8)) != 0;
+			if (BitsRead >= MaxBits) {
+				throw new IOException("Read overflow while reading compressed bits");
+			}
+
+			return (bytes[BitsRead / 8] & (1 << BitsRead++ % 8)) != 0;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Terraria.ModLoader.IO
+{
+	public class BitReader
+	{
+		private byte[] bytes;
+		private int i;
+
+		public BitReader(BinaryReader reader) {
+			bytes = reader.ReadBytes(reader.ReadVarInt());
+		}
+
+		public bool ReadBit() {
+			return (bytes[i / 8] & (1 << i++ % 8)) != 0;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
@@ -22,11 +22,11 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public void Flush(BinaryWriter w) {
+			w.WriteVarInt(bytes.Count * 8 + i);
+
 			if (i > 0) {
 				bytes.Add(cur);
 			}
-
-			w.WriteVarInt(bytes.Count);
 
 			foreach (var b in bytes) {
 				w.Write(b);

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Terraria.ModLoader.IO
+{
+	public class BitWriter
+	{
+		private List<byte> bytes = new();
+		private byte cur;
+		private int i;
+
+		public void WriteBit(bool b) {
+			if (b) {
+				cur |= (byte)(1 << i);
+			}
+
+			if (++i == 8) {
+				bytes.Add(cur);
+				cur = 0;
+				i = 0;
+			}
+		}
+
+		public void Flush(BinaryWriter w) {
+			if (i > 0) {
+				bytes.Add(cur);
+			}
+
+			w.WriteVarInt(bytes.Count);
+
+			foreach (var b in bytes) {
+				w.Write(b);
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -244,6 +244,14 @@ namespace Terraria.ModLoader
 			foreach (GlobalProjectile g in HookReceiveExtraAI.Enumerate(projectile.globalProjectiles)) {
 				g.ReceiveExtraAI(projectile, bitReader, modReader);
 			}
+
+			if (bitReader.BitsRead < bitReader.MaxBits) {
+				throw new IOException($"Read underflow {bitReader.MaxBits - bitReader.BitsRead} of {bitReader.MaxBits} bits in ReceiveExtraAI, a mod is not reading all compressed bits it sent");
+			}
+			
+			if (stream.Position < stream.Length) {
+				throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length} bytes in ReceiveExtraAI, a mod is not reading all data it sent");
+			}
 		}
 
 		private static HookList HookShouldUpdatePosition = AddHook<Func<Projectile, bool>>(g => g.ShouldUpdatePosition);


### PR DESCRIPTION
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->

### What is the new feature?
SendExtraAI and ReceiveExtraAI hooks for GlobalProjectile. A BitWriter/Reader are included for better boolean compression

### Why should this be part of tModLoader?
The core want is "facilitate multiplayer sync of EntitySource-dependent behaviour" but this fulfills other modder wants. OnSpawn() does not always have the true source in multiplayer (e.g. spawned by NPC server-side but client does not know that). Mods will also appreciate this for guaranteeing they can use this to run some source-dependent logic on the projectile's first client-side update.

BitWriter/Reader compress bits written to them by all mods. E.g. 3 mods writing a total of 10 booleans to every projectile would normally take up 10 more bytes, but are reduced to 2 bytes.

### Are there alternative designs?
You could somehow encode the actual entity source and send that instead. This would also give up the other applications of net extra AI and make it a bit harder for modders to buckle a server by bogging down every projectile with extra values to sync

### Use cases
* Attaching several bytes to specific projectiles for behaviour like boss-specific patterns or debuffs
* Seamlessly spawning normally hostile vanilla projectiles as friendly ones and vice versa
* Synchronizing projectile reflection mechanics
* Calamity rogue stealth strike netcode bit

### Notes to modders
* Use `AppliesToInstance`, `if (projectile.type == SomeType)`, etc. to filter down to only sending data on projectiles that need it. Make sure to use checks that are insensitive to desync.
* Do everything you can to avoid the scenario where your mod is to blame for massive multiplayer lag caused by excessive bytes attached to every single projectile update packet ever sent by anyone for any reason.

### Next steps for next month
* Make bitpacking available to all mod types