### PR TITLE
use different contributor icon website

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ TML is largely created and maintained by a core team of contributors: **Blushiem
 This project exists in its current state thanks to all the people who have contributed:
 
 <a href="https://github.com/tModLoader/tModLoader/graphs/contributors">
-<img src="https://opencollective.com/tModLoader/contributors.svg?width=890&button=false" />
+  <img src="https://contrib.rocks/image?repo=tModLoader/tModLoader&max=900&columns=20" />
 </a>
 
 ## License


### PR DESCRIPTION
### What is the bug?
The old contributor icon list is unsorted and is missing some contributors.
![image](https://user-images.githubusercontent.com/26361108/175297232-41169c74-134c-459e-9e00-789c4101e2ee.png)

For example the contributors **Ved-s**, **xKirtle** and **myself** are missing from the list.

### How did you fix the bug?
Instead of using [open collective](https://opencollective.com/), I used https://contrib.rocks/

### This is how the new contributor list looks like:
![image](https://user-images.githubusercontent.com/26361108/175299114-bd64345d-88fc-4682-ba98-3ed41c716347.png)


### Are there alternatives to your fix?
There are probably a multitude of other websites that do the same.