### PR TITLE
Recipe conditions player parameter

### DIFF
--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -86,7 +86,7 @@ namespace ExampleMod.Content
 				// Adds a custom condition, that the player must be at <1/2 health for the recipe to work.
 				// The first argument is a NetworkText instance, i.e. localized text. The key used here is defined in 'Localization/*.hjson' files.
 				// The second argument uses a lambda expression to create a delegate, you can learn more about both in Google.
-				.AddCondition(NetworkText.FromKey("RecipeConditions.LowHealth"), r => Main.LocalPlayer.statLife < Main.LocalPlayer.statLifeMax / 2)
+				.AddCondition(NetworkText.FromKey("RecipeConditions.LowHealth"), (r, p) => p.statLife < p.statLifeMax / 2)
 
 				// When you're done, call this to register the recipe. Note that there's a semicolon at the end of the chain.
 				.Register();

--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -15,7 +15,7 @@
 		/// <summary>
 		/// Whether or not the conditions are met for the given recipe to be available for the player to use. This hook can be used for conditions unrelated to items or tiles (for example, biome or time).
 		/// </summary>
-		public virtual bool RecipeAvailable(Recipe recipe) {
+		public virtual bool RecipeAvailable(Recipe recipe, Player player) {
 			return true;
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -146,9 +146,10 @@ namespace Terraria.ModLoader
 		/// Returns whether or not the conditions are met for this recipe to be available for the player to use.
 		/// </summary>
 		/// <param name="recipe">The recipe to check.</param>
+		/// <param name="player">The player trying to use this recipe.</param>
 		/// <returns>Whether or not the conditions are met for this recipe.</returns>
-		public static bool RecipeAvailable(Recipe recipe) {
-			return recipe.Conditions.All(c => c.RecipeAvailable(recipe)) && globalRecipes.All(globalRecipe => globalRecipe.RecipeAvailable(recipe));
+		public static bool RecipeAvailable(Recipe recipe, Player player) {
+			return recipe.Conditions.All(c => c.RecipeAvailable(recipe, player)) && globalRecipes.All(globalRecipe => globalRecipe.RecipeAvailable(recipe, player));
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -16,7 +16,7 @@ namespace Terraria
 		{
 			string Description { get; }
 
-			bool RecipeAvailable(Recipe recipe);
+			bool RecipeAvailable(Recipe recipe, Player player);
 		}
 
 		public sealed class Condition : ICondition
@@ -24,58 +24,60 @@ namespace Terraria
 			#region Conditions
 
 			//Liquids
-			public static readonly Condition NearWater = new Condition(NetworkText.FromKey("RecipeConditions.NearWater"), _ => Main.LocalPlayer.adjWater || Main.LocalPlayer.adjTile[TileID.Sinks]);
-			public static readonly Condition NearLava = new Condition(NetworkText.FromKey("RecipeConditions.NearLava"), _ => Main.LocalPlayer.adjLava);
-			public static readonly Condition NearHoney = new Condition(NetworkText.FromKey("RecipeConditions.NearHoney"), _ => Main.LocalPlayer.adjHoney);
+			public static readonly Condition NearWater = new Condition(NetworkText.FromKey("RecipeConditions.NearWater"), (r, p) => p.adjWater || p.adjTile[TileID.Sinks]);
+			public static readonly Condition NearLava = new Condition(NetworkText.FromKey("RecipeConditions.NearLava"), (r, p) => p.adjLava);
+			public static readonly Condition NearHoney = new Condition(NetworkText.FromKey("RecipeConditions.NearHoney"), (r, p) => p.adjHoney);
 			//Time
-			public static readonly Condition TimeDay = new Condition(NetworkText.FromKey("RecipeConditions.TimeDay"), _ => Main.dayTime);
-			public static readonly Condition TimeNight = new Condition(NetworkText.FromKey("RecipeConditions.TimeNight"), _ => !Main.dayTime);
+			public static readonly Condition TimeDay = new Condition(NetworkText.FromKey("RecipeConditions.TimeDay"), (r, p) => Main.dayTime);
+			public static readonly Condition TimeNight = new Condition(NetworkText.FromKey("RecipeConditions.TimeNight"), (r, p) => !Main.dayTime);
 			//Biomes
-			public static readonly Condition InDungeon = new Condition(NetworkText.FromKey("RecipeConditions.InDungeon"), _ => Main.LocalPlayer.ZoneDungeon);
-			public static readonly Condition InCorrupt = new Condition(NetworkText.FromKey("RecipeConditions.InCorrupt"), _ => Main.LocalPlayer.ZoneCorrupt);
-			public static readonly Condition InHallow = new Condition(NetworkText.FromKey("RecipeConditions.InHallow"), _ => Main.LocalPlayer.ZoneHallow);
-			public static readonly Condition InMeteor = new Condition(NetworkText.FromKey("RecipeConditions.InMeteor"), _ => Main.LocalPlayer.ZoneMeteor);
-			public static readonly Condition InJungle = new Condition(NetworkText.FromKey("RecipeConditions.InJungle"), _ => Main.LocalPlayer.ZoneJungle);
-			public static readonly Condition InSnow = new Condition(NetworkText.FromKey("RecipeConditions.InSnow"), _ => Main.LocalPlayer.ZoneSnow);
-			public static readonly Condition InCrimson = new Condition(NetworkText.FromKey("RecipeConditions.InCrimson"), _ => Main.LocalPlayer.ZoneCrimson);
-			public static readonly Condition InWaterCandle = new Condition(NetworkText.FromKey("RecipeConditions.InWaterCandle"), _ => Main.LocalPlayer.ZoneWaterCandle);
-			public static readonly Condition InPeaceCandle = new Condition(NetworkText.FromKey("RecipeConditions.InPeaceCandle"), _ => Main.LocalPlayer.ZonePeaceCandle);
-			public static readonly Condition InTowerSolar = new Condition(NetworkText.FromKey("RecipeConditions.InTowerSolar"), _ => Main.LocalPlayer.ZoneTowerSolar);
-			public static readonly Condition InTowerVortex = new Condition(NetworkText.FromKey("RecipeConditions.InTowerVortex"), _ => Main.LocalPlayer.ZoneTowerVortex);
-			public static readonly Condition InTowerNebula = new Condition(NetworkText.FromKey("RecipeConditions.InTowerNebula"), _ => Main.LocalPlayer.ZoneTowerNebula);
-			public static readonly Condition InTowerStardust = new Condition(NetworkText.FromKey("RecipeConditions.InTowerStardust"), _ => Main.LocalPlayer.ZoneTowerStardust);
-			public static readonly Condition InDesert = new Condition(NetworkText.FromKey("RecipeConditions.InDesert"), _ => Main.LocalPlayer.ZoneDesert);
-			public static readonly Condition InGlowshroom = new Condition(NetworkText.FromKey("RecipeConditions.InGlowshroom"), _ => Main.LocalPlayer.ZoneGlowshroom);
-			public static readonly Condition InUndergroundDesert = new Condition(NetworkText.FromKey("RecipeConditions.InUndergroundDesert"), _ => Main.LocalPlayer.ZoneUndergroundDesert);
-			public static readonly Condition InSkyHeight = new Condition(NetworkText.FromKey("RecipeConditions.InSkyHeight"), _ => Main.LocalPlayer.ZoneSkyHeight);
-			public static readonly Condition InOverworldHeight = new Condition(NetworkText.FromKey("RecipeConditions.InOverworldHeight"), _ => Main.LocalPlayer.ZoneOverworldHeight);
-			public static readonly Condition InDirtLayerHeight = new Condition(NetworkText.FromKey("RecipeConditions.InDirtLayerHeight"), _ => Main.LocalPlayer.ZoneDirtLayerHeight);
-			public static readonly Condition InRockLayerHeight = new Condition(NetworkText.FromKey("RecipeConditions.InRockLayerHeight"), _ => Main.LocalPlayer.ZoneRockLayerHeight);
-			public static readonly Condition InUnderworldHeight = new Condition(NetworkText.FromKey("RecipeConditions.InUnderworldHeight"), _ => Main.LocalPlayer.ZoneUnderworldHeight);
-			public static readonly Condition InBeach = new Condition(NetworkText.FromKey("RecipeConditions.InBeach"), _ => Main.LocalPlayer.ZoneBeach);
-			public static readonly Condition InRain = new Condition(NetworkText.FromKey("RecipeConditions.InRain"), _ => Main.LocalPlayer.ZoneRain);
-			public static readonly Condition InSandstorm = new Condition(NetworkText.FromKey("RecipeConditions.InSandstorm"), _ => Main.LocalPlayer.ZoneSandstorm);
-			public static readonly Condition InOldOneArmy = new Condition(NetworkText.FromKey("RecipeConditions.InOldOneArmy"), _ => Main.LocalPlayer.ZoneOldOneArmy);
-			public static readonly Condition InGranite = new Condition(NetworkText.FromKey("RecipeConditions.InGranite"), _ => Main.LocalPlayer.ZoneGranite);
-			public static readonly Condition InMarble = new Condition(NetworkText.FromKey("RecipeConditions.InMarble"), _ => Main.LocalPlayer.ZoneMarble);
-			public static readonly Condition InHive = new Condition(NetworkText.FromKey("RecipeConditions.InHive"), _ => Main.LocalPlayer.ZoneHive);
-			public static readonly Condition InGemCave = new Condition(NetworkText.FromKey("RecipeConditions.InGemCave"), _ => Main.LocalPlayer.ZoneGemCave);
-			public static readonly Condition InLihzhardTemple = new Condition(NetworkText.FromKey("RecipeConditions.InLihzardTemple"), _ => Main.LocalPlayer.ZoneLihzhardTemple);
-			public static readonly Condition InGraveyardBiome = new Condition(NetworkText.FromKey("RecipeConditions.InGraveyardBiome"), _ => Main.LocalPlayer.ZoneGraveyard);
+			public static readonly Condition InDungeon = new Condition(NetworkText.FromKey("RecipeConditions.InDungeon"), (r, p) => p.ZoneDungeon);
+			public static readonly Condition InCorrupt = new Condition(NetworkText.FromKey("RecipeConditions.InCorrupt"), (r, p) => p.ZoneCorrupt);
+			public static readonly Condition InHallow = new Condition(NetworkText.FromKey("RecipeConditions.InHallow"), (r, p) => p.ZoneHallow);
+			public static readonly Condition InMeteor = new Condition(NetworkText.FromKey("RecipeConditions.InMeteor"), (r, p) => p.ZoneMeteor);
+			public static readonly Condition InJungle = new Condition(NetworkText.FromKey("RecipeConditions.InJungle"), (r, p) => p.ZoneJungle);
+			public static readonly Condition InSnow = new Condition(NetworkText.FromKey("RecipeConditions.InSnow"), (r, p) => p.ZoneSnow);
+			public static readonly Condition InCrimson = new Condition(NetworkText.FromKey("RecipeConditions.InCrimson"), (r, p) => p.ZoneCrimson);
+			public static readonly Condition InWaterCandle = new Condition(NetworkText.FromKey("RecipeConditions.InWaterCandle"), (r, p) => p.ZoneWaterCandle);
+			public static readonly Condition InPeaceCandle = new Condition(NetworkText.FromKey("RecipeConditions.InPeaceCandle"), (r, p) => p.ZonePeaceCandle);
+			public static readonly Condition InTowerSolar = new Condition(NetworkText.FromKey("RecipeConditions.InTowerSolar"), (r, p) => p.ZoneTowerSolar);
+			public static readonly Condition InTowerVortex = new Condition(NetworkText.FromKey("RecipeConditions.InTowerVortex"), (r, p) => p.ZoneTowerVortex);
+			public static readonly Condition InTowerNebula = new Condition(NetworkText.FromKey("RecipeConditions.InTowerNebula"), (r, p) => p.ZoneTowerNebula);
+			public static readonly Condition InTowerStardust = new Condition(NetworkText.FromKey("RecipeConditions.InTowerStardust"), (r, p) => p.ZoneTowerStardust);
+			public static readonly Condition InDesert = new Condition(NetworkText.FromKey("RecipeConditions.InDesert"), (r, p) => p.ZoneDesert);
+			public static readonly Condition InGlowshroom = new Condition(NetworkText.FromKey("RecipeConditions.InGlowshroom"), (r, p) => p.ZoneGlowshroom);
+			public static readonly Condition InUndergroundDesert = new Condition(NetworkText.FromKey("RecipeConditions.InUndergroundDesert"), (r, p) => p.ZoneUndergroundDesert);
+			public static readonly Condition InSkyHeight = new Condition(NetworkText.FromKey("RecipeConditions.InSkyHeight"), (r, p) => p.ZoneSkyHeight);
+			public static readonly Condition InOverworldHeight = new Condition(NetworkText.FromKey("RecipeConditions.InOverworldHeight"), (r, p) => p.ZoneOverworldHeight);
+			public static readonly Condition InDirtLayerHeight = new Condition(NetworkText.FromKey("RecipeConditions.InDirtLayerHeight"), (r, p) => p.ZoneDirtLayerHeight);
+			public static readonly Condition InRockLayerHeight = new Condition(NetworkText.FromKey("RecipeConditions.InRockLayerHeight"), (r, p) => p.ZoneRockLayerHeight);
+			public static readonly Condition InUnderworldHeight = new Condition(NetworkText.FromKey("RecipeConditions.InUnderworldHeight"), (r, p) => p.ZoneUnderworldHeight);
+			public static readonly Condition InBeach = new Condition(NetworkText.FromKey("RecipeConditions.InBeach"), (r, p) => p.ZoneBeach);
+			public static readonly Condition InRain = new Condition(NetworkText.FromKey("RecipeConditions.InRain"), (r, p) => p.ZoneRain);
+			public static readonly Condition InSandstorm = new Condition(NetworkText.FromKey("RecipeConditions.InSandstorm"), (r, p) => p.ZoneSandstorm);
+			public static readonly Condition InOldOneArmy = new Condition(NetworkText.FromKey("RecipeConditions.InOldOneArmy"), (r, p) => p.ZoneOldOneArmy);
+			public static readonly Condition InGranite = new Condition(NetworkText.FromKey("RecipeConditions.InGranite"), (r, p) => p.ZoneGranite);
+			public static readonly Condition InMarble = new Condition(NetworkText.FromKey("RecipeConditions.InMarble"), (r, p) => p.ZoneMarble);
+			public static readonly Condition InHive = new Condition(NetworkText.FromKey("RecipeConditions.InHive"), (r, p) => p.ZoneHive);
+			public static readonly Condition InGemCave = new Condition(NetworkText.FromKey("RecipeConditions.InGemCave"), (r, p) => p.ZoneGemCave);
+			public static readonly Condition InLihzhardTemple = new Condition(NetworkText.FromKey("RecipeConditions.InLihzardTemple"), (r, p) => p.ZoneLihzhardTemple);
+			public static readonly Condition InGraveyardBiome = new Condition(NetworkText.FromKey("RecipeConditions.InGraveyardBiome"), (r, p) => p.ZoneGraveyard);
 
 			#endregion
 
+			public delegate bool Available(Recipe recipe, Player player);
+
 			private readonly NetworkText DescriptionText;
-			private readonly Predicate<Recipe> Predicate;
+			private readonly Available Predicate;
 
 			public string Description => DescriptionText.ToString();
 
-			public Condition(NetworkText description, Predicate<Recipe> predicate) {
+			public Condition(NetworkText description, Available predicate) {
 				DescriptionText = description ?? throw new ArgumentNullException(nameof(description));
 				Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
 			}
 
-			public bool RecipeAvailable(Recipe recipe) => Predicate(recipe);
+			public bool RecipeAvailable(Recipe recipe, Player player) => Predicate(recipe, player);
 		}
 
 		public static class ConsumptionRules
@@ -256,7 +258,7 @@ namespace Terraria
 		/// </summary>
 		/// <param name="condition">The predicate delegate condition.</param>
 		/// <param name="description">A description of this condition. Use NetworkText.FromKey, or NetworkText.FromLiteral for this.</param>
-		public Recipe AddCondition(NetworkText description, Predicate<Recipe> condition) => AddCondition(new Condition(description, condition));
+		public Recipe AddCondition(NetworkText description, Condition.Available condition) => AddCondition(new Condition(description, condition));
 
 		/// <summary>
 		/// Adds an array of conditions that will determine whether or not the recipe will be to be available for the player to use. The conditions can be unrelated to items or tiles (for example, biome or time).

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -247,7 +247,7 @@
  					}
  
 -					if (flag) {
-+					if (flag && RecipeLoader.RecipeAvailable(Main.recipe[n])) {
++					if (flag && RecipeLoader.RecipeAvailable(Main.recipe[n], Main.LocalPlayer)) {
  						Main.availableRecipe[Main.numAvailableRecipes] = n;
  						Main.numAvailableRecipes++;
  					}

--- a/tModPorter/tModPorter.Tests/TestData/AddRecipes.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/AddRecipes.Expected.cs
@@ -108,14 +108,14 @@ public class ModAddRecipes : Mod
 	};
 
 	public void PortModCreateRecipe(ModItem modItem) {
-		var recipe = Recipe.Create(ModContent.ItemType<ModItemAddRecipes>());
-		recipe.Register();
+		var recipe1 = Recipe.Create(ModContent.ItemType<ModItemAddRecipes>());
+		recipe1.Register();
 
-		var recipe = Recipe.Create(modItem.Type);
-		recipe.Register();
+		var recipe2 = Recipe.Create(modItem.Type);
+		recipe2.Register();
 	}
 
-	public Mod GetMod() => Mod;
+	public Mod GetMod() => this;
 
 	public void GetModMayHaveSideEffects() {
 		var recipe = /* GetMod() */Recipe.Create(ModContent.ItemType<ModItemAddRecipes>());

--- a/tModPorter/tModPorter.Tests/TestData/AddRecipes.cs
+++ b/tModPorter/tModPorter.Tests/TestData/AddRecipes.cs
@@ -120,14 +120,14 @@ public class ModAddRecipes : Mod
 	};
 
 	public void PortModCreateRecipe(ModItem modItem) {
-		var recipe = CreateRecipe(ModContent.ItemType<ModItemAddRecipes>());
-		recipe.Register();
+		var recipe1 = CreateRecipe(ModContent.ItemType<ModItemAddRecipes>());
+		recipe1.Register();
 
-		var recipe = modItem.Mod.CreateRecipe(modItem.Type);
-		recipe.Register();
+		var recipe2 = modItem.Mod.CreateRecipe(modItem.Type);
+		recipe2.Register();
 	}
 
-	public Mod GetMod() => Mod;
+	public Mod GetMod() => this;
 
 	public void GetModMayHaveSideEffects() {
 		var recipe = new ModRecipe(GetMod());

--- a/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.Expected.cs
@@ -1,0 +1,12 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class GlobalRecipeTest : GlobalRecipe
+	{
+		public override bool RecipeAvailable(Recipe recipe, Player player) {
+			return true;
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.cs
@@ -1,0 +1,12 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class GlobalRecipeTest : GlobalRecipe
+	{
+		public override bool RecipeAvailable(Recipe recipe) {
+			return true;
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/ModTreeTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModTreeTest.Expected.cs
@@ -1,15 +1,39 @@
-﻿using Terraria.ModLoader;
+﻿using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using Terraria;
+using Terraria.ID;
+using Terraria.GameContent;
+using Terraria.ModLoader;
 
 public class ModTreeTest : ModTree
 {
 	public override int TreeLeaf() {
 		return -1;
 	}
+
+	// Just so it compiles fine
+
+	public override TreePaintingSettings TreeShaderSettings => new();
+	public override void SetStaticDefaults() { }
+	public override Asset<Texture2D> GetTexture() => Asset<Texture2D>.Empty;
+	public override int DropWood() => ItemID.Wood;
+	public override void SetTreeFoliageSettings(Tile tile, ref int xoffset, ref int treeFrame, ref int floorY, ref int topTextureFrameWidth, ref int topTextureFrameHeight) { }
+	public override Asset<Texture2D> GetTopTextures() => Asset<Texture2D>.Empty;
+	public override Asset<Texture2D> GetBranchTextures() => Asset<Texture2D>.Empty;
 }
 
-public class ModTreeTest : ModPalmTree
+public class ModPalmTreeTest : ModPalmTree
 {
 	public override int TreeLeaf() {
 		return -1;
 	}
+
+	// Just so it compiles fine
+
+	public override TreePaintingSettings TreeShaderSettings => new();
+	public override void SetStaticDefaults() { }
+	public override Asset<Texture2D> GetTexture() => Asset<Texture2D>.Empty;
+	public override int DropWood() => ItemID.Wood;
+	public override Asset<Texture2D> GetTopTextures() => Asset<Texture2D>.Empty;
+	public override Asset<Texture2D> GetOasisTopTextures() => Asset<Texture2D>.Empty;
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModTreeTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModTreeTest.cs
@@ -1,15 +1,39 @@
-﻿using Terraria.ModLoader;
+﻿using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using Terraria;
+using Terraria.ID;
+using Terraria.GameContent;
+using Terraria.ModLoader;
 
 public class ModTreeTest : ModTree
 {
 	public override int GrowthFXGore() {
 		return -1;
 	}
+
+	// Just so it compiles fine
+
+	public override TreePaintingSettings TreeShaderSettings => new();
+	public override void SetStaticDefaults() { }
+	public override Asset<Texture2D> GetTexture() => Asset<Texture2D>.Empty;
+	public override int DropWood() => ItemID.Wood;
+	public override void SetTreeFoliageSettings(Tile tile, ref int xoffset, ref int treeFrame, ref int floorY, ref int topTextureFrameWidth, ref int topTextureFrameHeight) { }
+	public override Asset<Texture2D> GetTopTextures() => Asset<Texture2D>.Empty;
+	public override Asset<Texture2D> GetBranchTextures() => Asset<Texture2D>.Empty;
 }
 
-public class ModTreeTest : ModPalmTree
+public class ModPalmTreeTest : ModPalmTree
 {
 	public override int GrowthFXGore() {
 		return -1;
 	}
+
+	// Just so it compiles fine
+
+	public override TreePaintingSettings TreeShaderSettings => new();
+	public override void SetStaticDefaults() { }
+	public override Asset<Texture2D> GetTexture() => Asset<Texture2D>.Empty;
+	public override int DropWood() => ItemID.Wood;
+	public override Asset<Texture2D> GetTopTextures() => Asset<Texture2D>.Empty;
+	public override Asset<Texture2D> GetOasisTopTextures() => Asset<Texture2D>.Empty;
 }

--- a/tModPorter/tModPorter.Tests/TestData/RecipeConditionTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeConditionTest.Expected.cs
@@ -1,0 +1,48 @@
+﻿using Terraria;
+using Terraria.Localization;
+
+namespace tModPorter.Tests.TestData
+{
+	public class RecipeConditionTest
+	{
+		public void Method1()
+		{
+			Recipe.Condition condition1 = new(NetworkText.FromLiteral("Test"), (r, player) => player.ZoneGraveyard);
+		}
+
+		public void Method2(Recipe recipe)
+		{
+			recipe.AddCondition(NetworkText.FromLiteral("Test"), (r, player) => player.ZoneGraveyard);
+		}
+
+		public void Method3()
+		{
+			Recipe.Condition condition1 = new(NetworkText.FromLiteral("Test"), (_, player) => player.ZoneGraveyard);
+		}
+
+		public void Method4(Recipe recipe)
+		{
+			recipe.AddCondition(NetworkText.FromLiteral("Test"), (_, player) => player.ZoneGraveyard);
+		}
+
+		public void Method5(Recipe.Condition condition, Recipe recipe)
+		{
+			condition.RecipeAvailable(recipe, Main.LocalPlayer);
+		}
+
+		public bool Method6(Recipe.Condition condition, Recipe recipe)
+		{
+			return condition.RecipeAvailable(recipe, Main.LocalPlayer);
+		}
+
+		public void Method7(Recipe.Condition condition, Recipe recipe, Player player)
+		{
+			condition.RecipeAvailable(recipe, player);
+		}
+
+		public bool Method8(Recipe.Condition condition, Recipe recipe, Player player)
+		{
+			return condition.RecipeAvailable(recipe, player);
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/RecipeConditionTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeConditionTest.cs
@@ -1,0 +1,48 @@
+﻿using Terraria;
+using Terraria.Localization;
+
+namespace tModPorter.Tests.TestData
+{
+	public class RecipeConditionTest
+	{
+		public void Method1()
+		{
+			Recipe.Condition condition1 = new(NetworkText.FromLiteral("Test"), r => Main.LocalPlayer.ZoneGraveyard);
+		}
+
+		public void Method2(Recipe recipe)
+		{
+			recipe.AddCondition(NetworkText.FromLiteral("Test"), r => Main.LocalPlayer.ZoneGraveyard);
+		}
+
+		public void Method3()
+		{
+			Recipe.Condition condition1 = new(NetworkText.FromLiteral("Test"), _ => Main.LocalPlayer.ZoneGraveyard);
+		}
+
+		public void Method4(Recipe recipe)
+		{
+			recipe.AddCondition(NetworkText.FromLiteral("Test"), _ => Main.LocalPlayer.ZoneGraveyard);
+		}
+
+		public void Method5(Recipe.Condition condition, Recipe recipe)
+		{
+			condition.RecipeAvailable(recipe);
+		}
+
+		public bool Method6(Recipe.Condition condition, Recipe recipe)
+		{
+			return condition.RecipeAvailable(recipe);
+		}
+
+		public void Method7(Recipe.Condition condition, Recipe recipe, Player player)
+		{
+			condition.RecipeAvailable(recipe);
+		}
+
+		public bool Method8(Recipe.Condition condition, Recipe recipe, Player player)
+		{
+			return condition.RecipeAvailable(recipe);
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.Expected.cs
@@ -1,0 +1,28 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class RecipeLoaderTest
+	{
+		public void Method1(Recipe recipe)
+		{
+			RecipeLoader.RecipeAvailable(recipe, Main.LocalRecipe);
+		}
+
+		public bool Method2(Recipe recipe)
+		{
+			return RecipeLoader.RecipeAvailable(recipe, Main.LocalRecipe);
+		}
+
+		public void Method3(Recipe recipe, Player player)
+		{
+			RecipeLoader.RecipeAvailable(recipe, player);
+		}
+
+		public bool Method4(Recipe recipe, Player player)
+		{
+			return RecipeLoader.RecipeAvailable(recipe, player);
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.Expected.cs
@@ -7,12 +7,12 @@ namespace tModPorter.Tests.TestData
 	{
 		public void Method1(Recipe recipe)
 		{
-			RecipeLoader.RecipeAvailable(recipe, Main.LocalRecipe);
+			RecipeLoader.RecipeAvailable(recipe, Main.LocalPlayer);
 		}
 
 		public bool Method2(Recipe recipe)
 		{
-			return RecipeLoader.RecipeAvailable(recipe, Main.LocalRecipe);
+			return RecipeLoader.RecipeAvailable(recipe, Main.LocalPlayer);
 		}
 
 		public void Method3(Recipe recipe, Player player)

--- a/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeLoaderTest.cs
@@ -1,0 +1,28 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class RecipeLoaderTest
+	{
+		public void Method1(Recipe recipe)
+		{
+			RecipeLoader.RecipeAvailable(recipe);
+		}
+
+		public bool Method2(Recipe recipe)
+		{
+			return RecipeLoader.RecipeAvailable(recipe);
+		}
+
+		public void Method3(Recipe recipe, Player player)
+		{
+			RecipeLoader.RecipeAvailable(recipe);
+		}
+
+		public bool Method4(Recipe recipe, Player player)
+		{
+			return RecipeLoader.RecipeAvailable(recipe);
+		}
+	}
+}

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -156,6 +156,7 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.ModMount",			"JumpSpeed");
 		ChangeHookSignature("Terraria.ModLoader.ModType",			"IsLoadingEnabled");
 		ChangeHookSignature("Terraria.ModLoader.ModType",			"CloneNewInstances"); // public -> protected
+		ChangeHookSignature("Terraria.ModLoader.GlobalRecipe",		"RecipeAvailable");
 
 		HookRemoved("Terraria.ModLoader.EquipTexture",	"DrawHead",		"After registering this as EquipType.Head, use ArmorIDs.Head.Sets.DrawHead[slot] = false if you returned false");
 		HookRemoved("Terraria.ModLoader.ModItem",		"DrawHead",		"In SetStaticDefaults, use ArmorIDs.Head.Sets.DrawHead[Item.headSlot] = false if you returned false");


### PR DESCRIPTION
### What is the new feature?
Add `Player` parameter to the `Recipe.Condition` availability predicate

### Why should this be part of tModLoader?
Allows mods to provide dummy players to be used instead of the local player

### Are there alternative designs?
Keep current

### Sample usage for the new feature
```s
Player player = (Player) Main.LocalPlayer.Clone();
player.adjTile = myAdjTiles;

bool available = RecipeLoader.RecipeAvailable(Main.Recipe[123], player);
```

### ExampleMod updates
Use the player parameter instead of `Main.LocalPlayer`

