### PR TITLE
[1.4] NPC Dialogue Fixes

### DIFF
--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -152,7 +152,7 @@ Mods: {
 				StandardDialogue1 : "Sometimes my cousin feels like they're different from everyone else here."
 				StandardDialogue2 : "What's your favorite color? My cousin's favorite colors are white and black."
 				StandardDialogue3 : "I'm a traveling merchant, and I sell things."
-				HiveBackpackDialogue : "Hey, if you find a [i:3333], my cousin can upgrade it for you."
+				HiveBackpackDialogue : "Hey, if you find a [i:HiveBackpack], my cousin can upgrade it for you."
 			}
 		}
 	}

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -152,7 +152,7 @@ Mods: {
 				StandardDialogue1 : "Sometimes my cousin feels like they're different from everyone else here."
 				StandardDialogue2 : "What's your favorite color? My cousin's favorite colors are white and black."
 				StandardDialogue3 : "I'm a traveling merchant, and I sell things."
-				HiveBackpackDialogue : "Hey, if you find a {$ItemName.HiveBackpack}, my cousin can upgrade it for you."
+				HiveBackpackDialogue : "Hey, if you find a [i:3333], my cousin can upgrade it for you."
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -65,19 +65,24 @@
  				get;
  				private set;
  			}
-@@ -155,13 +_,14 @@
+@@ -155,13 +_,23 @@
  				private set;
  			}
  
--			public void PrepareCache(string text) {
++			// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
++			/*
+ 			public void PrepareCache(string text) {
+ 				if ((0 | ((screenWidth != _lastScreenWidth) ? 1 : 0) | ((screenHeight != _lastScreenHeight) ? 1 : 0) | ((_originalText != text) ? 1 : 0)) != 0) {
++			*/
 +			public void PrepareCache(string text, Color baseColor) {
--				if ((0 | ((screenWidth != _lastScreenWidth) ? 1 : 0) | ((screenHeight != _lastScreenHeight) ? 1 : 0) | ((_originalText != text) ? 1 : 0)) != 0) {
 +				if ((0 | ((screenWidth != _lastScreenWidth) ? 1 : 0) | ((screenHeight != _lastScreenHeight) ? 1 : 0) | ((_originalText != text) ? 1 : 0) | ((originalColor != baseColor) ? 1 : 0)) != 0) {
  					_lastScreenWidth = screenWidth;
  					_lastScreenHeight = screenHeight;
  					_originalText = text;
--					TextLines = Utils.WordwrapString(npcChatText, FontAssets.MouseText.Value, 460, 10, out int lineAmount);
--					AmountOfLines = lineAmount;
++					/*
+ 					TextLines = Utils.WordwrapString(npcChatText, FontAssets.MouseText.Value, 460, 10, out int lineAmount);
+ 					AmountOfLines = lineAmount;
++					*/
 +					originalColor = baseColor;
 +					TextLines = Utils.WordwrapStringSmart(npcChatText, baseColor, FontAssets.MouseText.Value, 460, 10);
 +					AmountOfLines = TextLines.Count;
@@ -2807,7 +2812,7 @@
  			int amountOfLines = _textDisplayCache.AmountOfLines;
  			bool flag2 = false;
  			if (editSign) {
-@@ -29221,23 +_,40 @@
+@@ -29221,23 +_,41 @@
  					textBlinkerCount = 0;
  				}
  
@@ -2825,6 +2830,7 @@
 +			//amountOfLines++;
  			spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.ChatBack.Width(), (amountOfLines + 1) * 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
  			spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100 + (amountOfLines + 1) * 30), new Microsoft.Xna.Framework.Rectangle(0, TextureAssets.ChatBack.Height() - 30, TextureAssets.ChatBack.Width(), 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
++			// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +			TextSnippet hoveredSnippet = null;
  			for (int i = 0; i < amountOfLines; i++) {
 -				string text = textLines[i];
@@ -2971,7 +2977,7 @@
  				npcChatFocus2 = false;
  			}
  
-+			//Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
++			// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus2) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
 +			/*
  			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus2) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
@@ -2980,10 +2986,11 @@
  			if (text.Length > 0) {
  				UILinkPointNavigator.SetPosition(2500, vector2 + stringSize * 0.5f);
  				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsLeft = true;
-@@ -29898,8 +_,11 @@
+@@ -29898,8 +_,12 @@
  				npcChatFocus1 = false;
  			}
  
++			// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus1) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
 +			/*
  			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus1) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
@@ -2992,10 +2999,11 @@
  			if (text.Length > 0) {
  				UILinkPointNavigator.SetPosition(2501, vector2 + stringSize * 0.5f);
  				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsMiddle = true;
-@@ -29935,8 +_,11 @@
+@@ -29935,8 +_,12 @@
  					npcChatFocus3 = false;
  				}
  
++				// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus3) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
 +				/*
  				ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus3) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
@@ -3004,10 +3012,11 @@
  				UILinkPointNavigator.SetPosition(2502, vector2 + stringSize * 0.5f);
  				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsRight = true;
  			}
-@@ -29972,8 +_,11 @@
+@@ -29972,8 +_,12 @@
  				npcChatFocus4 = false;
  			}
  
++			// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus4) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
 +			/*
  			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus4) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -54,6 +54,36 @@
  #endif
  	{
  		public delegate void OnPlayerSelected(PlayerFileData player);
+@@ -144,8 +_,9 @@
+ 			private string _originalText;
+ 			private int _lastScreenWidth;
+ 			private int _lastScreenHeight;
++			private Color originalColor;
+ 
+-			public string[] TextLines {
++			public List<List<TextSnippet>> TextLines {
+ 				get;
+ 				private set;
+ 			}
+@@ -155,13 +_,14 @@
+ 				private set;
+ 			}
+ 
+-			public void PrepareCache(string text) {
++			public void PrepareCache(string text, Color baseColor) {
+-				if ((0 | ((screenWidth != _lastScreenWidth) ? 1 : 0) | ((screenHeight != _lastScreenHeight) ? 1 : 0) | ((_originalText != text) ? 1 : 0)) != 0) {
++				if ((0 | ((screenWidth != _lastScreenWidth) ? 1 : 0) | ((screenHeight != _lastScreenHeight) ? 1 : 0) | ((_originalText != text) ? 1 : 0) | ((originalColor != baseColor) ? 1 : 0)) != 0) {
+ 					_lastScreenWidth = screenWidth;
+ 					_lastScreenHeight = screenHeight;
+ 					_originalText = text;
+-					TextLines = Utils.WordwrapString(npcChatText, FontAssets.MouseText.Value, 460, 10, out int lineAmount);
+-					AmountOfLines = lineAmount;
++					originalColor = baseColor;
++					TextLines = Utils.WordwrapStringSmart(npcChatText, baseColor, FontAssets.MouseText.Value, 460, 10);
++					AmountOfLines = TextLines.Count;
+ 				}
+ 			}
+ 		}
 @@ -241,7 +_,7 @@
  		public static List<TitleLinkButton> TitleLinks = new List<TitleLinkButton>();
  		public static string versionNumber = "v1.4.3.6";
@@ -2766,6 +2796,61 @@
  					spriteBatch.Draw(TextureAssets.Dust.Value, dust.position - screenPosition, dust.frame, newColor, dust.GetVisualRotation(), new Vector2(4f, 4f), scale, SpriteEffects.None, 0f);
  					if (dust.color.PackedValue != 0) {
  						Microsoft.Xna.Framework.Color color6 = dust.GetColor(newColor);
+@@ -29206,8 +_,8 @@
+ 			int num = (mouseTextColor * 2 + 255) / 3;
+ 			Microsoft.Xna.Framework.Color textColor = new Microsoft.Xna.Framework.Color(num, num, num, num);
+ 			bool flag = InGameUI.CurrentState is UIVirtualKeyboard && PlayerInput.UsingGamepad;
+-			_textDisplayCache.PrepareCache(npcChatText);
+-			string[] textLines = _textDisplayCache.TextLines;
++			_textDisplayCache.PrepareCache(npcChatText, textColor);
++			List<List<TextSnippet>> textLines = _textDisplayCache.TextLines;
+ 			int amountOfLines = _textDisplayCache.AmountOfLines;
+ 			bool flag2 = false;
+ 			if (editSign) {
+@@ -29221,23 +_,40 @@
+ 					textBlinkerCount = 0;
+ 				}
+ 
+-				if (textBlinkerState == 1)
++				if (textBlinkerState == 1) {
+ 					flag2 = true;
++
++					textLines[amountOfLines - 1].Add(new TextSnippet("|", Microsoft.Xna.Framework.Color.White, 1f));
++				}
+ 
+ 				instance.DrawWindowsIMEPanel(new Vector2(screenWidth / 2, 90f), 0.5f);
+ 			}
+ 
+-			amountOfLines++;
++			//amountOfLines++;
+ 			spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.ChatBack.Width(), (amountOfLines + 1) * 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
+ 			spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100 + (amountOfLines + 1) * 30), new Microsoft.Xna.Framework.Rectangle(0, TextureAssets.ChatBack.Height() - 30, TextureAssets.ChatBack.Width(), 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
++			TextSnippet hoveredSnippet = null;
+ 			for (int i = 0; i < amountOfLines; i++) {
+-				string text = textLines[i];
++				List<TextSnippet> text = textLines[i];
++				/*
+ 				if (text != null) {
+ 					if (i == amountOfLines - 1 && flag2)
+ 						text += "|";
+ 
+ 					Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.MouseText.Value, text, 170 + (screenWidth - 800) / 2, 120 + i * 30, textColor, Microsoft.Xna.Framework.Color.Black, Vector2.Zero);
+ 				}
++				*/
++				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, text.ToArray(), new Vector2(170 + (screenWidth - 800) / 2, 120 + i * 30), 0f, textColor, Color.Black, Vector2.Zero, Vector2.One, out int hoveredSnippetNum);
++
++				if (hoveredSnippetNum > -1)
++					hoveredSnippet = text[hoveredSnippetNum];
++			}
++
++			if (hoveredSnippet is not null) {
++				hoveredSnippet.OnHover();
++
++				if (Main.mouseLeft && Main.mouseLeftRelease)
++					hoveredSnippet.OnClick();
+ 			}
+ 
+ 			Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100, TextureAssets.ChatBack.Width(), (amountOfLines + 2) * 30);
 @@ -29272,12 +_,16 @@
  			string focusText = "";
  			string focusText2 = "";
@@ -2882,6 +2967,55 @@
  				if (npc[player[myPlayer].talkNPC].type == 20) {
  					SoundEngine.PlaySound(12);
  					npcChatText = Lang.GetDryadWorldStatusDialog();
+@@ -29867,8 +_,12 @@
+ 				npcChatFocus2 = false;
+ 			}
+ 
++			//Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
++			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus2) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
++			/*
+ 			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus2) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
+ 			ChatManager.DrawColorCodedString(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, 0f, stringSize * 0.5f, vector3 * value2);
++			*/
+ 			if (text.Length > 0) {
+ 				UILinkPointNavigator.SetPosition(2500, vector2 + stringSize * 0.5f);
+ 				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsLeft = true;
+@@ -29898,8 +_,11 @@
+ 				npcChatFocus1 = false;
+ 			}
+ 
++			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus1) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
++			/*
+ 			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus1) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
+ 			ChatManager.DrawColorCodedString(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, 0f, stringSize * 0.5f, vector3 * value2);
++			*/
+ 			if (text.Length > 0) {
+ 				UILinkPointNavigator.SetPosition(2501, vector2 + stringSize * 0.5f);
+ 				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsMiddle = true;
+@@ -29935,8 +_,11 @@
+ 					npcChatFocus3 = false;
+ 				}
+ 
++				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus3) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
++				/*
+ 				ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus3) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
+ 				ChatManager.DrawColorCodedString(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, 0f, stringSize * 0.5f, vector3 * value2);
++				*/
+ 				UILinkPointNavigator.SetPosition(2502, vector2 + stringSize * 0.5f);
+ 				UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsRight = true;
+ 			}
+@@ -29972,8 +_,11 @@
+ 				npcChatFocus4 = false;
+ 			}
+ 
++			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, (!npcChatFocus4) ? Microsoft.Xna.Framework.Color.Black : brown, 0f, stringSize * 0.5f, vector3 * value2);
++			/*
+ 			ChatManager.DrawColorCodedStringShadow(baseColor: (!npcChatFocus4) ? Microsoft.Xna.Framework.Color.Black : brown, spriteBatch: spriteBatch, font: value, text: text, position: vector2 + stringSize * value2 * 0.5f, rotation: 0f, origin: stringSize * 0.5f, baseScale: vector3 * value2);
+ 			ChatManager.DrawColorCodedString(spriteBatch, value, text, vector2 + stringSize * value2 * 0.5f, baseColor, 0f, stringSize * 0.5f, vector3 * value2);
++			*/
+ 			UILinkPointNavigator.SetPosition(2503, vector2 + stringSize * 0.5f);
+ 			UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsRight2 = true;
+ 		}
 @@ -30076,7 +_,7 @@
  
  				spriteBatch.Draw(value, new Vector2(homeTileX * 16 - (int)screenPosition.X + num8, num11 - (float)(int)screenPosition.Y + (float)num9 + (float)num10), value2, Lighting.GetColor(homeTileX, num3), 0f, new Vector2(value2.Width / 2, value2.Height / 2), 1f, effects, 0f);

--- a/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
@@ -1,0 +1,29 @@
+--- src/TerrariaNetCore/Terraria/UI/Chat/ChatManager.cs
++++ src/tModLoader/Terraria/UI/Chat/ChatManager.cs
+@@ -256,6 +_,11 @@
+ 			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
+ 		}
+ 
++		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, TextSnippet[] snippets, Vector2 position, float rotation, Color color, Color shadowColor, Vector2 origin, Vector2 baseScale, out int hoveredSnippet, float maxWidth = -1f, float spread = 2f) {
++			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, shadowColor, rotation, origin, baseScale, maxWidth, spread);
++			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
++		}
++
+ 		public static void DrawColorCodedStringShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, string text, Vector2 position, Color baseColor, float rotation, Vector2 origin, Vector2 baseScale, float maxWidth = -1f, float spread = 2f) {
+ 			for (int i = 0; i < ShadowDirections.Length; i++) {
+ 				DrawColorCodedString(spriteBatch, font, text, position + ShadowDirections[i] * spread, baseColor, rotation, origin, baseScale, maxWidth, ignoreColors: true);
+@@ -327,6 +_,14 @@
+ 			TextSnippet[] snippets = ParseMessage(text, baseColor).ToArray();
+ 			ConvertNormalSnippets(snippets);
+ 			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, new Color(0, 0, 0, baseColor.A), rotation, origin, baseScale, maxWidth, spread);
++			int hoveredSnippet;
++			return DrawColorCodedString(spriteBatch, font, snippets, position, Color.White, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
++		}
++
++		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, string text, Vector2 position, Color baseColor, Color shadowColor, float rotation, Vector2 origin, Vector2 baseScale, float maxWidth = -1f, float spread = 2f) {
++			TextSnippet[] snippets = ParseMessage(text, baseColor).ToArray();
++			ConvertNormalSnippets(snippets);
++			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, shadowColor, rotation, origin, baseScale, maxWidth, spread);
+ 			int hoveredSnippet;
+ 			return DrawColorCodedString(spriteBatch, font, snippets, position, Color.White, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
+ 		}

--- a/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
@@ -1,9 +1,10 @@
 --- src/TerrariaNetCore/Terraria/UI/Chat/ChatManager.cs
 +++ src/tModLoader/Terraria/UI/Chat/ChatManager.cs
-@@ -256,6 +_,11 @@
+@@ -256,6 +_,12 @@
  			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
  		}
  
++		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, TextSnippet[] snippets, Vector2 position, float rotation, Color color, Color shadowColor, Vector2 origin, Vector2 baseScale, out int hoveredSnippet, float maxWidth = -1f, float spread = 2f) {
 +			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, shadowColor, rotation, origin, baseScale, maxWidth, spread);
 +			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
@@ -12,7 +13,7 @@
  		public static void DrawColorCodedStringShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, string text, Vector2 position, Color baseColor, float rotation, Vector2 origin, Vector2 baseScale, float maxWidth = -1f, float spread = 2f) {
  			for (int i = 0; i < ShadowDirections.Length; i++) {
  				DrawColorCodedString(spriteBatch, font, text, position + ShadowDirections[i] * spread, baseColor, rotation, origin, baseScale, maxWidth, ignoreColors: true);
-@@ -327,6 +_,14 @@
+@@ -327,6 +_,15 @@
  			TextSnippet[] snippets = ParseMessage(text, baseColor).ToArray();
  			ConvertNormalSnippets(snippets);
  			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, new Color(0, 0, 0, baseColor.A), rotation, origin, baseScale, maxWidth, spread);
@@ -20,6 +21,7 @@
 +			return DrawColorCodedString(spriteBatch, font, snippets, position, Color.White, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
 +		}
 +
++		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, string text, Vector2 position, Color baseColor, Color shadowColor, float rotation, Vector2 origin, Vector2 baseScale, float maxWidth = -1f, float spread = 2f) {
 +			TextSnippet[] snippets = ParseMessage(text, baseColor).ToArray();
 +			ConvertNormalSnippets(snippets);

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -40,6 +40,17 @@
  							if (num3 < 0)
  								num3 = 0;
  
+@@ -306,8 +_,8 @@
+ 			}
+ 
+ 			if (maxLines != -1) {
+-				while (list.Count > 10) {
++				while (list.Count > maxLines) {
+-					list.RemoveAt(10);
++					list.RemoveAt(maxLines);
+ 				}
+ 			}
+ 
 @@ -529,18 +_,22 @@
  
  		public static void OpenFolder(string folderPath) {


### PR DESCRIPTION
### What is the bug?
Some code from 1.3 tModLoader which fixed NPC dialogue was missing in 1.4 tModLoader.  
This PR adds that code back while updating it slightly to fit the more modern codebase in the progress.

Note: this PR fixes #2113

### How did you fix the bug?
Reworked the NPC/sign dialogue drawing method to be able to parse and handle chat tags.

### Are there alternatives to your fix?
n/a

### Other noteworthy changes
`ChatManager` was given a few extra methods for better customization over the shadow colour when drawing text as well as finding which text snippet is being hovered over.  
A bug in the "smart wordwrap" Utils method erroneously clamped the line count to `10`, even if the `maxLines` parameter was more than that.  This PR fixes that as well.