### PR TITLE
Fix `ModSystem.ModifySunLightColor`

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4609,7 +4609,7 @@
  			tileColor.B = (byte)((colorOfTheSkies.R + colorOfTheSkies.G + colorOfTheSkies.B + colorOfTheSkies.B * 7) / 10);
  			tileColor = SkyManager.Instance.ProcessTileColor(tileColor);
 +			// TODO: Add in white and white2 as sunColor and moonColor
-+			SystemLoader.ModifySunLightColor(ref tileColor, ref colorOfTheSkies);
++			SystemLoader.ModifySunLightColor(ref tileColor, ref ColorOfTheSkies);
  		}
  
  		private static void UpdateAtmosphereTransparencyToSkyColor() {


### PR DESCRIPTION
### What is the bug?
Fixes #2598

### How did you fix the bug?
Fix typo that caused us to modify a local variable instead of the static `Main` field

### Are there alternatives to your fix?
No
