### PR TITLE
DamageClass.CountsAsClass

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -110,5 +110,11 @@ namespace Terraria.ModLoader
 		}
 
 		public sealed override void SetupContent() => SetStaticDefaults();
+
+		public bool CountsAsClass<T>() where T : DamageClass
+			=> CountsAsClass(ModContent.GetInstance<T>());
+
+		public bool CountsAsClass(DamageClass damageClass)
+			=> DamageClassLoader.effectInheritanceCache[Type, damageClass.Type];
 	}
 }


### PR DESCRIPTION
### What is the new feature?
`CountsAsClass` method variants for `DamageClass`

### Why should this be part of tModLoader?
given that `Item` and `Projectile` both have variants of this already, it makes sense for `DamageClass` itself to have an easy way to check this --- and a need has been expressed for it to have one. an example use case is if a modder passes a `DamageClass` into a given method, with no item or projectile necessarily present to tie it to, and needs to check if said `DamageClass` counts as a different one

### Are there alternative designs?
no

### Sample usage for the new feature
``` c#
if (damageClass.CountsAsClass(DamageClass.Melee))
{
    // do melee things
}
if (!damageClass.CountsAsClass(DamageClass.Magic))
{
    // do non-magic things
}
if (damageClass.CountsAsClass<ExampleDamageClass>())
{
    // do example things
}
```