### PR TITLE
Prevent registering a recipe twice

### DIFF
--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -412,6 +412,9 @@ namespace Terraria
 			if (createItem == null || createItem.type == 0)
 				throw new RecipeException("A recipe without any result has been added.");
 
+			if (RecipeIndex >= 0)
+				throw new RecipeException("There was an attempt to register an already registered recipe.");
+
 			if (requiredTile.Contains(TileID.Bottles))
 				AddConsumeItemCallback(ConsumptionRules.Alchemy);
 


### PR DESCRIPTION
### What is the bug?
Currently it is possible to register a recipe twice
```cs
var recipe = Recipe.Create(ItemID.Zenith);
recipe.AddIngredient(ItemID.DirtBlock, 10);
recipe.Register();
recipe.Register();
```

### How did you fix the bug?
Check that the recipe being registered is not already added by checking if `RecipeIndex` has been assigned a valid value

### Are there alternatives to your fix?
No
