### PR TITLE
Add SoundStyle.WithVolumeScale and WithPitchOffset

### DIFF
--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -249,6 +249,12 @@ namespace Terraria.Audio
 		internal SoundStyle WithPitchVariance(float pitchVariance)
 			=> this with { PitchVariance = pitchVariance };
 
+		public SoundStyle WithVolumeScale(float scale)
+			=> this with { Volume = Volume * scale };
+
+		public SoundStyle WithPitchOffset(float offset)
+			=> this with { Pitch = Pitch + offset };
+
 		private int GetRandomVariantIndex() {
 			if (variantsWeights == null) {
 				// Simple random.

--- a/tModPorter/tModPorter.Tests/TestData/SoundTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/SoundTest.Expected.cs
@@ -20,10 +20,10 @@ public class SoundTest : ModProjectile
 		SoundEngine.PlaySound(SoundID.MenuTick);
 
 		// named pitch variance or volume
-		SoundEngine.PlaySound(SoundID.MenuTick with { Volume = SoundID.MenuTick.Volume * 2f });
-		SoundEngine.PlaySound(SoundID.MenuTick with { Pitch = SoundID.MenuTick.Pitch + 0.1f });
-		SoundEngine.PlaySound(SoundID.MenuTick with { Volume = SoundID.MenuTick.Volume * 2f, Pitch = SoundID.MenuTick.Pitch + 0.1f });
-		SoundEngine.PlaySound(SoundID.MenuTick with { Pitch = SoundID.MenuTick.Pitch + 0.1f }, player.position);
+		SoundEngine.PlaySound(SoundID.MenuTick.WithVolumeScale(2f));
+		SoundEngine.PlaySound(SoundID.MenuTick.WithPitchOffset(0.1f));
+		SoundEngine.PlaySound(SoundID.MenuTick.WithVolumeScale(2f).WithPitchOffset(0.1f));
+		SoundEngine.PlaySound(SoundID.MenuTick.WithPitchOffset(0.1f), player.position);
 
 		SoundEngine.PlaySound(SoundID.MenuTick, new Vector2(420, 421)); // Convert x/y into Vector2
 		SoundEngine.PlaySound(SoundID.MenuTick, player.position); // Simplify manual x/y int conversion into Vector2


### PR DESCRIPTION
### Why should this be part of tModLoader?

You don't want to have to look up the original style definition and check if there's a programmatic volume scale or pitch shift already applied to the raw sample. Therefore ` style with { Volume = value }` is often insufficient, and you'd rather a `*=` or `+=` for pitch shifting.

Currently, you need to write 
```cs
SoundEngine.PlaySound(SoundID.Roar with { Volume = SoundID.MenuTick.Volume * 2f });
SoundEngine.PlaySound(SoundID.Roar with { Pitch = SoundID.MenuTick.Pitch + 0.1f });
SoundEngine.PlaySound(SoundID.Roar with { Volume = SoundID.MenuTick.Volume * 2f, Pitch = SoundID.MenuTick.Pitch + 0.1f });
```

### Sample usage for the new feature
```cs
SoundEngine.PlaySound(SoundID.Roar.WithVolumeScale(2f));
SoundEngine.PlaySound(SoundID.Roar.WithPitchOffset(0.1f));
SoundEngine.PlaySound(SoundID.Roar.WithVolumeScale(2f).WithPitchOffset(0.1f));
```

