### PR TITLE
Add CloneByReference attribute, improve IsCloneable logic

### DIFF
--- a/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
@@ -15,9 +15,8 @@ namespace ExampleMod.Content.Items.Consumables
 	public class ExampleCanStackItem : ModItem
 	{
 		// We set this when the item is crafted. In other contexts, this will be the empty string ""
+		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 		public string craftedPlayerName = string.Empty;
-
-		public override bool IsCloneable => true; // safe to share craftedPlayerName between clones, because it cannot be changed after creation/load
 
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("Example CanStack Item: Gift Bag");

--- a/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
@@ -15,7 +15,6 @@ namespace ExampleMod.Content.Items.Consumables
 	public class ExampleCanStackItem : ModItem
 	{
 		// We set this when the item is crafted. In other contexts, this will be the empty string ""
-		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 		public string craftedPlayerName = string.Empty;
 
 		public override void SetStaticDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/CloneByReference.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CloneByReference.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// Indicates that references to this object can be shread between clones.
+	/// When applied to a class, applies to all fields/properties of that type.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class)]
+	public class CloneByReference : Attribute
+	{
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/CloneByReference.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CloneByReference.cs
@@ -3,7 +3,7 @@
 namespace Terraria.ModLoader
 {
 	/// <summary>
-	/// Indicates that references to this object can be shread between clones.
+	/// Indicates that references to this object can be shared between clones.
 	/// When applied to a class, applies to all fields/properties of that type.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class)]

--- a/patches/tModLoader/Terraria/ModLoader/ContentInstance.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentInstance.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
@@ -47,6 +48,10 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		static ContentInstance() {
+			TypeCaching.OnClear += Clear;
+		}
+
 		private static ConcurrentDictionary<Type, ContentEntry> contentByType = new ConcurrentDictionary<Type, ContentEntry>();
 
 		private static ContentEntry Factory(Type t) => new ContentEntry();
@@ -55,7 +60,7 @@ namespace Terraria.ModLoader
 
 		public static void Register(object obj) => contentByType.GetOrAdd(obj.GetType(), Factory).Register(obj);
 
-		internal static void Clear() {
+		private static void Clear() {
 			foreach (var entry in contentByType) {
 				entry.Value.Clear();
 				if (entry.Key.Assembly != typeof(ContentEntry).Assembly)

--- a/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
@@ -1,0 +1,112 @@
+﻿using ReLogic.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Terraria.ModLoader.Core
+{
+	public static class Cloning
+	{
+		private class TypeCloningInfo
+		{
+			public Type type;
+			public bool overridesClone;
+			public FieldInfo[] fieldsWhichMightNeedDeepCloning;
+
+			public TypeCloningInfo baseTypeInfo;
+			public bool warnCheckDone;
+
+			public bool IsCloneable => overridesClone || fieldsWhichMightNeedDeepCloning.Length == 0 && baseTypeInfo.IsCloneable;
+
+			public void Warn() {
+				if (warnCheckDone)
+					return;
+
+				if (!IsCloneable) {
+					if (fieldsWhichMightNeedDeepCloning.Length == 0) {
+						baseTypeInfo.Warn();
+					}
+					else {
+
+						IEnumerable<FieldInfo> fields = fieldsWhichMightNeedDeepCloning;
+						var b = baseTypeInfo;
+						while (!b.overridesClone) {
+							fields = fields.Concat(b.fieldsWhichMightNeedDeepCloning);
+							b = b.baseTypeInfo;
+						}
+
+						var msg = $"{type.FullName} has reference fields ({string.Join(", ", fields.Select(f => f.Name))}) that may not be safe to share between clones." + Environment.NewLine +
+								$"For deep-cloning, add a custom Clone override. If shallow (memberwise) cloning is acceptable, mark the fields/types with [{nameof(CloneByReference)}] or properties with [field: {nameof(CloneByReference)}]";
+						Logging.tML.Warn(msg);
+					}
+
+				}
+				warnCheckDone = true;
+			}
+		}
+
+		private static Dictionary<Type, TypeCloningInfo> typeInfos = new();
+		private static ConditionalWeakTable<Type, object> immutableTypes = new();
+
+		public static bool IsCloneable<T, F>(T t, Expression<Func<T, F>> cloneMethod) where F : Delegate {
+			var type = t.GetType();
+			return typeInfos.TryGetValue(type, out var typeInfo) ? typeInfo.IsCloneable : ComputeInfo(t.GetType(), cloneMethod.ToMethodInfo()).IsCloneable;
+		}
+
+		public static bool IsCloneable(Type type, MethodInfo cloneMethod) => GetOrComputeInfo(type, cloneMethod).IsCloneable;
+
+		private static TypeCloningInfo GetOrComputeInfo(Type type, MethodInfo cloneMethod) =>
+			typeInfos.TryGetValue(type, out var typeInfo) ? typeInfo : ComputeInfo(type, cloneMethod);
+
+		private static TypeCloningInfo ComputeInfo(Type type, MethodInfo cloneMethod) {
+			var info = new TypeCloningInfo {
+				type = type,
+				overridesClone = LoaderUtils.GetDerivedDefinition(type, cloneMethod).DeclaringType == type,
+				fieldsWhichMightNeedDeepCloning =
+						type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+						.Where(f => f.DeclaringType == type && !IsCloneByReference(f))
+						.ToArray()
+			};
+
+			if (!info.overridesClone) {
+				info.baseTypeInfo = GetOrComputeInfo(type.BaseType, cloneMethod);
+			}
+
+			typeInfos[type] = info;
+			return info;
+		}
+
+		private static bool IsCloneByReference(FieldInfo f) {
+			return f.GetCustomAttribute<CloneByReference>() != null || IsCloneByReference(f.FieldType);
+		}
+
+		// note that value typed fields could still contain references... maybe detect later
+		private static bool IsCloneByReference(Type type) => type.IsValueType || type.GetCustomAttribute<CloneByReference>() != null || IsImmutable(type);
+
+		public static bool IsImmutable(Type type) {
+			if (type.IsGenericType && !type.IsGenericTypeDefinition && IsImmutable(type.GetGenericTypeDefinition()))
+				return true;
+
+			lock (immutableTypes) {
+				return immutableTypes.TryGetValue(type, out _);
+			}
+		}
+
+		public static void AddImmutableType(Type type) {
+			lock (immutableTypes) {
+				immutableTypes.AddOrUpdate(type, null);
+			}
+		}
+
+		public static void WarnNotCloneable(Type type) => typeInfos[type].Warn();
+
+		static Cloning() {
+			TypeCaching.OnClear += typeInfos.Clear;
+			AddImmutableType(typeof(string));
+			AddImmutableType(typeof(Asset<>));
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
@@ -39,7 +39,7 @@ namespace Terraria.ModLoader.Core
 						}
 
 						var msg = $"{type.FullName} has reference fields ({string.Join(", ", fields.Select(f => f.Name))}) that may not be safe to share between clones." + Environment.NewLine +
-								$"For deep-cloning, add a custom Clone override. If shallow (memberwise) cloning is acceptable, mark the fields with [{nameof(CloneByReference)}] or properties with [field: {nameof(CloneByReference)}]";
+								$"For deep-cloning, add a custom Clone override and make proper copies of these fields. If shallow (memberwise) cloning is acceptable, mark the fields with [{nameof(CloneByReference)}] or properties with [field: {nameof(CloneByReference)}]";
 						Logging.tML.Warn(msg);
 					}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
@@ -39,7 +39,7 @@ namespace Terraria.ModLoader.Core
 						}
 
 						var msg = $"{type.FullName} has reference fields ({string.Join(", ", fields.Select(f => f.Name))}) that may not be safe to share between clones." + Environment.NewLine +
-								$"For deep-cloning, add a custom Clone override. If shallow (memberwise) cloning is acceptable, mark the fields/types with [{nameof(CloneByReference)}] or properties with [field: {nameof(CloneByReference)}]";
+								$"For deep-cloning, add a custom Clone override. If shallow (memberwise) cloning is acceptable, mark the fields with [{nameof(CloneByReference)}] or properties with [field: {nameof(CloneByReference)}]";
 						Logging.tML.Warn(msg);
 					}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/TypeCaching.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TypeCaching.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Terraria.ModLoader.Core
+{
+	internal static class TypeCaching
+	{
+		public static event Action OnClear;
+
+		public static void Clear() {
+			OnClear?.Invoke();
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/StartBag.cs
@@ -6,9 +6,8 @@ namespace Terraria.ModLoader.Default
 {
 	public class StartBag : ModLoaderModItem
 	{
+		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 		private List<Item> items = new List<Item>();
-
-		public override bool IsCloneable => true; // safe to share items between clones, because it cannot be changed after creation/load
 
 		public override void SetStaticDefaults() {
 			DisplayName.SetDefault("{$tModLoader.StartBagItemName}");

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -5,9 +5,8 @@ namespace Terraria.ModLoader.Default
 {
 	public class UnloadedGlobalItem : GlobalItem
 	{
+		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 		internal IList<TagCompound> data = new List<TagCompound>();
-
-		public override bool IsCloneable => true; // safe to share data between clones, because it cannot be changed after creation/load
 
 		public override bool InstancePerEntity => true;
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -8,9 +8,8 @@ namespace Terraria.ModLoader.Default
 	[LegacyName("MysteryItem")]
 	public sealed class UnloadedItem : ModLoaderModItem
 	{
+		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 		private TagCompound data;
-
-		public override bool IsCloneable => true; // safe to share 'data' between clones, because it cannot be changed after creation/load
 
 		public string ModName { get; private set; }
 		public string ItemName { get; private set; }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -22,9 +22,9 @@ namespace Terraria.ModLoader
 
 			LoaderUtils.MustOverrideTogether(this, g => g.SaveData, g => g.LoadData);
 			LoaderUtils.MustOverrideTogether(this, g => g.NetSend, g => g.NetReceive);
-			
-			if (InstancePerEntity && !IsCloneable)
-				Logging.tML.Warn($"{GetType().FullName} has {nameof(InstancePerEntity)} but not {nameof(IsCloneable)}. See the documentation on {nameof(IsCloneable)}");
+
+			if (!IsCloneable)
+				Cloning.WarnNotCloneable(GetType());
 		}
 
 		protected sealed override void Register() {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -77,11 +77,12 @@ namespace Terraria.ModLoader
 
 	public abstract class GlobalType<TEntity, TGlobal> : GlobalType where TGlobal : GlobalType<TEntity, TGlobal>
 	{
+		private bool? _isCloneable;
 		/// <summary>
-		/// Whether or not this type is cloneable. By default, cloning is supported if this type has only value typed fields, or if it overrides <see cref="Clone"/><br/>
-		/// If this type has reference fields, which are safe to share between clones then override this property to return true.
+		/// Whether or not this type is cloneable. Cloning is supported if<br/>
+		/// all reference typed fields in each sub-class which doesn't override Clone are marked with [CloneByReference]
 		/// </summary>
-		public virtual bool IsCloneable => LoaderUtils.IsCloneable<GlobalType<TEntity, TGlobal>, Func<TEntity, TEntity, TGlobal>>(this, m => m.Clone);
+		public virtual bool IsCloneable => _isCloneable ??= Cloning.IsCloneable<GlobalType<TEntity, TGlobal>, Func<TEntity, TEntity, TGlobal>>(this, m => m.Clone);
 
 		/// <summary>
 		/// Whether to create new instances of this mod type via <see cref="Clone"/> or via the default constructor
@@ -108,7 +109,7 @@ namespace Terraria.ModLoader
 		/// <returns>A clone of this global</returns>
 		public virtual TGlobal Clone(TEntity from, TEntity to) {
 			if (!IsCloneable)
-				throw new NotSupportedException($"{GetType().FullName} has non value typed fields, but does not override {nameof(Clone)} or {nameof(IsCloneable)}");
+				Cloning.WarnNotCloneable(GetType());
 
 			return (TGlobal)MemberwiseClone();
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -443,9 +443,7 @@ namespace Terraria.ModLoader
 
 		//TODO: Unhardcode ALL of this.
 		internal static void Unload() {
-			ContentInstance.Clear();
-			ModTypeLookup.Clear();
-			LoaderUtils.ClearTypeInfo();
+			TypeCaching.Clear();
 			ItemLoader.Unload();
 			EquipLoader.Unload();
 			PrefixLoader.Unload();

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.Utilities;
 
@@ -57,9 +58,9 @@ namespace Terraria.ModLoader
 
 		protected override void ValidateType() {
 			base.ValidateType();
-			
+
 			if (!IsCloneable)
-				Logging.tML.Warn($"{GetType().FullName} is not cloneable, and ModItems must be cloneable. See the documentation on {nameof(IsCloneable)}");
+				Cloning.WarnNotCloneable(GetType());
 		}
 
 		protected sealed override void Register() {

--- a/patches/tModLoader/Terraria/ModLoader/ModTranslation.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTranslation.cs
@@ -4,6 +4,7 @@ using Terraria.Localization;
 
 namespace Terraria.ModLoader
 {
+	[CloneByReference]
 	public class ModTranslation
 	{
 		private const int fallback = 1;

--- a/patches/tModLoader/Terraria/ModLoader/ModTypeLookup.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTypeLookup.cs
@@ -1,26 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
-	internal static class ModTypeLookup
-	{
-		public static event Action OnClear;
-
-		public static void Clear() => OnClear?.Invoke();
-	}
-
 	public static class ModTypeLookup<T> where T : IModType
 	{
 		private static readonly Dictionary<string, T> dict = new Dictionary<string, T>();
 		private static readonly Dictionary<string, Dictionary<string, T>> tieredDict = new Dictionary<string, Dictionary<string, T>>();
 
 		static ModTypeLookup() {
-			ModTypeLookup.OnClear += () => {
-				dict.Clear();
-				tieredDict.Clear();
-			};
+			if (typeof(T).Assembly == typeof(ModTypeLookup<>).Assembly) {
+				TypeCaching.OnClear += () => {
+					dict.Clear();
+					tieredDict.Clear();
+				};
+			}
 		}
 
 		public static void Register(T instance) {


### PR DESCRIPTION
### What is the new feature?

Improving again on #2398. Calling `Clone` on a type with `IsCloneable => false` now just produces a warning, rather than an error, and the default logic for `IsCloneable` is now better, and involves a new attribute `[CloneByReference]` which you mark fields and types with, rather than just overriding `IsCloneable => true`. There should now be no reason to override `IsCloneable`, but it's been left as virtual to ease pain this preview, and as an escape hatch.

### Sample warning
For a class:
```cs
public class BaseItem : ModItem
{
	object field1;
	object field2;
}
```

```
[05:23:42] [.NET ThreadPool Worker/WARN] [tML]: ExampleMod.Content.Items.BaseItem has reference fields (field1, field2) that may not be safe to share between clones.
For deep-cloning, add a custom Clone override. If shallow (memberwise) cloning is acceptable, mark the fields with [CloneByReference] or properties with [field: CloneByReference]
```

### Sample usage for the new feature
```cs
	public class StartBag : ModLoaderModItem
	{
		[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
		private List<Item> items = new List<Item>();
```

Properties need the attribute on the backing field. This is done with `[field: CloneByReference]`. The compiler won't let you put the attribute on a property without the `field: ` prefix.
```cs
[field: CloneByReference]
public List<Item> Items { get; set; }
```

If an entire type is cloneable by reference (a common data structure), you can mark the type.
```cs
	[CloneByReference]
	public class ModTranslation
	{
```

If a type you don't own is immutable, and you want to save yourself the hassle of marking all the fields you have which use it:
```cs
	Cloning.AddImmutableType(typeof(string));
	Cloning.AddImmutableType(typeof(Asset<>));
```

