### PR TITLE
[1.4] NPC.Sets.AllowDoorInteraction Entry

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleBoneMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleBoneMerchant.cs
@@ -38,6 +38,10 @@ namespace ExampleMod.Content.NPCs
 			//In order to do this, we simply make this hook return true, which will make the game call the TownNPCName method when spawning the NPC to determine the NPC's name.
 			NPCID.Sets.SpawnsWithCustomName[Type] = true;
 
+			//The vanilla Bone Merchant cannot interact with doors (open or close them, specifically), but if you want your NPC to be able to interact with them despite this,
+			//uncomment this line below.
+			//NPCID.Sets.AllowDoorInteraction[Type] = true;
+
 			// Influences how the NPC looks in the Bestiary
 			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
 				Velocity = 1f, // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -40,6 +40,13 @@ namespace Terraria.ID
 			/// <br/>Do not add your NPC to this if it would be excluded automatically (i.e. critter, town NPC, or no coin drops)
 			/// </summary>
 			public static bool[] CannotDropSouls = Factory.CreateBoolSet(1, 13, 14, 15, 121, 535);
+
+			//No Default IDs, as there is no vanilla precedent for this functionality
+			/// <summary>
+			/// Whether or not this NPC can still interact with doors if they use the Vanilla Town NPC aiStyle (AKA aiStyle == 7)
+			/// but are not actually marked as Town NPCs (AKA npc.townNPC == true).
+			/// </summary>
+			public static bool[] AllowDoorInteraction = Factory.CreateBoolSet();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -43,9 +43,12 @@ namespace Terraria.ID
 
 			//No Default IDs, as there is no vanilla precedent for this functionality
 			/// <summary>
-			/// Whether or not this NPC can still interact with doors if they use the Vanilla Town NPC aiStyle (AKA aiStyle == 7)
+			/// Whether or not this NPC can still interact with doors if they use the Vanilla TownNPC aiStyle (AKA aiStyle == 7)
 			/// but are not actually marked as Town NPCs (AKA npc.townNPC == true).
 			/// </summary>
+			/// <remarks>
+			/// Note: This set DOES NOT DO ANYTHING if your NPC doesn't use the Vanilla TownNPC aiStyle (aiStyle == 7).
+			/// </remarks>
 			public static bool[] AllowDoorInteraction = Factory.CreateBoolSet();
 		}
 	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -515,7 +515,7 @@
  						Tile tileSafely5 = Framing.GetTileSafely(num18, num19 - 2);
  						bool flag18 = height / 16 < 3;
 -						if (townNPC && tileSafely5.nactive() && (tileSafely5.type == 10 || tileSafely5.type == 388) && (Main.rand.Next(10) == 0 || flag)) {
-+						if (townNPC && tileSafely5.nactive() && (TileLoader.OpenDoorID(tileSafely5) >= 0 || tileSafely5.type == 388) && (Main.rand.Next(10) == 0 || flag)) {
++						if ((townNPC || NPCID.Sets.AllowDoorInteraction[type]) && tileSafely5.nactive() && (TileLoader.OpenDoorID(tileSafely5) >= 0 || tileSafely5.type == 388) && (Main.rand.Next(10) == 0 || flag)) {
  							if (Main.netMode != 1) {
  								if (WorldGen.OpenDoor(num18, num19 - 2, base.direction)) {
  									closeDoor = true;


### PR DESCRIPTION
### What is the new feature?

A new `NPCID.Sets` entry that allow for NPCs that use the TownNPC aiStyle (aiStyle = 7) but are not explicitly defined as TownNPCs (npc.townNPC = true) to be able to open/close doors.

### Why should this be part of tModLoader?

Right now, the open/close door functionality is locked behind a `npc.townNPC` check, which poses a problem for NPCs that use `NPCID.Sets.ActsLikeTownNPC` or otherwise use the TownNPC aiStyle. This addition allows those kind of NPCs to interact with doors.

### Are there alternative designs?

Technically you could make this a hook, but for something this simple, a Sets entry is likely a much better idea.

### Sample usage for the new feature

In your ModNPC (or even GlobalNPC if you want) SetStaticDefaults, simple set the type of the NPC in question to true within the set: `NPCID.Sets.AllowDoorInteraction[Type] = true;`

### ExampleMod updates

Added (commented) line of code with explanation to ExampleBoneMerchant.cs that explains why it is commented, and tells the user when they should uncomment it depending on their intended functionality.
