### PR TITLE
The Super Grand Sound Playback Follow-Up #2

### DIFF
--- a/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
@@ -1,6 +1,15 @@
 --- src/TerrariaNetCore/Terraria/Audio/ActiveSound.cs
 +++ src/tModLoader/Terraria/Audio/ActiveSound.cs
-@@ -8,8 +_,8 @@
+@@ -1,15 +_,14 @@
+-#if FNA
+-using System.Threading;
+-#endif
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Audio;
++using System;
++using System.Threading.Tasks;
+ 
+ namespace Terraria.Audio
  {
  	public class ActiveSound
  	{
@@ -11,28 +20,29 @@
  		public float Volume;
  
  		public SoundEffectInstance Sound {
-@@ -22,15 +_,16 @@
+@@ -22,22 +_,20 @@
  			private set;
  		}
  
 -		public bool IsPlaying => Sound.State == SoundState.Playing;
-+		public bool IsPlaying => !Sound.IsDisposed && Sound.State == SoundState.Playing;
++		public bool IsPlaying => Sound?.IsDisposed == false && Sound.State == SoundState.Playing;
  
-+		//TML: Position parameter made nullable.
 -		public ActiveSound(SoundStyle style, Vector2 position) {
+-#if FNA
+-			Monitor.Enter(SoundEngine.AudioLock);
+-#endif
++		//TML: Position parameter made nullable.
 +		public ActiveSound(SoundStyle style, Vector2? position = null) {
- #if FNA
- 			Monitor.Enter(SoundEngine.AudioLock);
- #endif
  			Position = position;
  			Volume = 1f;
 -			IsGlobal = false;
 +			//IsGlobal = false;
  			Style = style;
++			
  			Play();
- #if FNA
-@@ -38,6 +_,8 @@
- #endif
+-#if FNA
+-			Monitor.Exit(SoundEngine.AudioLock);
+-#endif
  		}
  
 +		//TML: Merged with the above constructor.
@@ -40,24 +50,64 @@
  		public ActiveSound(SoundStyle style) {
  #if FNA
  			Monitor.Enter(SoundEngine.AudioLock);
-@@ -51,10 +_,12 @@
+@@ -51,10 +_,17 @@
  			Monitor.Exit(SoundEngine.AudioLock);
  #endif
  		}
 +		*/
  
  		private void Play() {
++			if (!Program.IsMainThread) {
++				RunOnMainThreadAndWait(Play);
++				return;
++			}
++
  			SoundEffectInstance soundEffectInstance = Style.GetRandomSound().CreateInstance();
  			soundEffectInstance.Pitch += Style.GetRandomPitch();
 +			soundEffectInstance.IsLooped = Style.IsLooped;
  			soundEffectInstance.Play();
  			SoundInstanceGarbageCollector.Track(soundEffectInstance);
  			Sound = soundEffectInstance;
-@@ -77,14 +_,17 @@
+@@ -62,29 +_,52 @@
+ 		}
+ 
+ 		public void Stop() {
++			if (!Program.IsMainThread) {
++				RunOnMainThreadAndWait(Stop);
++				return;
++			}
++			
+ 			if (Sound != null)
+ 				Sound.Stop();
+ 		}
+ 
+ 		public void Pause() {
++			if (!Program.IsMainThread) {
++				RunOnMainThreadAndWait(Pause);
++				return;
++			}
++			
+ 			if (Sound != null && Sound.State == SoundState.Playing)
+ 				Sound.Pause();
+ 		}
+ 
+ 		public void Resume() {
++			if (!Program.IsMainThread) {
++				RunOnMainThreadAndWait(Resume);
++				return;
++			}
++			
+ 			if (Sound != null && Sound.State == SoundState.Paused)
+ 				Sound.Resume();
  		}
  
  		public void Update() {
 -			if (Sound != null) {
++			if (!Program.IsMainThread) {
++				RunOnMainThreadAndWait(Update);
++				return;
++			}
++			
 +			if (Sound != null && !Sound.IsDisposed) {
  				Vector2 value = Main.screenPosition + new Vector2(Main.screenWidth / 2, Main.screenHeight / 2);
  				float num = 1f;
@@ -74,3 +124,23 @@
  					num = 1f - num2 / ((float)Main.screenWidth * 1.5f);
  				}
  
+@@ -104,6 +_,19 @@
+ 				num = MathHelper.Clamp(num, 0f, 1f);
+ 				Sound.Volume = num;
+ 			}
++		}
++
++		// Added by TML.
++		// As the name states, runs code on the main thread and waits for it to finish.
++		private static void RunOnMainThreadAndWait(Action action) {
++			var tcs = new TaskCompletionSource<bool>();
++
++			Main.QueueMainThreadAction(() => {
++				action();
++				tcs.SetResult(true);
++			});
++
++			tcs.Task.Wait();
+ 		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
@@ -22,6 +22,22 @@
  		}
  
  		public static void Load(IServiceProvider services) {
+@@ -30,6 +_,15 @@
+ 		}
+ 
+ 		public static void Update() {
++			// Thread safety test code, don't anyone dare to ship this.
++			/*
++			if (Main.rand.Next(3) == 0) {
++				System.Threading.ThreadPool.QueueUserWorkItem(_ => {
++					PlaySound(new SoundStyle($"Terraria/Sounds/Zombie_{Main.rand.Next(1, 100)}"));
++				});
++			}
++			*/
++
+ 			if (IsAudioSupported) {
+ 				if (Main.audioSystem != null)
+ 					Main.audioSystem.UpdateAudioEngine();
 @@ -56,6 +_,8 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
@@ -1,12 +1,13 @@
 --- src/TerrariaNetCore/Terraria/Audio/SoundPlayer.cs
 +++ src/tModLoader/Terraria/Audio/SoundPlayer.cs
-@@ -1,24 +_,66 @@
+@@ -1,24 +_,83 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Utilities;
  using System.Collections.Generic;
 +using System.Diagnostics.CodeAnalysis;
  #if FNA
  using System.Threading;
++using System.Threading.Tasks;
  #endif
  
  namespace Terraria.Audio
@@ -36,6 +37,22 @@
 +			if (style.PlayOnlyIfFocused && !Main.hasFocus)
 +				return SlotId.Invalid;
 +
++			// If not on the main thread - queue a main thread action, and wait for it to complete
++			if (!Program.IsMainThread) {
++				var taskCompletionSource = new TaskCompletionSource<SlotId>();
++				var styleCopy = style;
++
++				Main.QueueMainThreadAction(() => taskCompletionSource.SetResult(Play_Inner(styleCopy, position)));
++
++				taskCompletionSource.Task.Wait();
++
++				return taskCompletionSource.Task.Result;
++			}
++			
++			return Play_Inner(in style, position);
++		}
++
++		private SlotId Play_Inner(in SoundStyle style, Vector2? position) {
 +			// Handle the MaxInstances & RestartIfPlaying properties
 +			int maxInstances = style.MaxInstances;
 +
@@ -60,7 +77,7 @@
 +			}
 +
 +			SoundStyle styleCopy = style;
-+			
++
 +			// Handle 'UsesMusicPitch'.. This property is a weird solution for keeping vanilla's old instruments' behavior alive, and is currently internal.
 +			if (style.UsesMusicPitch) {
 +				styleCopy.Pitch += Main.musicPitch;

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -14,6 +14,7 @@ namespace Terraria.ID
 			public static readonly SoundStyleDefaults ItemDefaults = new(1f, 0.12f); // Pitch variance is now 'max - min', not a half.
 			public static readonly SoundStyleDefaults NPCHitDefaults = new(1f, 0.2f);
 			public static readonly SoundStyleDefaults NPCDeathDefaults = new(1f, 0.2f);
+			public static readonly SoundStyleDefaults ZombieDefaults = new(1f, 0.2f);
 		}
 
 		private const string Prefix = "Terraria/Sounds/";
@@ -401,9 +402,127 @@ namespace Terraria.ID
 		public static readonly SoundStyle Item170 = ItemSound(170);
 		public static readonly SoundStyle Item171 = ItemSound(171);
 		public static readonly SoundStyle Item172 = ItemSound(172);
+		// ZombieX sound styles are new, and weren't present in vanilla neither as int nor SoundStyle fields. 
+		public static readonly SoundStyle Zombie1 = ZombieSound(1);
+		public static readonly SoundStyle Zombie2 = ZombieSound(2);
+		public static readonly SoundStyle Zombie3 = ZombieSound(3);
+		public static readonly SoundStyle Zombie4 = ZombieSound(4);
+		public static readonly SoundStyle Zombie5 = ZombieSound(5);
+		public static readonly SoundStyle Zombie6 = ZombieSound(6);
+		public static readonly SoundStyle Zombie7 = ZombieSound(7);
+		public static readonly SoundStyle Zombie8 = ZombieSound(8);
+		public static readonly SoundStyle Zombie9 = ZombieSound(9);
+		public static readonly SoundStyle Zombie10 = ZombieSound(10);
+		public static readonly SoundStyle Zombie11 = ZombieSound(11);
+		public static readonly SoundStyle Zombie12 = ZombieSound(12);
+		public static readonly SoundStyle Zombie13 = ZombieSound(13);
+		public static readonly SoundStyle Zombie14 = ZombieSound(14);
+		public static readonly SoundStyle Zombie15 = ZombieSound(15);
+		public static readonly SoundStyle Zombie16 = ZombieSound(16);
+		public static readonly SoundStyle Zombie17 = ZombieSound(17);
+		public static readonly SoundStyle Zombie18 = ZombieSound(18);
+		public static readonly SoundStyle Zombie19 = ZombieSound(19);
+		public static readonly SoundStyle Zombie20 = ZombieSound(20);
+		public static readonly SoundStyle Zombie21 = ZombieSound(21);
+		public static readonly SoundStyle Zombie22 = ZombieSound(22);
+		public static readonly SoundStyle Zombie23 = ZombieSound(23);
+		public static readonly SoundStyle Zombie24 = ZombieSound(24) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie25 = ZombieSound(25) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie26 = ZombieSound(26) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie27 = ZombieSound(27) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie28 = ZombieSound(28) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie29 = ZombieSound(29) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie30 = ZombieSound(30) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie31 = ZombieSound(31) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie32 = ZombieSound(32) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie33 = ZombieSound(33) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie34 = ZombieSound(34) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie35 = ZombieSound(35) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie36 = ZombieSound(36) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie37 = ZombieSound(37) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie38 = ZombieSound(38) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie39 = ZombieSound(39) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie40 = ZombieSound(40) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie41 = ZombieSound(41) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie42 = ZombieSound(42) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie43 = ZombieSound(43) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie44 = ZombieSound(44) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie45 = ZombieSound(45) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie46 = ZombieSound(46) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie47 = ZombieSound(47) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie48 = ZombieSound(48) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie49 = ZombieSound(49) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie50 = ZombieSound(50) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie51 = ZombieSound(51) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie52 = ZombieSound(52) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie53 = ZombieSound(53) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie54 = ZombieSound(54) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie55 = ZombieSound(55) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie56 = ZombieSound(56) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie57 = ZombieSound(57) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie58 = ZombieSound(58) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie59 = ZombieSound(59) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie60 = ZombieSound(60) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie61 = ZombieSound(61) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie62 = ZombieSound(62) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie63 = ZombieSound(63) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie64 = ZombieSound(64) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie65 = ZombieSound(65) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie66 = ZombieSound(66) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie67 = ZombieSound(67) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie68 = ZombieSound(68) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie69 = ZombieSound(69) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie70 = ZombieSound(70) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie71 = ZombieSound(71) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie72 = ZombieSound(72) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie73 = ZombieSound(73) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie74 = ZombieSound(74) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie75 = ZombieSound(75) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie76 = ZombieSound(76) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie77 = ZombieSound(77) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie78 = ZombieSound(78) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie79 = ZombieSound(79) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie80 = ZombieSound(80) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie81 = ZombieSound(81) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie82 = ZombieSound(82) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie83 = ZombieSound(83) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie84 = ZombieSound(84) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie85 = ZombieSound(85) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie86 = ZombieSound(86) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie87 = ZombieSound(87) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie88 = ZombieSound(88) with { Volume = 0.7f };
+		public static readonly SoundStyle Zombie89 = ZombieSound(89) with { Volume = 0.7f };
+		public static readonly SoundStyle Zombie90 = ZombieSound(90) with { Volume = 0.7f };
+		public static readonly SoundStyle Zombie91 = ZombieSound(91) with { Volume = 0.7f };
+		public static readonly SoundStyle Zombie92 = ZombieSound(92) with { Volume = 0.5f };
+		public static readonly SoundStyle Zombie93 = ZombieSound(93) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie94 = ZombieSound(94) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie95 = ZombieSound(95) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie96 = ZombieSound(96) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie97 = ZombieSound(97) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie98 = ZombieSound(98) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie99 = ZombieSound(99) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie100 = ZombieSound(100) with { Volume = 0.25f };
+		public static readonly SoundStyle Zombie101 = ZombieSound(101) with { Volume = 0.25f };
+		public static readonly SoundStyle Zombie102 = ZombieSound(102) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie103 = ZombieSound(103) with { Volume = 0.4f };
+		public static readonly SoundStyle Zombie104 = ZombieSound(104) with { Volume = 0.55f };
+		public static readonly SoundStyle Zombie105 = ZombieSound(105);
+		public static readonly SoundStyle Zombie106 = ZombieSound(106);
+		public static readonly SoundStyle Zombie107 = ZombieSound(107);
+		public static readonly SoundStyle Zombie108 = ZombieSound(108);
+		public static readonly SoundStyle Zombie109 = ZombieSound(109);
+		public static readonly SoundStyle Zombie110 = ZombieSound(110);
+		public static readonly SoundStyle Zombie111 = ZombieSound(111);
+		public static readonly SoundStyle Zombie112 = ZombieSound(112);
+		public static readonly SoundStyle Zombie113 = ZombieSound(113);
+		public static readonly SoundStyle Zombie114 = ZombieSound(114);
+		public static readonly SoundStyle Zombie115 = ZombieSound(115);
+		public static readonly SoundStyle Zombie116 = ZombieSound(116);
+		public static readonly SoundStyle Zombie117 = ZombieSound(117);
 
 		// Mapping
-		
+
 		private static SoundStyle[][] legacyArrayedStylesMapping = new SoundStyle[LegacySoundIDs.Count][];
 
 		static SoundID() {
@@ -440,12 +559,7 @@ namespace Terraria.ID
 			AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 172);
 			AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 65);
 			AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 57);
-
-			var zombieArray = legacyArrayedStylesMapping[LegacySoundIDs.Zombie] = new SoundStyle[117 + 1];
-
-			for (int i = 0; i < zombieArray.Length; i++) {
-				zombieArray[i] = new SoundStyle($"{Prefix}Zombie_{i}");
-			}
+			AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 118);
 		}
 
 		// Helper methods
@@ -475,12 +589,17 @@ namespace Terraria.ID
 		private static SoundStyle ItemSound(ReadOnlySpan<int> soundStyles)
 			=> SoundWithDefaults(ItemDefaults, new($"{Prefix}Item_", soundStyles));
 
+		private static SoundStyle ZombieSound(int soundStyle)
+			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_{soundStyle}"));
+
+		private static SoundStyle ZombieSound(ReadOnlySpan<int> soundStyles)
+			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_", soundStyles));
+
 		// Moved to bottom for its size
 
 		internal static SoundStyle? GetLegacyStyle(int type, int style) => type switch {
 			// Arrayed
-			LegacySoundIDs.Zombie
-				=> new SoundStyle($"{Prefix}Zombie_{style}"),
+			LegacySoundIDs.Zombie or
 			LegacySoundIDs.Item or
 			LegacySoundIDs.NPCHit or
 			LegacySoundIDs.NPCKilled

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -439,7 +439,7 @@ namespace Terraria.ID
 
 			AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 172);
 			AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 65);
-			AddNumberedStyles(LegacySoundIDs.NPCKilled, nameof(LegacySoundIDs.NPCKilled), 0, 57);
+			AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 57);
 
 			var zombieArray = legacyArrayedStylesMapping[LegacySoundIDs.Zombie] = new SoundStyle[117 + 1];
 
@@ -484,7 +484,7 @@ namespace Terraria.ID
 			LegacySoundIDs.Item or
 			LegacySoundIDs.NPCHit or
 			LegacySoundIDs.NPCKilled
-				=> style >= 0 && style < legacyArrayedStylesMapping[type].Length ? legacyArrayedStylesMapping[type][style] : null,
+				=> style >= 1 && style < legacyArrayedStylesMapping[type].Length ? legacyArrayedStylesMapping[type][style] : null,
 			// Everything else
 			LegacySoundIDs.Dig => Dig,
 			LegacySoundIDs.PlayerHit => PlayerHit,

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -26,6 +26,17 @@
  	{
  		/* hide unused consts
  		public const bool IsServer = false;
+@@ -30,6 +_,10 @@
+ 		public static bool LoadedEverything;
+ 		public static IntPtr JitForcedMethodCache;
+ 
++		public static Thread MainThread { get; private set; }
++
++		public static bool IsMainThread => Thread.CurrentThread == MainThread;
++
+ 		public static float LoadedPercentage {
+ 			get {
+ 				if (ThingsToLoad == 0)
 @@ -55,21 +_,15 @@
  			LoadedEverything = true;
  		}
@@ -88,7 +99,7 @@
  
  			try {
  				Console.OutputEncoding = Encoding.UTF8;
-@@ -138,30 +_,78 @@
+@@ -138,30 +_,80 @@
  			}
  		}
  
@@ -100,7 +111,10 @@
 +		// Moving all calls to Main to LaunchGame_() mitigates this risk
  		public static void LaunchGame(string[] args, bool monoArgs = false) {
 +			// It's not the Entry Thread anymore, but it still is the base thread of FNA and Main
- 			Thread.CurrentThread.Name = "Main Thread";
++			MainThread = Thread.CurrentThread;
+-			Thread.CurrentThread.Name = "Main Thread";
++			MainThread.Name = "Main Thread";
++
  			if (monoArgs)
  				args = Utils.ConvertMonoArgsToDotNet(args);
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -85,7 +85,7 @@
  			}
  
  			if (x < roomX1)
-@@ -2309,19 +_,39 @@
+@@ -2309,15 +_,29 @@
  		public static void setWorldSize() {
  			Main.bottomWorld = Main.maxTilesY * 16;
  			Main.rightWorld = Main.maxTilesX * 16;
@@ -107,11 +107,7 @@
 +		}
 +
 +		public static void do_worldGenCallBack(object threadContext) {
-+			//TML: #PlaySoundThreadLockWorkaround - This is a workaround for lock freeze issues related to calling PlaySound outside the main thread.
-+			Main.QueueMainThreadAction(() => {
--			SoundEngine.PlaySound(10);
-+				SoundEngine.PlaySound(10);
-+			});
+ 			SoundEngine.PlaySound(10);
  			clearWorld();
  			GenerateWorld(Main.ActiveWorldFileData.Seed, threadContext as GenerationProgress);
  			WorldFile.SaveWorld(Main.ActiveWorldFileData.IsCloudSave, resetTime: true);
@@ -119,48 +115,18 @@
  			if (Main.menuMode == 10 || Main.menuMode == 888)
  				Main.menuMode = 6;
  
-+			//TML: #PlaySoundThreadLockWorkaround
-+			Main.QueueMainThreadAction(() => {
--			SoundEngine.PlaySound(10);
-+				SoundEngine.PlaySound(10);
-+			});
- 			generatingWorld = false;
- 		}
- 
-@@ -2395,12 +_,20 @@
- 			Rain.ClearRain();
- 			if (netMode == 0) {
- 				WorldFile.SaveWorld();
-+				//TML: #PlaySoundThreadLockWorkaround
-+				Main.QueueMainThreadAction(() => {
--				SoundEngine.PlaySound(10);
-+					SoundEngine.PlaySound(10);
-+				});
- 			}
- 			else {
- 				Netplay.Disconnect = true;
+@@ -2402,6 +_,11 @@
  				Main.netMode = 0;
  			}
-+
+ 
 +			//This is only called in case of a manual quit or disconnect.
 +			//There is a less common (client) call to this in Netplay.InnerClientLoop.
 +			SystemLoader.OnWorldUnload();
 +			TileIO.PostExitWorldCleanup();
- 
++
  			Main.fastForwardTime = false;
  			Main.UpdateTimeRate();
-@@ -2410,7 +_,10 @@
- 		}
- 
- 		public static void SaveAndQuit(Action callback = null) {
-+			//TML: #PlaySoundThreadLockWorkaround
-+			Main.QueueMainThreadAction(() => {
--			SoundEngine.PlaySound(11);
-+				SoundEngine.PlaySound(11);
-+			});
- 			ThreadPool.QueueUserWorkItem(SaveAndQuitCallBack, callback);
- 		}
- 
+ 			Main.menuMode = 0;
 @@ -2484,13 +_,20 @@
  					}
  
@@ -199,7 +165,7 @@
  							return;
  						}
  					}
-@@ -2525,12 +_,21 @@
+@@ -2525,6 +_,12 @@
  			if (Main.netMode == 0 && Main.anglerWhoFinishedToday.Contains(Main.player[Main.myPlayer].name))
  				Main.anglerQuestFinished = true;
  
@@ -212,16 +178,6 @@
  			Main.player[Main.myPlayer].Spawn(PlayerSpawnContext.SpawningIntoWorld);
  			Main.ActivePlayerFileData.StartPlayTimer();
  			_lastSeed = Main.ActiveWorldFileData.Seed;
- 			Player.Hooks.EnterWorld(Main.myPlayer);
- 			WorldFile.SetOngoingToTemps();
-+			//TML: #PlaySoundThreadLockWorkaround
-+			Main.QueueMainThreadAction(() => {
--			SoundEngine.PlaySound(11);
-+				SoundEngine.PlaySound(11);
-+			});
- 			Main.resetClouds = true;
- 			noMapUpdate = false;
- 		}
 @@ -2556,6 +_,7 @@
  		}
  
@@ -230,18 +186,6 @@
  			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
  			WorldFile.LoadWorld(Main.ActiveWorldFileData.IsCloudSave);
  			if (loadFailed || !loadSuccess) {
-@@ -2595,7 +_,10 @@
- 			}
- 
- 			_lastSeed = Main.ActiveWorldFileData.Seed;
-+			//TML: #PlaySoundThreadLockWorkaround
-+			Main.QueueMainThreadAction(() => {
--			SoundEngine.PlaySound(10);
-+				SoundEngine.PlaySound(10);
-+			});
- 			WorldFile.SetOngoingToTemps();
- 			Hooks.WorldLoaded();
- 		}
 @@ -2753,21 +_,26 @@
  			noLiquidCheck = false;
  			Liquid.numLiquid = 0;


### PR DESCRIPTION
Follow-up for #1084 and #2423

Does the following things (already described in commits):
- Fixed more enemy sound related crashes.
- Made sounds semi-thread-safe, using redirects to main thread & waits. This should fix various freezes, as well as crashes that would usually require complete PlaySound call spam on worker threads. Removes temporary workaround patches that were introduced with Thomas' PR.
- Added SoundID.ZombieX entries; Made playback vanilla-accurate.