### PR TITLE
Easier continuous projectile damage updates

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -723,12 +723,15 @@
  			if (myRect.Intersects(targetRect))
  				return true;
  
-@@ -11397,7 +_,7 @@
+@@ -11395,9 +_,9 @@
+ 				if (!noEnchantmentVisuals)
+ 					UpdateEnchantmentVisuals();
  
- 				if (numUpdates == -1 && (minion || sentry)) {
+-				if (numUpdates == -1 && (minion || sentry)) {
++				if ((minion || sentry || ContinuouslyUpdateDamage)) {
  					Player player = Main.player[owner];
 -					damage = (int)((float)originalDamage * player.minionDamage + (float)player.minionAddDamage + 5E-06f);
-+					damage = (int)player.GetTotalDamage(DamageClass.Summon).ApplyTo(originalDamage);
++					damage = (int)player.GetTotalDamage(DamageType).ApplyTo(originalDamage);
  				}
  
  				if (minion && numUpdates == -1 && type != 625 && type != 628) {


### PR DESCRIPTION
### What is the new feature?

Adds `Projectile.ContinuouslyUpdateDamage` to mimic the continual damage updates that minions and sentries get, but for all damage classes, with the `originalDamage` for the projectile set during `SetDefaults` via the `IEntitySource`. 

Also removes the need to set `originalDamage` yourself after spawning a projectile if the source is `EntitySource_ItemUse`.
### Why should this be part of tModLoader?

Makes it easier to make continual damage updating projectiles.

### Sample usage for the new feature
`Projectile.ContinuouslyUpdateDamage = true`

Don't forget to set `Projectile.DamageType` on your minions and sentries!
