### PR TITLE
Example Whip Quick Fixes

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleWhipProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleWhipProjectile.cs
@@ -51,16 +51,13 @@ namespace ExampleMod.Content.Projectiles
 			// Increase range up to 2x for full charge.
 			Projectile.WhipSettings.RangeMultiplier += 1 / 120f;
 
-			// Reset the animation and item timer while charging.
-			owner.itemAnimation = owner.itemAnimationMax;
-			owner.itemTime = owner.itemTimeMax;
-
 			return false; // Prevent the vanilla whip AI from running.
 		}
 
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit) {
 			target.AddBuff(ModContent.BuffType<ExampleWhipDebuff>(), 240);
 			Main.player[Projectile.owner].MinionAttackTargetNPC = target.whoAmI;
+			Projectile.damage = (int)(damage * 0.7f); // Multihit penalty. Decrease the damage the more enemies the whip hits.
 		}
 
 		// This method draws a line between all points of the whip, in case there's empty space between the sprites.

--- a/ExampleMod/Content/Projectiles/ExampleWhipProjectileAdvanced.cs
+++ b/ExampleMod/Content/Projectiles/ExampleWhipProjectileAdvanced.cs
@@ -66,10 +66,6 @@ namespace ExampleMod.Content.Projectiles
 
 			owner.heldProj = Projectile.whoAmI;
 
-			// These two lines ensure that the timing of the owner's use animation is correct.
-			owner.itemAnimation = owner.itemAnimationMax - (int)(Timer / Projectile.MaxUpdates);
-			owner.itemTime = owner.itemAnimation;
-
 			if (Timer == swingTime / 2) {
 				// Plays a whipcrack sound at the tip of the whip.
 				List<Vector2> points = Projectile.WhipPointsForCollision;
@@ -101,6 +97,7 @@ namespace ExampleMod.Content.Projectiles
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit) {
 			target.AddBuff(ModContent.BuffType<ExampleWhipDebuff>(), 240);
 			Main.player[Projectile.owner].MinionAttackTargetNPC = target.whoAmI;
+			Projectile.damage = (int)(damage * 0.7f); // Multihit penalty. Decrease the damage the more enemies the whip hits.
 		}
 
 		// This method draws a line between all points of the whip, in case there's empty space between the sprites.


### PR DESCRIPTION
### What is the bug?
Both Example Whip Projectiles were creating extra projectiles when swung continuously (most noticeable with Feral Claws/autoswing).
They were also missing the multihit penalty that all vanilla whips have, so I added that.

### How did you fix the bug?
By removing the two lines that set the `owner.itemAnimation` and `owner.itemTime`.

### Are there alternatives to your fix?
I don't think so. I don't see those two lines present in the vanilla source code, so I don't believe they are needed.