### PR TITLE
Fix DamageClass.MeleeNoSpeed benefiting from all classes

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -37,13 +37,8 @@ namespace Terraria.ModLoader
 	{
 		protected override string LangKey => "LegacyTooltip.2";
 
-		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) => new StatInheritanceData(
-			damageInheritance: 1f,
-			critChanceInheritance: 1f,
-			attackSpeedInheritance: 0f,
-			armorPenInheritance: 1f,
-			knockbackInheritance: 1f
-		);
+		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) =>
+			damageClass == Melee ? StatInheritanceData.Full with { attackSpeedInheritance = 0 } : StatInheritanceData.None;
 
 		public override bool GetEffectInheritance(DamageClass damageClass) => damageClass == Melee;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -37,8 +37,12 @@ namespace Terraria.ModLoader
 	{
 		protected override string LangKey => "LegacyTooltip.2";
 
-		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) =>
-			damageClass == Melee ? StatInheritanceData.Full with { attackSpeedInheritance = 0 } : StatInheritanceData.None;
+		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) {
+			if (damageClass == Generic || damageClass == Melee)
+				return StatInheritanceData.Full with { attackSpeedInheritance = 0 };
+
+			return StatInheritanceData.None;
+		}
 
 		public override bool GetEffectInheritance(DamageClass damageClass) => damageClass == Melee;
 	}


### PR DESCRIPTION
### What is the bug?
`DamageClass.MeleeNoSpeed` benefits from all other classes, not just Generic & Melee

### How did you fix the bug?
checked for `damageClass == Generic || damageClass == Melee` before returnin' the appropriate `StatInheritanceData`, and returned `StatInheritanceData.None` otherwise

### Are there alternatives to your fix?
no
