### PR TITLE
[1.4] "Quick Stack" fixes for prefixed items

### DIFF
--- a/patches/tModLoader/Terraria/Chest.cs.patch
+++ b/patches/tModLoader/Terraria/Chest.cs.patch
@@ -26,16 +26,17 @@
  			if (t.type == 21 && ((t.frameX >= 72 && t.frameX <= 106) || (t.frameX >= 144 && t.frameX <= 178) || (t.frameX >= 828 && t.frameX <= 1006) || (t.frameX >= 1296 && t.frameX <= 1330) || (t.frameX >= 1368 && t.frameX <= 1402) || (t.frameX >= 1440 && t.frameX <= 1474)))
  				return true;
  
-@@ -228,6 +_,9 @@
- 						if (!item.IsTheSameAs(Main.chest[i].item[j]))
+@@ -229,6 +_,10 @@
  							continue;
  
+ 						flag = true;
++						// flag set above means "item of same type found in chest, able to be put into an empty slot later", which means we have to respect it before CanStack
 +						if (!ItemLoader.CanStack(item, Main.chest[i].item[j]))
 +							continue;
 +
- 						flag = true;
  						int num = Main.chest[i].item[j].maxStack - Main.chest[i].item[j].stack;
  						if (num > 0) {
+ 							if (num > item.stack)
 @@ -273,6 +_,17 @@
  			Tile tileSafely = Framing.GetTileSafely(X, Y);
  			int type2 = tileSafely.type;

--- a/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
@@ -78,11 +78,12 @@
  						int num3 = inventory[item2.Key].stack;
  						int num4 = item[num2].maxStack - item[num2].stack;
  						if (num4 == 0)
-@@ -655,6 +_,9 @@
+@@ -655,6 +_,10 @@
  					if ((item5.Value != num6 || inventory[item5.Key].netID != num6) && (!flag || inventory[item5.Key].stack <= 0))
  						continue;
  
-+					if (!flag && !ItemLoader.CanStack(item[num5], inventory[item5.Key])) // outmost for iterates over empty slots, flag not true means item was not put in yet (meaning canstack does not have to be checked)
++					// Outmost for iterates over empty slots, flag not true means item was not put in yet (meaning CanStack does not have to be checked)
++					if (!flag && !ItemLoader.CanStack(item[num5], inventory[item5.Key]))
 +						continue;
 +
  					SoundEngine.PlaySound(7);

--- a/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
@@ -82,7 +82,7 @@
  					if ((item5.Value != num6 || inventory[item5.Key].netID != num6) && (!flag || inventory[item5.Key].stack <= 0))
  						continue;
  
-+					if (!ItemLoader.CanStack(item[num5], inventory[item5.Key]))
++					if (!flag && !ItemLoader.CanStack(item[num5], inventory[item5.Key])) // outmost for iterates over empty slots, flag not true means item was not put in yet (meaning canstack does not have to be checked)
 +						continue;
 +
  					SoundEngine.PlaySound(7);


### PR DESCRIPTION
### What is the bug?
The following two "Quick Stack" features are not working correctly when prefixed items are involved:

![Screenshot_1](https://user-images.githubusercontent.com/15894498/169598062-62c84803-3274-4701-9731-2ab9b35b5b17.png)
![Screenshot_2](https://user-images.githubusercontent.com/15894498/169598066-d9bad8fe-ad79-44b6-9c7e-b7f4d8f75d29.png)

### How did you fix the bug?
The way the current `ItemLoader.CanStack` calls are set up prevent prefixed items from entering a chest even if the same type of item already exists in it (vanilla behavior).

Example:
Unprefixed GPS is in a chest, there are empty slots available. Prefixed GPS in your inventory.
Pressing any of the buttons will move the prefixed GPS into the first empty slot.
HOWEVER, this does not happen currently.

### Are there alternatives to your fix?
The two mechanics required additional attention, as they have special code for allowing an item to go into the chest. I investigated the variables and figured out how the logic works, and adjusted the calls accordingly.
