### PR TITLE
Some Sound Bug Fixes

### DIFF
--- a/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
@@ -124,6 +124,19 @@
  					num = 1f - num2 / ((float)Main.screenWidth * 1.5f);
  				}
  
+@@ -95,6 +_,12 @@
+ 						break;
+ 					case SoundType.Ambient:
+ 						num *= Main.ambientVolume;
++
++						// Added by TML to mimic the behavior of the LegacySoundPlayer code.
++						if (Main.gameInactive) {
++							num = 0f;
++						}
++
+ 						break;
+ 					case SoundType.Music:
+ 						num *= Main.musicVolume;
 @@ -104,6 +_,19 @@
  				num = MathHelper.Clamp(num, 0f, 1f);
  				Sound.Volume = num;

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Audio/SoundPlayer.cs
 +++ src/tModLoader/Terraria/Audio/SoundPlayer.cs
-@@ -1,24 +_,83 @@
+@@ -1,24 +_,90 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Utilities;
  using System.Collections.Generic;
@@ -74,6 +74,13 @@
 +							return SlotId.Invalid;
 +					}
 +				}
++			}
++
++			// Handle special case for Waterfall/Lavafall logic.
++			// The volume being <= 0 or the position being null indicates that the sound should be stopped, rather than having a sound with no volume play.
++			// -- absoluteAquarian
++			if ((style.IsTheSameAs(ID.SoundID.Waterfall) || style.IsTheSameAs(ID.SoundID.Lavafall)) && (style.Volume <= 0 || position is null)) {
++				return SlotId.Invalid;
 +			}
 +
 +			SoundStyle styleCopy = style;

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Audio/SoundPlayer.cs
 +++ src/tModLoader/Terraria/Audio/SoundPlayer.cs
-@@ -1,24 +_,90 @@
+@@ -1,24 +_,83 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Utilities;
  using System.Collections.Generic;
@@ -76,13 +76,6 @@
 +				}
 +			}
 +
-+			// Handle special case for Waterfall/Lavafall logic.
-+			// The volume being <= 0 or the position being null indicates that the sound should be stopped, rather than having a sound with no volume play.
-+			// -- absoluteAquarian
-+			if ((style.IsTheSameAs(ID.SoundID.Waterfall) || style.IsTheSameAs(ID.SoundID.Lavafall)) && (style.Volume <= 0 || position is null)) {
-+				return SlotId.Invalid;
-+			}
-+
 +			SoundStyle styleCopy = style;
 +
 +			// Handle 'UsesMusicPitch'.. This property is a weird solution for keeping vanilla's old instruments' behavior alive, and is currently internal.
@@ -126,6 +119,28 @@
  
  		public void PauseAll() {
  			foreach (SlotVector<ActiveSound>.ItemPair item in (IEnumerable<SlotVector<ActiveSound>.ItemPair>)_trackedSounds) {
+@@ -61,6 +_,21 @@
+ 			_trackedSounds.Clear();
+ 		}
+ 
++		public void StopAll(in SoundStyle style) {
++			List<SlotVector<ActiveSound>.ItemPair> stopped = new();
++
++			foreach (SlotVector<ActiveSound>.ItemPair item in (IEnumerable<SlotVector<ActiveSound>.ItemPair>)_trackedSounds) {
++				if (style.IsTheSameAs(item.Value.Style)) {
++					item.Value.Stop();
++					stopped.Add(item);
++				}
++			}
++
++			foreach (var item in stopped) {
++				_trackedSounds.Remove(item.Id);
++			}
++		}
++
+ 		public void Update() {
+ #if FNA
+ 			Monitor.Enter(SoundEngine.AudioLock);
 @@ -80,7 +_,7 @@
  #endif
  		}

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -642,7 +642,7 @@ namespace Terraria.ID
 			LegacySoundIDs.Bird => Bird,
 			LegacySoundIDs.Critter => Critter,
 			LegacySoundIDs.Waterfall or
-			LegacySoundIDs.Lavafall => (type == LegacySoundIDs.Waterfall ? Waterfall : Lavafall) with { Volume = style / 50f },
+			LegacySoundIDs.Lavafall => (type == LegacySoundIDs.Waterfall ? Waterfall : Lavafall) with { Volume = (type == LegacySoundIDs.Waterfall ? Waterfall.Volume : Lavafall.Volume) * style / 50f },
 			LegacySoundIDs.ForceRoar => style switch { -1 => ForceRoarPitched, _ => ForceRoar },
 			LegacySoundIDs.Meowmere => Meowmere,
 			LegacySoundIDs.CoinPickup => CoinPickup,

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -68,8 +68,8 @@ namespace Terraria.ID
 		//TODO: Inaccurate variants, search & analyze "PlaySound(32," in vanilla src.
 		public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", 14, 5, SoundType.Ambient) { Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew };
 		public static readonly SoundStyle Critter = new($"{Prefix}Zombie_15", SoundType.Ambient) { Volume = 0.2f, PitchRange = (-0.1f, 0.3f), SoundLimitBehavior = IgnoreNew };
-		public static readonly SoundStyle Waterfall = new($"{Prefix}Liquid_0", SoundType.Ambient) { Volume = 0.2f, SoundLimitBehavior = IgnoreNew };
-		public static readonly SoundStyle Lavafall = new($"{Prefix}Liquid_1", SoundType.Ambient) { Volume = 0.65f, SoundLimitBehavior = IgnoreNew };
+		public static readonly SoundStyle Waterfall = new($"{Prefix}Liquid_0", SoundType.Ambient) { Volume = 0.2f, SoundLimitBehavior = ReplaceOldest };
+		public static readonly SoundStyle Lavafall = new($"{Prefix}Liquid_1", SoundType.Ambient) { Volume = 0.65f, SoundLimitBehavior = ReplaceOldest };
 		public static readonly SoundStyle ForceRoar = new($"{Prefix}Roar_0") { Identifier = "Terraria/Roar" };
 		public static readonly SoundStyle ForceRoarPitched = new($"{Prefix}Roar_0") { Pitch = 0.6f, Identifier = "Terraria/Roar" };
 		public static readonly SoundStyle Meowmere = new($"{Prefix}Item_", 57, 2) { PitchVariance = 0.8f };
@@ -641,9 +641,9 @@ namespace Terraria.ID
 			LegacySoundIDs.Frog => Frog,
 			LegacySoundIDs.Bird => Bird,
 			LegacySoundIDs.Critter => Critter,
-			LegacySoundIDs.Waterfall => Waterfall,
-			LegacySoundIDs.Lavafall => Lavafall,
-			LegacySoundIDs.ForceRoar => ForceRoar,
+			LegacySoundIDs.Waterfall or
+			LegacySoundIDs.Lavafall => (type == LegacySoundIDs.Waterfall ? Waterfall : Lavafall) with { Volume = style / 50f },
+			LegacySoundIDs.ForceRoar => style switch { -1 => ForceRoarPitched, _ => ForceRoar },
 			LegacySoundIDs.Meowmere => Meowmere,
 			LegacySoundIDs.CoinPickup => CoinPickup,
 			LegacySoundIDs.Drip => Drip,

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -641,8 +641,8 @@ namespace Terraria.ID
 			LegacySoundIDs.Frog => Frog,
 			LegacySoundIDs.Bird => Bird,
 			LegacySoundIDs.Critter => Critter,
-			LegacySoundIDs.Waterfall or
-			LegacySoundIDs.Lavafall => (type == LegacySoundIDs.Waterfall ? Waterfall : Lavafall) with { Volume = (type == LegacySoundIDs.Waterfall ? Waterfall.Volume : Lavafall.Volume) * style / 50f },
+			LegacySoundIDs.Waterfall => Waterfall with { Volume = Waterfall.Volume * style / 50f },
+			LegacySoundIDs.Lavafall => Lavafall with { Volume = Lavafall.Volume * style / 50f },
 			LegacySoundIDs.ForceRoar => style switch { -1 => ForceRoarPitched, _ => ForceRoar },
 			LegacySoundIDs.Meowmere => Meowmere,
 			LegacySoundIDs.CoinPickup => CoinPickup,

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -68,8 +68,8 @@ namespace Terraria.ID
 		//TODO: Inaccurate variants, search & analyze "PlaySound(32," in vanilla src.
 		public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", 14, 5, SoundType.Ambient) { Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew };
 		public static readonly SoundStyle Critter = new($"{Prefix}Zombie_15", SoundType.Ambient) { Volume = 0.2f, PitchRange = (-0.1f, 0.3f), SoundLimitBehavior = IgnoreNew };
-		public static readonly SoundStyle Waterfall = new($"{Prefix}Liquid_0", SoundType.Ambient) { Volume = 0.2f, SoundLimitBehavior = ReplaceOldest };
-		public static readonly SoundStyle Lavafall = new($"{Prefix}Liquid_1", SoundType.Ambient) { Volume = 0.65f, SoundLimitBehavior = ReplaceOldest };
+		public static readonly SoundStyle Waterfall = new($"{Prefix}Liquid_0", SoundType.Ambient) { Volume = 0.2f, SoundLimitBehavior = IgnoreNew };
+		public static readonly SoundStyle Lavafall = new($"{Prefix}Liquid_1", SoundType.Ambient) { Volume = 0.65f, SoundLimitBehavior = IgnoreNew };
 		public static readonly SoundStyle ForceRoar = new($"{Prefix}Roar_0") { Identifier = "Terraria/Roar" };
 		public static readonly SoundStyle ForceRoarPitched = new($"{Prefix}Roar_0") { Pitch = 0.6f, Identifier = "Terraria/Roar" };
 		public static readonly SoundStyle Meowmere = new($"{Prefix}Item_", 57, 2) { PitchVariance = 0.8f };
@@ -641,8 +641,8 @@ namespace Terraria.ID
 			LegacySoundIDs.Frog => Frog,
 			LegacySoundIDs.Bird => Bird,
 			LegacySoundIDs.Critter => Critter,
-			LegacySoundIDs.Waterfall => Waterfall with { Volume = Waterfall.Volume * style / 50f },
-			LegacySoundIDs.Lavafall => Lavafall with { Volume = Lavafall.Volume * style / 50f },
+			LegacySoundIDs.Waterfall => Waterfall,
+			LegacySoundIDs.Lavafall => Lavafall,
 			LegacySoundIDs.ForceRoar => style switch { -1 => ForceRoarPitched, _ => ForceRoar },
 			LegacySoundIDs.Meowmere => Meowmere,
 			LegacySoundIDs.CoinPickup => CoinPickup,

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1183,6 +1183,90 @@
  				cloudBGActive = rand.Next(num2 * 3, num * 2);
  				if (netMode == 2)
  					NetMessage.SendData(7);
+@@ -10184,6 +_,8 @@
+ 			}
+ 		}
+ 
++		private static SlotId waterfallSoundSlot, lavafallSoundSlot;
++
+ 		public static void Ambience() {
+ 			ambientCounter++;
+ 			if (ambientCounter < 15)
+@@ -10192,12 +_,35 @@
+ 			ambientCounter = 0;
+ 			Microsoft.Xna.Framework.Point point = LocalPlayer.Center.ToPoint();
+ 			if (ambientWaterfallStrength > 0f) {
++				SoundStyle copy = SoundID.Waterfall;
++				copy.Volume *= ambientWaterfallStrength / 50f;
++
++				if (copy.Volume > 0 && ambientWaterfallX != -1 && ambientWaterfallY != -1) {
++					_isWaterfallMusicPlaying = true;
++
++					Vector2 pos = new(ambientWaterfallX, ambientWaterfallY);
++
++					if (!SoundEngine.TryGetActiveSound(waterfallSoundSlot, out ActiveSound waterfall)) {
++						waterfallSoundSlot = SoundEngine.PlaySound(copy, pos);
++						waterfall = SoundEngine.GetActiveSound(waterfallSoundSlot);
++					}
++					
++					if (waterfall is not null) {
++						waterfall.Volume = copy.Volume;
++						waterfall.Position = pos;
++					}
++				} else {
++					SoundEngine.SoundPlayer.StopAll(copy);
++					_isWaterfallMusicPlaying = false;
++				}
++				/*
+ 				SoundEngine.PlaySound(34, (int)ambientWaterfallX, (int)ambientWaterfallY, (int)ambientWaterfallStrength);
+ 				_isWaterfallMusicPlaying = true;
++				*/
+ 			}
+ 			else {
+ 				if (_isWaterfallMusicPlaying)
+-					SoundEngine.PlaySound(34, point.X, point.Y, 0);
++					SoundEngine.SoundPlayer.StopAll(SoundID.Waterfall);
+ 
+ 				_isWaterfallMusicPlaying = false;
+ 			}
+@@ -10213,13 +_,36 @@
+ 
+ 			float num5 = ambientLavafallStrength + ambientLavaStrength;
+ 			if (ambientLavafallStrength > 0f) {
++				SoundStyle copy = SoundID.Lavafall;
++				copy.Volume *= num5 / 50f;
++
++				if (copy.Volume > 0 && num3 != -1 && num4 != -1) {
++					_isLavafallMusicPlaying = true;
++
++					Vector2 pos = new(num3, num4);
++
++					if (!SoundEngine.TryGetActiveSound(lavafallSoundSlot, out ActiveSound lavafall)) {
++						lavafallSoundSlot = SoundEngine.PlaySound(copy, pos);
++						lavafall = SoundEngine.GetActiveSound(lavafallSoundSlot);
++					}
++
++					if (lavafall is not null) {
++						lavafall.Volume = copy.Volume;
++						lavafall.Position = pos;
++					}
++				} else {
++					SoundEngine.SoundPlayer.StopAll(copy);
++					_isLavafallMusicPlaying = false;
++				}
++				/*
+ 				SoundEngine.PlaySound(35, (int)num3, (int)num4, (int)num5);
+ 				_isLavafallMusicPlaying = true;
++				*/
+ 				return;
+ 			}
+ 
+ 			if (_isLavafallMusicPlaying)
+-				SoundEngine.PlaySound(35, point.X, point.Y, 0);
++				SoundEngine.SoundPlayer.StopAll(SoundID.Lavafall);
+ 
+ 			_isLavafallMusicPlaying = false;
+ 		}
 @@ -12355,11 +_,16 @@
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1247,9 +1247,11 @@
  
  			float num = Math.Abs(ambientLavaX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavaY - (screenPosition.Y + (float)(screenHeight / 2)));
  			float num2 = Math.Abs(ambientLavafallX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavafallY - (screenPosition.Y + (float)(screenHeight / 2)));
-@@ -10212,6 +_,10 @@
+@@ -10211,7 +_,12 @@
+ 				num4 = ambientLavafallY;
  			}
  
++			// Weird: Vanilla uses this for adjusting lava sounds' volume, but doesn't consider it when checking if the sound should be playing, using the expression seen below.
  			float num5 = ambientLavafallStrength + ambientLavaStrength;
 +
 +			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, ref _isLavafallMusicPlaying, ambientLavafallStrength > 0f, num3, num4, num5);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1193,47 +1193,37 @@
  		public static void Ambience() {
  			ambientCounter++;
  			if (ambientCounter < 15)
-@@ -10191,6 +_,45 @@
+@@ -10191,6 +_,35 @@
  
  			ambientCounter = 0;
  			Microsoft.Xna.Framework.Point point = LocalPlayer.Center.ToPoint();
 +
 +			// Added by TML. Improves handling of waterfall and lavafall sounds for the new unified audio system.
-+			static void HandleAmbientSound(in SoundStyle soundStyle, ref SlotId slot, ref bool isPlaying, bool shouldBePlaying, float xPos, float yPos, float strength) {
-+				if (shouldBePlaying) {
-+					SoundStyle copy = soundStyle;
-+					
-+					copy.Volume *= strength / 50f;
++			static void HandleAmbientSound(in SoundStyle soundStyle, ref SlotId slot, float volume, Vector2 position) {
++				SoundEngine.TryGetActiveSound(slot, out var activeSound);
 +
-+					if (copy.Volume > 0f && xPos != -1 && yPos != -1) {
-+						isPlaying = true;
++				if (volume > 0f) {
++					if (activeSound == null) {
++						slot = SoundEngine.PlaySound(soundStyle, position);
 +
-+						Vector2 pos = new(xPos, yPos);
-+
-+						if (!SoundEngine.TryGetActiveSound(slot, out ActiveSound waterfall)) {
-+							slot = SoundEngine.PlaySound(copy, pos);
-+							waterfall = SoundEngine.GetActiveSound(slot);
-+						}
-+
-+						if (waterfall is not null) {
-+							waterfall.Volume = copy.Volume;
-+							waterfall.Position = pos;
++						if (!SoundEngine.TryGetActiveSound(slot, out activeSound)) {
++							return;
 +						}
 +					}
-+					else {
-+						SoundEngine.SoundPlayer.StopAll(copy);
-+						isPlaying = false;
-+					}
++
++					activeSound.Volume = volume;
++					activeSound.Position = position;
 +				}
-+				else {
-+					if (isPlaying)
-+						SoundEngine.SoundPlayer.StopAll(soundStyle);
++				else if (activeSound != null) {
++					activeSound.Stop();
 +
-+					isPlaying = false;
++					slot = SlotId.Invalid;
 +				}
 +			}
 +
-+			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, ref _isWaterfallMusicPlaying, ambientWaterfallStrength > 0f, ambientWaterfallX, ambientWaterfallY, ambientWaterfallStrength);
++			float usedWaterVolume = MathHelper.Clamp(ambientWaterfallStrength / 50f, 0f, 1f);
++
++			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, ambientWaterfallStrength, new Vector2(ambientWaterfallX, ambientWaterfallY));
 +			
 +			/*
  			if (ambientWaterfallStrength > 0f) {
@@ -1247,14 +1237,19 @@
  
  			float num = Math.Abs(ambientLavaX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavaY - (screenPosition.Y + (float)(screenHeight / 2)));
  			float num2 = Math.Abs(ambientLavafallX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavafallY - (screenPosition.Y + (float)(screenHeight / 2)));
-@@ -10211,7 +_,12 @@
+@@ -10210,8 +_,16 @@
+ 				num3 = ambientLavafallX;
  				num4 = ambientLavafallY;
  			}
- 
-+			// Weird: Vanilla uses this for adjusting lava sounds' volume, but doesn't consider it when checking if the sound should be playing, using the expression seen below.
+-
++			
  			float num5 = ambientLavafallStrength + ambientLavaStrength;
++			// Weird: Vanilla uses the above local for adjusting lava sounds' volume, but doesn't consider it when checking if the sound should be playing at all.
++			float usedLavaVolume = ambientLavaStrength > 0f
++				? MathHelper.Clamp(num5 / 50f, 0f, 1f)
++				: 0f;
 +
-+			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, ref _isLavafallMusicPlaying, ambientLavafallStrength > 0f, num3, num4, num5);
++			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, num5, new Vector2(num3, num4));
 +
 +			/*
  			if (ambientLavafallStrength > 0f) {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -233,6 +233,18 @@
  		private static float _minWind = 0.34f;
  		private static float _maxWind = 0.4f;
  		private static float _minRain = 0.4f;
+@@ -1987,8 +_,11 @@
+ 		public static float ambientLavaY = -1f;
+ 		public static float ambientLavaStrength;
+ 		public static int ambientCounter;
++		//TML: No longer of use due to changes in Main.Ambience().
++		/*
+ 		private static bool _isWaterfallMusicPlaying = false;
+ 		private static bool _isLavafallMusicPlaying = false;
++		*/
+ 		public static IChatMonitor chatMonitor = new RemadeChatMonitor();
+ 		public static int ProjectileUpdateLoopIndex = -1;
+ 		public static GameTipsDisplay gameTips;
 @@ -2009,16 +_,16 @@
  		private int selectedMenu2 = -1;
  		public static int selectedPlayer = 0;
@@ -1224,7 +1236,7 @@
 +			float usedWaterVolume = MathHelper.Clamp(ambientWaterfallStrength / 50f, 0f, 1f);
 +
 +			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, ambientWaterfallStrength, new Vector2(ambientWaterfallX, ambientWaterfallY));
-+			
++
 +			/*
  			if (ambientWaterfallStrength > 0f) {
  				SoundEngine.PlaySound(34, (int)ambientWaterfallX, (int)ambientWaterfallY, (int)ambientWaterfallStrength);
@@ -1237,12 +1249,9 @@
  
  			float num = Math.Abs(ambientLavaX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavaY - (screenPosition.Y + (float)(screenHeight / 2)));
  			float num2 = Math.Abs(ambientLavafallX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavafallY - (screenPosition.Y + (float)(screenHeight / 2)));
-@@ -10210,8 +_,16 @@
- 				num3 = ambientLavafallX;
- 				num4 = ambientLavafallY;
+@@ -10212,6 +_,14 @@
  			}
--
-+			
+ 
  			float num5 = ambientLavafallStrength + ambientLavaStrength;
 +			// Weird: Vanilla uses the above local for adjusting lava sounds' volume, but doesn't consider it when checking if the sound should be playing at all.
 +			float usedLavaVolume = ambientLavaStrength > 0f

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1235,7 +1235,7 @@
 +
 +			float usedWaterVolume = MathHelper.Clamp(ambientWaterfallStrength / 50f, 0f, 1f);
 +
-+			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, ambientWaterfallStrength, new Vector2(ambientWaterfallX, ambientWaterfallY));
++			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, usedWaterVolume, new Vector2(ambientWaterfallX, ambientWaterfallY));
 +
 +			/*
  			if (ambientWaterfallStrength > 0f) {
@@ -1258,7 +1258,7 @@
 +				? MathHelper.Clamp(num5 / 50f, 0f, 1f)
 +				: 0f;
 +
-+			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, num5, new Vector2(num3, num4));
++			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, usedLavaVolume, new Vector2(num3, num4));
 +
 +			/*
  			if (ambientLavafallStrength > 0f) {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1183,90 +1183,89 @@
  				cloudBGActive = rand.Next(num2 * 3, num * 2);
  				if (netMode == 2)
  					NetMessage.SendData(7);
-@@ -10184,6 +_,8 @@
+@@ -10184,6 +_,9 @@
  			}
  		}
  
++		// Added by TML, used below.
 +		private static SlotId waterfallSoundSlot, lavafallSoundSlot;
 +
  		public static void Ambience() {
  			ambientCounter++;
  			if (ambientCounter < 15)
-@@ -10192,12 +_,35 @@
+@@ -10191,6 +_,45 @@
+ 
  			ambientCounter = 0;
  			Microsoft.Xna.Framework.Point point = LocalPlayer.Center.ToPoint();
- 			if (ambientWaterfallStrength > 0f) {
-+				SoundStyle copy = SoundID.Waterfall;
-+				copy.Volume *= ambientWaterfallStrength / 50f;
 +
-+				if (copy.Volume > 0 && ambientWaterfallX != -1 && ambientWaterfallY != -1) {
-+					_isWaterfallMusicPlaying = true;
-+
-+					Vector2 pos = new(ambientWaterfallX, ambientWaterfallY);
-+
-+					if (!SoundEngine.TryGetActiveSound(waterfallSoundSlot, out ActiveSound waterfall)) {
-+						waterfallSoundSlot = SoundEngine.PlaySound(copy, pos);
-+						waterfall = SoundEngine.GetActiveSound(waterfallSoundSlot);
-+					}
++			// Added by TML. Improves handling of waterfall and lavafall sounds for the new unified audio system.
++			static void HandleAmbientSound(in SoundStyle soundStyle, ref SlotId slot, ref bool isPlaying, bool shouldBePlaying, float xPos, float yPos, float strength) {
++				if (shouldBePlaying) {
++					SoundStyle copy = soundStyle;
 +					
-+					if (waterfall is not null) {
-+						waterfall.Volume = copy.Volume;
-+						waterfall.Position = pos;
++					copy.Volume *= strength / 50f;
++
++					if (copy.Volume > 0f && xPos != -1 && yPos != -1) {
++						isPlaying = true;
++
++						Vector2 pos = new(xPos, yPos);
++
++						if (!SoundEngine.TryGetActiveSound(slot, out ActiveSound waterfall)) {
++							slot = SoundEngine.PlaySound(copy, pos);
++							waterfall = SoundEngine.GetActiveSound(slot);
++						}
++
++						if (waterfall is not null) {
++							waterfall.Volume = copy.Volume;
++							waterfall.Position = pos;
++						}
 +					}
-+				} else {
-+					SoundEngine.SoundPlayer.StopAll(copy);
-+					_isWaterfallMusicPlaying = false;
++					else {
++						SoundEngine.SoundPlayer.StopAll(copy);
++						isPlaying = false;
++					}
 +				}
-+				/*
++				else {
++					if (isPlaying)
++						SoundEngine.SoundPlayer.StopAll(soundStyle);
++
++					isPlaying = false;
++				}
++			}
++
++			HandleAmbientSound(in SoundID.Waterfall, ref waterfallSoundSlot, ref _isWaterfallMusicPlaying, ambientWaterfallStrength > 0f, ambientWaterfallX, ambientWaterfallY, ambientWaterfallStrength);
++			
++			/*
+ 			if (ambientWaterfallStrength > 0f) {
  				SoundEngine.PlaySound(34, (int)ambientWaterfallX, (int)ambientWaterfallY, (int)ambientWaterfallStrength);
  				_isWaterfallMusicPlaying = true;
-+				*/
- 			}
- 			else {
- 				if (_isWaterfallMusicPlaying)
--					SoundEngine.PlaySound(34, point.X, point.Y, 0);
-+					SoundEngine.SoundPlayer.StopAll(SoundID.Waterfall);
+@@ -10201,6 +_,7 @@
  
  				_isWaterfallMusicPlaying = false;
  			}
-@@ -10213,13 +_,36 @@
++			*/
  
- 			float num5 = ambientLavafallStrength + ambientLavaStrength;
- 			if (ambientLavafallStrength > 0f) {
-+				SoundStyle copy = SoundID.Lavafall;
-+				copy.Volume *= num5 / 50f;
-+
-+				if (copy.Volume > 0 && num3 != -1 && num4 != -1) {
-+					_isLavafallMusicPlaying = true;
-+
-+					Vector2 pos = new(num3, num4);
-+
-+					if (!SoundEngine.TryGetActiveSound(lavafallSoundSlot, out ActiveSound lavafall)) {
-+						lavafallSoundSlot = SoundEngine.PlaySound(copy, pos);
-+						lavafall = SoundEngine.GetActiveSound(lavafallSoundSlot);
-+					}
-+
-+					if (lavafall is not null) {
-+						lavafall.Volume = copy.Volume;
-+						lavafall.Position = pos;
-+					}
-+				} else {
-+					SoundEngine.SoundPlayer.StopAll(copy);
-+					_isLavafallMusicPlaying = false;
-+				}
-+				/*
- 				SoundEngine.PlaySound(35, (int)num3, (int)num4, (int)num5);
- 				_isLavafallMusicPlaying = true;
-+				*/
- 				return;
+ 			float num = Math.Abs(ambientLavaX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavaY - (screenPosition.Y + (float)(screenHeight / 2)));
+ 			float num2 = Math.Abs(ambientLavafallX - (screenPosition.X + (float)(screenWidth / 2))) + Math.Abs(ambientLavafallY - (screenPosition.Y + (float)(screenHeight / 2)));
+@@ -10212,6 +_,10 @@
  			}
  
- 			if (_isLavafallMusicPlaying)
--				SoundEngine.PlaySound(35, point.X, point.Y, 0);
-+				SoundEngine.SoundPlayer.StopAll(SoundID.Lavafall);
+ 			float num5 = ambientLavafallStrength + ambientLavaStrength;
++
++			HandleAmbientSound(in SoundID.Lavafall, ref lavafallSoundSlot, ref _isLavafallMusicPlaying, ambientLavafallStrength > 0f, num3, num4, num5);
++
++			/*
+ 			if (ambientLavafallStrength > 0f) {
+ 				SoundEngine.PlaySound(35, (int)num3, (int)num4, (int)num5);
+ 				_isLavafallMusicPlaying = true;
+@@ -10222,6 +_,7 @@
+ 				SoundEngine.PlaySound(35, point.X, point.Y, 0);
  
  			_isLavafallMusicPlaying = false;
++			*/
  		}
+ 
+ 		public static void AnimateTiles_CritterCages() {
 @@ -12355,11 +_,16 @@
  		}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -115,6 +115,72 @@
  			if (Main.menuMode == 10 || Main.menuMode == 888)
  				Main.menuMode = 6;
  
+@@ -2340,13 +_,6 @@
+ 		}
+ 
+ 		public static void JustQuit() {
+-			try {
+-				SoundEngine.PlaySound(34, -1, -1, 0);
+-				SoundEngine.PlaySound(35, -1, -1, 0);
+-			}
+-			catch {
+-			}
+-
+ 			Main.invasionProgress = -1;
+ 			Main.invasionProgressDisplayLeft = 0;
+ 			Main.invasionProgressAlpha = 0f;
+@@ -2354,6 +_,18 @@
+ 			Main.menuMode = 10;
+ 			Main.gameMenu = true;
+ 			SoundEngine.StopTrackedSounds();
++
++			try {
++				// Delay playing the "menu close" sound until AFTER all sounds have stopped
++				SoundEngine.PlaySound(11);
++			}
++			catch {
++			}
++
++			// Properly stop waterfall/lavafall sounds
++			Main.ambientWaterfallStrength = 0f;
++			Main.ambientLavafallStrength = 0f;
++
+ 			CaptureInterface.ResetFocus();
+ 			Main.ActivePlayerFileData.StopPlayTimer();
+ 			Main.fastForwardTime = false;
+@@ -2371,13 +_,6 @@
+ 
+ 		public static void SaveAndQuitCallBack(object threadContext) {
+ 			int netMode = Main.netMode;
+-			try {
+-				SoundEngine.PlaySound(34, -1, -1, 0);
+-				SoundEngine.PlaySound(35, -1, -1, 0);
+-			}
+-			catch {
+-			}
+-
+ 			if (netMode == 0)
+ 				WorldFile.CacheSaveTime();
+ 
+@@ -2388,6 +_,18 @@
+ 			Main.menuMode = 10;
+ 			Main.gameMenu = true;
+ 			SoundEngine.StopTrackedSounds();
++
++			try {
++				// Delay playing the "menu close" sound until AFTER all sounds have stopped
++				SoundEngine.PlaySound(11);
++			}
++			catch {
++			}
++			
++			// Properly stop waterfall/lavafall sounds
++			Main.ambientWaterfallStrength = 0f;
++			Main.ambientLavafallStrength = 0f;
++			
+ 			CaptureInterface.ResetFocus();
+ 			Main.ActivePlayerFileData.StopPlayTimer();
+ 			Player.SavePlayer(Main.ActivePlayerFileData);
 @@ -2402,6 +_,11 @@
  				Main.netMode = 0;
  			}
@@ -127,6 +193,14 @@
  			Main.fastForwardTime = false;
  			Main.UpdateTimeRate();
  			Main.menuMode = 0;
+@@ -2410,7 +_,6 @@
+ 		}
+ 
+ 		public static void SaveAndQuit(Action callback = null) {
+-			SoundEngine.PlaySound(11);
+ 			ThreadPool.QueueUserWorkItem(SaveAndQuitCallBack, callback);
+ 		}
+ 
 @@ -2484,13 +_,20 @@
  					}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -150,30 +150,22 @@
  			CaptureInterface.ResetFocus();
  			Main.ActivePlayerFileData.StopPlayTimer();
  			Main.fastForwardTime = false;
-@@ -2370,14 +_,16 @@
- 		}
+@@ -2371,12 +_,15 @@
  
  		public static void SaveAndQuitCallBack(object threadContext) {
-+			/*
-+			try {
-+				SoundEngine.PlaySound(34, -1, -1, 0);
-+				SoundEngine.PlaySound(35, -1, -1, 0);
-+			}
-+			catch {
-+			}
-+			*/
-+
  			int netMode = Main.netMode;
--			try {
--				SoundEngine.PlaySound(34, -1, -1, 0);
--				SoundEngine.PlaySound(35, -1, -1, 0);
--			}
--			catch {
--			}
--
++
++			/*
+ 			try {
+ 				SoundEngine.PlaySound(34, -1, -1, 0);
+ 				SoundEngine.PlaySound(35, -1, -1, 0);
+ 			}
+ 			catch {
+ 			}
++			*/
+ 
  			if (netMode == 0)
  				WorldFile.CacheSaveTime();
- 
 @@ -2388,6 +_,18 @@
  			Main.menuMode = 10;
  			Main.gameMenu = true;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -115,35 +115,37 @@
  			if (Main.menuMode == 10 || Main.menuMode == 888)
  				Main.menuMode = 6;
  
-@@ -2340,13 +_,6 @@
+@@ -2340,12 +_,19 @@
  		}
  
  		public static void JustQuit() {
--			try {
--				SoundEngine.PlaySound(34, -1, -1, 0);
--				SoundEngine.PlaySound(35, -1, -1, 0);
--			}
--			catch {
--			}
--
++			/*
+ 			try {
+ 				SoundEngine.PlaySound(34, -1, -1, 0);
+ 				SoundEngine.PlaySound(35, -1, -1, 0);
+ 			}
+ 			catch {
+ 			}
++			*/
++			
++			// Properly stop waterfall/lava(fall) sounds
++			Main.ambientWaterfallStrength = 0f;
++			Main.ambientLavafallStrength = 0f;
++			Main.ambientLavaStrength = 0f;
+ 
  			Main.invasionProgress = -1;
  			Main.invasionProgressDisplayLeft = 0;
- 			Main.invasionProgressAlpha = 0f;
-@@ -2354,6 +_,18 @@
+@@ -2354,6 +_,14 @@
  			Main.menuMode = 10;
  			Main.gameMenu = true;
  			SoundEngine.StopTrackedSounds();
 +
 +			try {
-+				// Delay playing the "menu close" sound until AFTER all sounds have stopped
++				// This has been moved here out of WorldGen.SaveAndQuit, so that the "menu close" sound plays AFTER all sounds have stopped
 +				SoundEngine.PlaySound(11);
 +			}
 +			catch {
 +			}
-+
-+			// Properly stop waterfall/lavafall sounds
-+			Main.ambientWaterfallStrength = 0f;
-+			Main.ambientLavafallStrength = 0f;
 +
  			CaptureInterface.ResetFocus();
  			Main.ActivePlayerFileData.StopPlayTimer();
@@ -193,11 +195,14 @@
  			Main.fastForwardTime = false;
  			Main.UpdateTimeRate();
  			Main.menuMode = 0;
-@@ -2410,7 +_,6 @@
+@@ -2410,7 +_,10 @@
  		}
  
  		public static void SaveAndQuit(Action callback = null) {
--			SoundEngine.PlaySound(11);
++			//TML: Moved to WorldGen.JustQuit(), see the comment there.
++			/*
+ 			SoundEngine.PlaySound(11);
++			*/
  			ThreadPool.QueueUserWorkItem(SaveAndQuitCallBack, callback);
  		}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -150,9 +150,19 @@
  			CaptureInterface.ResetFocus();
  			Main.ActivePlayerFileData.StopPlayTimer();
  			Main.fastForwardTime = false;
-@@ -2371,13 +_,6 @@
+@@ -2370,14 +_,16 @@
+ 		}
  
  		public static void SaveAndQuitCallBack(object threadContext) {
++			/*
++			try {
++				SoundEngine.PlaySound(34, -1, -1, 0);
++				SoundEngine.PlaySound(35, -1, -1, 0);
++			}
++			catch {
++			}
++			*/
++
  			int netMode = Main.netMode;
 -			try {
 -				SoundEngine.PlaySound(34, -1, -1, 0);


### PR DESCRIPTION
### What is the bug?
There were two bugs that this PR fixes.

The first bug:  
The Eye of Cthulhu was not playing the pitched roar (ID 36, Style -1) properly due to SoundID.ForceRoar not accounting for any styles whatsoever.
* Beforehand, any uses of ID 36 by vanilla would always use Style 1, even if a Style other than 1 was specified.

The second bug:  
Exiting a world would play a Lavafall sound perpetually until a world was re-entered.
* This was due to a previous fix to play the Waterfall (ID 34) and Lavafall (ID 35) sounds in `WorldGen.SaveAndQuitCallback()` with a Style of 0 in order to stop the sounds
* However, like the previous bug, the special "style = volume" logic was not handled whatsoever.  Using a Style of 0 did not play the Waterfall/Lavafall sounds at no volume, nor did it stop the existing sound (aka the intended behaviour).

### How did you fix the bug?
I modified the code that handles playing the `SoundID.Waterfall` and `SoundID.Lavafall` sounds in `Main.Ambience()`.  
I also edited the relevant `SoundStyle` initializations and retrieval from `SoundID.TML.cs` as part of of the bug fixes.

### Are there alternatives to your fix?
None that I can think of.