### PR TITLE
[1.4] Add fullyDestroyed parameter to (Mod/Global)BlockType.KillSound()

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent.Creative;
 using Terraria.ID;
@@ -70,6 +71,16 @@ namespace ExampleMod.Content.Tiles
 			// frameYOffset = modTile.animationFrameHeight * Main.tileFrame [type] will already be set before this hook is called
 			// But we have a horizontal animated texture, so we use frameXOffset instead of frameYOffset
 			frameXOffset = uniqueAnimationFrame * animationFrameWidth;
+		}
+
+		// This method allows you to change the sound a tile makes when hit
+		public override bool KillSound(int i, int j, bool fail) {
+			// Play the glass shattering sound instead of the normal digging sound if the tile is destroyed on this hit
+			if (!fail) {
+				SoundEngine.PlaySound(SoundID.Shatter, new Vector2(i, j).ToWorldCoordinates());
+				return false;
+			}
+			return base.KillSound(i, j, fail);
 		}
 
 		//TODO: It's better to have an actual class for this example, instead of comments

--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -74,13 +74,13 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		// This method allows you to change the sound a tile makes when hit
-		public override bool KillSound(int i, int j, bool fullyDestroyed) {
+		public override bool KillSound(int i, int j, bool fail) {
 			// Play the glass shattering sound instead of the normal digging sound if the tile is destroyed on this hit
-			if (fullyDestroyed) {
+			if (!fail) {
 				SoundEngine.PlaySound(SoundID.Shatter, new Vector2(i, j).ToWorldCoordinates());
 				return false;
 			}
-			return base.KillSound(i, j, fullyDestroyed);
+			return base.KillSound(i, j, fail);
 		}
 
 		//TODO: It's better to have an actual class for this example, instead of comments

--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -74,13 +74,13 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		// This method allows you to change the sound a tile makes when hit
-		public override bool KillSound(int i, int j, bool fail) {
+		public override bool KillSound(int i, int j, bool fullyDestroyed) {
 			// Play the glass shattering sound instead of the normal digging sound if the tile is destroyed on this hit
-			if (!fail) {
+			if (fullyDestroyed) {
 				SoundEngine.PlaySound(SoundID.Shatter, new Vector2(i, j).ToWorldCoordinates());
 				return false;
 			}
-			return base.KillSound(i, j, fail);
+			return base.KillSound(i, j, fullyDestroyed);
 		}
 
 		//TODO: It's better to have an actual class for this example, instead of comments

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -15,8 +15,9 @@ namespace Terraria.ModLoader
 		/// <param name="i"></param>
 		/// <param name="j"></param>
 		/// <param name="type"></param>
+		/// <param name="fail">Whether or not the tile/wall is actually destroyed.</param>
 		/// <returns></returns>
-		public virtual bool KillSound(int i, int j, int type) {
+		public virtual bool KillSound(int i, int j, int type, bool fail) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -15,9 +15,9 @@ namespace Terraria.ModLoader
 		/// <param name="i"></param>
 		/// <param name="j"></param>
 		/// <param name="type"></param>
-		/// <param name="fail">Whether or not the tile/wall is actually destroyed.</param>
+		/// <param name="fullyDestroyed">Whether or not the tile/wall is destroyed, as opposed to just being hit.</param>
 		/// <returns></returns>
-		public virtual bool KillSound(int i, int j, int type, bool fail) {
+		public virtual bool KillSound(int i, int j, int type, bool fullyDestroyed) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalBlockType.cs
@@ -15,9 +15,9 @@ namespace Terraria.ModLoader
 		/// <param name="i"></param>
 		/// <param name="j"></param>
 		/// <param name="type"></param>
-		/// <param name="fullyDestroyed">Whether or not the tile/wall is destroyed, as opposed to just being hit.</param>
+		/// <param name="fail">If true, the tile/wall is only partially damaged. If false, the tile/wall is fully destroyed.</param>
 		/// <returns></returns>
-		public virtual bool KillSound(int i, int j, int type, bool fullyDestroyed) {
+		public virtual bool KillSound(int i, int j, int type, bool fail) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -66,8 +66,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
-		/// <param name="fullyDestroyed">Whether or not the tile/wall is destroyed, as opposed to just being hit.</param>
-		public virtual bool KillSound(int i, int j, bool fullyDestroyed) {
+		/// <param name="fail">If true, the tile/wall is only partially damaged. If false, the tile/wall is fully destroyed.</param>
+		public virtual bool KillSound(int i, int j, bool fail) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -66,8 +66,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
-		/// <param name="fail">Whether or not the tile/wall is actually destroyed.</param>
-		public virtual bool KillSound(int i, int j, bool fail) {
+		/// <param name="fullyDestroyed">Whether or not the tile/wall is destroyed, as opposed to just being hit.</param>
+		public virtual bool KillSound(int i, int j, bool fullyDestroyed) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -66,7 +66,8 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="i">The x position in tile coordinates.</param>
 		/// <param name="j">The y position in tile coordinates.</param>
-		public virtual bool KillSound(int i, int j) {
+		/// <param name="fail">Whether or not the tile/wall is actually destroyed.</param>
+		public virtual bool KillSound(int i, int j, bool fail) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -45,7 +45,7 @@ namespace Terraria.ModLoader
 		private static readonly int vanillaTorchCount = TileID.Sets.RoomNeeds.CountsAsTorch.Length;
 		private static readonly int vanillaDoorCount = TileID.Sets.RoomNeeds.CountsAsDoor.Length;
 
-		private static Func<int, int, int, bool>[] HookKillSound;
+		private static Func<int, int, int, bool, bool>[] HookKillSound;
 		private delegate void DelegateNumDust(int i, int j, int type, bool fail, ref int num);
 		private static DelegateNumDust[] HookNumDust;
 		private delegate bool DelegateCreateDust(int i, int j, int type, ref int dustType);
@@ -418,16 +418,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type) {
+		public static bool KillSound(int i, int j, int type, bool fail) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type))
+				if (!hook(i, j, type, fail))
 					return false;
 			}
 			
 			var modTile = GetTile(type);
 
 			if (modTile != null) {
-				if (!modTile.KillSound(i, j))
+				if (!modTile.KillSound(i, j, fail))
 					return false;
 				
 				SoundEngine.PlaySound(modTile.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -418,16 +418,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type, bool fail) {
+		public static bool KillSound(int i, int j, int type, bool fullyDestroyed) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type, fail))
+				if (!hook(i, j, type, fullyDestroyed))
 					return false;
 			}
 			
 			var modTile = GetTile(type);
 
 			if (modTile != null) {
-				if (!modTile.KillSound(i, j, fail))
+				if (!modTile.KillSound(i, j, fullyDestroyed))
 					return false;
 				
 				SoundEngine.PlaySound(modTile.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -418,16 +418,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type, bool fullyDestroyed) {
+		public static bool KillSound(int i, int j, int type, bool fail) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type, fullyDestroyed))
+				if (!hook(i, j, type, fail))
 					return false;
 			}
 			
 			var modTile = GetTile(type);
 
 			if (modTile != null) {
-				if (!modTile.KillSound(i, j, fullyDestroyed))
+				if (!modTile.KillSound(i, j, fail))
 					return false;
 				
 				SoundEngine.PlaySound(modTile.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -21,7 +21,7 @@ namespace Terraria.ModLoader
 		internal static readonly IList<GlobalWall> globalWalls = new List<GlobalWall>();
 		private static bool loaded = false;
 
-		private static Func<int, int, int, bool>[] HookKillSound;
+		private static Func<int, int, int, bool, bool>[] HookKillSound;
 		private delegate void DelegateNumDust(int i, int j, int type, bool fail, ref int num);
 		private static DelegateNumDust[] HookNumDust;
 		private delegate bool DelegateCreateDust(int i, int j, int type, ref int dustType);
@@ -136,16 +136,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type) {
+		public static bool KillSound(int i, int j, int type, bool fail) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type))
+				if (!hook(i, j, type, fail))
 					return false;
 			}
 			
 			var modWall = GetWall(type);
 
 			if (modWall != null) {
-				if (!modWall.KillSound(i, j))
+				if (!modWall.KillSound(i, j, fail))
 					return false;
 				
 				SoundEngine.PlaySound(modWall.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -136,16 +136,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type, bool fullyDestroyed) {
+		public static bool KillSound(int i, int j, int type, bool fail) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type, fullyDestroyed))
+				if (!hook(i, j, type, fail))
 					return false;
 			}
 			
 			var modWall = GetWall(type);
 
 			if (modWall != null) {
-				if (!modWall.KillSound(i, j, fullyDestroyed))
+				if (!modWall.KillSound(i, j, fail))
 					return false;
 				
 				SoundEngine.PlaySound(modWall.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -136,16 +136,16 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static bool KillSound(int i, int j, int type, bool fail) {
+		public static bool KillSound(int i, int j, int type, bool fullyDestroyed) {
 			foreach (var hook in HookKillSound) {
-				if (!hook(i, j, type, fail))
+				if (!hook(i, j, type, fullyDestroyed))
 					return false;
 			}
 			
 			var modWall = GetWall(type);
 
 			if (modWall != null) {
-				if (!modWall.KillSound(i, j, fail))
+				if (!modWall.KillSound(i, j, fullyDestroyed))
 					return false;
 				
 				SoundEngine.PlaySound(modWall.HitSound, new Vector2(i * 16, j * 16));

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1518,7 +1518,7 @@
  
 -		private static void KillWall_PlaySounds(int i, int j, Tile tileCache) {
 +		private static void KillWall_PlaySounds(int i, int j, Tile tileCache, bool fail = false) {
-+			if (!WallLoader.KillSound(i,j,tileCache.wall, fail))
++			if (!WallLoader.KillSound(i,j,tileCache.wall,!fail))
 +				return;
 +
  			if (tileCache.wall == 241 || (tileCache.wall >= 88 && tileCache.wall <= 93) || tileCache.wall == 21 || tileCache.wall == 186 || tileCache.wall == 136 || tileCache.wall == 137 || tileCache.wall == 168 || tileCache.wall == 169 || tileCache.wall == 172 || tileCache.wall == 226 || tileCache.wall == 227 || tileCache.wall == 242 || tileCache.wall == 243)
@@ -1721,7 +1721,7 @@
  
  			int type = tileCache.type;
 +
-+			if(!TileLoader.KillSound(i,j,type,fail))
++			if(!TileLoader.KillSound(i,j,type,!fail))
 +				return;
 +
  			if (type == 127 || type == 623) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1518,7 +1518,7 @@
  
 -		private static void KillWall_PlaySounds(int i, int j, Tile tileCache) {
 +		private static void KillWall_PlaySounds(int i, int j, Tile tileCache, bool fail = false) {
-+			if (!WallLoader.KillSound(i,j,tileCache.wall,!fail))
++			if (!WallLoader.KillSound(i,j,tileCache.wall,fail))
 +				return;
 +
  			if (tileCache.wall == 241 || (tileCache.wall >= 88 && tileCache.wall <= 93) || tileCache.wall == 21 || tileCache.wall == 186 || tileCache.wall == 136 || tileCache.wall == 137 || tileCache.wall == 168 || tileCache.wall == 169 || tileCache.wall == 172 || tileCache.wall == 226 || tileCache.wall == 227 || tileCache.wall == 242 || tileCache.wall == 243)
@@ -1721,7 +1721,7 @@
  
  			int type = tileCache.type;
 +
-+			if(!TileLoader.KillSound(i,j,type,!fail))
++			if(!TileLoader.KillSound(i,j,type,fail))
 +				return;
 +
  			if (type == 127 || type == 623) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1493,7 +1493,8 @@
  
  			fail = KillWall_CheckFailure(fail, tile);
 +			WallLoader.KillWall(i, j, tile.wall, ref fail);
- 			KillWall_PlaySounds(i, j, tile);
+-			KillWall_PlaySounds(i, j, tile);
++			KillWall_PlaySounds(i, j, tile, fail);
  			int num = 10;
  			if (fail)
  				num = 3;
@@ -1511,11 +1512,13 @@
  				TileFrame(i, j);
  		}
  
-@@ -38346,6 +_,9 @@
+@@ -38345,7 +_,10 @@
+ 			return fail;
  		}
  
- 		private static void KillWall_PlaySounds(int i, int j, Tile tileCache) {
-+			if (!WallLoader.KillSound(i,j,tileCache.wall))
+-		private static void KillWall_PlaySounds(int i, int j, Tile tileCache) {
++		private static void KillWall_PlaySounds(int i, int j, Tile tileCache, bool fail = false) {
++			if (!WallLoader.KillSound(i,j,tileCache.wall, fail))
 +				return;
 +
  			if (tileCache.wall == 241 || (tileCache.wall >= 88 && tileCache.wall <= 93) || tileCache.wall == 21 || tileCache.wall == 186 || tileCache.wall == 136 || tileCache.wall == 137 || tileCache.wall == 168 || tileCache.wall == 169 || tileCache.wall == 172 || tileCache.wall == 226 || tileCache.wall == 227 || tileCache.wall == 242 || tileCache.wall == 243)
@@ -1718,7 +1721,7 @@
  
  			int type = tileCache.type;
 +
-+			if(!TileLoader.KillSound(i,j,type))
++			if(!TileLoader.KillSound(i,j,type,fail))
 +				return;
 +
  			if (type == 127 || type == 623) {

--- a/tModPorter/tModPorter/Config.cs
+++ b/tModPorter/tModPorter/Config.cs
@@ -125,6 +125,8 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.ModTile",			"DrawEffects");
 		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"DrawEffects");
 		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"IsTileDangerous", comment: "Suggestion: Return null instead of false");
+		ChangeHookSignature("Terraria.ModLoader.ModBlockType",		"KillSound");
+		ChangeHookSignature("Terraria.ModLoader.GlobalBlockType",	"KillSound");
 
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Load",	to: "LoadData");
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Save",	to: "SaveData");


### PR DESCRIPTION
### What is the new feature?
Added ~~`fail`~~ `fullyDestroyed` parameter to `ModBlockType.KillSound()`, `GlobalBlockType.KillSound()`, `TileLoader.KillSound()`, and `WallLoader.KillSound()`, and updates tModPorter to fix these method signatures. Resolves #2433.

### Why should this be part of tModLoader?
Requested in #2433, allows more modder control. From the issue:
> Crystal Block is an example of a tile that makes the normal mine sound on early hits, but changes to the crystal break sound once the tile is fully mined. This is not possible with the current hook.

### Are there alternative designs?
Not that I can think of.

### Sample usage for the new feature
See `ExampleAnimatedTile`.

### ExampleMod updates
Updates `ExampleAnimatedTile` to showcase the feature.