### PR TITLE
Run SetupContent on all content from all mods before PostSetupContent

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -375,7 +375,7 @@
 		"Packaging": "Packaging: {0}",
 		// There should be ModName after ':'
 		"MSFinding": "Finding Mods...",
-		"MSInstantiating": "Instantiating Mods...",
+		"MSInstantiating": "Constructing Mods...",
 		"MSSandboxing": "Sandboxing: {0}",
 		"MSLoading": "Adding Content: {0}",
 		"MSResizing": "Resizing...",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -377,13 +377,13 @@
 		"MSFinding": "Finding Mods...",
 		"MSInstantiating": "Instantiating Mods...",
 		"MSSandboxing": "Sandboxing: {0}",
-		"MSIntializing": "Initializing: {0}",
-		"MSLoading": "Loading: {0}",
+		"MSLoading": "Adding Content: {0}",
+		"MSResizing": "Resizing...",
+		"MSSetupContent": "Configuring Content: {0}",
+		"MSPostSetupContent": "Finalizing Content: {0}",
 		"MSUnloading": "Unloading: {0}",
 		"MSFinishingResourceLoading": "Finishing Resource Loading",
-		"MSSettingUp": "Setting up...",
 		"MSAddingRecipes": "Adding Recipes...",
-		"AddingModContent": "Adding mod content...",
 
 		// Mod Loader Mod
 		"StartBagTooltip": "Some starting items couldn't fit in your inventory",

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -245,7 +245,7 @@ namespace Terraria.ModLoader.Core
 				int i = 0;
 				foreach (var mod in modList) {
 					token.ThrowIfCancellationRequested();
-					Interface.loadMods.SetCurrentMod(i++, mod.Name);
+					Interface.loadMods.SetCurrentMod(i++, mod.Name, mod.properties?.displayName ?? "", mod.modFile.Version);
 					mod.LoadAssemblies();
 				}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -322,6 +322,8 @@ namespace Terraria.ModLoader
 				mod.SetupContent();
 			});
 
+			ContentSamples.Initialize();
+
 			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
 				mod.PostSetupContent();
@@ -344,7 +346,6 @@ namespace Terraria.ModLoader
 			PlantLoader.SetupPlants();
 			RarityLoader.Initialize();
 
-			ContentSamples.Initialize();
 			PlayerInput.reinitialize = true;
 			SetupBestiary();
 			SetupRecipes(token);

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -300,7 +300,7 @@ namespace Terraria.ModLoader
 		internal static void Load(CancellationToken token) {
 			CacheVanillaState();
 
-			Interface.loadMods.SetLoadStage("tModLoader.MSIntializing", ModLoader.Mods.Length);
+			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
 				if (mod.Code != Assembly.GetExecutingAssembly()) AssemblyManager.JITMod(mod);
 				ContentInstance.Register(mod);
@@ -313,18 +313,18 @@ namespace Terraria.ModLoader
 				mod.loading = false;
 			});
 
-			Interface.loadMods.SetLoadStage("tModLoader.MSSettingUp");
+			Interface.loadMods.SetLoadStage("tModLoader.MSResizing");
 			ResizeArrays();
 			RecipeGroupHelper.FixRecipeGroupLookups();
 
-			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
+			Interface.loadMods.SetLoadStage("tModLoader.MSSetupContent", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
 				mod.SetupContent();
 			});
 
 			ContentSamples.Initialize();
 
-			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
+			Interface.loadMods.SetLoadStage("tModLoader.MSPostSetupContent", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
 				mod.PostSetupContent();
 				SystemLoader.PostSetupContent(mod);

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -370,7 +370,7 @@ namespace Terraria.ModLoader
 			int num = 0;
 			foreach (var mod in ModLoader.Mods) {
 				token.ThrowIfCancellationRequested();
-				Interface.loadMods.SetCurrentMod(num++, $"{mod.Name} ({mod.DisplayName}) v{mod.Version}");
+				Interface.loadMods.SetCurrentMod(num++, mod);
 				try {
 					LoadingMod = mod;
 					loadAction(mod);
@@ -431,10 +431,7 @@ namespace Terraria.ModLoader
 
 			int i = 0;
 			foreach (var mod in ModLoader.Mods.Reverse()) {
-				if (Main.dedServ)
-					Console.WriteLine($"Unloading {mod.DisplayName}...");
-				else
-					Interface.loadMods.SetCurrentMod(i++, $"{mod.Name} ({mod.DisplayName}) v{mod.Version}");
+				Interface.loadMods.SetCurrentMod(i++, mod);
 
 				try {
 					MonoModHooks.RemoveAll(mod);

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -320,6 +320,10 @@ namespace Terraria.ModLoader
 			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
 				mod.SetupContent();
+			});
+
+			Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
+			LoadModContent(token, mod => {
 				mod.PostSetupContent();
 				SystemLoader.PostSetupContent(mod);
 				mod.TransferAllAssets();

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -220,13 +220,7 @@ namespace Terraria.ModLoader
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		private static void Mods_Unload()
 		{
-			Logging.tML.Info("Unloading mods");
-			if (Main.dedServ) {
-				Console.WriteLine("Unloading mods...");
-			}
-			else {
-				Interface.loadMods.SetLoadStage("tModLoader.MSUnloading", Mods.Length);
-			}
+			Interface.loadMods.SetLoadStage("tModLoader.MSUnloading", Mods.Length);
 
 			ModContent.UnloadModContent();
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -24,11 +24,11 @@ namespace Terraria.ModLoader
 			ModTypeLookup<ModSystem>.Register(this);
 		}
 
-		//ModSystem provides its own PostSetupContent hook which runs in a different context, closer to Mod
-		public sealed override void SetStaticDefaults() { }
-
-		//Per above comment, SetStaticDefaults is unused
-		public sealed override void SetupContent() { }
+		/// <summary>
+		/// Unlike other ModTypes, SetupContent is unsealed for you to do whatever you need (like setting up static defaults)
+		/// This is the place to finish initializing your mod's content. For content from other mods, and lookup tables, consider PostSetupContent
+		/// </summary>
+		public override void SetupContent() { }
 
 		//Hooks
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -39,15 +39,19 @@ namespace Terraria.ModLoader.UI
 			SubProgressText = "";
 		}
 
-		private void SetProgressText(string text) {
-			Logging.tML.Info(text);
+		private void SetProgressText(string text, string logText = null) {
+			Logging.tML.Info(logText ?? text);
 			if (Main.dedServ) Console.WriteLine(text);
 			else DisplayText = text;
 		}
 
-		public void SetCurrentMod(int i, string mod) {
-			SetProgressText(Language.GetTextValue(stageText, mod));
+		public void SetCurrentMod(int i, string modName, string displayName, Version version) {
+			var display = $"{displayName} v{version}";
+			var log = $"{modName} ({displayName}) v{version}";
+			SetProgressText(Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
 			Progress = i / (float)modCount;
 		}
+
+		public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.Version);
 	}
 }


### PR DESCRIPTION
### What is the new feature?
Change `PostSetupContent` to run after `SetupContent` has been called for all `ModType` from all mods, not just this mod.

To make it clearer what's expected at this phase, and to make `PostSetupContent` even more useful, `ContentSamples.Initialize` has been moved to between `SetupContent` and `PostSetupContent`

`ModSystem.SetupContent` has also been unsealed, allowing you to fully utilise this load phase in your `ModSystem`s


With this, the 3 key phases are:
`Mod.AddContent` / `ModType.SetupContent` / `ModSystem.PostSetupContent + Mod.TransferAllAssets`
Followed by recipes (`AddRecipes` / `PostAddRecipes` / `PostSetupRecipes`)

New localisations for the 3 phases are:
`Adding Content` / `Configuring Content` / `Finalizing Content`

### Why should this be part of tModLoader?
It's what people expect...
![image](https://user-images.githubusercontent.com/388233/174881442-e4498646-064c-45de-bcbc-e6e685c8358c.png)

Makes `PostSetupContent` more useful for cross mod content. As an example, it should be safe to create item instances and lookup tables. A lot of mods end up using `AddRecipes` for stuff that should/could really go in `PostSetupContent`.

This of course, means that if mod B depends on mod A, and B had some code in a `SetStaticDefaults` method which depended on code from mod A's `PostSetupContent` it would break. But the code could just be moved to `PostSetupContent` in `B`.

### Are there alternative designs?
Consider re-ordering more or less of the vanilla content setup

Should there be a separate message for the 2 phases? Currently every mod looks like it goes through 'Loading: ModName' twice.

### ExampleMod updates
None required

