### PR TITLE
Make ItemSlot.SellOrTrash() public

### DIFF
--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -251,7 +251,15 @@
  					flag = (Main.player[Main.myPlayer].chest == -1);
  
  				if (ShiftInUse && flag) {
-@@ -761,20 +_,22 @@
+@@ -754,27 +_,29 @@
+ 			return result;
+ 		}
+ 
+-		private static void SellOrTrash(Item[] inv, int context, int slot) {
++		public static void SellOrTrash(Item[] inv, int context, int slot) {
+ 			Player player = Main.player[Main.myPlayer];
+ 			if (inv[slot].type <= 0)
+ 				return;
  
  			if (Main.npcShop > 0 && !inv[slot].favorited) {
  				Chest chest = Main.instance.shop[Main.npcShop];


### PR DESCRIPTION
Because why not?
This would be good for modders like me who want to write a custom item slot.
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->