### PR TITLE
Fix issue with recipe ordering

### DIFF
--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -321,7 +321,7 @@ namespace Terraria
 			} while (target != null);
 
 
-			return recipe;
+			return this;
 		}
 
 		/// <summary>


### PR DESCRIPTION
### What is the bug?
`Recipe.SetOrdering` returns the wrong recipe

### How did you fix the bug?
Return the correct recipe

### Are there alternatives to your fix?
No
