### PR TITLE
Pointing start-tML directly to script caller to avoid double spawn

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader.bat
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /D "%~dp0"
 
-start "" "LaunchUtils/busybox64.exe" bash "./start-tModLoader.sh" %*
+start "" "LaunchUtils/busybox64.exe" bash "./LaunchUtils/ScriptCaller.sh" %*


### PR DESCRIPTION
Potential busybox problem with some windows terminals not running script if an `&` excecuted script does I/O but the parent is closed.
This is ok because that was redundant and present in the `bat` file too.