### PR TITLE
Fix language packs don't work issue

### DIFF
--- a/patches/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs.patch
@@ -1,6 +1,10 @@
 --- src/TerrariaNetCore/ReLogic/Content/Sources/FileSystemContentSource.cs
 +++ src/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs
-@@ -4,13 +_,17 @@
+@@ -1,16 +_,21 @@
+ using System;
+ using System.Collections.Generic;
+ using System.IO;
++using System.Linq;
  
  namespace ReLogic.Content.Sources;
  
@@ -19,13 +23,18 @@
  
  	public int FileCount => _nameToAbsolutePath.Count;
  
-@@ -21,8 +_,12 @@
+@@ -21,8 +_,17 @@
  			_basePath += Path.DirectorySeparatorChar;
  
  		BuildNameToAbsolutePathDictionary();
 +
 +		// Added by TML.
 +		SetAssetNames(_nameToAbsolutePath.Keys);
++
++		// #2617 - Allow using paths with extensions in GetExtension calls, because we happen to return such paths in EnumerateAssets().
++		foreach (var pair in assetExtensions.ToArray()) {
++			assetExtensions.TryAdd(pair.Key + pair.Value, pair.Value);
++		}
  	}
  
 +	/*

--- a/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
@@ -7,7 +7,7 @@
  
  namespace ReLogic.Content.Sources;
  
-@@ -7,17 +_,48 @@
+@@ -7,17 +_,53 @@
  {
  	IContentValidator ContentValidator { get; set; }
  
@@ -54,6 +54,11 @@
 +		!Rejections.IsRejected(assetName) && GetExtension(assetName) != null;
 +
 +	// Added by TML.
-+	IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart) =>
-+		EnumerateAssets().Where(s => s.StartsWith(assetNameStart));
++	IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart, bool lower = false)
++	{
++		if (lower)
++			return EnumerateAssets().Where(s => s.ToLower().StartsWith(assetNameStart));
++
++		return EnumerateAssets().Where(s => s.StartsWith(assetNameStart));
++	}
  }

--- a/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
@@ -1,13 +1,15 @@
 --- src/TerrariaNetCore/ReLogic/Content/Sources/IContentSource.cs
 +++ src/tModLoader/ReLogic/Content/Sources/IContentSource.cs
-@@ -1,5 +_,6 @@
+@@ -1,5 +_,8 @@
++using System;
  using System.Collections.Generic;
++using System.Diagnostics.CodeAnalysis;
  using System.IO;
 +using System.Linq;
  
  namespace ReLogic.Content.Sources;
  
-@@ -7,17 +_,53 @@
+@@ -7,17 +_,57 @@
  {
  	IContentValidator ContentValidator { get; set; }
  
@@ -54,11 +56,15 @@
 +		!Rejections.IsRejected(assetName) && GetExtension(assetName) != null;
 +
 +	// Added by TML.
-+	IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart, bool lower = false)
-+	{
-+		if (lower)
-+			return EnumerateAssets().Where(s => s.ToLower().StartsWith(assetNameStart));
++	[Obsolete, SuppressMessage("CodeQuality", "IDE0051:Remove unused private members")]
++	private IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart)
++		=> GetAllAssetsStartingWith(assetNameStart, ignoreCase: false);
 +
-+		return EnumerateAssets().Where(s => s.StartsWith(assetNameStart));
++	// Added by TML.
++	IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart, bool ignoreCase = false)
++	{
++		var comparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
++
++		return EnumerateAssets().Where(s => s.StartsWith(assetNameStart, comparison));
 +	}
  }

--- a/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
+++ b/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
@@ -84,7 +84,7 @@
  	private void ProcessCopyCommandsInTexts()
  	{
  		Regex regex = new Regex("{\\$(\\w+\\.\\w+)}", RegexOptions.Compiled);
-@@ -155,15 +_,30 @@
+@@ -155,18 +_,33 @@
  					break;
  
  				value.SetValue(text);
@@ -113,8 +113,13 @@
  		LoadLanguage(ActiveCulture, processCopyCommands: false);
 +		*/
  		foreach (IContentSource item in sourcesFromLowestToHighest) {
- 			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart)) {
- 				string extension = item.GetExtension(item2);
+-			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart)) {
++			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart, true)) {
+-				string extension = item.GetExtension(item2);
++				string extension = item.GetExtension(item2) ?? "";
+ 				if (!(extension == ".json") && !(extension == ".csv"))
+ 					continue;
+ 
 @@ -181,8 +_,10 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
+++ b/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
@@ -114,8 +114,8 @@
 +		*/
  		foreach (IContentSource item in sourcesFromLowestToHighest) {
 -			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart)) {
-+			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart, true)) {
 -				string extension = item.GetExtension(item2);
++			foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart, ignoreCase: true)) {
 +				string extension = item.GetExtension(item2) ?? "";
  				if (!(extension == ".json") && !(extension == ".csv"))
  					continue;


### PR DESCRIPTION
### What is the bug?
Fixes #2615

### How did you fix the bug?
In `LanguageManager.UseSources`, I found that the `assetNameStart` used `ToLower()`
```
string name = ActiveCulture.Name;
string assetNameStart = ("Localization" + Path.DirectorySeparatorChar + name).ToLower();
LoadLanguage(ActiveCulture, processCopyCommands: false);
foreach (IContentSource item in sourcesFromLowestToHighest) {
	foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart)) {
		string extension = item.GetExtension(item2);
```
But it doesn't use `ToLower()` in the method it calls `IContentSource.GetAllAssetsStartingWith()`
```
IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart, bool lower = false) =>
    EnumerateAssets().Where(s => s.StartsWith(assetNameStart));
```
So the `assetNameStart` never finds any asset name starts with `Localization\[LanguageName]`
The incoming parameter will only be `localization\[LanguageName]`, which is not uppercase

I replaced the method and call with these
```
string name = ActiveCulture.Name;
string assetNameStart = ("Localization" + Path.DirectorySeparatorChar + name).ToLower();
LoadLanguage(ActiveCulture, processCopyCommands: false);
foreach (IContentSource item in sourcesFromLowestToHighest) {
	// Added a "true" parameter so that it can search by lowercase paths
	foreach (string item2 in item.GetAllAssetsStartingWith(assetNameStart, true)) {
		string extension = item.GetExtension(item2);
```
```
IEnumerable<string> GetAllAssetsStartingWith(string assetNameStart, bool lower = false) {
	if (lower)
		return EnumerateAssets().Where(s => s.ToLower().StartsWith(assetNameStart));
	return EnumerateAssets().Where(s => s.StartsWith(assetNameStart));
}
```
Now it will find the correct file

However, it didn't end here, since I found that `item.GetExtension(item2)` can actually get nothing but an empty string
I looked into the vanilla code of `GetExtension()`, in `FileSystemContentSource.GetExtension()`
```
public string GetExtension(string assetName) {
	if (!_nameToAbsolutePath.TryGetValue(assetName, out string value))
		throw AssetLoadException.FromMissingAsset(assetName);

	return Path.GetExtension(value) ?? "";
}
```
I found it used `Path.GetExtension(value) ?? ""`, so I replaced  `item.GetExtension(item2)` with it:
```
string extension = Path.GetExtension(item2) ?? "";
```
And the language packs just started to work.
This could be a temporary solution.