### PR TITLE
[1.4] Reintroduce several 1.3 thrower fields

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -268,15 +268,17 @@ namespace Terraria
 		public float ThrownVelocity { get; set; }
 
 		/// <summary>
-		/// If true, player has a 33% chance of not consuming the thrown item. Projectiles spawned this way will set <see cref="Projectile.noDropItem"/> to prevent duplication
-		/// <br/>Only applies to consumable items and projectiles counted as the <see cref="DamageClass.Throwing"/> damage type
+		/// If true, player has a 33% chance of not consuming the thrown item.
+		/// <br/>Only applies to consumable items and projectiles counted as the <see cref="DamageClass.Throwing"/> damage type.
+		/// <br/>Projectiles spawned from a player who holds such item will set <see cref="Projectile.noDropItem"/> to prevent duplication.
 		/// <br/>Stacks with <see cref="ThrownCost50"/> multiplicatively
 		/// </summary>
 		public bool ThrownCost33 { get; set; }
 
 		/// <summary>
-		/// If true, player has a 50% chance of not consuming the thrown item. Projectiles spawned this way will set <see cref="Projectile.noDropItem"/> to prevent duplication
-		/// <br/>Only applies to consumable items counted as the <see cref="DamageClass.Throwing"/> damage type
+		/// If true, player has a 50% chance of not consuming the thrown item.
+		/// <br/>Only applies to consumable items counted as the <see cref="DamageClass.Throwing"/> damage type.
+		/// <br/>Projectiles spawned from a player who holds such item will set <see cref="Projectile.noDropItem"/> to prevent duplication.
 		/// <br/>Stacks with <see cref="ThrownCost33"/> multiplicatively
 		/// </summary>
 		public bool ThrownCost50 { get; set; }

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -259,7 +259,32 @@ namespace Terraria
 			return attackSpeed;
 		}
 
+		// Legacy Thrower properties (uppercase+property in TML)
 
+		/// <summary>
+		/// Multiplier to shot projectile velocity before throwing. Result will be capped to 16f.
+		/// <br/>Only applies to items counted as the <see cref="DamageClass.Throwing"/> damage type
+		/// </summary>
+		public float ThrownVelocity { get; set; }
+
+		/// <summary>
+		/// If true, player has a 33% chance of not consuming the thrown item. Projectiles spawned this way will set <see cref="Projectile.noDropItem"/> to prevent duplication
+		/// <br/>Only applies to consumable items and projectiles counted as the <see cref="DamageClass.Throwing"/> damage type
+		/// <br/>Stacks with <see cref="ThrownCost50"/> multiplicatively
+		/// </summary>
+		public bool ThrownCost33 { get; set; }
+
+		/// <summary>
+		/// If true, player has a 50% chance of not consuming the thrown item. Projectiles spawned this way will set <see cref="Projectile.noDropItem"/> to prevent duplication
+		/// <br/>Only applies to consumable items counted as the <see cref="DamageClass.Throwing"/> damage type
+		/// <br/>Stacks with <see cref="ThrownCost33"/> multiplicatively
+		/// </summary>
+		public bool ThrownCost50 { get; set; }
+
+		/// <summary>
+		/// Returns true if either <see cref="ThrownCost33"/> or <see cref="ThrownCost50"/> are true
+		/// </summary>
+		public bool AnyThrownCostReduction => ThrownCost33 || ThrownCost50;
 
 		/// <summary>
 		/// Container for current SceneEffect client properties such as: Backgrounds, music, and water styling

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5200,10 +5200,19 @@
  
  			if (huntressAmmoCost90 && Main.rand.Next(10) == 0)
  				flag2 = true;
-@@ -37226,6 +_,7 @@
+@@ -37226,6 +_,16 @@
  			if (ammoCost75 && Main.rand.Next(4) == 0)
  				flag2 = true;
  
++			// Copied as-is from 1.3
++			if (item.CountsAsClass(DamageClass.Throwing)) {
++				if (ThrownCost50 && Main.rand.Next(100) < 50)
++					flag2 = true;
++
++				if (ThrownCost33 && Main.rand.Next(100) < 33)
++					flag2 = true;
++			}
++
 +			/* Flamethrower + Elf Melter (handled by consumeAmmoOnFirstShotOnly) + Clentaminator (handled by consumeAmmoOnFirstShotOnly)
  			if (projToShoot == 85 && itemAnimation < itemAnimationMax - 2)
  				flag2 = true;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2347,8 +2347,13 @@
  			hasFootball = false;
  			drawingFootball = false;
  			minionKB = 0f;
-@@ -13118,9 +_,14 @@
+@@ -13116,11 +_,19 @@
+ 			huntressAmmoCost90 = false;
+ 			ammoCost80 = false;
  			ammoCost75 = false;
++			ThrownCost50 = false;
++			ThrownCost33 = false;
++			ThrownVelocity = 1f;
  			manaRegenBuff = false;
  			hasCreditsSceneMusicBox = false;
 +			arrowDamage = StatModifier.Default;
@@ -4592,7 +4597,7 @@
  				if (sItem.stack <= 0)
  					sItem.SetDefaults();
  			}
-@@ -33081,16 +_,21 @@
+@@ -33081,16 +_,28 @@
  		}
  
  		private void ItemCheck_Shoot(int i, Item sItem, int weaponDamage) {
@@ -4605,6 +4610,13 @@
  			if (sItem.melee && projToShoot != 699 && projToShoot != 707 && (uint)(projToShoot - 877) > 2u)
 -				speed /= meleeSpeed;
 +				speed /= inverseMeleeSpeed;
++
++			// Copied as-is from 1.3
++			if (sItem.CountsAsClass(DamageClass.Throwing) && speed < 16f) {
++				speed *= ThrownVelocity;
++				if (speed > 16f)
++					speed = 16f;
++			}
  
  			bool canShoot = false;
  			int Damage = weaponDamage;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -324,7 +324,19 @@
  
  			if (Owner == Main.myPlayer) {
  				if (ProjectileID.Sets.IsAGolfBall[Type] && Damage <= 0) {
-@@ -8330,6 +_,11 @@
+@@ -8325,11 +_,23 @@
+ 
+ 				if (Type == 777 || Type == 781 || Type == 794 || Type == 797 || Type == 800 || Type == 785 || Type == 788 || Type == 791 || Type == 903 || Type == 904 || Type == 905 || Type == 906 || Type == 910 || Type == 911)
+ 					projectile.timeLeft = 180;
++
++				// Copied from 1.3, adjusted to check for actual player (servers never shoot thrower projectiles)
++				if (Main.netMode != NetmodeID.Server) {
++					Player throwingPlayer = Main.player[Owner];
++					if (throwingPlayer.AnyThrownCostReduction && throwingPlayer.HeldItem.CountsAsClass(DamageClass.Throwing))
++						projectile.noDropItem = true;
++				}
+ 			}
+ 
  			if (Type == 249)
  				projectile.frame = Main.rand.Next(5);
  

--- a/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.Expected.cs
@@ -86,6 +86,9 @@ public class SimpleRenamedVanillaMembersTest
 		var hasBanner = Main.SceneMetrics.hasBanner;
 		var bannerBuff = Main.SceneMetrics.NPCBannerBuff;
 		var extraAccessorySlots = player.GetAmountOfExtraAccessorySlotsToShow();
+		var thrownCost33 = player.ThrownCost33;
+		var thrownCost50 = player.ThrownCost50;
+		var thrownVelocity = player.ThrownVelocity;
 
 		Main.PlayerRenderer.DrawPlayer(Main.Camera, player, Vector2.Zero, 0f, Vector2.Zero, 1f);
 

--- a/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.cs
@@ -85,6 +85,9 @@ public class SimpleRenamedVanillaMembersTest
 		var hasBanner = player.hasBanner;
 		var bannerBuff = player.NPCBannerBuff;
 		var extraAccessorySlots = player.extraAccessorySlots;
+		var thrownCost33 = player.thrownCost33;
+		var thrownCost50 = player.thrownCost50;
+		var thrownVelocity = player.thrownVelocity;
 
 		Main.DrawPlayer(player, Vector2.Zero, 0f, Vector2.Zero, 1f);
 

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -119,6 +119,9 @@ public static partial class Config
 		RenameInstanceField("Terraria.Player",	from: "doubleJumpSail",		to: "hasJumpOption_Sail");
 		RenameInstanceField("Terraria.Player",	from: "doubleJumpSandstorm",to: "hasJumpOption_Sandstorm");
 		RenameInstanceField("Terraria.Player",	from: "doubleJumpUnicorn",	to: "hasJumpOption_Unicorn");
+		RenameInstanceField("Terraria.Player",	from: "thrownCost33",		to: "ThrownCost33");
+		RenameInstanceField("Terraria.Player",	from: "thrownCost50",		to: "ThrownCost50");
+		RenameInstanceField("Terraria.Player",	from: "thrownVelocity",		to: "ThrownVelocity");
 
 		RenameMethod("Terraria.Item",		from: "IsNotTheSameAs",			to: "IsNotSameTypePrefixAndStack");
 		RenameMethod("Terraria.Lighting",	from: "BlackOut",				to: "Clear");


### PR DESCRIPTION
### What is the new feature?
**Disclaimer: I have not tested the functionality yet, will do so in a few hours or tomorrow**

Ports legacy 1.3 fields `Player.thrownVelocity`, `thrownCost33`, and `thrownCost50` including their functionality.

The `noDropItem` application was moved to `NewProjectile` (before `OnSpawn`) to capture all projectiles created, not just the single projectile coming from `Shoot` (as it was the case in 1.3, forcing modders to set the flag true manually, respecting the conditions)

### Why should this be part of tModLoader?
As TML already provides support for thrower class (which were removed in 1.4), for completeness, it should provide the other fields associated with the thrower class

### Are there alternative designs?
Regarding setting `noDropItem`, an alternative would be to not check the players held item damage class, and instead check the projectiles damage class.

Both options have trade offs:
* checking item: "Item swapping" which would allow duplicating projectiles
* checking projectile: The consumption and flag set are not based on the same condition, and item/projectile do not have the same damage class necessarily, causing even more inconsistency. Can allow non-thrower projectile duplication

### Sample usage for the new feature
`player.ThrownCost33 = true; //33% chance of not consuming any consumable thrown item`

### ExampleMod updates
If needed, please mention

