### PR TITLE
Add Mod/GlobalType NewInstance, IsCloneable, Clone and CloneNewInstances

### DIFF
--- a/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
@@ -17,6 +17,8 @@ namespace ExampleMod.Content.Items.Consumables
 		// We set this when the item is crafted. In other contexts, this will be the empty string ""
 		public string craftedPlayerName = string.Empty;
 
+		public override bool IsCloneable => true; // safe to share craftedPlayerName between clones, because it cannot be changed after creation/load
+
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Example CanStack Item: Gift Bag");
 			Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}"); // References a language key that says "Right Click To Open" in the language of the game

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.GameContent.Creative;
+using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -10,21 +11,30 @@ namespace ExampleMod.Content.Items
 {
 	public class ExampleInstancedItem : ModItem
 	{
+		public Color[] colors;
+
 		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
 
 		public override void SetStaticDefaults() {
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 99;
 		}
 
+		public override void SetDefaults() {
+			Item.useAnimation = 30;
+			Item.useStyle = ItemUseStyleID.Swing;
+		}
+
 		public override ModItem Clone(Item item) {
 			ExampleInstancedItem clone = (ExampleInstancedItem)base.Clone(item);
-			clone.colors = (Color[])colors.Clone();
+			clone.colors = (Color[])colors?.Clone(); // note the ? here is important, colors may be null if spawned from other mods which don't call OnCreate
 			return clone;
 		}
 
-		public Color[] colors;
-
 		public override void OnCreate(ItemCreationContext context) {
+			GenerateNewColors();
+		}
+
+		private void GenerateNewColors() {
 			colors = new Color[5];
 			for (int i = 0; i < 5; i++) {
 				colors[i] = Main.hslToRgb(Main.rand.NextFloat(), 1f, 0.7f);
@@ -32,9 +42,22 @@ namespace ExampleMod.Content.Items
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
+			if (colors == null) //colors may be null if spawned from other mods which don't call OnCreate
+				return;
+
 			for (int i = 0; i < colors.Length; i++) {
 				TooltipLine tooltipLine = new TooltipLine(Mod, "EM" + i, "Example " + i) { OverrideColor = colors[i] };
 				tooltips.Add(tooltipLine);
+			}
+		}
+
+		public override void UseAnimation(Player player) {
+			if (colors == null) {
+				GenerateNewColors();
+			}
+			else {
+				// cycle through the colours
+				colors = colors.Skip(1).Concat(colors.Take(1)).ToArray();
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -92,12 +92,12 @@ namespace Terraria
 
 		/// <summary> Gets the instance of the specified GlobalItem type. </summary>
 		public bool TryGetGlobalItem<T>(out T result, bool exactType = true) where T : GlobalItem
-			=> GlobalType.TryGetGlobal<GlobalItem, T>(globalItems, exactType, out result);
+			=> GlobalType.TryGetGlobal(globalItems, exactType, out result);
 
 		/// <summary> Safely attempts to get the local instance of the type of the specified GlobalItem instance. </summary>
 		/// <returns> Whether or not the requested instance has been found. </returns>
 		public bool TryGetGlobalItem<T>(T baseInstance, out T result) where T : GlobalItem
-			=> GlobalType.TryGetGlobal<GlobalItem, T>(globalItems, baseInstance, out result);
+			=> GlobalType.TryGetGlobal(globalItems, baseInstance, out result);
 
 		public TagCompound SerializeData() => ItemIO.Save(this);
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -107,29 +107,33 @@ namespace Terraria.ModLoader.Core
 
 		private static void MustOverrideTogether(Type type, params MethodInfo[] methods) {
 			int c = methods.Count(m => HasOverride(type, m));
+			
 			if (c > 0 && c < methods.Length)
 				throw new Exception($"{type} must override all of ({string.Join('/', methods.Select(m => m.Name))}) or none");
 		}
 
-		private static HashSet<Type> ValidatedTypes = new();
-		internal static bool IsValidated(Type type) => !ValidatedTypes.Add(type);
+		private static HashSet<Type> validatedTypes = new();
 
-		private static Dictionary<Type, bool> TypeIsCloneable = new();
+		internal static bool IsValidated(Type type) => !validatedTypes.Add(type);
+
+		private static Dictionary<Type, bool> typeIsCloneable = new();
+		
 		internal static bool IsCloneable<T, F>(T t, Expression<Func<T, F>> cloneMethod) where F : Delegate {
 			var rootCloneableType = typeof(T);
 			var type = t.GetType();
-			if (TypeIsCloneable.TryGetValue(type, out var cloneable))
+			
+			if (typeIsCloneable.TryGetValue(type, out var cloneable))
 				return cloneable;
 
 			bool hasReferenceTypedFieldsOnSubclass = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
 				.Any(f => f.DeclaringType.IsSubclassOf(rootCloneableType) && !f.FieldType.IsValueType);
 
-			return TypeIsCloneable[type] = !hasReferenceTypedFieldsOnSubclass || HasOverride(type, cloneMethod);
+			return typeIsCloneable[type] = !hasReferenceTypedFieldsOnSubclass || HasOverride(type, cloneMethod);
 		}
 
 		internal static void ClearTypeInfo() {
-			ValidatedTypes.Clear();
-			TypeIsCloneable.Clear();
+			validatedTypes.Clear();
+			typeIsCloneable.Clear();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Terraria.ModLoader.Core
@@ -37,10 +38,10 @@ namespace Terraria.ModLoader.Core
 			}
 		}
 
-		public static void InstantiateGlobals<TGlobal, TEntity>(TEntity entity, IEnumerable<TGlobal> globals, ref Instanced<TGlobal>[] entityGlobals, Func<TGlobal, TGlobal> getInstance, Action midInstantiationAction) where TGlobal : GlobalType<TEntity> {
+		public static void InstantiateGlobals<TGlobal, TEntity>(TEntity entity, IEnumerable<TGlobal> globals, ref Instanced<TGlobal>[] entityGlobals, Action midInstantiationAction) where TGlobal : GlobalType<TEntity, TGlobal> {
 			entityGlobals = globals
 				.Where(g => g.AppliesToEntity(entity, false))
-				.Select(g => new Instanced<TGlobal>(g.index, getInstance(g)))
+				.Select(g => new Instanced<TGlobal>(g.index, g.NewInstance(entity)))
 				.ToArray();
 
 			midInstantiationAction();
@@ -49,7 +50,7 @@ namespace Terraria.ModLoader.Core
 			var entityGlobalsCopy = entityGlobals;
 			var lateInitGlobals = globals
 				.Where(g => !entityGlobalsCopy.Any(i => i.Index == g.index) && g.AppliesToEntity(entity, true))
-				.Select(g => new Instanced<TGlobal>(g.index, getInstance(g)));
+				.Select(g => new Instanced<TGlobal>(g.index, g.NewInstance(entity)));
 
 			entityGlobals = entityGlobals
 				.Union(lateInitGlobals)
@@ -64,6 +65,71 @@ namespace Terraria.ModLoader.Core
 				return false;
 
 			return methodInfo.DeclaringType != declaringType;
+		}
+
+		public static MethodInfo ToMethodInfo<T, F>(this Expression<Func<T, F>> expr) where F : Delegate {
+			MethodInfo method;
+
+			try {
+				var convert = expr.Body as UnaryExpression;
+				var makeDelegate = convert.Operand as MethodCallExpression;
+				var methodArg = makeDelegate.Object as ConstantExpression;
+				method = methodArg.Value as MethodInfo;
+				if (method == null)
+					throw new NullReferenceException();
+			}
+			catch (Exception e) {
+				throw new ArgumentException("Invalid hook expression " + expr, e);
+			}
+
+			return method;
+		}
+
+		public static bool HasOverride(Type t, MethodInfo baseMethod) =>
+			baseMethod.DeclaringType.IsInterface ? t.IsAssignableTo(baseMethod.DeclaringType) :
+			t.GetMethods().Single(m => m.GetBaseDefinition() == baseMethod).DeclaringType != baseMethod.DeclaringType;
+
+		public static bool HasOverride<T, F>(Type t, Expression<Func<T, F>> expr) where F : Delegate =>
+			HasOverride(t, expr.ToMethodInfo());
+
+		public static IEnumerable<T> WhereMethodIsOverridden<T>(this IEnumerable<T> providers, MethodInfo method) {
+			if (!method.IsVirtual)
+				throw new ArgumentException("Non-virtual method: " + method);
+
+			return providers.Where(p => HasOverride(p.GetType(), method));
+		}
+
+		public static IEnumerable<T> WhereMethodIsOverridden<T, F>(this IEnumerable<T> providers, Expression<Func<T, F>> expr) where F : Delegate =>
+			WhereMethodIsOverridden(providers, expr.ToMethodInfo());
+
+		public static void MustOverrideTogether<T>(T t, params Expression<Func<T, Delegate>>[] methods) =>
+			MustOverrideTogether(t.GetType(), methods.Select(m => m.ToMethodInfo()).ToArray());
+
+		private static void MustOverrideTogether(Type type, params MethodInfo[] methods) {
+			int c = methods.Count(m => HasOverride(type, m));
+			if (c > 0 && c < methods.Length)
+				throw new Exception($"{type} must override all of ({string.Join('/', methods.Select(m => m.Name))}) or none");
+		}
+
+		private static HashSet<Type> ValidatedTypes = new();
+		internal static bool IsValidated(Type type) => !ValidatedTypes.Add(type);
+
+		private static Dictionary<Type, bool> TypeIsCloneable = new();
+		internal static bool IsCloneable<T, F>(T t, Expression<Func<T, F>> cloneMethod) where F : Delegate {
+			var rootCloneableType = typeof(T);
+			var type = t.GetType();
+			if (TypeIsCloneable.TryGetValue(type, out var cloneable))
+				return cloneable;
+
+			bool hasReferenceTypedFieldsOnSubclass = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+				.Any(f => f.DeclaringType.IsSubclassOf(rootCloneableType) && !f.FieldType.IsValueType);
+
+			return TypeIsCloneable[type] = !hasReferenceTypedFieldsOnSubclass || HasOverride(type, cloneMethod);
+		}
+
+		internal static void ClearTypeInfo() {
+			ValidatedTypes.Clear();
+			TypeIsCloneable.Clear();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/JofairdenArmorEffectPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/JofairdenArmorEffectPlayer.cs
@@ -13,8 +13,6 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 
 		public bool HasAura => _auraTime > 0;
 
-		public override bool CloneNewInstances => true;
-
 		public override void ResetEffects() {
 			HasSetBonus = false;
 		}
@@ -70,10 +68,6 @@ namespace Terraria.ModLoader.Default.Developer.Jofairden
 			}
 
 			_lastLife = Player.statLife;
-		}
-
-		public object Clone() {
-			return MemberwiseClone();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -22,8 +22,6 @@ namespace Terraria.ModLoader.Default
 		internal bool scrollSlots;
 		internal int scrollbarSlotPosition;
 
-		public override bool CloneNewInstances => false;
-
 		public int SlotCount => slots.Count;
 		public int LoadedSlotCount => SlotCount - UnloadedSlotCount;
 		public int UnloadedSlotCount { get; private set; } = 0;

--- a/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
@@ -8,6 +8,8 @@ namespace Terraria.ModLoader.Default
 	{
 		private List<Item> items = new List<Item>();
 
+		public override bool IsCloneable => true; // safe to share items between clones, because it cannot be changed after creation/load
+
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("{$tModLoader.StartBagItemName}");
 			Tooltip.SetDefault("{$tModLoader.StartBagTooltip}\n{$CommonItemTooltip.RightClickToOpen}");

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -7,15 +7,9 @@ namespace Terraria.ModLoader.Default
 	{
 		internal IList<TagCompound> data = new List<TagCompound>();
 
-		public override bool InstancePerEntity => true;
+		public override bool IsCloneable => true; // safe to share data between clones, because it cannot be changed after creation/load
 
-		public override GlobalItem Clone(Item item, Item newItem) {
-			UnloadedGlobalItem clone = (UnloadedGlobalItem)base.Clone(item, newItem);
-			if (data != null) {
-				clone.data = TagIO.Clone(data);
-			}
-			return clone;
-		}
+		public override bool InstancePerEntity => true;
 
 		public override void SaveData(Item item, TagCompound tag) {
 			if (data.Count > 0) {

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -10,6 +10,8 @@ namespace Terraria.ModLoader.Default
 	{
 		private TagCompound data;
 
+		public override bool IsCloneable => true; // safe to share 'data' between clones, because it cannot be changed after creation/load
+
 		public string ModName { get; private set; }
 		public string ItemName { get; private set; }
 
@@ -75,12 +77,6 @@ namespace Terraria.ModLoader.Default
 
 		public override void NetReceive(BinaryReader reader) {
 			Setup(TagIO.Read(reader));
-		}
-
-		public override ModItem Clone(Item item) {
-			var clone = (UnloadedItem)base.Clone(item);
-			clone.data = (TagCompound)data?.Clone();
-			return clone;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -19,8 +19,10 @@ namespace Terraria.ModLoader
 	{
 		protected override void ValidateType() {
 			base.ValidateType();
+
 			LoaderUtils.MustOverrideTogether(this, g => g.SaveData, g => g.LoadData);
 			LoaderUtils.MustOverrideTogether(this, g => g.NetSend, g => g.NetReceive);
+			
 			if (InstancePerEntity && !IsCloneable)
 				throw new Exception($"{GetType().FullName} has {nameof(InstancePerEntity)} but not {nameof(IsCloneable)}. See the documentation on {nameof(IsCloneable)}");
 		}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -8,18 +8,24 @@ using Terraria.ModLoader.IO;
 using Terraria.Utilities;
 using Terraria.ID;
 using Terraria.ModLoader.Core;
-using static Terraria.GameContent.Creative.CreativeUI;
+using System;
 
 namespace Terraria.ModLoader
 {
 	/// <summary>
 	/// This class allows you to modify and use hooks for all items, including vanilla items. Create an instance of an overriding class then call Mod.AddGlobalItem to use this.
 	/// </summary>
-	public abstract class GlobalItem : GlobalType<Item>
+	public abstract class GlobalItem : GlobalType<Item, GlobalItem>
 	{
-		protected sealed override void Register() {
-			ItemLoader.VerifyGlobalItem(this);
+		protected override void ValidateType() {
+			base.ValidateType();
+			LoaderUtils.MustOverrideTogether(this, g => g.SaveData, g => g.LoadData);
+			LoaderUtils.MustOverrideTogether(this, g => g.NetSend, g => g.NetReceive);
+			if (InstancePerEntity && !IsCloneable)
+				throw new Exception($"{GetType().FullName} has {nameof(InstancePerEntity)} but not {nameof(IsCloneable)}. See the documentation on {nameof(IsCloneable)}");
+		}
 
+		protected sealed override void Register() {
 			ModTypeLookup<GlobalItem>.Register(this);
 
 			index = (ushort)ItemLoader.globalItems.Count;
@@ -30,13 +36,6 @@ namespace Terraria.ModLoader
 		public sealed override void SetupContent() => SetStaticDefaults();
 
 		public GlobalItem Instance(Item item) => Instance(item.globalItems, index);
-
-		/// <summary>
-		/// Create a copy of this instanced GlobalItem. Called when an item is cloned.
-		/// </summary>
-		/// <param name="item">The item being cloned</param>
-		/// <param name="itemClone">The new item</param>
-		public virtual GlobalItem Clone(Item item, Item itemClone) => (GlobalItem)MemberwiseClone();
 
 		/// <summary>
 		/// Allows you to set the properties of any and every item that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -1,19 +1,16 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
-using Terraria.GameContent.ItemDropRules;
-using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
 	/// <summary>
 	/// This class allows you to modify and use hooks for all NPCs, including vanilla mobs. Create an instance of an overriding class then call Mod.AddGlobalNPC to use this.
 	/// </summary>
-	public abstract class GlobalNPC : GlobalType<NPC>
+	public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	{
 		protected sealed override void Register() {
 			NPCLoader.VerifyGlobalNPC(this);
@@ -28,13 +25,6 @@ namespace Terraria.ModLoader
 		public sealed override void SetupContent() => SetStaticDefaults();
 
 		public GlobalNPC Instance(NPC npc) => Instance(npc.globalNPCs, index);
-
-		/// <summary>
-		/// Create a copy of this instanced GlobalNPC. Called when an npc is cloned.
-		/// </summary>
-		/// <param name="npc">The npc being cloned</param>
-		/// <param name="npcClone">The new npc</param>
-		public virtual GlobalNPC Clone(NPC npc, NPC npcClone) => (GlobalNPC)MemberwiseClone();
 
 		/// <summary>
 		/// Allows you to set the properties of any and every NPC that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -1,16 +1,13 @@
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
 using Terraria.DataStructures;
-using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
 	/// <summary>
 	/// This class allows you to modify and use hooks for all projectiles, including vanilla projectiles. Create an instance of an overriding class then call Mod.AddGlobalProjectile to use this.
 	/// </summary>
-	public abstract class GlobalProjectile : GlobalType<Projectile>
+	public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile>
 	{
 		protected sealed override void Register() {
 			ProjectileLoader.VerifyGlobalProjectile(this);
@@ -25,13 +22,6 @@ namespace Terraria.ModLoader
 		public sealed override void SetupContent() => SetStaticDefaults();
 
 		public GlobalProjectile Instance(Projectile projectile) => Instance(projectile.globalProjectiles, index);
-
-		/// <summary>
-		/// Create a copy of this instanced GlobalProjectile. Called when a projectile is cloned.
-		/// </summary>
-		/// <param name="projectile">The projectile being cloned</param>
-		/// <param name="projectileClone">The new projectile</param>
-		public virtual GlobalProjectile Clone(Projectile projectile, Projectile projectileClone) => (GlobalProjectile)MemberwiseClone();
 
 		/// <summary>
 		/// Allows you to set the properties of any and every projectile that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using System.IO;
 using Terraria.DataStructures;
+using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
@@ -15,7 +19,18 @@ namespace Terraria.ModLoader
 
 		internal GlobalType() { }
 
-		public static T Instance<T>(Instanced<T>[] globals, ushort index) where T : GlobalType {
+		protected override void ValidateType() {
+			base.ValidateType();
+
+			var type = GetType();
+			bool hasInstanceFields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+				.Any(f => f.DeclaringType.IsSubclassOf(typeof(GlobalType)));
+
+			if (hasInstanceFields && !InstancePerEntity)
+				throw new Exception($" {GetType().FullName} instance fields but {nameof(InstancePerEntity)} returns false. Either use static fields, or override {nameof(InstancePerEntity)} to return true");
+		}
+
+		public static T Instance<T>(Instanced<T>[] globals, ushort index) where T : class {
 			for (int i = 0; i < globals.Length; i++) {
 				var g = globals[i];
 
@@ -24,35 +39,22 @@ namespace Terraria.ModLoader
 				}
 			}
 
-			return null;
+			return default;
 		}
 
-		public static TResult GetGlobal<TEntity, TGlobal, TResult>(Instanced<TGlobal>[] globals, TResult baseInstance) where TGlobal : GlobalType<TEntity> where TResult : TGlobal
-			=> Instance(globals, baseInstance.index) as TResult ?? throw new KeyNotFoundException($"Instance of '{typeof(TResult).Name}' does not exist on the current {typeof(TEntity).Name}.");
+		public static TResult GetGlobal<TEntity, TGlobal, TResult>(Instanced<TGlobal>[] globals, TResult baseInstance) where TGlobal : GlobalType where TResult : TGlobal
+			=> TryGetGlobal(globals, baseInstance, out TResult result) ? result : throw new KeyNotFoundException($"Instance of '{typeof(TResult).Name}' does not exist on the current {typeof(TEntity).Name}.");
 
-		public static TResult GetGlobal<TEntity, TGlobal, TResult>(Instanced<TGlobal>[] globals, bool exactType) where TGlobal : GlobalType<TEntity> where TResult : TGlobal {
-			if (exactType) {
-				return GetGlobal<TEntity, TGlobal, TResult>(globals, ModContent.GetInstance<TResult>());
-			}
-
-			for (int i = 0; i < globals.Length; i++) {
-				if (globals[i].Instance is TResult result) {
-					return result;
-				}
-			}
-
-			throw new KeyNotFoundException($"Instance of '{typeof(TResult).Name}' does not exist on the current {typeof(TEntity).Name}.");
-		}
+		public static TResult GetGlobal<TEntity, TGlobal, TResult>(Instanced<TGlobal>[] globals, bool exactType) where TGlobal : GlobalType where TResult : TGlobal
+			=> TryGetGlobal(globals, exactType, out TResult result) ? result : throw new KeyNotFoundException($"Instance of '{typeof(TResult).Name}' does not exist on the current {typeof(TEntity).Name}.");
 
 		public static bool TryGetGlobal<TGlobal, TResult>(Instanced<TGlobal>[] globals, TResult baseInstance, out TResult result) where TGlobal : GlobalType where TResult : TGlobal {
 			if (baseInstance == null) {
 				result = default;
-
 				return false;
 			}
 
 			result = Instance(globals, baseInstance.index) as TResult;
-
 			return result != null;
 		}
 
@@ -64,19 +66,29 @@ namespace Terraria.ModLoader
 			for (int i = 0; i < globals.Length; i++) {
 				if (globals[i].Instance is TResult t) {
 					result = t;
-
 					return true;
 				}
 			}
 
 			result = default;
-
 			return false;
 		}
 	}
 
-	public abstract class GlobalType<TEntity> : GlobalType
+	public abstract class GlobalType<TEntity, TGlobal> : GlobalType where TGlobal : GlobalType<TEntity, TGlobal>
 	{
+		/// <summary>
+		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
+		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
+		/// </summary>
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
+
+		/// <summary>
+		/// Whether to create new instances of this mod type via <see cref="Clone"/> or via the default constructor
+		/// Defaults to false (default constructor).
+		/// </summary>
+		protected virtual bool CloneNewInstances => false;
+
 		/// <summary>
 		/// Use this to control whether or not this global should be associated with the provided entity instance.
 		/// </summary>
@@ -87,5 +99,33 @@ namespace Terraria.ModLoader
 		/// <code> lateInstantiation &amp;&amp; ... </code>
 		/// </param>
 		public virtual bool AppliesToEntity(TEntity entity, bool lateInstantiation) => true;
+
+		/// <summary>
+		/// Create a copy of this instanced global. Called when an entity is cloned.
+		/// </summary>
+		/// <param name="from">The entity being cloned</param>
+		/// <param name="to">The new clone of the entity</param>
+		/// <returns>A clone of this global</returns>
+		public virtual TGlobal Clone(TEntity from, TEntity to) {
+			if (!IsCloneable)
+				throw new NotSupportedException($"{GetType().FullName} has non value typed fields, but does not override {nameof(Clone)} or {nameof(IsCloneable)}");
+
+			return (TGlobal)MemberwiseClone();
+		}
+
+		/// <summary>
+		/// Only called if <see cref="GlobalType.InstancePerEntity"/> and <see cref="AppliesToEntity"/>(<paramref name="target"/>, ...) are both true
+		/// </summary>
+		/// <param name="target">The entity instance the global is being instantiated for</param>
+		/// <returns></returns>
+		public virtual TGlobal NewInstance(TEntity target) {
+			if (CloneNewInstances)
+				return Clone(default, target);
+
+			var inst = (TGlobal)Activator.CreateInstance(GetType());
+			inst.Mod = Mod;
+			inst.index = index;
+			return inst;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -81,7 +81,7 @@ namespace Terraria.ModLoader
 		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
 		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
 		/// </summary>
-		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable<GlobalType<TEntity, TGlobal>, Func<TEntity, TEntity, TGlobal>>(this, m => m.Clone);
 
 		/// <summary>
 		/// Whether to create new instances of this mod type via <see cref="Clone"/> or via the default constructor

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -81,7 +81,7 @@ namespace Terraria.ModLoader
 		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
 		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
 		/// </summary>
-		public virtual bool IsCloneable => LoaderUtils.IsCloneable<GlobalType<TEntity, TGlobal>, Func<TEntity, TEntity, TGlobal>>(this, m => m.Clone);
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
 
 		/// <summary>
 		/// Whether to create new instances of this mod type via <see cref="Clone"/> or via the default constructor

--- a/patches/tModLoader/Terraria/ModLoader/Instanced.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Instanced.cs
@@ -4,7 +4,7 @@ namespace Terraria.ModLoader
 {
 	/// <summary> The purpose of this struct is to micro-optimize lookups of GlobalX indices by providing these associations without additional retrievals from the heap. </summary>
 	[StructLayout(LayoutKind.Sequential, Pack = 2)]
-	public readonly struct Instanced<T> where T : GlobalType
+	public readonly struct Instanced<T>
 	{
 		public readonly ushort Index;
 		public readonly T Instance;

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -6,14 +6,12 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
-using Terraria.ModLoader.IO;
 using Terraria.UI;
 using Terraria.Utilities;
 using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.GlobalItem>;
@@ -37,8 +35,8 @@ namespace Terraria.ModLoader
 		private static readonly List<HookList> hooks = new List<HookList>();
 		private static readonly List<HookList> modHooks = new List<HookList>();
 
-		private static HookList AddHook<F>(Expression<Func<GlobalItem, F>> func) {
-			var hook = new HookList(ModLoader.Method(func));
+		private static HookList AddHook<F>(Expression<Func<GlobalItem, F>> func) where F : Delegate {
+			var hook = HookList.Create(func);
 
 			hooks.Add(hook);
 
@@ -125,7 +123,7 @@ namespace Terraria.ModLoader
 				.Select(g => new Instanced<GlobalItem>(g.index, g))
 				.ToArray();
 
-			NetGlobals = ModLoader.BuildGlobalHook<GlobalItem, Action<Item, BinaryWriter>>(globalItems, g => g.NetSend);
+			NetGlobals = globalItems.WhereMethodIsOverridden(g => g.NetSend).ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(globalItems);
@@ -161,12 +159,9 @@ namespace Terraria.ModLoader
 
 		internal static void SetDefaults(Item item, bool createModItem = true) {
 			if (IsModItem(item.type) && createModItem)
-				item.ModItem = GetItem(item.type).Clone(item);
+				item.ModItem = GetItem(item.type).NewInstance(item);
 
-			GlobalItem Instantiate(GlobalItem g)
-				=> g.InstancePerEntity ? g.Clone(item, item) : g;
-
-			LoaderUtils.InstantiateGlobals(item, globalItems, ref item.globalItems, Instantiate, () => {
+			LoaderUtils.InstantiateGlobals(item, globalItems, ref item.globalItems, () => {
 				item.ModItem?.AutoDefaults();
 				item.ModItem?.SetDefaults();
 			});
@@ -1996,50 +1991,6 @@ namespace Terraria.ModLoader
 			NetGlobals = new GlobalItem[n];
 			for (short i = 0; i < n; i++)
 				NetGlobals[i] = ModContent.Find<GlobalItem>(ModNet.GetMod(r.ReadInt16()).Name, r.ReadString());
-		}
-
-		internal static void VerifyGlobalItem(GlobalItem item) {
-			var type = item.GetType();
-			int saveMethods = 0;
-
-			// Shortcut
-			static bool HasMethod(Type type, string method, params Type[] parameters) => LoaderUtils.HasMethod(type, typeof(GlobalItem), method, parameters);
-
-			if (HasMethod(type, nameof(GlobalItem.SaveData), typeof(Item), typeof(TagCompound)))
-				saveMethods++;
-
-			if (HasMethod(type, nameof(GlobalItem.LoadData), typeof(Item), typeof(TagCompound)))
-				saveMethods++;
-
-			if (saveMethods == 1)
-				throw new Exception($"{type} must override both of ({nameof(GlobalItem.SaveData)}/{nameof(GlobalItem.LoadData)}) or none");
-
-			// @TODO: Remove on release
-			if ((saveMethods == 0) && HasMethod(type, "Save", typeof(Item)))
-				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
-			// @TODO: END Remove on release
-
-			int netMethods = 0;
-
-			if (HasMethod(type, nameof(GlobalItem.NetSend), typeof(Item), typeof(BinaryWriter)))
-				netMethods++;
-
-			if (HasMethod(type, nameof(GlobalItem.NetReceive), typeof(Item), typeof(BinaryReader)))
-				netMethods++;
-
-			if (netMethods == 1)
-				throw new Exception($"{type} must override both of ({nameof(GlobalItem.NetSend)}/{nameof(GlobalItem.NetReceive)}) or none");
-
-			bool hasInstanceFields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-				.Any(f => f.DeclaringType.IsSubclassOf(typeof(GlobalItem)));
-
-			if (hasInstanceFields) {
-				if (!item.InstancePerEntity)
-					throw new Exception(type + " has instance fields but does not set InstancePerEntity to true. Either use static fields, or per instance globals");
-
-				if (!HasMethod(type, "Clone", typeof(Item), typeof(Item)))
-					throw new Exception(type + " has InstancePerEntity but does not override Clone(Item, Item)");
-			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -123,7 +123,7 @@ namespace Terraria.ModLoader
 				.Select(g => new Instanced<GlobalItem>(g.index, g))
 				.ToArray();
 
-			NetGlobals = globalItems.WhereMethodIsOverridden<GlobalItem, Action<Item, BinaryWriter>>(g => g.NetSend).ToArray();
+			NetGlobals = globalItems.WhereMethodIsOverridden(g => g.NetSend).ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(globalItems);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -123,7 +123,7 @@ namespace Terraria.ModLoader
 				.Select(g => new Instanced<GlobalItem>(g.index, g))
 				.ToArray();
 
-			NetGlobals = globalItems.WhereMethodIsOverridden(g => g.NetSend).ToArray();
+			NetGlobals = globalItems.WhereMethodIsOverridden<GlobalItem, Action<Item, BinaryWriter>>(g => g.NetSend).ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(globalItems);

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -444,6 +444,7 @@ namespace Terraria.ModLoader
 		internal static void Unload() {
 			ContentInstance.Clear();
 			ModTypeLookup.Clear();
+			LoaderUtils.ClearTypeInfo();
 			ItemLoader.Unload();
 			EquipLoader.Unload();
 			PrefixLoader.Unload();
@@ -473,7 +474,6 @@ namespace Terraria.ModLoader
 			GlobalBackgroundStyleLoader.Unload();
 			PlayerDrawLayerLoader.Unload();
 			SystemLoader.Unload();
-			TileEntity.manager.Reset();
 			ResizeArrays(true);
 			for (int k = 0; k < Recipe.maxRecipes; k++) {
 				Main.recipe[k] = new Recipe();
@@ -481,6 +481,7 @@ namespace Terraria.ModLoader
 			Recipe.numRecipes = 0;
 			RecipeGroupHelper.ResetRecipeGroups();
 			Recipe.SetupRecipes();
+			TileEntity.manager.Reset();
 			MapLoader.UnloadModMap();
 			ItemSorting.SetupWhiteLists();
 			RecipeLoader.Unload();

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -57,6 +57,7 @@ namespace Terraria.ModLoader
 
 		protected override void ValidateType() {
 			base.ValidateType();
+			
 			if (!IsCloneable)
 				throw new Exception($"{GetType().FullName} is not cloneable, and ModItems must be cloneable. See the documentation on {nameof(IsCloneable)}");
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -9,11 +9,8 @@ using System.Text.RegularExpressions;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
-using Terraria.Localization;
-using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
-using static Terraria.GameContent.Creative.CreativeUI;
 
 namespace Terraria.ModLoader
 {
@@ -21,12 +18,12 @@ namespace Terraria.ModLoader
 	/// This class serves as a place for you to place all your properties and hooks for each item. Create instances of ModItem (preferably overriding this class) to pass as parameters to Mod.AddItem.<br/>
 	/// The <see href="https://github.com/tModLoader/tModLoader/wiki/Basic-Item">Basic Item Guide</see> teaches the basics of making a modded item.
 	/// </summary>
-	public abstract class ModItem : ModTexturedType
+	public abstract class ModItem : ModType<Item, ModItem>
 	{
 		/// <summary>
 		/// The item object that this ModItem controls.
 		/// </summary>
-		public Item Item { get; internal set; }
+		public Item Item => Entity;
 
 		/// <summary>
 		/// Shorthand for Item.type;
@@ -44,26 +41,28 @@ namespace Terraria.ModLoader
 		public ModTranslation Tooltip { get; internal set; }
 
 		/// <summary>
+		/// The file name of this type's texture file in the mod loader's file space.
+		/// </summary>
+		public virtual string Texture => (GetType().Namespace + "." + Name).Replace('.', '/');//GetType().FullName.Replace('.', '/');
+
+		/// <summary>
 		/// Easy get/set for an item's Sacrifice Total Count
 		/// </summary>
 		public int SacrificeTotal {
-			get => Terraria.GameContent.Creative.CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type];
-			set => Terraria.GameContent.Creative.CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = value;
+			get => GameContent.Creative.CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type];
+			set => GameContent.Creative.CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = value;
 		}
 
-		public ModItem() {
-			Item = new Item { ModItem = this };
+		protected override Item CreateTemplateEntity() => new() { ModItem = this };
+
+		protected override void ValidateType() {
+			base.ValidateType();
+			if (!IsCloneable)
+				throw new Exception($"{GetType().FullName} is not cloneable, and ModItems must be cloneable. See the documentation on {nameof(IsCloneable)}");
 		}
 
 		protected sealed override void Register() {
 			ModTypeLookup<ModItem>.Register(this);
-
-			// @TODO: Remove on release
-			var type = GetType();
-
-			if (!LoaderUtils.HasMethod(type, typeof(ModItem), nameof(SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModItem), "Save"))
-				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
-			// @TODO: END Remove on release
 
 			DisplayName = LocalizationLoader.GetOrCreateTranslation(Mod, $"ItemName.{Name}");
 			Tooltip = LocalizationLoader.GetOrCreateTranslation(Mod, $"ItemTooltip.{Name}", true);
@@ -88,16 +87,6 @@ namespace Terraria.ModLoader
 			AutoStaticDefaults();
 			SetStaticDefaults();
 			ItemID.Search.Add(FullName, Type);
-		}
-
-		/// <summary>
-		/// Create a copy of this ModItem. Called when an item is cloned.
-		/// </summary>
-		/// <param name="item">The new item</param>
-		public virtual ModItem Clone(Item item) {
-			ModItem clone = (ModItem)MemberwiseClone();
-			clone.Item = item;
-			return clone;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -8,7 +8,6 @@ using System.Text.RegularExpressions;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
-using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 using Terraria.Localization;
 
@@ -17,16 +16,21 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// This class serves as a place for you to place all your properties and hooks for each NPC. Create instances of ModNPC (preferably overriding this class) to pass as parameters to Mod.AddNPC.
 	/// </summary>
-	public abstract class ModNPC : ModTexturedType
+	public abstract class ModNPC : ModType<NPC, ModNPC>
 	{
 		/// <summary> The NPC object that this ModNPC controls. </summary>
-		public NPC NPC { get; internal set; }
+		public NPC NPC => Entity;
 
 		/// <summary> Shorthand for NPC.type; </summary>
 		public int Type => NPC.type;
 
 		/// <summary> The translations for the display name of this NPC. </summary>
 		public ModTranslation DisplayName { get; internal set; }
+
+		/// <summary>
+		/// The file name of this type's texture file in the mod loader's file space.
+		/// </summary>
+		public virtual string Texture => (GetType().Namespace + "." + Name).Replace('.', '/');//GetType().FullName.Replace('.', '/');
 
 		/// <summary> The file name of this NPC's head texture file, to be used in autoloading. </summary>
 		public virtual string HeadTexture => Texture + "_Head";
@@ -66,9 +70,7 @@ namespace Terraria.ModLoader
 		/// <summary> The ModBiome Types associated with this NPC spawning, if applicable. Used in Bestiary </summary>
 		public int[] SpawnModBiomes { get; set; } = new int[0];
 
-		public ModNPC() {
-			NPC = new NPC{ModNPC = this};
-		}
+		protected override NPC CreateTemplateEntity() => new() { ModNPC = this };
 
 		protected sealed override void Register() {
 			ModTypeLookup<ModNPC>.Register(this);
@@ -95,17 +97,6 @@ namespace Terraria.ModLoader
 			SetStaticDefaults();
 
 			NPCID.Search.Add(FullName, Type);
-		}
-
-		/// <summary>
-		/// Returns a clone of this ModNPC. 
-		/// Allows you to decide which fields of your ModNPC class are copied over when a new NPC is created. 
-		/// By default this will return a memberwise clone; you will want to override this if your ModNPC contains object references. 
-		/// </summary>
-		public virtual ModNPC Clone(NPC npc) {
-			ModNPC clone = (ModNPC)MemberwiseClone();
-			clone.NPC = npc;
-			return clone;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -35,6 +35,7 @@ namespace Terraria.ModLoader
 
 		protected override void ValidateType() {
 			base.ValidateType();
+			
 			LoaderUtils.MustOverrideTogether(this, p => SaveData, p => LoadData);
 			LoaderUtils.MustOverrideTogether(this, p => p.clientClone, p => p.SendClientChanges);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1,11 +1,10 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.GameInput;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
@@ -13,36 +12,34 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// A ModPlayer instance represents an extension of a Player instance. You can store fields in the ModPlayer classes, much like how the Player class abuses field usage, to keep track of mod-specific information on the player that a ModPlayer instance represents. It also contains hooks to insert your code into the Player class.
 	/// </summary>
-	public abstract class ModPlayer : ModType
+	public abstract class ModPlayer : ModType<Player, ModPlayer>
 	{
 		/// <summary>
 		/// The Player instance that this ModPlayer instance is attached to.
 		/// </summary>
-		public Player Player { get; internal set; }
+		public Player Player => Entity;
 
-		internal int index;
+		internal ushort index;
 
-		internal ModPlayer CreateFor(Player newPlayer) {
-			ModPlayer modPlayer = (ModPlayer)(CloneNewInstances ? MemberwiseClone() : Activator.CreateInstance(GetType()));
-			modPlayer.Mod = Mod;
-			modPlayer.Player = newPlayer;
-			modPlayer.index = index;
-			modPlayer.Initialize();
-			return modPlayer;
+		protected override Player CreateTemplateEntity() => null;
+
+		public override ModPlayer NewInstance(Player entity) {
+			var inst = base.NewInstance(entity);
+			inst.index = index;
+			return inst;
 		}
 
 		public bool TypeEquals(ModPlayer other) {
 			return Mod == other.Mod && Name == other.Name;
 		}
 
-		/// <summary>
-		/// Whether each player gets a ModPlayer by cloning the ModPlayer added to the Mod or by creating a new ModPlayer object with the same type as the ModPlayer added to the Mod. The accessor returns true by default. Return false if you want to assign fields through the constructor.
-		/// </summary>
-		public virtual bool CloneNewInstances => true;
+		protected override void ValidateType() {
+			base.ValidateType();
+			LoaderUtils.MustOverrideTogether(this, p => SaveData, p => LoadData);
+			LoaderUtils.MustOverrideTogether(this, p => p.clientClone, p => p.SendClientChanges);
+		}
 
 		protected sealed override void Register() {
-			PlayerLoader.VerifyModPlayer(this);
-
 			ModTypeLookup<ModPlayer>.Register(this);
 			PlayerLoader.Add(this);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -1,6 +1,5 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -14,10 +13,13 @@ namespace Terraria.ModLoader
 	/// This class serves as a place for you to place all your properties and hooks for each projectile. Create instances of ModProjectile (preferably overriding this class) to pass as parameters to Mod.AddProjectile.<br/>
 	/// The <see href="https://github.com/tModLoader/tModLoader/wiki/Basic-Projectile">Basic Projectile Guide</see> teaches the basics of making a modded projectile.
 	/// </summary>
-	public abstract class ModProjectile : ModTexturedType
+	public abstract class ModProjectile : ModType<Projectile, ModProjectile>
 	{
 		/// <summary> The projectile object that this ModProjectile controls. </summary>
-		public Projectile Projectile { get; internal set; }
+		public Projectile Projectile => Entity;
+
+		/// <summary>  Shorthand for Projectile.type; </summary>
+		public int Type => Projectile.type;
 
 		/// <summary> The translations for the display name of this projectile. </summary>
 		public ModTranslation DisplayName { get; internal set; }
@@ -40,15 +42,15 @@ namespace Terraria.ModLoader
 		/// <summary> If this projectile is held by the player, determines whether it is drawn in front of or behind the player's arms. Defaults to false. </summary>
 		public bool DrawHeldProjInFrontOfHeldItemAndArms { get; set; }
 
+		/// <summary>
+		/// The file name of this type's texture file in the mod loader's file space.
+		/// </summary>
+		public virtual string Texture => (GetType().Namespace + "." + Name).Replace('.', '/');//GetType().FullName.Replace('.', '/');
+
 		/// <summary> The file name of this projectile's glow texture file in the mod loader's file space. If it does not exist it is ignored. </summary>
 		public virtual string GlowTexture => Texture + "_Glow"; //TODO: this is wasteful. We should consider AutoStaticDefaults or something... requesting assets regularly is bad perf
 
-		/// <summary>  Shorthand for Projectile.type; </summary>
-		public int Type => Projectile.type;
-
-		public ModProjectile() {
-			Projectile = new Projectile { ModProjectile = this };
-		}
+		protected override Projectile CreateTemplateEntity() => new() { ModProjectile = this };
 
 		protected sealed override void Register() {
 			ModTypeLookup<ModProjectile>.Register(this);
@@ -65,17 +67,6 @@ namespace Terraria.ModLoader
 			SetStaticDefaults();
 
 			ProjectileID.Search.Add(FullName, Type);
-		}
-
-		/// <summary>
-		/// Returns a clone of this ModProjectile. 
-		/// Allows you to decide which fields of your ModProjectile class are copied over when a new Projectile is created. 
-		/// By default this will return a memberwise clone; you will want to override this if your ModProjectile contains object references. 
-		/// </summary>
-		public virtual ModProjectile Clone(Projectile projectile) {
-			ModProjectile clone = (ModProjectile)MemberwiseClone();
-			clone.Projectile = projectile;
-			return clone;
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -8,7 +8,6 @@ using Terraria.ID;
 using Terraria.IO;
 using Terraria.Localization;
 using Terraria.Map;
-using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.UI;
 using Terraria.WorldBuilding;
@@ -21,13 +20,6 @@ namespace Terraria.ModLoader
 	public abstract partial class ModSystem : ModType
 	{
 		protected override void Register() {
-			// @TODO: Remove on release
-			var type = GetType();
-
-			if (!LoaderUtils.HasMethod(type, typeof(ModSystem), nameof(SaveWorldData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModSystem), "SaveWorldData"))
-				throw new Exception($"{type} has old SaveData callback with no arguments but not new SaveData with TagCompound, not loading the mod to avoid wiping mod data");
-			// @TODO: END Remove on release
-
 			SystemLoader.Add(this);
 			ModTypeLookup<ModSystem>.Register(this);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -171,13 +171,6 @@ namespace Terraria.ModLoader
 			if (!Mod.loading)
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
-			// @TODO: Remove on release
-			var type = GetType();
-
-			if (!LoaderUtils.HasMethod(type, typeof(ModTileEntity), nameof(ModTileEntity.SaveData), typeof(TagCompound)) && LoaderUtils.HasMethod(type, typeof(ModTileEntity), "Save"))
-				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
-			// @TODO: END Remove on release
-
 			manager.Register(this);
 			ModTypeLookup<ModTileEntity>.Register(this);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -93,7 +93,7 @@ namespace Terraria.ModLoader
 		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
 		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
 		/// </summary>
-		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable<ModType<TEntity, TModType>, Func<TEntity, TModType>>(this, m => m.Clone);
 
 		/// <summary>
 		/// Whether to create new instances of this mod type via <see cref="Clone(TEntity)"/> or via the default constructor

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -93,7 +93,7 @@ namespace Terraria.ModLoader
 		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
 		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
 		/// </summary>
-		public virtual bool IsCloneable => LoaderUtils.IsCloneable<ModType<TEntity, TModType>, Func<TEntity, TModType>>(this, m => m.Clone);
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
 
 		/// <summary>
 		/// Whether to create new instances of this mod type via <see cref="Clone(TEntity)"/> or via the default constructor

--- a/patches/tModLoader/Terraria/ModLoader/ModType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModType.cs
@@ -1,4 +1,7 @@
-﻿namespace Terraria.ModLoader
+﻿using System;
+using Terraria.ModLoader.Core;
+
+namespace Terraria.ModLoader
 {
 	/// <summary>
 	/// The base type for most modded things.
@@ -21,7 +24,11 @@
 		public string FullName => $"{Mod?.Name ?? "Terraria"}/{Name}";
 
 		void ILoadable.Load(Mod mod) {
+			if (!LoaderUtils.IsValidated(GetType()))
+				ValidateType();
+
 			Mod = mod;
+			InitTemplateInstance();
 			Load();
 			Register();
 		}
@@ -57,5 +64,70 @@
 		/// Allows you to safely unload things you added in <see cref="Load"/>.
 		/// </summary>
 		public virtual void Unload() { }
+
+		/// <summary>
+		/// Create dummy objects for instanced mod-types
+		/// </summary>
+		protected virtual void InitTemplateInstance() { }
+
+		/// <summary>
+		/// Check for the correct overrides of different hook methods and fields and properties
+		/// </summary>
+		protected virtual void ValidateType() { }
+	}
+
+	public abstract class ModType<TEntity> : ModType
+	{
+		public TEntity Entity { get; internal set; }
+
+		protected override void InitTemplateInstance() {
+			Entity = CreateTemplateEntity();
+		}
+
+		protected abstract TEntity CreateTemplateEntity();
+	}
+
+	public abstract class ModType<TEntity, TModType> : ModType<TEntity> where TModType : ModType<TEntity, TModType>
+	{
+		/// <summary>
+		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
+		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
+		/// </summary>
+		public virtual bool IsCloneable => LoaderUtils.IsCloneable(this, m => m.Clone);
+
+		/// <summary>
+		/// Whether to create new instances of this mod type via <see cref="Clone(TEntity)"/> or via the default constructor
+		/// Defaults to false (default constructor).
+		/// </summary>
+		protected virtual bool CloneNewInstances => false;
+
+		/// <summary>
+		/// Create a copy of this instanced global. Called when an entity is cloned.
+		/// </summary>
+		/// <param name="newEntity">The new clone of the entity</param>
+		/// <returns>A clone of this mod type</returns>
+		public virtual TModType Clone(TEntity newEntity) {
+			if (!IsCloneable)
+				throw new NotSupportedException($"{GetType().FullName} has non value typed fields, but does not override {nameof(Clone)} or {nameof(IsCloneable)}");
+
+			var inst = (TModType)MemberwiseClone();
+			inst.Entity = newEntity;
+			return inst;
+		}
+
+		/// <summary>
+		/// Create a new instance of this ModType for a specific entity
+		/// </summary>
+		/// <param name="entity">The entity instance the mod type is being instantiated for</param>
+		/// <returns></returns>
+		public virtual TModType NewInstance(TEntity entity) {
+			if (CloneNewInstances)
+				return Clone(entity);
+
+			var inst = (TModType)Activator.CreateInstance(GetType());
+			inst.Mod = Mod;
+			inst.Entity = entity;
+			return inst;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/MountLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MountLoader.cs
@@ -53,12 +53,6 @@ namespace Terraria.ModLoader
 			return mountData.ModMount != null;
 		}
 
-		internal static void SetupMount(Mount.MountData mount) {
-			if (IsModMount(mount)) {
-				GetMount(mount.ModMount.Type).SetupMount(mount);
-			}
-		}
-
 		public static void JumpHeight(Player mountedPlayer, Mount.MountData mount, ref int jumpHeight, float xVelocity) {
 			if (IsModMount(mount)) {
 				mount.ModMount.JumpHeight(mountedPlayer, ref jumpHeight, xVelocity);

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -14,9 +14,8 @@ using Terraria.GameContent.Bestiary;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
-using Terraria.GameContent.ItemDropRules;
-using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.GlobalNPC>;
 using Terraria.ModLoader.Utilities;
+using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.GlobalNPC>;
 
 namespace Terraria.ModLoader
 {
@@ -41,8 +40,8 @@ namespace Terraria.ModLoader
 		private static readonly List<HookList> hooks = new List<HookList>();
 		private static readonly List<HookList> modHooks = new List<HookList>();
 
-		private static HookList AddHook<F>(Expression<Func<GlobalNPC, F>> func) {
-			var hook = new HookList(ModLoader.Method(func));
+		private static HookList AddHook<F>(Expression<Func<GlobalNPC, F>> func) where F : Delegate {
+			var hook = HookList.Create(func);
 
 			hooks.Add(hook);
 
@@ -162,7 +161,7 @@ namespace Terraria.ModLoader
 		internal static void SetDefaults(NPC npc, bool createModNPC = true) {
 			if (IsModNPC(npc)) {
 				if (createModNPC) {
-					npc.ModNPC = GetNPC(npc.type).Clone(npc);
+					npc.ModNPC = GetNPC(npc.type).NewInstance(npc);
 				}
 				else //the default NPCs created and bound to ModNPCs are initialized before ResizeArrays. They come here during SetupContent.
 				{
@@ -170,10 +169,7 @@ namespace Terraria.ModLoader
 				}
 			}
 
-			GlobalNPC Instantiate(GlobalNPC g)
-				=> g.InstancePerEntity ? g.Clone(npc, npc) : g;
-
-			LoaderUtils.InstantiateGlobals(npc, globalNPCs, ref npc.globalNPCs, Instantiate, () => {
+			LoaderUtils.InstantiateGlobals(npc, globalNPCs, ref npc.globalNPCs, () => {
 				npc.ModNPC?.SetDefaults();
 			});
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -53,7 +53,7 @@ namespace Terraria.ModLoader
 			players.Clear();
 		}
 
-		private static HookList HookInitialize = AddHook(p => p.Initialize);
+		private static HookList HookInitialize = AddHook<Action>(p => p.Initialize);
 		internal static void SetupPlayer(Player player) {
 			player.modPlayers = players.Select(modPlayer => modPlayer.NewInstance(player)).ToArray();
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -53,7 +53,7 @@ namespace Terraria.ModLoader
 			players.Clear();
 		}
 
-		private static HookList HookInitialize = AddHook<Action>(p => p.Initialize);
+		private static HookList HookInitialize = AddHook(p => p.Initialize);
 		internal static void SetupPlayer(Player player) {
 			player.modPlayers = players.Select(modPlayer => modPlayer.NewInstance(player)).ToArray();
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -2,16 +2,13 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Terraria.DataStructures;
 using Terraria.GameInput;
-using Terraria.ID;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Default;
-using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {
@@ -35,20 +32,20 @@ namespace Terraria.ModLoader
 
 		private static List<HookList> hooks = new List<HookList>();
 
-		private static HookList AddHook<F>(Expression<Func<ModPlayer, F>> func) {
-			var hook = new HookList(ModLoader.Method(func));
+		private static HookList AddHook<F>(Expression<Func<ModPlayer, F>> func) where F : Delegate {
+			var hook = new HookList(func.ToMethodInfo());
 			hooks.Add(hook);
 			return hook;
 		}
 
 		internal static void Add(ModPlayer player) {
-			player.index = players.Count;
+			player.index = (ushort)players.Count;
 			players.Add(player);
 		}
 
 		internal static void RebuildHooks() {
 			foreach (var hook in hooks) {
-				hook.arr = ModLoader.BuildGlobalHook(players, hook.method).Select(p => p.index).ToArray();
+				hook.arr = players.WhereMethodIsOverridden(hook.method).Select(p => (int)p.index).ToArray();
 			}
 		}
 
@@ -56,8 +53,13 @@ namespace Terraria.ModLoader
 			players.Clear();
 		}
 
+		private static HookList HookInitialize = AddHook(p => p.Initialize);
 		internal static void SetupPlayer(Player player) {
-			player.modPlayers = players.Select(modPlayer => modPlayer.CreateFor(player)).ToArray();
+			player.modPlayers = players.Select(modPlayer => modPlayer.NewInstance(player)).ToArray();
+
+			foreach (int index in HookInitialize.arr) {
+				player.modPlayers[index].Initialize();
+			}
 		}
 
 		private static HookList HookResetEffects = AddHook<Action>(p => p.ResetEffects);
@@ -988,45 +990,6 @@ namespace Terraria.ModLoader
 				}
 			}
 			return false;
-		}
-
-		internal static void VerifyModPlayer(ModPlayer player) {
-			var type = player.GetType();
-
-			// Shortcut
-			static bool HasMethod(Type type, string method, params Type[] parameters) => LoaderUtils.HasMethod(type, typeof(ModPlayer), method, parameters);
-
-			/*
-			int netClientMethods = 0;
-
-			if (HasMethod(type, nameof(ModPlayer.clientClone), typeof(ModPlayer)))
-				netClientMethods++;
-
-			if (HasMethod(type, nameof(ModPlayer.SyncPlayer), typeof(int), typeof(int), typeof(bool)))
-				netClientMethods++;
-
-			if (HasMethod(type, nameof(ModPlayer.SendClientChanges), typeof(ModPlayer)))
-				netClientMethods++;
-
-			if (netClientMethods > 0 && netClientMethods < 3)
-				throw new Exception($"{type} must override all of ({nameof(ModPlayer.clientClone)}/{nameof(ModPlayer.SyncPlayer)}/{nameof(ModPlayer.SendClientChanges)}) or none");
-			*/
-
-			int saveMethods = 0;
-
-			if (HasMethod(type, nameof(ModPlayer.SaveData), typeof(TagCompound)))
-				saveMethods++;
-
-			if (HasMethod(type, nameof(ModPlayer.LoadData), typeof(TagCompound)))
-				saveMethods++;
-
-			if (saveMethods == 1)
-				throw new Exception($"{type} must override both of ({nameof(ModPlayer.SaveData)}/{nameof(ModPlayer.LoadData)}) or none");
-
-			// @TODO: Remove on release
-			if ((saveMethods == 0) && HasMethod(type, "Save"))
-				throw new Exception($"{type} has old Load/Save callbacks but not new LoadData/SaveData ones, not loading the mod to avoid wiping mod data");
-			// @TODO: END Remove on release
 		}
 
 		private static HookList HookPostSellItem = AddHook<Action<NPC, Item[], Item>>(p => p.PostSellItem);

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -1,5 +1,4 @@
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -29,8 +28,8 @@ namespace Terraria.ModLoader
 		private static readonly List<HookList> modHooks = new List<HookList>();
 		private static Instanced<GlobalProjectile>[] globalProjectilesArray = new Instanced<GlobalProjectile>[0];
 
-		private static HookList AddHook<F>(Expression<Func<GlobalProjectile, F>> func) {
-			var hook = new HookList(ModLoader.Method(func));
+		private static HookList AddHook<F>(Expression<Func<GlobalProjectile, F>> func) where F : Delegate {
+			var hook = HookList.Create(func);
 
 			hooks.Add(hook);
 
@@ -112,13 +111,10 @@ namespace Terraria.ModLoader
 
 		internal static void SetDefaults(Projectile projectile, bool createModProjectile = true) {
 			if (IsModProjectile(projectile) && createModProjectile) {
-				projectile.ModProjectile = GetProjectile(projectile.type).Clone(projectile);
+				projectile.ModProjectile = GetProjectile(projectile.type).NewInstance(projectile);
 			}
 
-			GlobalProjectile Instantiate(GlobalProjectile g)
-				=> g.InstancePerEntity ? g.Clone(projectile, projectile) : g;
-
-			LoaderUtils.InstantiateGlobals(projectile, globalProjectiles, ref projectile.globalProjectiles, Instantiate, () => {
+			LoaderUtils.InstantiateGlobals(projectile, globalProjectiles, ref projectile.globalProjectiles, () => {
 				projectile.ModProjectile?.SetDefaults();
 			});
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -3,12 +3,14 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Terraria.Graphics;
 using Terraria.IO;
 using Terraria.Localization;
 using Terraria.Map;
+using Terraria.ModLoader.Core;
 using Terraria.UI;
 using Terraria.WorldBuilding;
 
@@ -31,8 +33,8 @@ namespace Terraria.ModLoader
 
 		private static readonly List<HookList> hooks = new List<HookList>();
 
-		private static HookList AddHook<F>(Expression<Func<ModSystem, F>> func) {
-			var hook = new HookList(ModLoader.Method(func));
+		private static HookList AddHook<F>(Expression<Func<ModSystem, F>> func) where F : Delegate {
+			var hook = new HookList(func.ToMethodInfo());
 
 			hooks.Add(hook);
 
@@ -41,7 +43,7 @@ namespace Terraria.ModLoader
 
 		private static void RebuildHooks() {
 			foreach (var hook in hooks) {
-				hook.arr = ModLoader.BuildGlobalHook(Systems, hook.method);
+				hook.arr = Systems.WhereMethodIsOverridden(hook.method).ToArray();
 			}
 		}
 


### PR DESCRIPTION
### What is the new feature?

With some cleanups to the `ModType` and `GlobalType` base classes, all mod-type creation now flows through `NewInstance` which is overridable for modder convenience.

The default method of `NewInstance` creation is via the default constructor (`Activator.CreateInstance`) saving you from having to write clone methods which duplicate your constructor or field initializers.

_However_ `ModItem`s and `GlobalItem`s with `InstancePerEntity` must support cloning, as Terraria uses `Item.Clone` for a few different things.

Towards this goal, `IsCloneable` has been implemented, which looks at the fields defined on a type, and returns `false` if any new reference typed fields have been added to a subclass. _Unless_ the type also contains a custom `Clone` override, in which case it's assumed that `Clone` is supported.

If you have 'static' data that can safely be cloned by just copying the reference (`MemberwiseClone`) then you can overrride `IsCloneable => true` instead of making a custom `Clone` impl which does nothing.

No change is required for the majority of mods. If you want to create new instances via cloning rather than the default constructor, you can override `CloneNewInstances => true` once again.

### Why should this be part of tModLoader?

1.4 made a change to make cloning the default method of creating mod type instances from the 'templates' or 'prefabs' which get auto-loaded (and registered to `ModContent`/`ModTypeLookup`)

A clone based prefab system does work well for content in many games, but we don't have the right tooling in tML for it not to cause heaps of confusion and gotchas (why does cloning work here but not here).

Additionally, it's a silent and difficult to understand breaking change from 1.3 behaviour, which had `CloneNewInstances => false`

See discussion in <https://discordapp.com/channels/103110554649894912/971883536393048064>

### Why do I get a `NullReferenceException` when accessing `Item/NPC/Projectile` from my `ModItem/ModNPC/ModProjectile` constructor?
Accessing the `Item/NPC/Projectile` from your constructor never did anything anyway, this instance was always overwritten immediately after the constructor ran, and prior to `SetDefaults`. That's what `SetDefaults` is for. I removed the 'create dummy in constructor' behaviour to save memory.

More detail:
Previously, every `ModItem/ModNPC/ModProjectile` created a new `Item/NPC/Projectile` in its constructor. This instance existed for there to be something on the 'template' instances which are passed to `Mod.AddContent` and which receive the call to `ModType.Load`

Every other time an instance is created in the game (ie, whenever `SetDefaults` is called), the `ModItem.Item` field is replaced with the instance of `Item` which `SetDefaults` is called on, so making one in the constructor is a needless waste of memory for it just to be immediately discarded.

The 'template instance' setup is now in the new method `ModType.InitTemplateInstance`

### Are there alternative designs?

Yep, but they need PRs, documentation and discussion to really evaluate. I'm open to suggestions.

### ExampleMod updates

Made `ExampleInstancedItem` cycle through colours in right click. To give an example of a case where a `Clone` override should be written, rather than just `IsCloneable => true`  because the `colors` array can change during the item's lifetime
