### PR TITLE
Restore vanilla melee speed balance 

### DIFF
--- a/ExampleMod/Common/GlobalItems/ShortswordGlobalItem.cs
+++ b/ExampleMod/Common/GlobalItems/ShortswordGlobalItem.cs
@@ -17,6 +17,8 @@ namespace ExampleMod.Common.GlobalItems
 		}
 
 		public override void SetDefaults(Item item) {
+			item.StatsModifiedBy.Add(Mod); // Notify the game that we've made a functional change to this item.
+
 			item.damage = 50; // Change damage to 50!
 		}
 

--- a/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
@@ -40,6 +40,8 @@ namespace ExampleMod.Content.Items.Weapons
 
 			Item.shoot = ProjectileID.StarWrath; // ID of the projectiles the sword will shoot
 			Item.shootSpeed = 8f; // Speed of the projectiles the sword will shoot
+
+			Item.attackSpeedOnlyAffectsWeaponAnimation = true; // Make melee speed only affect the swing speed of the weapon
 		}
 		// This method gets called when firing your weapon/sword.
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {

--- a/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
@@ -41,7 +41,8 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.shoot = ProjectileID.StarWrath; // ID of the projectiles the sword will shoot
 			Item.shootSpeed = 8f; // Speed of the projectiles the sword will shoot
 
-			Item.attackSpeedOnlyAffectsWeaponAnimation = true; // Make melee speed only affect the swing speed of the weapon
+			// If you want melee speed to only affect the swing speed of the weapon and not the shoot speed (not recommended)
+			// Item.attackSpeedOnlyAffectsWeaponAnimation = true;
 		}
 		// This method gets called when firing your weapon/sword.
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {

--- a/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
@@ -23,7 +23,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.width = 32;
 			Item.height = 32;
 			Item.UseSound = SoundID.Item1;
-			Item.DamageType = DamageClass.Melee;
+			Item.DamageType = DamageClass.MeleeNoSpeed;
 			Item.autoReuse = false;
 			Item.noUseGraphic = true; // The sword is actually a "projectile", so the item should not be visible when used
 			Item.noMelee = true; // The projectile will do the damage and not the item

--- a/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
@@ -32,7 +32,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.damage = 25;
 			Item.knockBack = 6.5f;
 			Item.noUseGraphic = true; // When true, the item's sprite will not be visible while the item is in use. This is true because the spear projectile is what's shown so we do not want to show the spear sprite as well.
-			Item.DamageType = DamageClass.Melee;
+			Item.DamageType = DamageClass.MeleeNoSpeed;
 			Item.noMelee = true; // Allows the item's animation to do damage. This is important because the spear is actually a projectile instead of an item. This prevents the melee hitbox of this item.
 
 			// Projectile Properties

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -67,7 +67,7 @@
  			public static int[] GamepadExtraRange = Factory.CreateIntSet(0, 2797, 20, 3278, 4, 3285, 6, 3279, 8, 3280, 8, 3281, 9, 3262, 10, 3317, 10, 3282, 10, 3315, 10, 3316, 11, 3283, 12, 3290, 13, 3289, 11, 3284, 13, 3286, 13, 3287, 18, 3288, 18, 3291, 17, 3292, 18, 3389, 21);
  			public static bool[] GamepadWholeScreenUseRange = Factory.CreateBoolSet(1326, 1256, 1244, 3014, 113, 218, 495, 114, 496, 2796, 494, 3006, 65, 1931, 3570, 2750, 3065, 3029, 3030, 4381, 4956, 5065, 1309, 2364, 2365, 2551, 2535, 2584, 1157, 2749, 1802, 2621, 3249, 3531, 3474, 2366, 1572, 3569, 3571, 4269, 4273, 4281, 5119, 3611, 1299, 1254);
 -			public static float[] BonusMeleeSpeedMultiplier = Factory.CreateFloatSet(1f, 1827f, 0.5f, 3013f, 0.25f, 3106f, 0.33f);
-+			public static float[] BonusAttackSpeedMultiplier = Factory.CreateFloatSet(1f, 1827f, 0.5f, 3013f, 0.25f, 3106f, 0.33f, 4956f, 0f);
++			public static float[] BonusAttackSpeedMultiplier = Factory.CreateFloatSet(1f, 1827f, 0.5f, 3013f, 0.25f, 3106f, 0.33f);
  			public static bool[] GamepadSmartQuickReach = Factory.CreateBoolSet(2798, 2797, 3030, 3262, 3278, 3279, 3280, 3281, 3282, 3283, 3284, 3285, 3286, 3287, 3288, 3289, 3290, 3291, 3292, 3315, 3316, 3317, 3389, 2798, 65, 1931, 3570, 2750, 3065, 3029, 4956, 5065, 1256, 1244, 3014, 113, 218, 495);
  			public static bool[] Yoyo = Factory.CreateBoolSet(3262, 3278, 3279, 3280, 3281, 3282, 3283, 3284, 3285, 3286, 3287, 3288, 3289, 3290, 3291, 3292, 3315, 3316, 3317, 3389);
  			public static bool[] AlsoABuildingItem = Factory.CreateBoolSet(3031, 205, 1128, 207, 206, 3032, 849, 3620, 509, 851, 850, 3625, 510, 1071, 1543, 1072, 1544, 1100, 1545, 4820, 4872);

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -169,6 +169,15 @@ namespace Terraria
 			currentUseAnimationCompensation = 0;
 		}
 
+		private void AdjustItemMeleeSpeedEffects() {
+			if (melee && shoot > 0) {
+				if (noMelee)
+					DamageType = DamageClass.MeleeNoSpeed;
+				else
+					attackSpeedOnlyAffectsWeaponAnimation = true;
+			}
+		}
+
 		// Internal utility method. Move somewhere, if there's a better place.
 		internal static void DropItem(IEntitySource source, Item item, Rectangle rectangle) {
 			int droppedItemId = NewItem(source, rectangle, item.netID, 1, noBroadcast: true, prefixGiven: item.prefix);

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -20,6 +20,8 @@ namespace Terraria
 
 		public RefReadOnlyArray<Instanced<GlobalItem>> Globals => new(globalItems);
 
+		public List<Mod> StatsModifiedBy = new List<Mod>();
+
 		/// <summary>
 		/// Dictates whether or not attack speed modifiers on this weapon will actually affect its use time.<br/>
 		/// Defaults to false, which allows attack speed modifiers to affect use time. Set this to true to prevent this from happening.<br/>

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -21,6 +21,13 @@ namespace Terraria
 		public RefReadOnlyArray<Instanced<GlobalItem>> Globals => new(globalItems);
 
 		/// <summary>
+		/// Dictates whether or not attack speed modifiers on this weapon will actually affect its use time.<br/>
+		/// Defaults to false, which allows attack speed modifiers to affect use time. Set this to true to prevent this from happening.<br/>
+		/// Used in vanilla by all melee weapons which shoot a projectile and have <see cref="noMelee"/> set to false.
+		/// </summary>
+		public bool attackSpeedOnlyAffectsWeaponAnimation { get; set; }
+
+		/// <summary>
 		/// Set to true in SetDefaults to allow this item to receive a prefix on reforge even if maxStack is not 1.
 		/// <br>This prevents it from receiving a prefix on craft.</br>
 		/// </summary>

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -20,7 +20,7 @@ namespace Terraria
 
 		public RefReadOnlyArray<Instanced<GlobalItem>> Globals => new(globalItems);
 
-		public List<Mod> StatsModifiedBy = new List<Mod>();
+		public List<Mod> StatsModifiedBy { get; private set; } = new();
 
 		/// <summary>
 		/// Dictates whether or not attack speed modifiers on this weapon will actually affect its use time.<br/>
@@ -152,7 +152,7 @@ namespace Terraria
 		public static int NewItem(IEntitySource source, Vector2 position, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false)
 			=> NewItem(source, (int)position.X, (int)position.Y, 0, 0, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
-		private void ApplyItemAnimationCompensations() {
+		private void ApplyItemAnimationCompensationsToVanillaItems() {
 			// #2351
 			// Compensate for the change of itemAnimation getting reset at 0 instead of vanilla's 1.
 			// all items with autoReuse in vanilla are affected, but the animation only has a physical effect for !noMelee items
@@ -171,7 +171,7 @@ namespace Terraria
 			currentUseAnimationCompensation = 0;
 		}
 
-		private void AdjustItemMeleeSpeedEffects() {
+		private void RestoreMeleeSpeedBehaviorOnVanillaItems() {
 			if (type < ItemID.Count && melee && shoot > 0) {
 				if (noMelee)
 					DamageType = DamageClass.MeleeNoSpeed;

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -170,7 +170,7 @@ namespace Terraria
 		}
 
 		private void AdjustItemMeleeSpeedEffects() {
-			if (melee && shoot > 0) {
+			if (type < ItemID.Count && melee && shoot > 0) {
 				if (noMelee)
 					DamageType = DamageClass.MeleeNoSpeed;
 				else

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -8,12 +8,13 @@
  using Terraria.Audio;
  using Terraria.DataStructures;
  using Terraria.Enums;
-@@ -11,10 +_,12 @@
+@@ -11,10 +_,13 @@
  using Terraria.ID;
  using Terraria.UI;
  using Terraria.Utilities;
 +using Terraria.ModLoader;
 +using Terraria.ModLoader.IO;
++using System.Collections.Generic;
  
  namespace Terraria
  {

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -585,7 +585,7 @@
  
  			if (type == 0) {
  				netID = 0;
-@@ -45044,7 +_,15 @@
+@@ -45044,7 +_,24 @@
  				SetDefaults5(type);
  			}
  
@@ -595,6 +595,15 @@
 +			//Set 'master' bool for vanilla items with master rarity.
 +			if (type < ItemID.Count && rare == ItemRarityID.Master) {
 +				master = true;
++			}
++
++			// tML: make sure some vanilla balance doesn't get obliterated through clever damage class abuse
++			if (melee && shoot > 0)
++			{
++				if (noMelee)
++					DamageType = DamageClass.MeleeNoSpeed;
++				else
++					attackSpeedOnlyAffectsWeaponAnimation = true;
 +			}
 +
 -			dye = (byte)GameShaders.Armor.GetShaderIdFromItemId(type);
@@ -616,13 +625,14 @@
  				netID = 0;
  				type = 0;
  				stack = 0;
-@@ -45207,14 +_,23 @@
+@@ -45207,14 +_,24 @@
  		public void ResetStats(int Type) {
  			tooltipContext = -1;
  			BestiaryNotes = null;
 +			ModItem = null;
 +			globalItems = new Instanced<GlobalItem>[0];
 +			AllowReforgeForStackableItem = false;
++			attackSpeedOnlyAffectsWeaponAnimation = false;
 +			useLimitPerAnimation = null;
 +			consumeAmmoOnFirstShotOnly = false;
 +			consumeAmmoOnLastShotOnly = false;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -585,26 +585,21 @@
  
  			if (type == 0) {
  				netID = 0;
-@@ -45044,7 +_,24 @@
+@@ -45044,7 +_,19 @@
  				SetDefaults5(type);
  			}
  
 +			// Compensate for the change of itemAnimation getting reset at 0 instead of vanilla's 1.
 +			ApplyItemAnimationCompensations();
 +
++			// tML: make sure some vanilla balance doesn't get obliterated by attack speed changes
++			AdjustItemMeleeSpeedEffects();
++
 +			//Set 'master' bool for vanilla items with master rarity.
 +			if (type < ItemID.Count && rare == ItemRarityID.Master) {
 +				master = true;
 +			}
 +
-+			// tML: make sure some vanilla balance doesn't get obliterated through clever damage class abuse
-+			if (melee && shoot > 0)
-+			{
-+				if (noMelee)
-+					DamageType = DamageClass.MeleeNoSpeed;
-+				else
-+					attackSpeedOnlyAffectsWeaponAnimation = true;
-+			}
 +
 -			dye = (byte)GameShaders.Armor.GetShaderIdFromItemId(type);
 +			dye = GameShaders.Armor.GetShaderIdFromItemId(type);

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -620,12 +620,13 @@
  				netID = 0;
  				type = 0;
  				stack = 0;
-@@ -45207,14 +_,24 @@
+@@ -45207,14 +_,25 @@
  		public void ResetStats(int Type) {
  			tooltipContext = -1;
  			BestiaryNotes = null;
 +			ModItem = null;
 +			globalItems = new Instanced<GlobalItem>[0];
++			StatsModifiedBy = new List<Mod>();
 +			AllowReforgeForStackableItem = false;
 +			attackSpeedOnlyAffectsWeaponAnimation = false;
 +			useLimitPerAnimation = null;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -77,7 +77,7 @@
 +				if (value)
 +					DamageType = DamageClass.Melee;
 +				else if (DamageType == DamageClass.Melee)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		internal bool magic {
@@ -86,7 +86,7 @@
 +				if (value)
 +					DamageType = DamageClass.Magic;
 +				else if (DamageType == DamageClass.Magic)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		internal bool ranged {
@@ -95,7 +95,7 @@
 +				if (value)
 +					DamageType = DamageClass.Ranged;
 +				else if (DamageType == DamageClass.Ranged)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		internal bool summon {
@@ -104,7 +104,7 @@
 +				if (value)
 +					DamageType = DamageClass.Summon;
 +				else if (DamageType == DamageClass.Summon)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
  		public bool sentry;
@@ -633,7 +633,7 @@
 +			useLimitPerAnimation = null;
 +			consumeAmmoOnFirstShotOnly = false;
 +			consumeAmmoOnLastShotOnly = false;
-+			DamageType = DamageClass.Generic;
++			DamageType = DamageClass.Default;
  			sentry = false;
  			canBePlacedInVanityRegardlessOfConditions = false;
  			DD2Summon = false;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -8,13 +8,12 @@
  using Terraria.Audio;
  using Terraria.DataStructures;
  using Terraria.Enums;
-@@ -11,10 +_,13 @@
+@@ -11,10 +_,12 @@
  using Terraria.ID;
  using Terraria.UI;
  using Terraria.Utilities;
 +using Terraria.ModLoader;
 +using Terraria.ModLoader.IO;
-+using System.Collections.Generic;
  
  namespace Terraria
  {
@@ -303,7 +302,7 @@
 +			if (num >= PrefixID.Count)
 +				PrefixLoader.GetPrefix(num)?.Apply(this);
 +
-+			ApplyItemAnimationCompensations();
++			ApplyItemAnimationCompensationsToVanillaItems();
 +
  			float num14 = 1f * num2 * (2f - num4) * (2f - num7) * num5 * num3 * num6 * (1f + (float)num8 * 0.02f);
  			if (num == 62 || num == 69 || num == 73 || num == 77)
@@ -586,21 +585,20 @@
  
  			if (type == 0) {
  				netID = 0;
-@@ -45044,7 +_,19 @@
+@@ -45044,7 +_,18 @@
  				SetDefaults5(type);
  			}
  
 +			// Compensate for the change of itemAnimation getting reset at 0 instead of vanilla's 1.
-+			ApplyItemAnimationCompensations();
++			ApplyItemAnimationCompensationsToVanillaItems();
 +
 +			// tML: make sure some vanilla balance doesn't get obliterated by attack speed changes
-+			AdjustItemMeleeSpeedEffects();
++			RestoreMeleeSpeedBehaviorOnVanillaItems();
 +
 +			//Set 'master' bool for vanilla items with master rarity.
 +			if (type < ItemID.Count && rare == ItemRarityID.Master) {
 +				master = true;
 +			}
-+
 +
 -			dye = (byte)GameShaders.Armor.GetShaderIdFromItemId(type);
 +			dye = GameShaders.Armor.GetShaderIdFromItemId(type);
@@ -627,7 +625,7 @@
  			BestiaryNotes = null;
 +			ModItem = null;
 +			globalItems = new Instanced<GlobalItem>[0];
-+			StatsModifiedBy = new List<Mod>();
++			StatsModifiedBy = new();
 +			AllowReforgeForStackableItem = false;
 +			attackSpeedOnlyAffectsWeaponAnimation = false;
 +			useLimitPerAnimation = null;

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -271,6 +271,9 @@
 		"ExperimentalFeaturesNo": "Experimental Features: Off",
 		"RemoveForcedMinimumZoomYes": "Remove Forced Minimum Zoom: On",
 		"RemoveForcedMinimumZoomNo": "Remove Forced Minimum Zoom: Off",
+		"MeleeSpeedScalingTooltipVisibility0": "Melee Speed Effect Tooltips: Show All",
+		"MeleeSpeedScalingTooltipVisibility1": "Melee Speed Effect Tooltips: Show Adjusted Effectiveness",
+		"MeleeSpeedScalingTooltipVisibility2": "Melee Speed Effect Tooltips: Hidden",
 		"AllowGreaterResolutionsYes": "Allow Greater Resolutions: On",
 		"AllowGreaterResolutionsNo": "Allow Greater Resolutions: Off",
 		"ShowMemoryEstimatesYes": "Show Mod Memory Estimates: On",
@@ -394,7 +397,7 @@
 
 		// Tooltip lines
 		"NoAttackSpeedScaling": "Does not scale with attack speed",
-		"SpecialAttackSpeedScaling": "Attack speed boosts reduced to {0}%",
+		"SpecialAttackSpeedScaling": "{0}% benefit from attack speed boosts",
 		"ModifiedByModsHoldSHIFT": "Stats have been modified (hold SHIFT for more info)",
 		"ModifiedByMods": "Stats have been modified by ",
 

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -395,6 +395,7 @@
 		// Tooltip lines
 		"NoAttackSpeedScaling": "Does not scale with attack speed",
 		"SpecialAttackSpeedScaling": "Attack speed boosts reduced to {0}%",
+		"ModifiedByModsHoldSHIFT": "Stats have been modified (hold SHIFT for more info)",
 		"ModifiedByMods": "Stats have been modified by ",
 
 		// Memory bar

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -395,6 +395,7 @@
 		// Tooltip lines
 		"NoAttackSpeedScaling": "Does not scale with attack speed",
 		"SpecialAttackSpeedScaling": "Attack speed boosts reduced to {0}%",
+		"ModifiedByMods": "Stats have been modified by ",
 
 		// Memory bar
 		"LastLoadRamUsage": "Estimated last load RAM usage: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -392,6 +392,10 @@
 		"DefaultTownNPCChat": "My modder forgot to give me a chat message.",
 		"DefaultNurseCantHealChat": "I don't know why I can't heal you, the modder forgot to give me a chat message.",
 
+		// Tooltip lines
+		"NoAttackSpeedScaling": "Does not scale with attack speed",
+		"SpecialAttackSpeedScaling": "Attack speed boosts reduced to {0}%",
+
 		// Memory bar
 		"LastLoadRamUsage": "Estimated last load RAM usage: {0}",
 		"AvailableMemory": "Available Memory: {0}",

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2212,7 +2212,7 @@
  				numLines++;
  			}
  
-@@ -15718,8 +_,23 @@
+@@ -15718,8 +_,27 @@
  				if (amountNeeded - sacrificeCount > 0) {
  					toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.CreativeSacrificeNeeded", amountNeeded - sacrificeCount);
  					researchLine = numLines;
@@ -2223,13 +2223,17 @@
 +
 +			if (item.StatsModifiedBy != null && item.StatsModifiedBy.Count > 0)
 +			{
-+				toolTipLine[numLines] = Language.GetTextValue("tModLoader.ModifiedByMods");
-+				for (int i = 0; i < item.StatsModifiedBy.Count; i++)
-+				{
-+					Mod mod = item.StatsModifiedBy[i];
-+					if (i > 0)
-+						toolTipLine[numLines] += ", ";
-+					toolTipLine[numLines] += mod.DisplayName;
++				if (keyState.PressingShift()) {
++					toolTipLine[numLines] = Language.GetTextValue("tModLoader.ModifiedByMods");
++					for (int i = 0; i < item.StatsModifiedBy.Count; i++) {
++						Mod mod = item.StatsModifiedBy[i];
++						if (i > 0)
++							toolTipLine[numLines] += ", ";
++						toolTipLine[numLines] += mod.DisplayName;
++					}
++				}
++				else {
++					toolTipLine[numLines] = Language.GetTextValue("tModLoader.ModifiedByModsHoldSHIFT");
 +				}
 +				toolTipNames[numLines] = "ModifiedByMods";
 +				numLines++;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1801,7 +1801,7 @@
 +							double attackSpeedScaling = ItemID.Sets.BonusAttackSpeedMultiplier[item.type] * 100.0;
 +							toolTipLine[numLines] = Language.GetTextValue(
 +								"tModLoader.SpecialAttackSpeedScaling",
-+								Math.Round(attackSpeedScaling * Math.Pow(10.0, (double)decimalPlaces)) / Math.Pow(10.0, (double)decimalPlaces) + "%"
++								Math.Round(attackSpeedScaling * Math.Pow(10.0, (double)decimalPlaces)) / Math.Pow(10.0, (double)decimalPlaces)
 +							);
 +							toolTipNames[numLines] = "SpecialSpeedScaling";
 +							numLines++;
@@ -2228,8 +2228,8 @@
 +				{
 +					Mod mod = item.StatsModifiedBy[i];
 +					if (i > 0)
-+						toolTipLine += ", ";
-+					toolTipLine += mod.DisplayName;
++						toolTipLine[numLines] += ", ";
++					toolTipLine[numLines] += mod.DisplayName;
 +				}
 +				toolTipNames[numLines] = "ModifiedByMods";
 +				numLines++;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1774,26 +1774,36 @@
  						if (item.useAnimation <= 8)
  							toolTipLine[numLines] = Lang.tip[6].Value;
  						else if (item.useAnimation <= 20)
-@@ -15283,10 +_,32 @@
+@@ -15283,10 +_,42 @@
  						else
  							toolTipLine[numLines] = Lang.tip[13].Value;
  
 +						toolTipNames[numLines] = "Speed";
  						numLines++;
 +
++						/*
++						tML:
++						these lines add a degree of transparency which vanilla doesn't provide by tellin' the player what
++						does and doesn't get affected by attack speed bonuses, as well as if the item in question has any
++						special scalin' rules. they're tML-specific, and can be messed with at the will of the modder
++
++						as for why they're differently named: prep for when that tooltip rework comes out
++						-thomas
++						*/
 +						if (item.DamageType == DamageClass.MeleeNoSpeed || ItemID.Sets.BonusAttackSpeedMultiplier[item.type] == 0f) {
 +							toolTipLine[numLines] = Language.GetTextValue("tModLoader.NoAttackSpeedScaling");
-+							toolTipNames[numLines] = "SpeedScaling";
++							toolTipNames[numLines] = "NoSpeedScaling";
 +							numLines++;
 +						}
 +						else if (ItemID.Sets.BonusAttackSpeedMultiplier[item.type] != 1f) {
++							// we want to convert the multiplier into a percentage before showin' it     -thomas
 +							int decimalPlaces = 2;
 +							double attackSpeedScaling = ItemID.Sets.BonusAttackSpeedMultiplier[item.type] * 100.0;
 +							toolTipLine[numLines] = Language.GetTextValue(
 +								"tModLoader.SpecialAttackSpeedScaling",
 +								Math.Round(attackSpeedScaling * Math.Pow(10.0, (double)decimalPlaces)) / Math.Pow(10.0, (double)decimalPlaces) + "%"
 +							);
-+							toolTipNames[numLines] = "SpeedScaling";
++							toolTipNames[numLines] = "SpecialSpeedScaling";
 +							numLines++;
 +						}
  					}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1774,7 +1774,7 @@
  						if (item.useAnimation <= 8)
  							toolTipLine[numLines] = Lang.tip[6].Value;
  						else if (item.useAnimation <= 20)
-@@ -15283,10 +_,42 @@
+@@ -15283,10 +_,41 @@
  						else
  							toolTipLine[numLines] = Lang.tip[13].Value;
  
@@ -1791,20 +1791,19 @@
 +						-thomas
 +						*/
 +						if (item.DamageType == DamageClass.MeleeNoSpeed || ItemID.Sets.BonusAttackSpeedMultiplier[item.type] == 0f) {
-+							toolTipLine[numLines] = Language.GetTextValue("tModLoader.NoAttackSpeedScaling");
-+							toolTipNames[numLines] = "NoSpeedScaling";
-+							numLines++;
++							if (ModLoader.ModLoader.meleeSpeedScalingTooltipVisibility == 0) {
++								toolTipLine[numLines] = Language.GetTextValue("tModLoader.NoAttackSpeedScaling");
++								toolTipNames[numLines] = "NoSpeedScaling";
++								numLines++;
++							}
 +						}
 +						else if (ItemID.Sets.BonusAttackSpeedMultiplier[item.type] != 1f) {
-+							// we want to convert the multiplier into a percentage before showin' it     -thomas
-+							int decimalPlaces = 2;
-+							double attackSpeedScaling = ItemID.Sets.BonusAttackSpeedMultiplier[item.type] * 100.0;
-+							toolTipLine[numLines] = Language.GetTextValue(
-+								"tModLoader.SpecialAttackSpeedScaling",
-+								Math.Round(attackSpeedScaling * Math.Pow(10.0, (double)decimalPlaces)) / Math.Pow(10.0, (double)decimalPlaces)
-+							);
-+							toolTipNames[numLines] = "SpecialSpeedScaling";
-+							numLines++;
++							if (ModLoader.ModLoader.meleeSpeedScalingTooltipVisibility <= 1) {
++								int attackSpeedScaling = (int)(ItemID.Sets.BonusAttackSpeedMultiplier[item.type] * 100);
++								toolTipLine[numLines] = Language.GetTextValue("tModLoader.SpecialAttackSpeedScaling", attackSpeedScaling);
++								toolTipNames[numLines] = "SpecialSpeedScaling";
++								numLines++;
++							}
 +						}
  					}
 +

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2221,7 +2221,7 @@
  				}
 +			}
 +
-+			if (item.StatsModifiedBy != null && item.StatsModifiedBy.Count > 0)
++			if (item.StatsModifiedBy.Count > 0)
 +			{
 +				if (keyState.PressingShift()) {
 +					toolTipLine[numLines] = Language.GetTextValue("tModLoader.ModifiedByMods");

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1774,12 +1774,28 @@
  						if (item.useAnimation <= 8)
  							toolTipLine[numLines] = Lang.tip[6].Value;
  						else if (item.useAnimation <= 20)
-@@ -15283,10 +_,16 @@
+@@ -15283,10 +_,32 @@
  						else
  							toolTipLine[numLines] = Lang.tip[13].Value;
  
 +						toolTipNames[numLines] = "Speed";
  						numLines++;
++
++						if (item.DamageType == DamageClass.MeleeNoSpeed || ItemID.Sets.BonusAttackSpeedMultiplier[item.type] == 0f) {
++							toolTipLine[numLines] = Language.GetTextValue("tModLoader.NoAttackSpeedScaling");
++							toolTipNames[numLines] = "SpeedScaling";
++							numLines++;
++						}
++						else if (ItemID.Sets.BonusAttackSpeedMultiplier[item.type] != 1f) {
++							int decimalPlaces = 2;
++							double attackSpeedScaling = ItemID.Sets.BonusAttackSpeedMultiplier[item.type] * 100.0;
++							toolTipLine[numLines] = Language.GetTextValue(
++								"tModLoader.SpecialAttackSpeedScaling",
++								Math.Round(attackSpeedScaling * Math.Pow(10.0, (double)decimalPlaces)) / Math.Pow(10.0, (double)decimalPlaces) + "%"
++							);
++							toolTipNames[numLines] = "SpeedScaling";
++							numLines++;
++						}
  					}
 +
 +					if (!item.DamageType.ShowStatTooltipLine(player[myPlayer], "Knockback"))

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2212,14 +2212,30 @@
  				numLines++;
  			}
  
-@@ -15718,6 +_,7 @@
+@@ -15718,8 +_,23 @@
  				if (amountNeeded - sacrificeCount > 0) {
  					toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.CreativeSacrificeNeeded", amountNeeded - sacrificeCount);
  					researchLine = numLines;
 +					toolTipNames[numLines] = "JourneyResearch";
  					numLines++;
  				}
++			}
++
++			if (item.StatsModifiedBy != null && item.StatsModifiedBy.Count > 0)
++			{
++				toolTipLine[numLines] = Language.GetTextValue("tModLoader.ModifiedByMods");
++				for (int i = 0; i < item.StatsModifiedBy.Count; i++)
++				{
++					Mod mod = item.StatsModifiedBy[i];
++					if (i > 0)
++						toolTipLine += ", ";
++					toolTipLine += mod.DisplayName;
++				}
++				toolTipNames[numLines] = "ModifiedByMods";
++				numLines++;
  			}
+ 
+ 			string bestiaryNotes = item.BestiaryNotes;
 @@ -15727,11 +_,12 @@
  				string[] array = bestiaryNotes.Split('\n');
  				foreach (string text2 in array) {

--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -122,11 +122,11 @@ namespace Terraria.ModLoader
 			return PlayerLoader.UseSpeedMultiplier(player, item) * ItemLoader.UseSpeedMultiplier(item, player) * player.GetWeaponAttackSpeed(item);
 		}
 
-		public static float TotalUseTimeMultiplier(Player player, Item item)
-		{
+		public static float TotalUseTimeMultiplier(Player player, Item item) {
 			float useTimeMult = PlayerLoader.UseTimeMultiplier(player, item) * ItemLoader.UseTimeMultiplier(item, player);
 			if (!item.attackSpeedOnlyAffectsWeaponAnimation)
 				useTimeMult /= TotalUseSpeedMultiplier(player, item);
+
 			return useTimeMult;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -122,8 +122,12 @@ namespace Terraria.ModLoader
 			return PlayerLoader.UseSpeedMultiplier(player, item) * ItemLoader.UseSpeedMultiplier(item, player) * player.GetWeaponAttackSpeed(item);
 		}
 
-		public static float TotalUseTimeMultiplier(Player player, Item item) {
-			return PlayerLoader.UseTimeMultiplier(player, item) * ItemLoader.UseTimeMultiplier(item, player) / TotalUseSpeedMultiplier(player, item);
+		public static float TotalUseTimeMultiplier(Player player, Item item)
+		{
+			float useTimeMult = PlayerLoader.UseTimeMultiplier(player, item) * ItemLoader.UseTimeMultiplier(item, player);
+			if (!item.attackSpeedOnlyAffectsWeaponAnimation)
+				useTimeMult /= TotalUseSpeedMultiplier(player, item);
+			return useTimeMult;
 		}
 
 		public static int TotalUseTime(float useTime, Player player, Item item) {
@@ -132,6 +136,7 @@ namespace Terraria.ModLoader
 			return result;
 		}
 
+		// TO-DO: should this be affected by item.attackSpeedOnlyAffectsWeaponAnimation?
 		public static float TotalUseAnimationMultiplier(Player player, Item item) {
 			float result = PlayerLoader.UseAnimationMultiplier(player, item) * ItemLoader.UseAnimationMultiplier(item, player);
 

--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -17,6 +17,11 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static DamageClass Generic { get; private set; } = new GenericDamageClass();
 		public static DamageClass Melee { get; private set; } = new MeleeDamageClass();
+
+		/// <summary>
+		/// This is a damage class used by various projectile-only vanilla melee weapons. Attack speed has no effect on items with this damage class.
+		/// </summary>
+		public static DamageClass MeleeNoSpeed { get; private set; } = new MeleeNoSpeedDamageClass();
 		public static DamageClass Ranged { get; private set; } = new RangedDamageClass();
 		public static DamageClass Magic { get; private set; } = new MagicDamageClass();
 		public static DamageClass Summon { get; private set; } = new SummonDamageClass();

--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -13,6 +13,7 @@ namespace Terraria.ModLoader
 			DamageClass.Default,
 			DamageClass.Generic,
 			DamageClass.Melee,
+			DamageClass.MeleeNoSpeed,
 			DamageClass.Ranged,
 			DamageClass.Magic,
 			DamageClass.Summon,

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -56,6 +56,7 @@ namespace Terraria.ModLoader
 		internal static bool dontRemindModBrowserUpdateReload;
 		internal static bool dontRemindModBrowserDownloadEnable;
 		internal static bool removeForcedMinimumZoom;
+		internal static int meleeSpeedScalingTooltipVisibility = 0; // Shown, WhenNonZero, Hidden
 		internal static bool showMemoryEstimates = true;
 		internal static bool notifyNewMainMenuThemes = true;
 		internal static bool showNewUpdatedModsInfo = true;
@@ -332,6 +333,7 @@ namespace Terraria.ModLoader
 			Main.Configuration.Put("DontRemindModBrowserUpdateReload", dontRemindModBrowserUpdateReload);
 			Main.Configuration.Put("DontRemindModBrowserDownloadEnable", dontRemindModBrowserDownloadEnable);
 			Main.Configuration.Put("RemoveForcedMinimumZoom", removeForcedMinimumZoom);
+			Main.Configuration.Put(nameof(meleeSpeedScalingTooltipVisibility).ToUpperInvariant(), meleeSpeedScalingTooltipVisibility);
 			Main.Configuration.Put("ShowMemoryEstimates", showMemoryEstimates);
 			Main.Configuration.Put("AvoidGithub", UI.ModBrowser.UIModBrowser.AvoidGithub);
 			Main.Configuration.Put("AvoidImgur", UI.ModBrowser.UIModBrowser.AvoidImgur);
@@ -358,6 +360,7 @@ namespace Terraria.ModLoader
 			Main.Configuration.Get("DontRemindModBrowserUpdateReload", ref dontRemindModBrowserUpdateReload);
 			Main.Configuration.Get("DontRemindModBrowserDownloadEnable", ref dontRemindModBrowserDownloadEnable);
 			Main.Configuration.Get("RemoveForcedMinimumZoom", ref removeForcedMinimumZoom);
+			Main.Configuration.Get(nameof(meleeSpeedScalingTooltipVisibility).ToUpperInvariant(), ref meleeSpeedScalingTooltipVisibility);
 			Main.Configuration.Get("ShowMemoryEstimates", ref showMemoryEstimates);
 			Main.Configuration.Get("AvoidGithub", ref UI.ModBrowser.UIModBrowser.AvoidGithub);
 			Main.Configuration.Get("AvoidImgur", ref UI.ModBrowser.UIModBrowser.AvoidImgur);

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -224,7 +224,7 @@ namespace Terraria.ModLoader.UI
 			else if (Main.menuMode == tModLoaderSettingsID) {
 				offY = 210;
 				spacing = 42;
-				numButtons = 9;
+				numButtons = 10;
 				buttonVerticalSpacing[numButtons - 1] = 18;
 				for (int i = 0; i < numButtons; i++) {
 					buttonScales[i] = 0.75f;
@@ -272,6 +272,13 @@ namespace Terraria.ModLoader.UI
 				if (selectedMenu == buttonIndex) {
 					SoundEngine.PlaySound(SoundID.MenuTick);
 					ModLoader.removeForcedMinimumZoom = !ModLoader.removeForcedMinimumZoom;
+				}
+
+				buttonIndex++;
+				buttonNames[buttonIndex] = Language.GetTextValue($"tModLoader.MeleeSpeedScalingTooltipVisibility{ModLoader.meleeSpeedScalingTooltipVisibility}");
+				if (selectedMenu == buttonIndex) {
+					SoundEngine.PlaySound(SoundID.MenuTick);
+					ModLoader.meleeSpeedScalingTooltipVisibility = (ModLoader.meleeSpeedScalingTooltipVisibility + 1) % 3;
 				}
 
 				buttonIndex++;

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -33,6 +33,19 @@ namespace Terraria.ModLoader
 		protected override string LangKey => "LegacyTooltip.2";
 	}
 
+	public class MeleeNoSpeedDamageClass : VanillaDamageClass
+	{
+		protected override string LangKey => "LegacyTooltip.2";
+
+		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) => new StatInheritanceData(
+			damageInheritance: 1f,
+			critChanceInheritance: 1f,
+			attackSpeedInheritance: 0f,
+			armorPenInheritance: 1f,
+			knockbackInheritance: 1f
+		);
+	}
+
 	public class RangedDamageClass : VanillaDamageClass
 	{
 		protected override string LangKey => "LegacyTooltip.3";

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -44,6 +44,8 @@ namespace Terraria.ModLoader
 			armorPenInheritance: 1f,
 			knockbackInheritance: 1f
 		);
+
+		public override bool GetEffectInheritance(DamageClass damageClass) => damageClass == Melee;
 	}
 
 	public class RangedDamageClass : VanillaDamageClass

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4822,7 +4822,7 @@
 +			if (CombinedHooks.CanAutoReuseItem(this, sItem) is bool autoReuse)
 +				return autoReuse;
 +
-+			return sItem.autoReuse || autoReuseGlove && (sItem.DamageType == DamageClass.Melee || sItem.DamageType == DamageClass.SummonMeleeSpeed);
++			return sItem.autoReuse || autoReuseGlove && (sItem.CountsAsClass(DamageClass.Melee) || sItem.DamageType == DamageClass.SummonMeleeSpeed);
  		}
  
  		private void ItemCheck_HandleMount() {

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -46,7 +46,7 @@
 +				if (value)
 +					DamageType = DamageClass.Melee;
 +				else if (DamageType == DamageClass.Melee)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		internal bool magic {
@@ -55,7 +55,7 @@
 +				if (value)
 +					DamageType = DamageClass.Magic;
 +				else if (DamageType == DamageClass.Magic)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		internal bool ranged {
@@ -64,7 +64,7 @@
 +				if (value)
 +					DamageType = DamageClass.Ranged;
 +				else if (DamageType == DamageClass.Ranged)
-+					DamageType = DamageClass.Generic;
++					DamageType = DamageClass.Default;
 +			}
 +		}
 +		public bool minion;
@@ -125,13 +125,25 @@
  		public void SetDefaults(int Type) {
 +			ModProjectile = null;
 +			globalProjectiles = new Instanced<GlobalProjectile>[0];
-+			DamageType = DamageClass.Generic;
++			DamageType = DamageClass.Default;
 +			ArmorPenetration = 0;
 +			CritChance = 0;
 +			nameOverride = null;
  			ownerHitCheckDistance = 1000f;
  			counterweight = false;
  			sentry = false;
+@@ -269,9 +_,11 @@
+ 			minionSlots = 0f;
+ 			soundDelay = 0;
+ 			spriteDirection = 1;
++			/*
+ 			melee = false;
+ 			ranged = false;
+ 			magic = false;
++			*/
+ 			ownerHitCheck = false;
+ 			hide = false;
+ 			lavaWet = false;
 @@ -1806,6 +_,7 @@
  				ignoreWater = true;
  			}


### PR DESCRIPTION
# Summary
Restores the balance/stats of vanilla melee weapons by adding `DamageClass.MeleeNoSpeed` and `Item.attackSpeedOnlyAffectsWeaponAnimation`

Adds a tooltip for weapons which are not affected by attack speed, or have custom attack speed scaling.
![image](https://user-images.githubusercontent.com/388233/172236463-ad1a0fd8-d420-4d3c-a4a8-6cadeaee7ea4.png)![image](https://user-images.githubusercontent.com/388233/172236479-f037f112-6db0-4ee8-9072-8ac406daeeb2.png)

Adds a setting for the tooltip.
![image](https://user-images.githubusercontent.com/388233/172236347-c6210c70-1969-4e83-95f2-4d6d2cbfdad5.png)
![image](https://user-images.githubusercontent.com/388233/172236365-a965e409-f9c9-4bd1-8a66-4180e387821e.png)
![image](https://user-images.githubusercontent.com/388233/172236383-7a23aabd-7dcb-4af5-8c0c-a34222cc84f4.png)

Adds `Item.StatsModifiedBy` for mods to declare that stats have been changed on an item, and corresponding tooltip.
![image](https://user-images.githubusercontent.com/388233/172237224-bbb6edef-b45d-40f0-ba84-ef52d4cd6cba.png)
![image](https://user-images.githubusercontent.com/388233/172237258-16407f24-f3fe-439c-8d69-afecfebec9ab.png)

Also fixes a minor bug where the default damage class of items and projectiles was `Generic` instead of `Default`

# Why should this be part of tModLoader?
#2351 and #2196 made attack speed (melee speed in vanilla) apply to both item use time and item animation. This was evaluated as a moderate buff to vanilla melee weapons which both shoot and swing (like Terra Blade) and deemed reasonable, but completely overlooked melee weapons which are only projectiles (vampire knives, yoyos, spears, zenith etc).


Additionally, it has been heavily requested that the vanilla balance be kept by default, hence `Item.attackSpeedOnlyAffectsWeaponAnimation`

# Are there alternative designs?
The tooltips are up for debate. It would be good to shorten mod display names and provide `Mod.Title` instead for the mods menu, removing the need for the `Press SHIFT for more info` 

# Porting Notes
- Check any items which you didn't set a damage class for. They're now `Default` (no scaling). Set them to `Generic` if you want them to benefit from all damage bonuses (like avenger emblem)
- re-check your melee weapons, and apply the new `MeleeNoSpeed` damage type (and `attackSpeedOnlyAffectsAnimationTime` if you really want to match vanilla 100%. We don't recommend using this field though)
- Add `item.StatsModifiedBy.Add(Mod);` to any `GlobalItem.SetDefaults` where you change the stats of an item

# ExampleMod updates
`ExampleSpear` and `ExampleShortSword` now have `DamageType = DamageClass.MeleeNoSpeed`