### PR TITLE
[1.4] Fix modded tiles breaking golf

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleHerb.cs
+++ b/ExampleMod/Content/Tiles/ExampleHerb.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
+using Terraria.GameContent.Metadata;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -37,6 +38,7 @@ namespace ExampleMod.Content.Tiles
 			TileID.Sets.ReplaceTileBreakUp[Type] = true;
 			TileID.Sets.IgnoredInHouseScore[Type] = true;
 			TileID.Sets.IgnoredByGrowingSaplings[Type] = true;
+			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]);
 
 			// We do not use this because our tile should only be spelunkable when it's fully grown. That's why we use the IsTileSpelunkable hook instead
 			//Main.tileSpelunker[Type] = true;

--- a/ExampleMod/Content/Tiles/ExampleHerb.cs
+++ b/ExampleMod/Content/Tiles/ExampleHerb.cs
@@ -38,7 +38,7 @@ namespace ExampleMod.Content.Tiles
 			TileID.Sets.ReplaceTileBreakUp[Type] = true;
 			TileID.Sets.IgnoredInHouseScore[Type] = true;
 			TileID.Sets.IgnoredByGrowingSaplings[Type] = true;
-			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]);
+			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]); // Make this tile interact with golf balls in the same way other plants do
 
 			// We do not use this because our tile should only be spelunkable when it's fully grown. That's why we use the IsTileSpelunkable hook instead
 			//Main.tileSpelunker[Type] = true;

--- a/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
+++ b/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
@@ -48,7 +48,7 @@ namespace ExampleMod.Content.Tiles.Plants
 			TileID.Sets.TreeSapling[Type] = true;
 			TileID.Sets.CommonSapling[Type] = true;
 			TileID.Sets.SwaysInWindBasic[Type] = true;
-			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]);
+			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]); // Make this tile interact with golf balls in the same way other plants do
 
 			DustType = ModContent.DustType<Sparkle>();
 

--- a/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
+++ b/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.Enums;
+using Terraria.GameContent.Metadata;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ObjectData;
@@ -47,6 +48,7 @@ namespace ExampleMod.Content.Tiles.Plants
 			TileID.Sets.TreeSapling[Type] = true;
 			TileID.Sets.CommonSapling[Type] = true;
 			TileID.Sets.SwaysInWindBasic[Type] = true;
+			TileMaterials.SetForTileId(Type, TileMaterials._materialsByName["Plant"]);
 
 			DustType = ModContent.DustType<Sparkle>();
 

--- a/patches/tModLoader/Terraria/GameContent/Metadata/TileMaterials.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Metadata/TileMaterials.cs.patch
@@ -1,0 +1,13 @@
+--- src/TerrariaNetCore/Terraria/GameContent/Metadata/TileMaterials.cs
++++ src/tModLoader/Terraria/GameContent/Metadata/TileMaterials.cs
+@@ -8,8 +_,8 @@
+ {
+ 	public static class TileMaterials
+ 	{
+-		private static Dictionary<string, TileMaterial> _materialsByName;
+-		private static readonly TileMaterial[] MaterialsByTileId;
++		public static Dictionary<string, TileMaterial> _materialsByName; // TML: Changed to public so modders can access vanilla TileMaterials
++		internal static TileMaterial[] MaterialsByTileId; // TML: Changed to internal and removed readonly so the array can be resized for modded tiles
+ 
+ 		static TileMaterials() {
+ 			MaterialsByTileId = new TileMaterial[625];

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -174,6 +174,7 @@ namespace Terraria.ModLoader
 			Array.Resize(ref WorldGen.houseTile, nextTile);
 			//Array.Resize(ref GameContent.Biomes.CaveHouseBiome._blacklistedTiles, nextTile);
 			Array.Resize(ref GameContent.Biomes.CorruptionPitBiome.ValidTiles, nextTile);
+			Array.Resize(ref GameContent.Metadata.TileMaterials.MaterialsByTileId, nextTile);
 			Array.Resize(ref HouseUtils.BlacklistedTiles, nextTile);
 			Array.Resize(ref HouseUtils.BeelistedTiles, nextTile);
 
@@ -183,6 +184,7 @@ namespace Terraria.ModLoader
 
 			for (int i = TileID.Count; i < nextTile; i++) {
 				Main.tileGlowMask[i] = -1; //If we don't this, every modded tile will have a glowmask by default.
+				GameContent.Metadata.TileMaterials.MaterialsByTileId[i] = GameContent.Metadata.TileMaterials._materialsByName["Default"];
 			}
 
 			while (TileObjectData._data.Count < nextTile) {

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -184,7 +184,7 @@ namespace Terraria.ModLoader
 
 			for (int i = TileID.Count; i < nextTile; i++) {
 				Main.tileGlowMask[i] = -1; //If we don't this, every modded tile will have a glowmask by default.
-				GameContent.Metadata.TileMaterials.MaterialsByTileId[i] = GameContent.Metadata.TileMaterials._materialsByName["Default"];
+				GameContent.Metadata.TileMaterials.MaterialsByTileId[i] = GameContent.Metadata.TileMaterials._materialsByName["Default"]; //Set this so golf balls know how to interact with modded tiles physics-wise. If not set, then golf balls vanish when touching modded tiles.
 			}
 
 			while (TileObjectData._data.Count < nextTile) {


### PR DESCRIPTION
### What is the bug?
When aiming a golf ball using any golf club, aiming at any modded tile makes the prediction line disappear.
If a golf ball hits any modded tile, it immediately despawns.

https://user-images.githubusercontent.com/33076411/170099304-ebe7bbf7-c5fc-43a2-aacb-7383c5cc5ac2.mp4

https://user-images.githubusercontent.com/33076411/170100417-ac8b4ea3-6ff6-450f-9570-8f92cd69960d.mp4

### How did you fix the bug?
* Made TileMaterials._materialsByName public (from private) and made TileMaterials.MaterialsByTileId internal (from private readonly).
* Auto-set all tiles to have the default tile material.
* Updated ExampleHerb and ExampleSapling to use the Plant tile material, in-line with vanilla's herbs and saplings.

### Are there alternatives to your fix?
Vanilla sets tile materials using a .json file (`Terraria.GameContent.Metadata.MaterialData.Tiles.json`), so mods could do something similar instead of setting materials in `SetStaticDefaults()`.