### PR TITLE
[1.4] Use `MaxBuffs` where it's needed

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1393,6 +1393,24 @@
  			}
  
  			UpdateHungerBuffs();
+@@ -8237,7 +_,7 @@
+ 		}
+ 
+ 		public void UpdateHungerBuffs() {
+-			for (int i = 0; i < 22; i++) {
++			for (int i = 0; i < MaxBuffs; i++) {
+ 				if (buffType[i] <= 0 || buffTime[i] <= 0)
+ 					continue;
+ 
+@@ -8270,7 +_,7 @@
+ 				return;
+ 
+ 			bool flag = false;
+-			for (int i = 0; i < 22; i++) {
++			for (int i = 0; i < MaxBuffs; i++) {
+ 				if (buffTime[i] > 0 && BuffID.Sets.IsFedState[buffType[i]]) {
+ 					flag = true;
+ 					break;
 @@ -8577,12 +_,19 @@
  			}
  		}


### PR DESCRIPTION
### What is the bug?
Fixes #2458

### How did you fix the bug?
Switch to `MaxBuffs`

### Are there alternatives to your fix?
No
