### PR TITLE
[1.4] Call OnWorldLoad after clearWorld (if it precedes GenerateWorld) to initialize ModSystems fully and restore 1.3 behavior

### DIFF
--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -44,14 +44,14 @@
  			if (!FileUtilities.Exists(Main.worldPathName, flag) && Main.autoGen) {
  				if (!flag) {
  					for (int num = Main.worldPathName.Length - 1; num >= 0; num--) {
-@@ -321,6 +_,7 @@
- 				}
+@@ -329,6 +_,7 @@
+ 					Main.ActiveWorldFileData.SetSeed(text);
  
- 				WorldGen.clearWorld();
+ 				UIWorldCreation.ProcessSpecialWorldSeeds(text);
 +				SystemLoader.OnWorldLoad();
- 				Main.ActiveWorldFileData = CreateMetadata((Main.worldName == "") ? "World" : Main.worldName, flag, Main.GameMode);
- 				string text = (Main.AutogenSeedName ?? "").Trim();
- 				if (text.Length == 0)
+ 				WorldGen.GenerateWorld(Main.ActiveWorldFileData.Seed, Main.AutogenProgress);
+ 				SaveWorld();
+ 			}
 @@ -356,6 +_,8 @@
  							CheckSavedOreTiers();
  							binaryReader.Close();

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -44,6 +44,14 @@
  			if (!FileUtilities.Exists(Main.worldPathName, flag) && Main.autoGen) {
  				if (!flag) {
  					for (int num = Main.worldPathName.Length - 1; num >= 0; num--) {
+@@ -321,6 +_,7 @@
+ 				}
+ 
+ 				WorldGen.clearWorld();
++				SystemLoader.OnWorldLoad();
+ 				Main.ActiveWorldFileData = CreateMetadata((Main.worldName == "") ? "World" : Main.worldName, flag, Main.GameMode);
+ 				string text = (Main.AutogenSeedName ?? "").Trim();
+ 				if (text.Length == 0)
 @@ -356,6 +_,8 @@
  							CheckSavedOreTiers();
  							binaryReader.Close();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -934,6 +934,14 @@
  
  			musicFade[50] = 1f;
  			for (int i = 0; i < 10; i++) {
+@@ -5071,6 +_,7 @@
+ 
+ 			if (skipMenu) {
+ 				WorldGen.clearWorld();
++				SystemLoader.OnWorldLoad();
+ 				gameMenu = false;
+ 				LoadPlayers();
+ 				PlayerList[0].SetAsActive();
 @@ -8372,11 +_,17 @@
  		public static void LoadTestLog(string logname) {
  		}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -934,14 +934,14 @@
  
  			musicFade[50] = 1f;
  			for (int i = 0; i < 10; i++) {
-@@ -5071,6 +_,7 @@
- 
- 			if (skipMenu) {
- 				WorldGen.clearWorld();
-+				SystemLoader.OnWorldLoad();
- 				gameMenu = false;
+@@ -5075,6 +_,7 @@
  				LoadPlayers();
  				PlayerList[0].SetAsActive();
+ 				LoadWorlds();
++				SystemLoader.OnWorldLoad();
+ 				WorldGen.GenerateWorld(new UnifiedRandom().Next());
+ 				WorldGen.EveryTileFrame();
+ 				player[myPlayer].Spawn(PlayerSpawnContext.SpawningIntoWorld);
 @@ -8372,11 +_,17 @@
  		public static void LoadTestLog(string logname) {
  		}

--- a/patches/tModLoader/Terraria/WorldBuilding/WorldUtils.cs.patch
+++ b/patches/tModLoader/Terraria/WorldBuilding/WorldUtils.cs.patch
@@ -1,0 +1,17 @@
+--- src/TerrariaNetCore/Terraria/WorldBuilding/WorldUtils.cs
++++ src/tModLoader/Terraria/WorldBuilding/WorldUtils.cs
+@@ -1,5 +_,6 @@
+ using Microsoft.Xna.Framework;
+ using System;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.WorldBuilding
+ {
+@@ -81,6 +_,7 @@
+ 
+ 		public static void DebugRegen() {
+ 			WorldGen.clearWorld();
++			SystemLoader.OnWorldLoad();
+ 			WorldGen.GenerateWorld(Main.ActiveWorldFileData.Seed);
+ 			Main.NewText("World Regen Complete.");
+ 		}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -85,7 +85,7 @@
  			}
  
  			if (x < roomX1)
-@@ -2309,15 +_,29 @@
+@@ -2309,15 +_,30 @@
  		public static void setWorldSize() {
  			Main.bottomWorld = Main.maxTilesY * 16;
  			Main.rightWorld = Main.maxTilesX * 16;
@@ -109,6 +109,7 @@
 +		public static void do_worldGenCallBack(object threadContext) {
  			SoundEngine.PlaySound(10);
  			clearWorld();
++			SystemLoader.OnWorldLoad();
  			GenerateWorld(Main.ActiveWorldFileData.Seed, threadContext as GenerationProgress);
  			WorldFile.SaveWorld(Main.ActiveWorldFileData.IsCloudSave, resetTime: true);
 +			BackupIO.archiveLock = false;


### PR DESCRIPTION
### Description
This restores 1.3 behavior for `ModSystem.OnWorldLoad` (`ModWorld.Initialize` called within `clearWorld`, before `GenerateWorld`) in a way that doesn't move it into `clearWorld` (as that is also called in an "unload"-y context, which is handled by `ModSystem.OnWorldUnload` separately)

This is important so that world data is set up to possibly get populated during worldgen (i.e. saving special coordinates in a list)

"Use PreWorldGen for such purposes" just invites the modder for oversights while they develop their mod as they need to remember adding such code in both `OnWorldLoad` and `PreWorldGen` (i.e. the list needs to be populated through IO/Net, so it HAS to be initialized in `OnWorldLoad` aswell)

Please discuss and bring up counterpoints here, previous discussions about this were fragmented on the discord