### PR TITLE
Damage class name

### DIFF
--- a/ExampleMod/Content/DamageClasses/ExampleDamageClass.cs
+++ b/ExampleMod/Content/DamageClasses/ExampleDamageClass.cs
@@ -7,6 +7,10 @@ namespace ExampleMod.Content.DamageClasses
 {
 	public class ExampleDamageClass : DamageClass
 	{
+		public override void SetStaticDefaults()
+        {
+			ClassName.SetDefault("Example Damage");
+        }
 		// This is an example damage class designed to demonstrate all the current functionality of the feature and explain how to create one of your own, should you need one.
 		// For information about how to apply stat bonuses to specific damage classes, please instead refer to ExampleMod/Content/Items/Accessories/ExampleStatBonusAccessory.
 		public override StatInheritanceData GetModifierInheritance(DamageClass damageClass) {


### PR DESCRIPTION
Added name for damage class so its not displayed in game while used by weapons as path to damage class.

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->