### PR TITLE
new NPC hover-with-mouse hooks

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3006,7 +3006,7 @@
  
  						MouseTextHackZoom(text, rare, 0);
  						mouseText = true;
-@@ -32050,6 +_,9 @@
+@@ -32050,18 +_,22 @@
  					if (!npc[k].active)
  						continue;
  
@@ -3016,7 +3016,12 @@
  					int type = npc[k].type;
  					LoadNPC(type);
  					npc[k].position += npc[k].netOffset;
-@@ -32061,7 +_,7 @@
+ 					Microsoft.Xna.Framework.Rectangle value3 = new Microsoft.Xna.Framework.Rectangle((int)npc[k].Bottom.X - npc[k].frame.Width / 2, (int)npc[k].Bottom.Y - npc[k].frame.Height, npc[k].frame.Width, npc[k].frame.Height);
+ 					if (npc[k].type >= 87 && npc[k].type <= 92)
+ 						value3 = new Microsoft.Xna.Framework.Rectangle((int)((double)npc[k].position.X + (double)npc[k].width * 0.5 - 32.0), (int)((double)npc[k].position.Y + (double)npc[k].height * 0.5 - 32.0), 64, 64);
++					NPCLoader.ModifyHoverBoundingBox(npc[k], ref value3);
+ 
+ 					bool flag = rectangle.Intersects(value3);
  					bool flag2 = flag || (SmartInteractShowingGenuine && SmartInteractNPC == k);
  					if (flag2 && ((npc[k].type != 85 && npc[k].type != 341 && npc[k].type != 629 && npc[k].aiStyle != 87) || npc[k].ai[0] != 0f) && npc[k].type != 488) {
  						bool flag3 = SmartInteractShowingGenuine && SmartInteractNPC == k;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3010,7 +3010,7 @@
  					if (!npc[k].active)
  						continue;
  
-+					if (!NPCLoader.ShowNameOnHover(npc[k]))
++					if (!npc[k].ShowNameOnHover)
 +						continue;
 +
  					int type = npc[k].type;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3006,6 +3006,16 @@
  
  						MouseTextHackZoom(text, rare, 0);
  						mouseText = true;
+@@ -32050,6 +_,9 @@
+ 					if (!npc[k].active)
+ 						continue;
+ 
++					if (!NPCLoader.ShowNameOnHover(npc[k]))
++						continue;
++
+ 					int type = npc[k].type;
+ 					LoadNPC(type);
+ 					npc[k].position += npc[k].netOffset;
 @@ -32061,7 +_,7 @@
  					bool flag2 = flag || (SmartInteractShowingGenuine && SmartInteractNPC == k);
  					if (flag2 && ((npc[k].type != 85 && npc[k].type != 341 && npc[k].type != 629 && npc[k].aiStyle != 87) || npc[k].ai[0] != 0f) && npc[k].type != 488) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -73,6 +73,16 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to decide whether or not the given NPC should display its name when hovering over it.
+		/// Defaults to true.
+		/// </summary>
+		/// <param name="npc">The NPC in question.</param>
+		/// <returns>True if the name should be shown; false if it should not.</returns>
+		public virtual bool ShowNameOnHover(NPC npc) {
+			return true;
+		}
+
+		/// <summary>
 		/// Allows you to set the town NPC profile that a given NPC uses.
 		/// </summary>
 		/// <param name="npc">The NPC in question.</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -73,16 +73,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to decide whether or not the given NPC should display its name when hovering over it.<br></br>
-		/// Defaults to true.
-		/// </summary>
-		/// <param name="npc">The NPC in question.</param>
-		/// <returns>True if the name should be shown; false if it should not.</returns>
-		public virtual bool ShowNameOnHover(NPC npc) {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to modify the bounding box for hovering over the given NPC (affects things like whether or not its name is displayed).
 		/// </summary>
 		/// <param name="npc">The NPC in question.</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -73,13 +73,21 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to decide whether or not the given NPC should display its name when hovering over it.
+		/// Allows you to decide whether or not the given NPC should display its name when hovering over it.<br></br>
 		/// Defaults to true.
 		/// </summary>
 		/// <param name="npc">The NPC in question.</param>
 		/// <returns>True if the name should be shown; false if it should not.</returns>
 		public virtual bool ShowNameOnHover(NPC npc) {
 			return true;
+		}
+
+		/// <summary>
+		/// Allows you to modify the bounding box for hovering over the given NPC (affects things like whether or not its name is displayed).
+		/// </summary>
+		/// <param name="npc">The NPC in question.</param>
+		/// <param name="boundingBox">The bounding box used for determining whether or not the NPC counts as being hovered over.</param>
+		public virtual void ModifyHoverBoundingBox(NPC npc, ref Rectangle boundingBox) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -162,6 +162,37 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify the type name of this NPC dynamically.
+		/// </summary>
+		public virtual void ModifyTypeName(ref string typeName) {
+		}
+
+		/// <summary>
+		/// Allows you to decide whether or not this NPC should display its name when hovering over it.<br></br>
+		/// Defaults to true.
+		/// </summary>
+		/// <returns>True if the name should be shown; false if it should not.</returns>
+		public virtual bool ShowNameOnHover() {
+			return true;
+		}
+
+		/// <summary>
+		/// Allows you to modify the bounding box for hovering over this NPC (affects things like whether or not its name is displayed).
+		/// </summary>
+		/// <param name="boundingBox">The bounding box used for determining whether or not the NPC counts as being hovered over.</param>
+		public virtual void ModifyHoverBoundingBox(ref Rectangle boundingBox) {
+		}
+
+		/// <summary>
+		/// Allows you to give a list of names this NPC can be given on spawn.<br></br>
+		/// By default, returns a blank list, which means the NPC will simply use its type name as its given name when prompted.
+		/// </summary>
+		/// <returns></returns>
+		public virtual List<string> SetNPCNameList() {
+			return new List<string>();
+		}
+
+		/// <summary>
 		/// Allows you to set the town NPC profile that this NPC uses.<br></br>
 		/// By default, returns null, meaning that the NPC doesn't use one.
 		/// </summary>
@@ -561,30 +592,6 @@ namespace Terraria.ModLoader
 		/// <returns></returns>
 		public virtual bool CheckConditions(int left, int right, int top, int bottom) {
 			return true;
-		}
-
-		/// <summary>
-		/// Allows you to modify the type name of this NPC dynamically.
-		/// </summary>
-		public virtual void ModifyTypeName(ref string typeName) {
-		}
-
-		/// <summary>
-		/// Allows you to decide whether or not this NPC should display its name when hovering over it.
-		/// Defaults to true.
-		/// </summary>
-		/// <returns>True if the name should be shown; false if it should not.</returns>
-		public virtual bool ShowNameOnHover() {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to give a list of names this NPC can be given on spawn.
-		/// By default, returns a blank list, which means the NPC will simply use its type name as its given name when prompted.
-		/// </summary>
-		/// <returns></returns>
-		public virtual List<string> SetNPCNameList() {
-			return new List<string>();
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -570,6 +570,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to decide whether or not this NPC should display its name when hovering over it.
+		/// Defaults to true.
+		/// </summary>
+		/// <returns>True if the name should be shown; false if it should not.</returns>
+		public virtual bool ShowNameOnHover() {
+			return true;
+		}
+
+		/// <summary>
 		/// Allows you to give a list of names this NPC can be given on spawn.
 		/// By default, returns a blank list, which means the NPC will simply use its type name as its given name when prompted.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -168,15 +168,6 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Allows you to decide whether or not this NPC should display its name when hovering over it.<br></br>
-		/// Defaults to true.
-		/// </summary>
-		/// <returns>True if the name should be shown; false if it should not.</returns>
-		public virtual bool ShowNameOnHover() {
-			return true;
-		}
-
-		/// <summary>
 		/// Allows you to modify the bounding box for hovering over this NPC (affects things like whether or not its name is displayed).
 		/// </summary>
 		/// <param name="boundingBox">The bounding box used for determining whether or not the NPC counts as being hovered over.</param>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -942,6 +942,17 @@ namespace Terraria.ModLoader
 			return shouldShowName;
 		}
 
+		private delegate void DelegateModifyHoverBoundingBox(NPC npc, ref Rectangle boundingBox);
+		private static HookList HookModifyHoverBoundingBox = AddHook<DelegateModifyHoverBoundingBox>(g => g.ModifyHoverBoundingBox);
+		public static void ModifyHoverBoundingBox(NPC npc, ref Rectangle boundingBox) {
+			if (npc.ModNPC != null)
+				npc.ModNPC.ModifyHoverBoundingBox(ref boundingBox);
+
+			foreach (GlobalNPC g in HookModifyHoverBoundingBox.Enumerate(npc.globalNPCs)) {
+				g.ModifyHoverBoundingBox(npc, ref boundingBox);
+			}
+		}
+
 		private static HookList HookModifyNPCNameList = AddHook<Action<NPC, List<string>>>(g => g.ModifyNPCNameList);
 		public static List<string> ModifyNPCNameList(NPC npc, List<string> nameList) {
 			if (npc.ModNPC != null)

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -926,22 +926,6 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		private static HookList HookShowNameOnHover = AddHook<Func<NPC, bool>>(g => g.ShowNameOnHover);
-		public static bool ShowNameOnHover(NPC npc) {
-			bool shouldShowName = true;
-			foreach (GlobalNPC g in HookShowNameOnHover.Enumerate(npc.globalNPCs)) {
-				bool globalShowName = g.ShowNameOnHover(npc);
-				if (!globalShowName)
-					return false;
-
-				shouldShowName = true;
-			}
-			if (npc.ModNPC != null)
-				shouldShowName &= npc.ModNPC.ShowNameOnHover();
-
-			return shouldShowName;
-		}
-
 		private delegate void DelegateModifyHoverBoundingBox(NPC npc, ref Rectangle boundingBox);
 		private static HookList HookModifyHoverBoundingBox = AddHook<DelegateModifyHoverBoundingBox>(g => g.ModifyHoverBoundingBox);
 		public static void ModifyHoverBoundingBox(NPC npc, ref Rectangle boundingBox) {

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -926,6 +926,22 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private static HookList HookShowNameOnHover = AddHook<Func<NPC, bool>>(g => g.ShowNameOnHover);
+		public static bool ShowNameOnHover(NPC npc) {
+			bool shouldShowName = true;
+			foreach (GlobalNPC g in HookShowNameOnHover.Enumerate(npc.globalNPCs)) {
+				bool globalShowName = g.ShowNameOnHover(npc);
+				if (!globalShowName)
+					return false;
+
+				shouldShowName = true;
+			}
+			if (npc.ModNPC != null)
+				shouldShowName &= npc.ModNPC.ShowNameOnHover();
+
+			return shouldShowName;
+		}
+
 		private static HookList HookModifyNPCNameList = AddHook<Action<NPC, List<string>>>(g => g.ModifyNPCNameList);
 		public static List<string> ModifyNPCNameList(NPC npc, List<string> nameList) {
 			if (npc.ModNPC != null)

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -21,6 +21,8 @@ namespace Terraria
 		/// <summary> Provides access to (static) happiness data associated with this NPC's type. </summary>
 		public NPCHappiness Happiness => NPCHappiness.Get(type);
 
+		public bool ShowNameOnHover { get; set; }
+
 		/// <summary>
 		/// Assign a special boss bar, vanilla or modded. Not used by vanilla.
 		/// <para>To assign a modded boss bar, use NPC.BossBar = ModContent.GetInstance&lt;ExampleBossBar&gt;(); where ExampleBossBar is a ModBossBar</para>

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -283,11 +283,12 @@
  		}
  
  		public void SetDefaultsKeepPlayerInteraction(int Type) {
-@@ -1910,6 +_,8 @@
+@@ -1910,6 +_,9 @@
  				return;
  			}
  
 +			ModNPC = null;
++			ShowNameOnHover = true;
 +			globalNPCs = new Instanced<GlobalNPC>[0];
  			waterMovementSpeed = (lavaMovementSpeed = 0.5f);
  			honeyMovementSpeed = 0.25f;


### PR DESCRIPTION
nothing big, just a small feature thing I did while waitin' for a review on something else. needed this stuff for my own purposes, and found out that other people need it as well, so I figured "eh, why not"

## changelog
- added the `NPC.ShowNameOnHover` field, which allows you to prevent an NPC from showin' their name on hover by settin' it to false --- it defaults to true
- added the `(ModNPC/GlobalNPC).ModifyHoverBoundingBox` hook, which allows you to modify the boundin' box that an NPC uses to determine whether or not its name should be shown when hoverin' over it