### PR TITLE
[1.4] Publicise Player.OpenChest, tweak ExampleChest

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -130,7 +130,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.npcChatCornerItem = 0;
 			Main.npcChatText = "";
 			if (Main.editChest) {
-				SoundEngine.PlaySound(SoundID.MenuOpen);
+				SoundEngine.PlaySound(SoundID.MenuTick);
 				Main.editChest = false;
 				Main.npcChatText = string.Empty;
 			}

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -56,11 +56,17 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.addTile(Type);
 		}
 
-		public override ushort GetMapOption(int i, int j) => (ushort)(Main.tile[i, j].TileFrameX / 36);
+		public override ushort GetMapOption(int i, int j) {
+			return (ushort)(Main.tile[i, j].TileFrameX / 36);
+		}
 
-		public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) => true;
+		public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) {
+			return true;
+		}
 
-		public override bool IsLockedChest(int i, int j) => Main.tile[i, j].TileFrameX / 36 == 1;
+		public override bool IsLockedChest(int i, int j) {
+			return Main.tile[i, j].TileFrameX / 36 == 1;
+		}
 
 		public override bool UnlockChest(int i, int j, ref short frameXAdjustment, ref int dustType, ref bool manual) {
 			if (Main.dayTime) {
@@ -119,17 +125,14 @@ namespace ExampleMod.Content.Tiles.Furniture
 				top--;
 			}
 
-			if (player.sign >= 0) {
-				SoundEngine.PlaySound(SoundID.MenuClose);
-				player.sign = -1;
-				Main.editSign = false;
-				Main.npcChatText = "";
-			}
-
+			player.CloseSign();
+			player.SetTalkNPC(-1);
+			Main.npcChatCornerItem = 0;
+			Main.npcChatText = "";
 			if (Main.editChest) {
-				SoundEngine.PlaySound(SoundID.MenuTick);
+				SoundEngine.PlaySound(SoundID.MenuOpen);
 				Main.editChest = false;
-				Main.npcChatText = "";
+				Main.npcChatText = string.Empty;
 			}
 
 			if (player.editedChestName) {
@@ -137,7 +140,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 				player.editedChestName = false;
 			}
 
-			bool isLocked = IsLockedChest(left, top);
+			bool isLocked = Chest.IsLocked(left, top);
 			if (Main.netMode == NetmodeID.MultiplayerClient && !isLocked) {
 				if (left == player.chestX && top == player.chestY && player.chest >= 0) {
 					player.chest = -1;
@@ -168,12 +171,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 							SoundEngine.PlaySound(SoundID.MenuClose);
 						}
 						else {
-							SoundEngine.PlaySound(player.chest < 0 ? SoundID.MenuOpen : SoundID.MenuTick);
-							player.chest = chest;
-							Main.playerInventory = true;
-							Main.recBigList = false;
-							player.chestX = left;
-							player.chestY = top;
+							player.OpenChest(left, top, chest);
+							SoundEngine.PlaySound(player.chest < 0 ? SoundID.MenuOpen : SoundID.MenuOpen);
 						}
 
 						Recipe.FindRecipes();
@@ -198,12 +197,14 @@ namespace ExampleMod.Content.Tiles.Furniture
 			}
 
 			int chest = Chest.FindChest(left, top);
+			player.cursorItemIconID = -1;
 			if (chest < 0) {
 				player.cursorItemIconText = Language.GetTextValue("LegacyChestType.0");
 			}
 			else {
-				player.cursorItemIconText = Main.chest[chest].name.Length > 0 ? Main.chest[chest].name : "Example Chest";
-				if (player.cursorItemIconText == "Example Chest") {
+				string defaultName = TileLoader.ContainerName(tile.TileType); // This gets the ContainerName text for the currently selected language
+				player.cursorItemIconText = Main.chest[chest].name.Length > 0 ? Main.chest[chest].name : defaultName;
+				if (player.cursorItemIconText == defaultName) {
 					player.cursorItemIconID = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 					if (Main.tile[left, top].TileFrameX / 36 == 1) {
 						player.cursorItemIconID = ModContent.ItemType<ExampleChestKey>();

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3270,6 +3270,22 @@
  			short frameX = Main.tile[myX, myY].frameX;
  			bool flag = frameX / 72 == 1;
  			bool flag2 = frameX % 72 < 36;
+@@ -23248,7 +_,14 @@
+ 				StopPettingAnimal();
+ 		}
+ 
++		/// <summary>
++		/// Handles boilerplate for gamepad and UI when opening or closing a container.
++		/// <br/>Sets <see cref="Player.chestX"/>, and <see cref="Player.chestY"/>, and <see cref="Player.chest"/> to the given coordinates.
++		/// </summary>
++		/// <param name="x">The top-left X coordinate of the container.</param>
++		/// <param name="y">The top-left Y coordinate of the container.</param>
++		/// <param name="newChest">The container index in <see cref="Main.chest"/> if opening, or -1 if closing.</param>
+-		private void OpenChest(int x, int y, int newChest) {
++		public void OpenChest(int x, int y, int newChest) {
+ 			if (chest != -1 && Main.myPlayer == whoAmI) {
+ 				for (int i = 0; i < 40; i++) {
+ 					ItemSlot.SetGlow(i, -1f, chest: true);
 @@ -24067,7 +_,7 @@
  				cursorItemIconID = 3747;
  			}


### PR DESCRIPTION
### What is the new feature?
Publicise `Player.OpenChest`, useful method for chests and dressers.
Tweaks ExampleChest to use it, and also some more general method usages

### Why should this be part of tModLoader?
Helps modders write less boilerplate

### Are there alternative designs?
No

### Sample usage for the new feature
ExampleChest

