### PR TITLE
NPC catching expansion: now with added modder-friendliness

### DIFF
--- a/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
@@ -45,11 +45,7 @@ namespace ExampleMod.Content.Items.Tools
 			// If you're unsure what to return, return null.
 			// For this example, we'll give our example bug net a 20% chance to catch lava critters successfully (50% with a Warmth Potion buff active).
 			if (ItemID.Sets.IsLavaBait[target.catchItem]) {
-				if (!player.resistCold && Main.rand.NextBool(5)) {
-					return true;
-				}
-
-				if (player.resistCold && Main.rand.NextBool()) {
+				if (Main.rand.NextBool(player.resistCold ? 2 : 5)) {
 					return true;
 				}
 			}

--- a/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
@@ -45,11 +45,13 @@ namespace ExampleMod.Content.Items.Tools
 			// If you're unsure what to return, return null.
 			// For this example, we'll give our example bug net a 20% chance to catch lava critters successfully (50% with a Warmth Potion buff active).
 			if (ItemID.Sets.IsLavaBait[target.catchItem]) {
-				if (!player.resistCold && Main.rand.NextBool(5))
+				if (!player.resistCold && Main.rand.NextBool(5)) {
 					return true;
+				}
 
-				if (player.resistCold && Main.rand.NextBool())
+				if (player.resistCold && Main.rand.NextBool()) {
 					return true;
+				}
 			}
 
 			// For all cases where true isn't explicitly returned, we'll return null so that vanilla catching rules and effects can take place.
@@ -69,8 +71,9 @@ namespace ExampleMod.Content.Items.Tools
 	public class ExampleCatchItemModification : GlobalItem
 	{
 		public override void OnSpawn(Item item, IEntitySource source) {
-			if (source is not EntitySource_CatchEntity catchEntity)
+			if (source is not EntitySource_CatchEntity catchEntity) {
 				return;
+			}
 
 			if (catchEntity.Entity is Player player) {
 				// Gives a 5% chance for the Example Bug Net to duplicate caught NPCs.

--- a/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
@@ -50,10 +50,9 @@ namespace ExampleMod.Content.Items.Tools
 
 				if (player.resistCold && Main.rand.NextBool())
 					return true;
-
-				// As a note, we don't want to return false here, since that would prevent vanilla's code for failed catches on lava critters from running.
-				// Thus, we'll return nothing special if both of the above fail, and simply allow our "default" null return to deal with the remaining cases.
 			}
+
+			// For all cases where true isn't explicitly returned, we'll return null so that vanilla catching rules and effects can take place.
 			return null;
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.GameContent.Creative;
+using Terraria.ModLoader;
+using Terraria.DataStructures;
+
+namespace ExampleMod.Content.Items.Tools
+{
+	// This is an example bug net designed to demonstrate the use cases for various hooks related to catching NPCs such as critters with items.
+	public class ExampleBugNet : ModItem
+	{
+		public override string Texture => $"Terraria/Images/Item_{ItemID.BugNet}";
+
+		public override void SetStaticDefaults() {
+			// This set is needed to define an item as a tool for catching NPCs at all.
+			// An additional set exists called LavaproofCatchingTool which will allow your item to freely catch the Underworld's lava critters. Use it accordingly.
+			ItemID.Sets.CatchingTool[Item.type] = true;
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
+		}
+
+		public override void SetDefaults() {
+			// These are, with a few modifications, the properties applied to the base Bug Net; they're provided here so that you can mess with them as you please.
+			// Explanations on them will be glossed over here, as they're not the primary point of the lesson.
+			// Common Properties
+			Item.width = 24;
+			Item.height = 28;
+			Item.rare = ItemRarityID.Blue;
+			Item.value = Item.buyPrice(0, 0, 40);
+
+			// Use Properties
+			Item.useAnimation = 25;
+			Item.useTurn = true;
+			Item.autoReuse = true;
+			Item.useStyle = ItemUseStyleID.Swing;
+			Item.UseSound = SoundID.Item1;
+		}
+
+		public override bool? CanCatchNPC(NPC target, Player player) {
+			// This hook is used to determine whether or not your catching tool can catch a given NPC.
+			// This returns null by default, which allows vanilla to decide whether or not the NPC should be caught.
+			// Returning true forces the NPC to be caught, while returning false forces the NPC to not be caught.
+			// If you're unsure what to return, return null.
+			// For this example, we'll give our example bug net a 20% chance to catch lava critters successfully (50% with a Warmth Potion buff active).
+			if (ItemID.Sets.IsLavaBait[target.catchItem]) {
+				if (!player.resistCold && Main.rand.NextBool(5))
+					return true;
+
+				if (player.resistCold && Main.rand.NextBool())
+					return true;
+
+				// As a note, we don't want to return false here, since that would prevent vanilla's code for failed catches on lava critters from running.
+				// Thus, we'll return nothing special if both of the above fail, and simply allow our "default" null return to deal with the remaining cases.
+			}
+			return null;
+		}
+
+		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
+		public override void AddRecipes() {
+			CreateRecipe()
+				.AddIngredient<ExampleItem>()
+				.AddTile<Tiles.Furniture.ExampleWorkbench>()
+				.Register();
+		}
+	}
+
+	// This class is included here as a demonstration of how to use OnSpawn to modify the item spawned from catching an NPC or other entity.
+	public class ExampleCatchItemModification : GlobalItem
+	{
+		public override void OnSpawn(Item item, IEntitySource source) {
+			if (source is not EntitySource_CatchEntity catchEntity)
+				return;
+
+			if (catchEntity.Entity is Player player) {
+				// Gives a 5% chance for the Example Bug Net to duplicate caught NPCs.
+				if (player.HeldItem.type == ModContent.ItemType<ExampleBugNet>() && Main.rand.NextBool(20)) {
+					item.stack *= 2;
+				}
+			}
+		}
+	}
+}

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -56,6 +56,13 @@ Mods: {
 				Summons a {$Mods.ExampleMod.Common.PaperAirplane} to follow aimlessly behind you
 				Second Line!
 				'''
+			ExampleBugNet:
+				'''
+				Used to catch critters
+				Has a 20% chance to successfully catch lava critters
+				This increases to 50% if the Warmth Potion buff is active
+				Has a 5% chance to duplicate caught critters
+				'''
 			ExampleSpecificAmmoGun:
 				'''
 				Does not accept cursed bullets as ammunition

--- a/patches/tModLoader/Terraria/DataStructures/EntitySource_CatchEntity.cs
+++ b/patches/tModLoader/Terraria/DataStructures/EntitySource_CatchEntity.cs
@@ -7,7 +7,16 @@ namespace Terraria.DataStructures
 	/// </summary>
 	public class EntitySource_CatchEntity : IEntitySource
 	{
+		/// <summary>
+		/// The entity which performed the act of catching the <see cref="CaughtEntity"/>.<br></br>
+		/// In the vast majority of cases, this will be a <see cref="Player"/>.
+		/// </summary>
 		public readonly Entity Entity;
+
+		/// <summary>
+		/// The entity which was caught by the <see cref="Entity"/>.<br></br>
+		/// In the vast majority of cases, this will be an <see cref="NPC"/>.
+		/// </summary>
 		public readonly Entity CaughtEntity;
 
 		public string? Context { get; }

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -22,7 +22,7 @@
  	{
  		private string _nameOverride;
  		public const int luckPotionDuration1 = 10800;
-@@ -51,18 +_,20 @@
+@@ -51,18 +_,24 @@
  		public int tileWand = -1;
  		public bool wornArmor;
  		public int tooltipContext = -1;
@@ -35,6 +35,10 @@
  		public static int lifeGrabRange = 250;
  		public static int treasureGrabRange = 150;
 -		public short makeNPC;
++		/// <summary>
++		/// The numerical ID of the NPC that this item creates when used.<br></br>
++		/// Mainly used for caught critters as items so that they can be released into the world.
++		/// </summary>
 +		public int makeNPC; // tML: changed to int for convenience and consistency purposes
  		public bool expertOnly;
  		public bool expert;

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -97,7 +97,7 @@ namespace Terraria
 		/// Runs most code related to the process of checking whether or not an NPC can be caught.<br></br>
 		/// After that, <see cref="CombinedHooks.OnCatchNPC"/> is run, followed by the code responsible for catching the NPC if applicable.<br></br>
 		/// You will need to call this manually if you want to make an NPC-catching tool which acts differently from vanilla's, such as one that uses a projectile instead of an item.<br></br>
-		/// As a note, if calling this manually, you will need to check <c>npc.active &amp;&amp; npc.catchItem > 0</c> yourself.
+		/// As a note, if calling this manually, you will need to check <c>npc.active &amp;&amp; npc.catchItem &gt; 0</c> yourself.
 		/// </summary>
 		/// <param name="npc">The NPC which can potentially be caught.</param>
 		/// <param name="catchToolRectangle">The hitbox of the tool being used to catch the NPC --- be it an item, a projectile, or something else entirely.</param>

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -94,9 +94,10 @@ namespace Terraria
 		}
 
 		/// <summary>
-		/// Runs all code related to the process of checking whether or not an NPC can be caught.<br></br>
+		/// Runs most code related to the process of checking whether or not an NPC can be caught.<br></br>
 		/// After that, <see cref="CombinedHooks.OnCatchNPC"/> is run, followed by the code responsible for catching the NPC if applicable.<br></br>
-		/// You will need to call this manually if you want to make an NPC-catching tool which acts differently from vanilla's, such as one that uses a projectile instead of an item.
+		/// You will need to call this manually if you want to make an NPC-catching tool which acts differently from vanilla's, such as one that uses a projectile instead of an item.<br></br>
+		/// As a note, if calling this manually, you will need to check <c>npc.active || npc.catchItem > 0</c> yourself.
 		/// </summary>
 		/// <param name="npc">The NPC which can potentially be caught.</param>
 		/// <param name="catchToolRectangle">The hitbox of the tool being used to catch the NPC --- be it an item, a projectile, or something else entirely.</param>

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -97,7 +97,7 @@ namespace Terraria
 		/// Runs most code related to the process of checking whether or not an NPC can be caught.<br></br>
 		/// After that, <see cref="CombinedHooks.OnCatchNPC"/> is run, followed by the code responsible for catching the NPC if applicable.<br></br>
 		/// You will need to call this manually if you want to make an NPC-catching tool which acts differently from vanilla's, such as one that uses a projectile instead of an item.<br></br>
-		/// As a note, if calling this manually, you will need to check <c>npc.active || npc.catchItem > 0</c> yourself.
+		/// As a note, if calling this manually, you will need to check <c>npc.active &amp;&amp; npc.catchItem > 0</c> yourself.
 		/// </summary>
 		/// <param name="npc">The NPC which can potentially be caught.</param>
 		/// <param name="catchToolRectangle">The hitbox of the tool being used to catch the NPC --- be it an item, a projectile, or something else entirely.</param>

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -13,11 +13,16 @@
  	{
  		private const int NPC_TARGETS_START = 300;
  		public bool IsABestiaryIconDummy;
-@@ -58,7 +_,7 @@
+@@ -58,7 +_,12 @@
  		public int altTexture;
  		public int townNpcVariationIndex;
  		public Vector2 netOffset = Vector2.Zero;
 -		public short catchItem;
++		/// <summary>
++		/// The numerical ID of the item that this NPC becomes when caught.<br></br>
++		/// Mainly used for critters that can be caught with bug nets, such as butterflies and worms.<br></br>
++		/// Bug nets and other catching tools will only work on NPCs with this field set to something greater than 0.
++		/// </summary>
 +		public int catchItem; // tML: changed to int for convenience and consistency purposes
  		public short releaseOwner = 255;
  		public int rarity;


### PR DESCRIPTION
this is a simple follow-up PR to the original one I made for NPC catchin' extensions (see also: #2321)

## changelog
- added documentation to the different properties that make up `EntitySource_CatchEntity`, save for context (seriously, how am I supposed to un-nonsense-ify that property)
- slightly updated the documentation on `NPC.CheckCatchNPC` to clarify that you still need to check `npc.active && npc.catchItem > 0` yourself
- added light documentation for the `Item.makeNPC` and `NPC.catchItem` fields
  - I know this isn't something tML usually does, but it seems notably important to make sure people know how to make use of these fields as part of the critter expansion (and it also works towards solvin' a long-standin' issue with how much the API actually tells you about certain more obscure fields on vanilla entities)
- added a brand-new `ExampleBugNet`, with an accompanyin' `GlobalItem` called `ExampleCatchItemModification`. with their powers combined, they're here to teach all about how the new NPC catchin' hooks work, and how to make the most of what's available

## portin' notes
none. in fact, this PR was made primarily to clarify a lot of stuff that *wasn't* clear enough in the original PR's portin' notes