### PR TITLE
[Draft] Add ChooseBestTorch Hook (resolves #2475)

### DIFF
--- a/ExampleMod/Common/Players/ExampleChooseBestTorch.cs
+++ b/ExampleMod/Common/Players/ExampleChooseBestTorch.cs
@@ -1,0 +1,35 @@
+﻿using ExampleMod.Content.Biomes;
+using ExampleMod.Content.Tiles;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	public class ExampleChooseBestTorch : ModPlayer
+	{
+		// ChooseBestTorch gives you control over the type and style of a torch if it's manipulated by Torch God's Favor.
+		// Technically, you can use this to manipulate the placement of other tiles if you're so inclined, which is why
+		// we need to check if the player has the Torch God's Favor enabled here.
+		public override bool? ChooseBestTorch(ref int type, ref int style) {
+			// As per the comment above, we must check for whether Torch God's Favor is being used to ensure vanilla parity,
+			// since we're modifying the tile that gets placed.
+			bool torchGodsFavor = Player.UsingBiomeTorches && type == TileID.Torches && style == 0;
+
+			// Check if the player is in any Example biome.
+			bool inExampleSurface = Player.InModBiome(ModContent.GetInstance<ExampleSurfaceBiome>());
+			bool inExampleUnderground = Player.InModBiome(ModContent.GetInstance<ExampleUndergroundBiome>());
+
+			// If the player is in any Example biome, set the tile style to zero and the tile type to the *placeable* ExampleTorch tile.
+			if (torchGodsFavor && (inExampleSurface || inExampleUnderground)) {
+				type = ModContent.TileType<ExampleTorch>();
+				style = 0;
+			}
+
+			// Since this method expects a bool? return value, we can return "true", "false", or "null".
+			// Returning true causes the Torch God's Favor to always execute the vanilla behavior as well, which may cause your torch's style to get overridden.
+			// Returning false causes the Torch God's Favor to never execute the vanilla behavior.
+			// Returning null causes the Torch God's Favor to use vanilla's conditions for executing behavior.
+			return false;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -965,5 +965,9 @@ namespace Terraria.ModLoader
 		/// <param name="mediumCoreDeath">Whether you are setting up a mediumcore player's inventory after their death.</param>
 		public virtual void ModifyStartingInventory(IReadOnlyDictionary<string, List<Item>> itemsByMod, bool mediumCoreDeath) {
 		}
+
+		public virtual bool? ChooseBestTorch(ref int type, ref int style) {
+			return null;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1110,5 +1110,26 @@ namespace Terraria.ModLoader
 				.SelectMany(kv => kv.Value)
 				.ToList();
 		}
+
+		private delegate bool? DelegateChooseBestTorch(ref int type, ref int style);
+		private static HookList HookChooseBestTorch = AddHook<DelegateChooseBestTorch>(p => p.ChooseBestTorch);
+
+		public static bool? ChooseBestTorch(Player player, ref int type, ref int style) {
+			bool? flag = null;
+
+			foreach (int index in HookChooseBestTorch.arr) {
+				bool? allow = player.modPlayers[index].ChooseBestTorch(ref type, ref style);
+
+				if (allow.HasValue) {
+					if (!allow.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3816,6 +3816,23 @@
  						for (int i = 0; i < num2; i++) {
  							WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  						}
+@@ -28394,10 +_,14 @@
+ 					SoundEngine.PlaySound(0, tileTargetX * 16, tileTargetY * 16);
+ 			}
+ 			else {
++				// TML: Run ModPlayer hook to determine Torch God's Favor behavior.
++				int type = inventory[selectedItem].createTile;
++				bool? doTorchGodsFavor = PlayerLoader.ChooseBestTorch(this, ref type, ref num);
+-				if (UsingBiomeTorches && inventory[selectedItem].createTile == 4 && num == 0)
++				if (doTorchGodsFavor ?? (UsingBiomeTorches && inventory[selectedItem].createTile == 4 && num == 0))
+ 					num = BiomeTorchPlaceStyle(num);
+ 
++				// Replace inventory[selectedItem].createTile with a ref'd variale that may be modified by modders.
+-				flag = WorldGen.PlaceTile(tileTargetX, tileTargetY, inventory[selectedItem].createTile, mute: false, forced, whoAmI, num);
++				flag = WorldGen.PlaceTile(tileTargetX, tileTargetY, type, mute: false, forced, whoAmI, num);
+ 			}
+ 
+ 			if (flag) {
 @@ -28420,8 +_,11 @@
  				PlaceThing_Tiles_PlaceIt_UnslopeForSolids();
  				PlaceThing_Tiles_PlaceIt_KillGrassForSolids();


### PR DESCRIPTION
### What is the new feature?
Resolves #2475, adds a new hook that lets modders manipulate the torch placed when Torch God's Favor is active (as well as other tiles, technically).

A proposal to move this functionality to `ModSceneEffect` was raised, but I am not concerned since vanilla doesn't have a concept of scene effects and attempting to use a `ModSceneEffect` for arbitrary custom logic is not desirable here. Additionally, this logic is traditionally located only in `Player`, and I wish to keep it that way. Torch variations shouldn't be restricted to `ModSceneEffect`s since you can absolutely use this functionality for other reasons, such as custom torch variations for vanilla biomes, accessories and whatnot that may disable or modify every placed torch, among other possibilities.

This hook allows modders to manipulate more about tiles that just when Torch God's Favor is active, due to the nature of the hook and its ability to toggle vanilla behavior and override the need for Torch God's Favor. There is no easy or convenient way around this.

### Why should this be part of tModLoader?
See #2475.

### Are there alternative designs?
Not really, but there are a some ways to rewrite the code. needs discussion.

### Sample usage for the new feature
See ExampleChooseBestTorch.cs.

### ExampleMod updates
See ExampleChooseBestTorch.cs.

