### PR TITLE
Aggregate loading exceptions across content instances.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -39,7 +39,7 @@ namespace Terraria.ModLoader.Core
 			}
 		}
 
-		public static void ForEachAggregateExceptions<T>(IEnumerable<T> enumerable, Action<T> action) {
+		public static void ForEachAndAggregateExceptions<T>(IEnumerable<T> enumerable, Action<T> action) {
 			var exceptions = new List<Exception>();
 			foreach (var t in enumerable) {
 				try {

--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Terraria.ModLoader.Exceptions;
 
 namespace Terraria.ModLoader.Core
 {
@@ -36,6 +37,24 @@ namespace Terraria.ModLoader.Core
 					ResetStaticMembers(nestedType, recursive);
 				}
 			}
+		}
+
+		public static void ForEachAggregateExceptions<T>(IEnumerable<T> enumerable, Action<T> action) {
+			var exceptions = new List<Exception>();
+			foreach (var t in enumerable) {
+				try {
+					action(t);
+				}
+				catch (Exception ex) {
+					exceptions.Add(ex);
+				}
+			}
+
+			if (exceptions.Count == 1)
+				throw exceptions[0];
+
+			if (exceptions.Count > 0)
+				throw new MultipleException(exceptions);
 		}
 
 		public static void InstantiateGlobals<TGlobal, TEntity>(TEntity entity, IEnumerable<TGlobal> globals, ref Instanced<TGlobal>[] entityGlobals, Action midInstantiationAction) where TGlobal : GlobalType<TEntity, TGlobal> {

--- a/patches/tModLoader/Terraria/ModLoader/Exceptions/MultipleException.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Exceptions/MultipleException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Terraria.ModLoader.Exceptions
+{
+	public class MultipleException : AggregateException
+	{
+		public static readonly string DefaultMessage = "Multiple errors occured.";
+
+		private readonly string _message;
+
+		public MultipleException(IEnumerable<Exception> exceptions) : this(DefaultMessage, exceptions) { }
+
+		public MultipleException(string message, IEnumerable<Exception> exceptions) : base(exceptions) {
+			_message = message;
+		}
+
+
+		public override string Message => _message;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader
 		internal readonly IList<ILoadable> content = new List<ILoadable>();
 
 		internal void SetupContent() {
-			LoaderUtils.ForEachAggregateExceptions(GetContent<ModType>(), e => e.SetupContent());
+			LoaderUtils.ForEachAndAggregateExceptions(GetContent<ModType>(), e => e.SetupContent());
 		}
 
 		internal void UnloadContent() {
@@ -57,7 +57,7 @@ namespace Terraria.ModLoader
 					.Where(t => AutoloadAttribute.GetValue(t).NeedsAutoloading)
 					.OrderBy(type => type.FullName, StringComparer.InvariantCulture);
 
-				LoaderUtils.ForEachAggregateExceptions(loadableTypes, t => AddContent((ILoadable)Activator.CreateInstance(t, true)));
+				LoaderUtils.ForEachAndAggregateExceptions(loadableTypes, t => AddContent((ILoadable)Activator.CreateInstance(t, true)));
 			}
 
 			// Skip loading client assets if this is a dedicated server;

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -35,8 +35,8 @@ namespace Terraria.ModLoader
 				try {
 					mod.AddRecipes();
 					SystemLoader.AddRecipes(mod);
-					LoaderUtils.ForEachAggregateExceptions(mod.GetContent<ModItem>(), item => item.AddRecipes());
-					LoaderUtils.ForEachAggregateExceptions(mod.GetContent<GlobalItem>(), global => global.AddRecipes());
+					LoaderUtils.ForEachAndAggregateExceptions(mod.GetContent<ModItem>(), item => item.AddRecipes());
+					LoaderUtils.ForEachAndAggregateExceptions(mod.GetContent<GlobalItem>(), global => global.AddRecipes());
 				}
 				catch (Exception e) {
 					e.Data["mod"] = mod.Name;

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Terraria.ID;
 using Terraria.ModLoader.Exceptions;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
@@ -34,12 +35,8 @@ namespace Terraria.ModLoader
 				try {
 					mod.AddRecipes();
 					SystemLoader.AddRecipes(mod);
-
-					foreach (ModItem item in mod.GetContent<ModItem>())
-						item.AddRecipes();
-
-					foreach (GlobalItem globalItem in mod.GetContent<GlobalItem>())
-						globalItem.AddRecipes();
+					LoaderUtils.ForEachAggregateExceptions(mod.GetContent<ModItem>(), item => item.AddRecipes());
+					LoaderUtils.ForEachAggregateExceptions(mod.GetContent<GlobalItem>(), global => global.AddRecipes());
 				}
 				catch (Exception e) {
 					e.Data["mod"] = mod.Name;


### PR DESCRIPTION
### What is the new feature?

Collect exceptions from all content pieces (within a mod) during `Load` and `AddRecipes` and display them together.

### Why should this be part of tModLoader?

Shows modders all of their mod-types which fail to load at once, rather than one by one.

### Are there alternative designs?

Could also be applied to mod-systems, or inside some of the other loaders. (eg, `SetStaticDefaults`)

### Sample log output for the new feature

```
[12:35:54] [.NET ThreadPool Worker/ERROR] [tML]: An error occurred while loading 
The mod responsible is unknown and tModLoader must be restarted.
Terraria.ModLoader.Exceptions.MultipleException: Multiple errors occured.
 ---> System.NotSupportedException: Terraria.ModLoader.Default.StartBag is not cloneable, and ModItems must be cloneable. See the documentation on IsCloneable
   at Terraria.ModLoader.ModItem.ValidateType() in tModLoader\Terraria\ModLoader\ModItem.cs:line 62
   at Terraria.ModLoader.ModType.Terraria.ModLoader.ILoadable.Load(Mod mod) in tModLoader\Terraria\ModLoader\ModType.cs:line 28
   at Terraria.ModLoader.Mod.AddContent(ILoadable instance) in tModLoader\Terraria\ModLoader\Mod.cs:line 139
   at Terraria.ModLoader.Mod.<Autoload>b__106_5(Type t) in tModLoader\Terraria\ModLoader\Mod.Internals.cs:line 60
   at Terraria.ModLoader.Core.LoaderUtils.ForEachAggregateExceptions[T](IEnumerable`1 enumerable, Action`1 action) in tModLoader\Terraria\ModLoader\Core\LoaderUtils.cs:line 46
   --- End of inner exception stack trace ---
   at Terraria.ModLoader.Core.LoaderUtils.ForEachAggregateExceptions[T](IEnumerable`1 enumerable, Action`1 action) in tModLoader\Terraria\ModLoader\Core\LoaderUtils.cs:line 57
   at Terraria.ModLoader.Mod.Autoload() in tModLoader\Terraria\ModLoader\Mod.Internals.cs:line 60
   at Terraria.ModLoader.ModContent.<>c.<Load>b__41_0(Mod mod) in tModLoader\Terraria\ModLoader\ModContent.cs:line 310
   at Terraria.ModLoader.ModContent.LoadModContent(CancellationToken token, Action`1 loadAction) in tModLoader\Terraria\ModLoader\ModContent.cs:line 369
   at Terraria.ModLoader.ModContent.Load(CancellationToken token) in tModLoader\Terraria\ModLoader\ModContent.cs:line 304
   at Terraria.ModLoader.ModLoader.Load(CancellationToken token) in tModLoader\Terraria\ModLoader\ModLoader.cs:line 120
 ---> (Inner Exception #1) System.NotSupportedException: Terraria.ModLoader.Default.UnloadedGlobalItem has InstancePerEntity but not IsCloneable. See the documentation on IsCloneable
   at Terraria.ModLoader.GlobalItem.ValidateType() in tModLoader\Terraria\ModLoader\GlobalItem.cs:line 27
   at Terraria.ModLoader.ModType.Terraria.ModLoader.ILoadable.Load(Mod mod) in tModLoader\Terraria\ModLoader\ModType.cs:line 28
   at Terraria.ModLoader.Mod.AddContent(ILoadable instance) in tModLoader\Terraria\ModLoader\Mod.cs:line 139
   at Terraria.ModLoader.Mod.<Autoload>b__106_5(Type t) in tModLoader\Terraria\ModLoader\Mod.Internals.cs:line 60
   at Terraria.ModLoader.Core.LoaderUtils.ForEachAggregateExceptions[T](IEnumerable`1 enumerable, Action`1 action) in tModLoader\Terraria\ModLoader\Core\LoaderUtils.cs:line 46<---

 ---> (Inner Exception #2) System.NotSupportedException: Terraria.ModLoader.Default.UnloadedItem is not cloneable, and ModItems must be cloneable. See the documentation on IsCloneable
   at Terraria.ModLoader.ModItem.ValidateType() in tModLoader\Terraria\ModLoader\ModItem.cs:line 62
   at Terraria.ModLoader.ModType.Terraria.ModLoader.ILoadable.Load(Mod mod) in tModLoader\Terraria\ModLoader\ModType.cs:line 28
   at Terraria.ModLoader.Mod.AddContent(ILoadable instance) in tModLoader\Terraria\ModLoader\Mod.cs:line 139
   at Terraria.ModLoader.Mod.<Autoload>b__106_5(Type t) in tModLoader\Terraria\ModLoader\Mod.Internals.cs:line 60
   at Terraria.ModLoader.Core.LoaderUtils.ForEachAggregateExceptions[T](IEnumerable`1 enumerable, Action`1 action) in tModLoader\Terraria\ModLoader\Core\LoaderUtils.cs:line 46<---
   ```

### Porting notes

None

