### PR TITLE
[1.4] Fix #2419

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIText.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIText.cs.patch
@@ -1,0 +1,19 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UIText.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/UIText.cs
+@@ -4,6 +_,7 @@
+ using System;
+ using Terraria.Localization;
+ using Terraria.UI;
++using Terraria.UI.Chat;
+ 
+ namespace Terraria.GameContent.UI.Elements
+ {
+@@ -132,7 +_,7 @@
+ 			else
+ 				_visibleText = _lastTextReference;
+ 
+-			Vector2 vector = dynamicSpriteFont.MeasureString(_visibleText);
++			Vector2 vector = ChatManager.GetStringSize(dynamicSpriteFont, _visibleText, new Vector2(textScale)); // TML: Changed to use ChatManager.GetStringSize() since using DynamicSpriteFont.MeasureString() ignores chat tags, giving the UI element a much larger calculated size than it should have.
+ 			Vector2 vector2 = _textSize = ((!IsWrapped) ? (new Vector2(vector.X, large ? 32f : 16f) * textScale) : (new Vector2(vector.X, vector.Y + WrappedTextBottomPadding) * textScale));
+ 			MinWidth.Set(vector2.X + PaddingLeft + PaddingRight, 0f);
+ 			MinHeight.Set(vector2.Y + PaddingTop + PaddingBottom, 0f);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -155,6 +155,7 @@ namespace Terraria.ModLoader.UI
 				Append(_keyImage);
 
 				_modName.Left.Pixels += _keyImage.Width.Pixels + PADDING * 2f;
+				_modName.Recalculate();
 			}
 
 			/*


### PR DESCRIPTION
### What is the bug?
#2419.
Edit: Also fixes https://github.com/tModLoader/tModLoader/issues/2419#issuecomment-1134886548.

### How did you fix the bug?
Added `_modName.Recalculate()` to `UIModItem.OnInitialize()` after `_modName` is offset.
Edit: Also changed `UIText.SetTextInner()` to set its dimensions based on `ChatManager.GetStringSize()` instead of `DynamicSpriteFont.MeasureString()`.

### Are there alternatives to your fix?
Not that I am aware of.
Edit: For the second change, I'm not sure of all the implications of changing `UIText.SetTextInner()`. Nothing has broken from what I can see, but I'd like it if someone else looked over it.