### PR TITLE
Faster InstantiateGlobals

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -60,7 +60,7 @@ namespace Terraria.ModLoader.Core
 				throw new MultipleException(exceptions);
 		}
 
-		[Obsolete("Use ReadOnlySpan or List variant variant", true)]
+		[Obsolete("Use ReadOnlySpan or List variant", true)]
 		public static void InstantiateGlobals<TGlobal, TEntity>(TEntity entity, IEnumerable<TGlobal> globals, ref Instanced<TGlobal>[] entityGlobals, Action midInstantiationAction) where TGlobal : GlobalType<TEntity, TGlobal>
 			=> InstantiateGlobals(entity, globals.ToArray().AsSpan(), ref entityGlobals, midInstantiationAction);
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -24,7 +24,7 @@ namespace Terraria.ModLoader
 	public static class ItemLoader
 	{
 		internal static readonly IList<ModItem> items = new List<ModItem>();
-		internal static readonly IList<GlobalItem> globalItems = new List<GlobalItem>();
+		internal static readonly List<GlobalItem> globalItems = new();
 		internal static GlobalItem[] NetGlobals;
 		internal static readonly int vanillaQuestFishCount = 41;
 		internal static readonly int[] vanillaWings = new int[Main.maxWings];

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -28,7 +28,7 @@ namespace Terraria.ModLoader
 		internal static bool loaded = false;
 		private static int nextNPC = NPCID.Count;
 		internal static readonly IList<ModNPC> npcs = new List<ModNPC>();
-		internal static readonly IList<GlobalNPC> globalNPCs = new List<GlobalNPC>();
+		internal static readonly List<GlobalNPC> globalNPCs = new();
 		internal static readonly IDictionary<int, int> bannerToItem = new Dictionary<int, int>();
 		private static readonly int[] shopToNPC = new int[Main.MaxShopIDs - 1];
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader
 	public static class ProjectileLoader
 	{
 		internal static readonly IList<ModProjectile> projectiles = new List<ModProjectile>();
-		internal static readonly IList<GlobalProjectile> globalProjectiles = new List<GlobalProjectile>();
+		internal static readonly List<GlobalProjectile> globalProjectiles = new();
 
 		private static int nextProjectile = ProjectileID.Count;
 		private static readonly List<HookList> hooks = new List<HookList>();


### PR DESCRIPTION
### What is the new feature?

No change to behavior, just faster global instantiation!

### Why should this be part of tModLoader?

The LINQ queries in `LoaderUtils.InstantiateGlobals` were _slow_. In some cases being responsible for 75% of frame time due to `Player.clientClone` calling a bunch of `Item.SetDefaults` in poorly implemented mods.

### Are there alternative designs?

Not faster ones :) I think I made a good tradeoff with the `ArrayPool` stuff for the 'set' of which globals apply to this entity.
Could potentially be sped up with a custom `ArrayPool` implementation, which only returns one buffer size. The only reason to use a pool is for recursive calls or thread-safety.

### Sample usage for the new feature
No change.

### ExampleMod updates
None

