### PR TITLE
[1.4] Fix `GlobalInfoDisplay` running twice in one frame

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/InfoDisplayLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/InfoDisplayLoader.cs
@@ -82,8 +82,9 @@ namespace Terraria.ModLoader
 		public static bool Active(InfoDisplay info) {
 			bool active = info.Active();
 			foreach (GlobalInfoDisplay global in globalInfoDisplays) {
-				if (global.Active(info).HasValue)
-					active &= global.Active(info).Value;
+				bool? val = global.Active(info);
+				if (val.HasValue)
+					active &= val.Value;
 			}
 			return active;
 		}


### PR DESCRIPTION
### What is the bug?
`GlobalInfoDisplay.Active` runs twice in one frame when it has a `!= null` return value

### How did you fix the bug?
Cache the return value

### Are there alternatives to your fix?
No
