### PR TITLE
Fix `Player.ZonePurity` always false on servers

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -432,12 +432,13 @@
  								break;
  							case 4:
  								if (num29 == -1) {
-@@ -1776,6 +_,9 @@
+@@ -1776,6 +_,10 @@
  						obj8.zone2 = reader.ReadByte();
  						obj8.zone3 = reader.ReadByte();
  						obj8.zone4 = reader.ReadByte();
 +						if (!ModNet.AllowVanillaClients)
 +							BiomeLoader.ReceiveCustomBiomes(obj8, reader);
++						obj8.ZonePurity = obj8.InZonePurity();
 +
  						if (Main.netMode == 2)
  							NetMessage.TrySendData(36, -1, whoAmI, null, num228);


### PR DESCRIPTION
### What is the bug?
`Player.ZonePurity` is always false on server

### How did you fix the bug?
Calculate `ZonePurity` after receiving zone data

### Are there alternatives to your fix?
No

