### PR TITLE
[1.4] InModBiome<T> and ExampleSoulCondition

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
@@ -100,8 +100,8 @@ namespace ExampleMod.Common.GlobalNPCs
 		// Vanilla uses this for the biome keys, souls of night/light, as well as the holiday drops.
 		// Any drop rules in ModifyGlobalLoot should only run once. Everything else should go in ModifyNPCLoot.
 		public override void ModifyGlobalLoot(GlobalLoot globalLoot) {
-			globalLoot.Add(ItemDropRule.ByCondition(new Conditions.IsMasterMode(), ModContent.ItemType<ExampleSoul>(), 5, 1, 1)); // If the world is in master mode, drop ExampleSouls 20% of the time from every npc.
-			//TODO: Make it so it only drops from enemies in ExampleBiome when that gets made.
+			// If the ExampleSoulCondition is true, drop ExampleSoul 20% of the time. See Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs for how it's determined
+			globalLoot.Add(ItemDropRule.ByCondition(new ExampleSoulCondition(), ModContent.ItemType<ExampleSoul>(), 5, 1, 1));
 		}
 	}
 }

--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
@@ -3,11 +3,12 @@ using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 using Terraria.ModLoader;
 using ExampleMod.Content.Items;
-using ExampleMod.Common.ItemDropRules.Conditions;
+using ExampleMod.Common.ItemDropRules.DropConditions;
 
 namespace ExampleMod.Common.GlobalNPCs
 {
 	// This file shows numerous examples of what you can do with the extensive NPC Loot lootable system.
+	// You can find more info on the wiki: https://github.com/tModLoader/tModLoader/wiki/Basic-NPC-Drops-and-Loot-1.4
 	// Despite this file being GlobalNPC, everything here can be used with a ModNPC as well! See examples of this in the Content/NPCs folder.
 	public class ExampleNPCLoot : GlobalNPC
 	{

--- a/ExampleMod/Common/ItemDropRules/DropConditions/ExampleDropCondition.cs
+++ b/ExampleMod/Common/ItemDropRules/DropConditions/ExampleDropCondition.cs
@@ -1,7 +1,7 @@
 ﻿using Terraria;
 using Terraria.GameContent.ItemDropRules;
 
-namespace ExampleMod.Common.ItemDropRules.Conditions
+namespace ExampleMod.Common.ItemDropRules.DropConditions
 {
 	// Very simple drop condition: drop during daytime
 	public class ExampleDropCondition : IItemDropRuleCondition

--- a/ExampleMod/Common/ItemDropRules/DropConditions/ExampleJourneyModeDropCondition.cs
+++ b/ExampleMod/Common/ItemDropRules/DropConditions/ExampleJourneyModeDropCondition.cs
@@ -1,7 +1,7 @@
 ﻿using Terraria;
 using Terraria.GameContent.ItemDropRules;
 
-namespace ExampleMod.Common.ItemDropRules.Conditions
+namespace ExampleMod.Common.ItemDropRules.DropConditions
 {
 	// Drop condition where items drop only on Journey mode.
 	public class ExampleJourneyModeDropCondition : IItemDropRuleCondition

--- a/ExampleMod/Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs
+++ b/ExampleMod/Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs
@@ -13,25 +13,15 @@ namespace ExampleMod.Common.ItemDropRules.DropConditions
 				// Disclaimer: This is adapted from Conditions.SoulOfWhateverConditionCanDrop(info) to remove the cavern layer restriction, because ExampleUndergroundBiome also extends into the dirt layer
 
 				NPC npc = info.npc;
-				if (npc.boss) {
+				if (npc.boss || NPCID.Sets.CannotDropSouls[npc.type]) {
 					return false;
 				}
 
-				switch (npc.type) {
-					// TODO NPCID.Sets?
-					case NPCID.BlueSlime:
-					case NPCID.EaterofWorldsHead:
-					case NPCID.EaterofWorldsBody:
-					case NPCID.EaterofWorldsTail:
-					case NPCID.Slimer:
-					case NPCID.SlimeSpiked:
-						return false;
-					default:
-						if (!Main.hardMode || npc.lifeMax <= 1 || npc.friendly /*|| npc.position.Y <= Main.rockLayer * 16.0*/ || npc.value < 1f) {
-							return false;
-						}
-						return info.player.InModBiome<ExampleUndergroundBiome>();
+				if (!Main.hardMode || npc.lifeMax <= 1 || npc.friendly /*|| npc.position.Y <= Main.rockLayer * 16.0*/ || npc.value < 1f) {
+					return false;
 				}
+
+				return info.player.InModBiome<ExampleUndergroundBiome>();
 			}
 			return false;
 		}

--- a/ExampleMod/Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs
+++ b/ExampleMod/Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs
@@ -1,0 +1,47 @@
+﻿using ExampleMod.Content.Biomes;
+using Terraria;
+using Terraria.ID;
+using Terraria.GameContent.ItemDropRules;
+
+namespace ExampleMod.Common.ItemDropRules.DropConditions
+{
+	public class ExampleSoulCondition : IItemDropRuleCondition
+	{
+		public bool CanDrop(DropAttemptInfo info) {
+			if (!info.IsInSimulation) {
+				// Can drop if it's not hardmode, and not a critter or an irrelevant enemy, and player is in the ExampleUndergroundBiome
+				// Disclaimer: This is adapted from Conditions.SoulOfWhateverConditionCanDrop(info) to remove the cavern layer restriction, because ExampleUndergroundBiome also extends into the dirt layer
+
+				NPC npc = info.npc;
+				if (npc.boss) {
+					return false;
+				}
+
+				switch (npc.type) {
+					// TODO NPCID.Sets?
+					case NPCID.BlueSlime:
+					case NPCID.EaterofWorldsHead:
+					case NPCID.EaterofWorldsBody:
+					case NPCID.EaterofWorldsTail:
+					case NPCID.Slimer:
+					case NPCID.SlimeSpiked:
+						return false;
+					default:
+						if (!Main.hardMode || npc.lifeMax <= 1 || npc.friendly /*|| npc.position.Y <= Main.rockLayer * 16.0*/ || npc.value < 1f) {
+							return false;
+						}
+						return info.player.InModBiome<ExampleUndergroundBiome>();
+				}
+			}
+			return false;
+		}
+
+		public bool CanShowItemDropInUI() {
+			return true;
+		}
+
+		public string GetConditionDescription() {
+			return "Drops in 'Example Underground Biome' in hardmode";
+		}
+	}
+}

--- a/ExampleMod/Common/Players/ExampleCostumePlayer.cs
+++ b/ExampleMod/Common/Players/ExampleCostumePlayer.cs
@@ -61,7 +61,7 @@ namespace ExampleMod.Common.Players
 			if ((BlockyPower || BlockyForceVanity) && !BlockyHideVanity) {
 				Player.headRotation = Player.velocity.Y * Player.direction * 0.1f;
 				Player.headRotation = Utils.Clamp(Player.headRotation, -0.3f, 0.3f);
-				if (Player.InModBiome(ModContent.GetInstance<ExampleSurfaceBiome>())) {
+				if (Player.InModBiome<ExampleSurfaceBiome>()) {
 					Player.headRotation = (float)Main.time * 0.1f * Player.direction;
 				}
 			}

--- a/ExampleMod/Common/Players/ExampleFishingPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleFishingPlayer.cs
@@ -13,7 +13,7 @@ namespace ExampleMod.Common.Players
 	{
 		public override void CatchFish(FishingAttempt attempt, ref int itemDrop, ref int npcSpawn, ref AdvancedPopupRequest sonar, ref Vector2 sonarPosition) {
 			bool inWater = !attempt.inLava && !attempt.inHoney;
-			bool inExampleSurfaceBiome = Player.InModBiome(ModContent.GetInstance<ExampleSurfaceBiome>());
+			bool inExampleSurfaceBiome = Player.InModBiome<ExampleSurfaceBiome>();
 			if (attempt.playerFishingConditions.PoleItemType == ModContent.ItemType<ExampleFishingRod>() && inWater && inExampleSurfaceBiome) {
 				// In this example, we will fish up an Example Person from the water in Example Surface Biome,
 				// as long as there isn't one in the world yet

--- a/ExampleMod/Content/Items/ExampleSoul.cs
+++ b/ExampleMod/Content/Items/ExampleSoul.cs
@@ -43,14 +43,4 @@ namespace ExampleMod.Content.Items
 				.Register();
 		}
 	}
-
-	// todo: implement
-	// public class SoulGlobalNPC : GlobalNPC
-	// {
-	// 	public override void NPCLoot(NPC npc) {
-	// 		if (Main.player[Player.FindClosest(npc.position, npc.width, npc.height)].GetModPlayer<ExamplePlayer>().ZoneExample) { // Drop this item only in the ExampleBiome.
-	// 			Item.NewItem(npc.getRect(), ItemType<ExampleSoul>()); // get the npc's hitbox rectangle and spawn an item of choice
-	// 		}
-	// 	}
-	// }
 }

--- a/ExampleMod/Content/Tiles/ExampleTorch.cs
+++ b/ExampleMod/Content/Tiles/ExampleTorch.cs
@@ -76,7 +76,7 @@ namespace ExampleMod.Content.Tiles
 
 			// The influence positive torch luck can have overall is 0.1 (if positive luck is any number less than 1) or 0.2 (if positive luck is greater than or equal to 1)
 
-			bool inExampleUndergroundBiome = Main.LocalPlayer.InModBiome(ModContent.GetInstance<ExampleUndergroundBiome>());
+			bool inExampleUndergroundBiome = player.InModBiome<ExampleUndergroundBiome>();
 			return inExampleUndergroundBiome ? 1f : -0.1f; // ExampleTorch gives maximum positive luck when in example biome, otherwise a small negative luck
 		}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/Conditions.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/Conditions.cs.patch
@@ -1,0 +1,18 @@
+--- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/Conditions.cs
++++ src/tModLoader/Terraria/GameContent/ItemDropRules/Conditions.cs
+@@ -659,12 +_,15 @@
+ 				return false;
+ 
+ 			switch (info.npc.type) {
++				case int _ when ID.NPCID.Sets.CannotDropSouls[info.npc.type]:
++				/*
+ 				case 1:
+ 				case 13:
+ 				case 14:
+ 				case 15:
+ 				case 121:
+ 				case 535:
++				*/
+ 					return false;
+ 				default:
+ 					if (!Main.hardMode || info.npc.lifeMax <= 1 || info.npc.friendly || (double)info.npc.position.Y <= Main.rockLayer * 16.0 || info.npc.value < 1f)

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -32,6 +32,14 @@ namespace Terraria.ID
 			/// Whether or not a given NPC can sit on suitable furniture (<see cref="TileID.Sets.CanBeSatOnForNPCs"/>)
 			/// </summary>
 			public static bool[] CannotSitOnFurniture = Factory.CreateBoolSet(638, 656);
+
+			// IDs taken from Conditions.SoulOfWhateverConditionCanDrop
+			/// <summary>
+			/// Whether or not a given NPC is excluded from dropping hardmode souls (Soul of Night/Light)
+			/// <br/>Contains vanilla NPCs that are easy to spawn in large numbers, preventing easy soul farming
+			/// <br/>Do not add your NPC to this if it would be excluded automatically (i.e. critter, town NPC, or no coin drops)
+			/// </summary>
+			public static bool[] CannotDropSouls = Factory.CreateBoolSet(1, 13, 14, 15, 121, 535);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -278,6 +278,9 @@ namespace Terraria
 		/// <exception cref="NullReferenceException"/>
 		public bool InModBiome(ModBiome baseInstance) => modBiomeFlags[baseInstance.ZeroIndexType];
 
+		/// <inheritdoc cref="InModBiome"/>
+		public bool InModBiome<T>() where T : ModBiome => InModBiome(ModContent.GetInstance<T>());
+
 		/// <summary>
 		/// The zone property storing if the player is not in any particular biome. Updated in <see cref="UpdateBiomes"/>
 		/// Does NOT account for height. Please use ZoneForest / ZoneNormalX for height based derivatives.


### PR DESCRIPTION
### Description
Adds the `Player.InModBiome<T>()` method as a natural extension to the API alongside `Player.InModBiome(ModBiome)` to bring it in line with similar methods (such as `GetModPlayer`)

Adds the `ExampleSoulCondition` drop condition for use in `ModifyGlobalLoot`, resolving a TODO.

Adds the `NPCID.Sets.CannotDropSouls` set which contains certain vanilla NPCs that are explicitely prevented from dropping souls of night/light (preventing cheese (i.e. king slime)).

Porting Notes: 
* None

