### PR TITLE
[1.4] TileLoader.HasSolidTopCollision()

### DIFF
--- a/ExampleMod/Content/NPCs/Worm.cs
+++ b/ExampleMod/Content/NPCs/Worm.cs
@@ -302,7 +302,7 @@ namespace ExampleMod.NPCs
 					Tile tile = Main.tile[i, j];
 
 					// If the tile is solid or is considered a platform, then there's valid collision
-					if (tile.HasUnactuatedTile && (Main.tileSolid[tile.TileType] || Main.tileSolidTop[tile.TileType] && tile.TileFrameY == 0) || tile.LiquidAmount > 64) {
+					if (tile.HasUnactuatedTile && (Main.tileSolid[tile.TileType] || TileLoader.HasSolidTopCollision(i, j, tile.TileType)) || tile.LiquidAmount > 64) {
 						Vector2 tileWorld = new Point16(i, j).ToWorldCoordinates(0, 0);
 
 						if (NPC.Right.X > tileWorld.X && NPC.Left.X < tileWorld.X + 16 && NPC.Bottom.Y > tileWorld.Y && NPC.Top.Y < tileWorld.Y + 16) {

--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -1,5 +1,58 @@
 --- src/TerrariaNetCore/Terraria/Collision.cs
 +++ src/tModLoader/Terraria/Collision.cs
+@@ -3,6 +_,7 @@
+ using System.Collections.Generic;
+ using Terraria.DataStructures;
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria
+ {
+@@ -1296,7 +_,7 @@
+ 			Vector2 vector4 = default(Vector2);
+ 			for (int i = num; i < value2; i++) {
+ 				for (int j = value3; j < value4; j++) {
+-					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || Main.tile[i, j].inActive() || (!Main.tileSolid[Main.tile[i, j].type] && (!Main.tileSolidTop[Main.tile[i, j].type] || Main.tile[i, j].frameY != 0)))
++					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || Main.tile[i, j].inActive() || (!Main.tileSolid[Main.tile[i, j].type] && !TileLoader.HasSolidTopCollision(i, j, Main.tile[i, j].type)))
+ 						continue;
+ 
+ 					vector4.X = i * 16;
+@@ -1484,7 +_,7 @@
+ 			Vector2 vector4 = default(Vector2);
+ 			for (int i = num5; i < value2; i++) {
+ 				for (int j = value3; j < value4; j++) {
+-					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || (!Main.tileSolid[Main.tile[i, j].type] && (!Main.tileSolidTop[Main.tile[i, j].type] || Main.tile[i, j].frameY != 0)))
++					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || (!Main.tileSolid[Main.tile[i, j].type] && !TileLoader.HasSolidTopCollision(i, j, Main.tile[i, j].type)))
+ 						continue;
+ 
+ 					vector4.X = i * 16;
+@@ -1567,7 +_,7 @@
+ 			Vector2 vector4 = default(Vector2);
+ 			for (int i = num5; i < value2; i++) {
+ 				for (int j = value3; j < value4; j++) {
+-					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || Main.tile[i, j].inActive() || (!Main.tileSolid[Main.tile[i, j].type] && (!Main.tileSolidTop[Main.tile[i, j].type] || Main.tile[i, j].frameY != 0)))
++					if (Main.tile[i, j] == null || !Main.tile[i, j].active() || Main.tile[i, j].inActive() || (!Main.tileSolid[Main.tile[i, j].type] && !TileLoader.HasSolidTopCollision(i, j, Main.tile[i, j].type)))
+ 						continue;
+ 
+ 					vector4.X = i * 16;
+@@ -1835,7 +_,7 @@
+ 
+ 					bool flag = Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type];
+ 					if (acceptTopSurfaces)
+-						flag |= (Main.tileSolidTop[tile.type] && tile.frameY == 0);
++						flag |= TileLoader.HasSolidTopCollision(i, j, tile.type);
+ 
+ 					if (flag) {
+ 						vector.X = i * 16;
+@@ -2063,7 +_,7 @@
+ 			Vector2 vector2 = default(Vector2);
+ 			for (int i = num; i < num2; i++) {
+ 				for (int j = num3; j < num4; j++) {
+-					if (Main.tile[i, j] != null && !Main.tile[i, j].inActive() && Main.tile[i, j].active() && (Main.tileSolid[Main.tile[i, j].type] || (Main.tileSolidTop[Main.tile[i, j].type] && Main.tile[i, j].frameY == 0))) {
++					if (Main.tile[i, j] != null && !Main.tile[i, j].inActive() && Main.tile[i, j].active() && (Main.tileSolid[Main.tile[i, j].type] || TileLoader.HasSolidTopCollision(i, j, Main.tile[i, j].type))) {
+ 						vector2.X = i * 16;
+ 						vector2.Y = j * 16;
+ 						int num5 = 16;
 @@ -2100,7 +_,7 @@
  			Vector2 vector2 = default(Vector2);
  			for (int i = num; i < num2; i++) {
@@ -84,7 +137,16 @@
  				}
  			}
  
-@@ -2564,7 +_,8 @@
+@@ -2448,7 +_,7 @@
+ 						ushort type = tile.type;
+ 						bool flag = Main.tileSolid[type] && !Main.tileSolidTop[type];
+ 						if (allowTopSurfaces)
+-							flag |= (Main.tileSolidTop[type] && tile.frameY == 0);
++							flag |= TileLoader.HasSolidTopCollision(i, j, Main.tile[i, j].type);
+ 
+ 						if (flag)
+ 							return true;
+@@ -2564,9 +_,10 @@
  				tile = Main.tile[num2, num3];
  				tile2 = Main.tile[num2, num3 - 1];
  				if (specialChecksMode == 1)
@@ -92,8 +154,20 @@
 +					//flag5 = (tile.type != 16 && tile.type != 18 && tile.type != 14 && tile.type != 469 && tile.type != 134);
 +					flag5 = !TileID.Sets.IgnoredByNpcStepUp[tile.type];
  
- 				flag4 = (flag4 && ((tile.nactive() && (!tile.topSlope() || (tile.slope() == 1 && position.X + (float)(width / 2) < (float)(num2 * 16)) || (tile.slope() == 2 && position.X + (float)(width / 2) > (float)(num2 * 16 + 16))) && (!tile.topSlope() || position.Y + (float)height > (float)(num3 * 16)) && ((Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]) || (holdsMatching && ((Main.tileSolidTop[tile.type] && tile.frameY == 0) || TileID.Sets.Platforms[tile.type]) && (!Main.tileSolid[tile2.type] || !tile2.nactive()) && flag5))) || (tile2.halfBrick() && tile2.nactive())));
+-				flag4 = (flag4 && ((tile.nactive() && (!tile.topSlope() || (tile.slope() == 1 && position.X + (float)(width / 2) < (float)(num2 * 16)) || (tile.slope() == 2 && position.X + (float)(width / 2) > (float)(num2 * 16 + 16))) && (!tile.topSlope() || position.Y + (float)height > (float)(num3 * 16)) && ((Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]) || (holdsMatching && ((Main.tileSolidTop[tile.type] && tile.frameY == 0) || TileID.Sets.Platforms[tile.type]) && (!Main.tileSolid[tile2.type] || !tile2.nactive()) && flag5))) || (tile2.halfBrick() && tile2.nactive())));
++				flag4 = (flag4 && ((tile.nactive() && (!tile.topSlope() || (tile.slope() == 1 && position.X + (float)(width / 2) < (float)(num2 * 16)) || (tile.slope() == 2 && position.X + (float)(width / 2) > (float)(num2 * 16 + 16))) && (!tile.topSlope() || position.Y + (float)height > (float)(num3 * 16)) && ((Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]) || (holdsMatching && (TileLoader.HasSolidTopCollision(num2, num3, tile.type) || TileID.Sets.Platforms[tile.type]) && (!Main.tileSolid[tile2.type] || !tile2.nactive()) && flag5))) || (tile2.halfBrick() && tile2.nactive())));
  				flag4 &= (!Main.tileSolidTop[tile.type] || !Main.tileSolidTop[tile2.type]);
+ 			}
+ 			else {
+@@ -2575,7 +_,7 @@
+ 				flag3 = (flag3 && (!tile.nactive() || !Main.tileSolid[tile.type] || Main.tileSolidTop[tile.type] || tile.slope() != 0 || (tile.halfBrick() && (!tile2.nactive() || !Main.tileSolid[tile2.type] || Main.tileSolidTop[tile2.type]))));
+ 				tile = Main.tile[num2, num3];
+ 				tile2 = Main.tile[num2, num3 + 1];
+-				flag4 = (flag4 && ((tile.nactive() && ((Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]) || (holdsMatching && Main.tileSolidTop[tile.type] && tile.frameY == 0 && (!Main.tileSolid[tile2.type] || !tile2.nactive())))) || (tile2.halfBrick() && tile2.nactive())));
++				flag4 = (flag4 && ((tile.nactive() && ((Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]) || (holdsMatching && TileLoader.HasSolidTopCollision(num2, num3, tile.type) && (!Main.tileSolid[tile2.type] || !tile2.nactive())))) || (tile2.halfBrick() && tile2.nactive())));
+ 			}
+ 
+ 			if (!((float)(num2 * 16) < vector.X + (float)width) || !((float)(num2 * 16 + 16) > vector.X))
 @@ -2642,7 +_,7 @@
  				if (tile.active()) {
  					if (Main.tileSolid[tile.type]) {
@@ -103,3 +177,21 @@
  							switch (num5) {
  								case 1:
  									return 0f;
+@@ -2685,7 +_,7 @@
+ 								return 0f;
+ 						}
+ 					}
+-					else if (Main.tileSolidTop[tile.type] && tile.frameY == 0 && flag) {
++					else if (TileLoader.HasSolidTopCollision(num2, num3, tile.type) && flag) {
+ 						return 0f;
+ 					}
+ 				}
+@@ -2922,7 +_,7 @@
+ 			for (int i = num5; i < value2; i++) {
+ 				for (int j = value3; j < value4; j++) {
+ 					Tile tile = Main.tile[i, j];
+-					if (tile == null || !tile.active() || tile.inActive() || forcedIgnoredTiles[tile.type] || (!Main.tileSolid[tile.type] && (!Main.tileSolidTop[tile.type] || tile.frameY != 0)))
++					if (tile == null || !tile.active() || tile.inActive() || forcedIgnoredTiles[tile.type] || (!Main.tileSolid[tile.type] && !TileLoader.HasSolidTopCollision(i, j, tile.type)))
+ 						continue;
+ 
+ 					vector4.X = i * 16;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -249,5 +249,15 @@ namespace Terraria.ModLoader
 		/// <param name="style"></param>
 		public virtual void ChangeWaterfallStyle(int type, ref int style) {
 		}
+
+		/// <summary>
+		/// Allows you to determine whether this tile has solid top collision.
+		/// Return true to indicate that this tile has solid top collision, false for no collision and null to use the vanilla code for whether this tile has solid top collsion.
+		/// This hook does not run if the <see cref="Main.tileSolidTop"/> index for this tile is false.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		/// <param name="type"></param>
+		public virtual bool? HasSolidTopCollision(int i, int j, int type) => null;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -472,5 +472,14 @@ namespace Terraria.ModLoader
 		/// <param name="manual">Set this to true to bypass the code playing the unlock sound, adjusting the tile frame, and spawning dust. Network syncing will still happen.</param>
 		/// <returns>Return true if this tile truly is a locked chest and the chest can be unlocked</returns>
 		public virtual bool UnlockChest(int i, int j, ref short frameXAdjustment, ref int dustType, ref bool manual) => false;
+
+		/// <summary>
+		/// Allows you to determine whether this tile has solid top collision.
+		/// Return true to indicate that this tile has solid top collision, false for no collision and null to use the vanilla code for whether this tile has solid top collsion.
+		/// This hook does not run if the <see cref="Main.tileSolidTop"/> index for this tile is false.
+		/// </summary>
+		/// <param name="i">The x position in tile coordinates.</param>
+		/// <param name="j">The y position in tile coordinates.</param>
+		public virtual bool? HasSolidTopCollision(int i, int j) => null;
 	}
 }

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -401,6 +401,24 @@
  			if (timeLeft < 0)
  				timeLeft = 0;
  
+@@ -35052,7 +_,7 @@
+ 				Vector2 vector2 = default(Vector2);
+ 				for (int k = num11; k < num12; k++) {
+ 					for (int l = num13; l < num14; l++) {
+-						if (Main.tile[k, l] != null && ((Main.tile[k, l].nactive() && (Main.tileSolid[Main.tile[k, l].type] || (Main.tileSolidTop[Main.tile[k, l].type] && Main.tile[k, l].frameY == 0))) || Main.tile[k, l].liquid > 64)) {
++						if (Main.tile[k, l] != null && ((Main.tile[k, l].nactive() && (Main.tileSolid[Main.tile[k, l].type] || TileLoader.HasSolidTopCollision(k, l, Main.tile[k, l].type))) || Main.tile[k, l].liquid > 64)) {
+ 							vector2.X = k * 16;
+ 							vector2.Y = l * 16;
+ 							if (position.X + (float)width > vector2.X && position.X < vector2.X + 16f && position.Y + (float)height > vector2.Y && position.Y < vector2.Y + 16f) {
+@@ -36265,7 +_,7 @@
+ 				Vector2 vector = default(Vector2);
+ 				for (int num40 = num36; num40 < num37; num40++) {
+ 					for (int num41 = num38; num41 < num39; num41++) {
+-						if (Main.tile[num40, num41] == null || ((!Main.tile[num40, num41].nactive() || (!Main.tileSolid[Main.tile[num40, num41].type] && (!Main.tileSolidTop[Main.tile[num40, num41].type] || Main.tile[num40, num41].frameY != 0))) && Main.tile[num40, num41].liquid <= 64))
++						if (Main.tile[num40, num41] == null || ((!Main.tile[num40, num41].nactive() || (!Main.tileSolid[Main.tile[num40, num41].type] && !TileLoader.HasSolidTopCollision(num40, num41, Main.tile[num40, num41].type))) && Main.tile[num40, num41].liquid <= 64))
+ 							continue;
+ 
+ 						vector.X = num40 * 16;
 @@ -37185,13 +_,14 @@
  			int num = -1;
  			int num2 = 7;

--- a/patches/tModLoader/Terraria/Physics/BallCollision.cs.patch
+++ b/patches/tModLoader/Terraria/Physics/BallCollision.cs.patch
@@ -1,5 +1,13 @@
 --- src/TerrariaNetCore/Terraria/Physics/BallCollision.cs
 +++ src/tModLoader/Terraria/Physics/BallCollision.cs
+@@ -2,6 +_,7 @@
+ using System;
+ using System.Diagnostics;
+ using Terraria.DataStructures;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.Physics
+ {
 @@ -151,7 +_,7 @@
  			tileEdges = ((!(velocity.Y > velocity.X)) ? (tileEdges | TileEdges.TopRightSlope) : (tileEdges | TileEdges.BottomLeftSlope));
  			tileEdges = ((!(velocity.Y > 0f - velocity.X)) ? (tileEdges | TileEdges.TopLeftSlope) : (tileEdges | TileEdges.BottomRightSlope));
@@ -9,3 +17,12 @@
  			float num = float.MaxValue;
  			Vector2 closestPointOut = default(Vector2);
  			float distanceSquaredOut = 0f;
+@@ -174,7 +_,7 @@
+ 			if (tile == null || !tile.nactive() || (!Main.tileSolid[tile.type] && !Main.tileSolidTop[tile.type]))
+ 				return false;
+ 
+-			if (!Main.tileSolid[tile.type] && Main.tileSolidTop[tile.type] && tile.frameY != 0)
++			if (!Main.tileSolid[tile.type] && TileLoader.HasSolidTopCollision(x, y, tile.type))
+ 				return false;
+ 
+ 			if (Main.tileSolidTop[tile.type])

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1089,6 +1089,15 @@
  				Item.NewItem(GetItemSource_FromTileBreak(i, j), i * 16, j * 16, 32, 32, 1263);
  
  			for (int l = num; l < num + 3; l++) {
+@@ -30130,7 +_,7 @@
+ 						break;
+ 				}
+ 
+-				if (!SolidTileAllowBottomSlope(k, num8) && (Main.tile[k, num8] == null || !Main.tile[k, num8].nactive() || !Main.tileSolidTop[Main.tile[k, num8].type] || Main.tile[k, num8].frameY != 0) && (Main.tile[k, num8] == null || !Main.tile[k, num8].active() || !TileID.Sets.Platforms[Main.tile[k, num8].type]))
++				if (!SolidTileAllowBottomSlope(k, num8) && (Main.tile[k, num8] == null || !Main.tile[k, num8].nactive() || !TileLoader.HasSolidTopCollision(k, num8, Main.tile[k, num8].type)) && (Main.tile[k, num8] == null || !Main.tile[k, num8].active() || !TileID.Sets.Platforms[Main.tile[k, num8].type]))
+ 					flag = true;
+ 			}
+ 
 @@ -30186,6 +_,9 @@
  				}
  			}
@@ -1161,6 +1170,15 @@
  			destroyObject = false;
  			for (int num5 = num - 1; num5 < num + 6; num5++) {
  				for (int num6 = num2 - 1; num6 < num2 + 5; num6++) {
+@@ -30998,7 +_,7 @@
+ 				if (Main.tile[k, num2 + 3] == null)
+ 					Main.tile[k, num2 + 3] = new Tile();
+ 
+-				if (!SolidTileAllowBottomSlope(k, num2 + 3) && (!Main.tile[k, num2 + 3].nactive() || !Main.tileSolidTop[Main.tile[k, num2 + 3].type] || Main.tile[k, num2 + 3].frameY != 0))
++				if (!SolidTileAllowBottomSlope(k, num2 + 3) && (!Main.tile[k, num2 + 3].nactive() || !TileLoader.HasSolidTopCollision(k, num2 + 3, Main.tile[k, num2 + 3].type)))
+ 					flag = true;
+ 			}
+ 
 @@ -31013,6 +_,9 @@
  				}
  			}
@@ -1184,6 +1202,15 @@
  					TileFrame(num4, num5);
  				}
  			}
+@@ -31143,7 +_,7 @@
+ 				if (Main.tile[i, y + 1] == null)
+ 					Main.tile[i, y + 1] = new Tile();
+ 
+-				if (!SolidTile2(i, y + 1) && (!Main.tile[i, y + 1].nactive() || !Main.tileSolidTop[Main.tile[i, y + 1].type] || Main.tile[i, y + 1].frameY != 0))
++				if (!SolidTile2(i, y + 1) && (!Main.tile[i, y + 1].nactive() || !TileLoader.HasSolidTopCollision(i, y + 1, Main.tile[i, y + 1].type)))
+ 					flag = false;
+ 			}
+ 
 @@ -31442,6 +_,9 @@
  				}
  			}
@@ -1278,7 +1305,14 @@
  			for (int m = x - 1; m < x + width + 1; m++) {
  				for (int n = y - 1; n < y + height + 1; n++) {
  					TileFrame(m, n);
-@@ -32542,7 +_,7 @@
+@@ -32536,13 +_,13 @@
+ 					case 362:
+ 					case 363:
+ 					case 364:
+-						if (!SolidTile2(i, y + 1) && (!Main.tile[i, y + 1].nactive() || !Main.tileSolidTop[Main.tile[i, y + 1].type] || Main.tile[i, y + 1].frameY != 0))
++						if (!SolidTile2(i, y + 1) && (!Main.tile[i, y + 1].nactive() || !TileLoader.HasSolidTopCollision(i, y + 1, Main.tile[i, y + 1].type)))
+ 							flag2 = false;
+ 						break;
  				}
  			}
  


### PR DESCRIPTION
### What is the new feature?
Added a new hook to `TileLoader`:  `HasSolidTopCollision()`

### Why should this be part of tModLoader?
Currently, "solid top" tiles can only be walked on for the uppermost subtiles in the spritesheet.  
This is a problem for mods like Magic Storage, which uses one spritesheet for all Storage Units (except the Creative Storage Unit), which results in the player being able to walk on only the basic Storage Unit and none of the others.

### Are there alternative designs?
A possible alternative could be retrieving the TileObjectData for the tile and relying on CoordinateHeights.

### Sample usage for the new feature
n/a

### ExampleMod updates
Updated `Worm.cs` due to it previously reading from `Main.tileSolidTop[]`
