### PR TITLE
[1.4] Fix music loading

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
@@ -166,7 +166,7 @@ namespace Terraria.ModLoader
 			if (mod.File is null)
 				return;
 
-			foreach (string musicPath in mod.RootContentSource.EnumerateAssets().Where(path => supportedExtensions.Contains(Path.GetExtension(path)) && path.StartsWith("Music/") || path.Contains("/Music/"))) {
+			foreach (string musicPath in mod.RootContentSource.EnumerateAssets().Where(path => supportedExtensions.Contains(Path.GetExtension(path)) && (path.StartsWith("Music/") || path.Contains("/Music/")))) {
 				AddMusic(mod, Path.ChangeExtension(musicPath, null));
 			}
 		}


### PR DESCRIPTION
### What is the bug?
Music extension check is skipped if the `Music` folder is in another folder (eg. `Assets/Music/`)

### How did you fix the bug?
Fix logic flaw caused by missing parentheses

### Are there alternatives to your fix?
No
