### PR TITLE
Fix PickAmmo (modder convenience version) not including weapon damage bonuses

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4959,8 +4959,8 @@
 +		public bool PickAmmo(Item weapon, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId, bool dontConsume = false) {
 +			projToShoot = weapon.shoot;
 +			speed = weapon.shootSpeed;
-+			damage = GetTotalDamage(weapon.DamageType).ApplyTo(weapon.damage);
-+			knockBack = GetTotalKnockback(weapon.DamageType).ApplyTo(weapon.knockBack);
++			damage = GetWeaponDamage(weapon);
++			knockBack = GetWeaponKnockback(weapon);
 +			bool canShoot = false;
 +			PickAmmo(weapon, ref projToShoot, ref speed, ref canShoot, ref damage, ref knockBack, out usedAmmoItemId, dontConsume);
 +			if (!canShoot) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4959,8 +4959,8 @@
 +		public bool PickAmmo(Item weapon, out int projToShoot, out float speed, out int damage, out float knockBack, out int usedAmmoItemId, bool dontConsume = false) {
 +			projToShoot = weapon.shoot;
 +			speed = weapon.shootSpeed;
-+			damage = weapon.damage;
-+			knockBack = weapon.knockBack;
++			damage = GetTotalDamage(weapon.DamageType).ApplyTo(weapon.damage);
++			knockBack = GetTotalKnockback(weapon.DamageType).ApplyTo(weapon.knockBack);
 +			bool canShoot = false;
 +			PickAmmo(weapon, ref projToShoot, ref speed, ref canShoot, ref damage, ref knockBack, out usedAmmoItemId, dontConsume);
 +			if (!canShoot) {


### PR DESCRIPTION
**hi**

**the bug:** `PickAmmo`'s public variant didn't respect weapon damage and knockback bonuses, thus resultin' in lower numbers than should've been received
**the fix:** `PickAmmo`'s public variant now respects weapon damage and knockback bonuses
**are there alternative fixes?** no