### PR TITLE
fix `AmmoID` sets

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -88,6 +88,7 @@ namespace Terraria.ModLoader
 
 			//Sets
 			LoaderUtils.ResetStaticMembers(typeof(ItemID), true);
+			LoaderUtils.ResetStaticMembers(typeof(AmmoID), true);
 
 			//Etc
 			Array.Resize(ref Item.cachedItemSpawnsByType, nextItem);


### PR DESCRIPTION
### What is the bug?
`AmmoID` sets not being resized

### How did you fix the bug?
Resize them right after `ItemID` sets

### Are there alternatives to your fix?
No

