### PR TITLE
[1.4] Fix zombie sounds

### DIFF
--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -590,10 +590,10 @@ namespace Terraria.ID
 			=> SoundWithDefaults(ItemDefaults, new($"{Prefix}Item_", soundStyles));
 
 		private static SoundStyle ZombieSound(int soundStyle)
-			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_{soundStyle}"));
+			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_{soundStyle}")) with { SoundLimitBehavior = IgnoreNew };
 
 		private static SoundStyle ZombieSound(ReadOnlySpan<int> soundStyles)
-			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_", soundStyles));
+			=> SoundWithDefaults(ZombieDefaults, new($"{Prefix}Zombie_", soundStyles)) with { SoundLimitBehavior = IgnoreNew };
 
 		// Moved to bottom for its size
 


### PR DESCRIPTION
### What is the bug?
Zombie sounds overwrite/replace old sounds

### How did you fix the bug?
Switch the zombie sounds to `SoundLimitBehavior.IgnoreNew`

### Are there alternatives to your fix?
No
