### PR TITLE
Custom Game Tips

### DIFF
--- a/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
@@ -22,7 +22,9 @@ namespace ExampleMod.Common.Systems
 			gameTips[GameTipID.SolarEclipseCreepyMonsters].Hide();
 
 			// Now, say you want to modify OTHER mod's tips? You can do that too! Make sure you use the right mod and key name.
-			GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod == "ExampleMod" && tip.ShortKey == "DisabledExampleTip");
+			GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.FullName == "ExampleMod/DisabledExampleTip");
+			// Optionally, if you want to be a bit more specific with the tip name and mod name, you can also do that with the Mod and Name properties, like so:
+			// GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod.Name == "ExampleMod" && tip.Name == "DisabledExampleTip");
 
 			// If you haven't seen null propagation before, in short, the question mark checks if the value is null, and if it is,
 			// nothing happens and no error is thrown; but if it isn't null, call the method as usual!

--- a/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Terraria;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Systems
+{
+	/// <summary>
+	/// This small ModSystem shows off the <seealso cref="ModSystem.ModifyGameTips"/> hook, which allows you to modify
+	/// the tips/hints that show up during loading screens.
+	/// </summary>
+	public class ExampleGameTipsSystem : ModSystem
+	{
+		//Set this value to the HIGHEST number for tips that appears in your localization file. For ExampleMod, it's 2.
+		public const int TipCount = 2;
+
+		public override void ModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips) {
+			//What if we want to modify Vanilla tips? There is a GameTipID built into tModLoader that should make
+			//disabling certain tips easier.
+			//For example, let's turn off the blood moon and solar eclipse tips!
+			gameTips[GameTipID.BloodMoonZombieDoorOpening].DisableVisibility();
+			gameTips[GameTipID.SolarEclipseCreepyMonsters].DisableVisibility();
+
+			//Do you just want to add your own tips? Just return a list of texts that you want to add!
+			//If you have a ton of tips within your localization file, you're going to have to create said translations yourself,
+			//since they are not autoloaded:
+			for (int i = 0; i <= TipCount; i++) {
+				LocalizationLoader.GetOrCreateTranslation(Mod, $"GameTips.ExampleTip{i}");
+			}
+
+			newTips = Language.FindAll(Lang.CreateDialogFilter("Mods.ExampleMod.GameTips.")).ToList();
+		}
+	}
+}

--- a/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Terraria;
-using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Common.Systems
@@ -12,24 +10,23 @@ namespace ExampleMod.Common.Systems
 	/// </summary>
 	public class ExampleGameTipsSystem : ModSystem
 	{
-		//Set this value to the HIGHEST number for tips that appears in your localization file. For ExampleMod, it's 2.
-		public const int TipCount = 2;
 
-		public override void ModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips) {
+		public override void ModifyGameTips(IReadOnlyList<GameTipData> gameTips) {
+			//If you wish to add your OWN tips, then you have to put them in a Localization file. Check out
+			//the GameTips key in the en-US for functionality.
+
 			//What if we want to modify Vanilla tips? There is a GameTipID built into tModLoader that should make
 			//disabling certain tips easier.
 			//For example, let's turn off the blood moon and solar eclipse tips!
 			gameTips[GameTipID.BloodMoonZombieDoorOpening].DisableVisibility();
 			gameTips[GameTipID.SolarEclipseCreepyMonsters].DisableVisibility();
 
-			//Do you just want to add your own tips? Just return a list of texts that you want to add!
-			//If you have a ton of tips within your localization file, you're going to have to create said translations yourself,
-			//since they are not autoloaded:
-			for (int i = 0; i <= TipCount; i++) {
-				LocalizationLoader.GetOrCreateTranslation(Mod, $"GameTips.ExampleTip{i}");
-			}
+			//Now, say you want to modify OTHER mod's tips? You can do that too! Make sure you use the right mod and key name.
+			GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod == "ExampleMod" && tip.ShortKey == "DisabledExampleTip");
 
-			newTips = Language.FindAll(Lang.CreateDialogFilter("Mods.ExampleMod.GameTips.")).ToList();
+			//If you haven't seen null propagation before, in short, the question mark checks if the value is null, and if it is,
+			//nothing happens and no error is thrown; but if it isn't null, call the method as usual!
+			disabledTip?.DisableVisibility();
 		}
 	}
 }

--- a/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
@@ -13,7 +13,7 @@ namespace ExampleMod.Common.Systems
 
 		public override void ModifyGameTipVisibility(IReadOnlyList<GameTipData> gameTips) {
 			// If you wish to add your OWN tips, then you have to put them in a Localization file. Check out
-			// the GameTips key in the en-US for functionality.
+			// the GameTips key in the Localization/en-US.hjson file for functionality.
 
 			// What if we want to modify Vanilla tips? There is a GameTipID built into tModLoader that should make
 			// disabling certain tips easier.
@@ -24,7 +24,7 @@ namespace ExampleMod.Common.Systems
 			// Now, say you want to modify OTHER mod's tips? You can do that too! Make sure you use the right mod and key name.
 			GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.FullName == "ExampleMod/DisabledExampleTip");
 			// Optionally, if you want to be a bit more specific with the tip name and mod name, you can also do that with the Mod and Name properties, like so:
-			// GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod.Name == "ExampleMod" && tip.Name == "DisabledExampleTip");
+			// GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod is Mod { Name: "ExampleMod" } && tip.Name == "DisabledExampleTip");
 
 			// If you haven't seen null propagation before, in short, the question mark checks if the value is null, and if it is,
 			// nothing happens and no error is thrown; but if it isn't null, call the method as usual!

--- a/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleGameTipsSystem.cs
@@ -5,28 +5,28 @@ using Terraria.ModLoader;
 namespace ExampleMod.Common.Systems
 {
 	/// <summary>
-	/// This small ModSystem shows off the <seealso cref="ModSystem.ModifyGameTips"/> hook, which allows you to modify
+	/// This small ModSystem shows off the <seealso cref="ModSystem.ModifyGameTipVisibility"/> hook, which allows you to modify
 	/// the tips/hints that show up during loading screens.
 	/// </summary>
 	public class ExampleGameTipsSystem : ModSystem
 	{
 
-		public override void ModifyGameTips(IReadOnlyList<GameTipData> gameTips) {
-			//If you wish to add your OWN tips, then you have to put them in a Localization file. Check out
-			//the GameTips key in the en-US for functionality.
+		public override void ModifyGameTipVisibility(IReadOnlyList<GameTipData> gameTips) {
+			// If you wish to add your OWN tips, then you have to put them in a Localization file. Check out
+			// the GameTips key in the en-US for functionality.
 
-			//What if we want to modify Vanilla tips? There is a GameTipID built into tModLoader that should make
-			//disabling certain tips easier.
-			//For example, let's turn off the blood moon and solar eclipse tips!
-			gameTips[GameTipID.BloodMoonZombieDoorOpening].DisableVisibility();
-			gameTips[GameTipID.SolarEclipseCreepyMonsters].DisableVisibility();
+			// What if we want to modify Vanilla tips? There is a GameTipID built into tModLoader that should make
+			// disabling certain tips easier.
+			// For example, let's turn off the blood moon and solar eclipse tips!
+			gameTips[GameTipID.BloodMoonZombieDoorOpening].Hide();
+			gameTips[GameTipID.SolarEclipseCreepyMonsters].Hide();
 
-			//Now, say you want to modify OTHER mod's tips? You can do that too! Make sure you use the right mod and key name.
+			// Now, say you want to modify OTHER mod's tips? You can do that too! Make sure you use the right mod and key name.
 			GameTipData disabledTip = gameTips.FirstOrDefault(tip => tip.Mod == "ExampleMod" && tip.ShortKey == "DisabledExampleTip");
 
-			//If you haven't seen null propagation before, in short, the question mark checks if the value is null, and if it is,
-			//nothing happens and no error is thrown; but if it isn't null, call the method as usual!
-			disabledTip?.DisableVisibility();
+			// If you haven't seen null propagation before, in short, the question mark checks if the value is null, and if it is,
+			// nothing happens and no error is thrown; but if it isn't null, call the method as usual!
+			disabledTip?.Hide();
 		}
 	}
 }

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -155,5 +155,11 @@ Mods: {
 				HiveBackpackDialogue : "Hey, if you find a {$ItemName.HiveBackpack}, my cousin can upgrade it for you."
 			}
 		}
+
+		GameTips: {
+			ExampleTip0: "Woah! Example Tip!"
+			ExampleTip1: "This tip was added by Example Mod!"
+			ExampleTip2: "This is yet another tip added by Example Mod!"
+		}
 	}
 }

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -160,6 +160,7 @@ Mods: {
 			ExampleTip0: "Woah! Example Tip!"
 			ExampleTip1: "This tip was added by Example Mod!"
 			ExampleTip2: "This is yet another tip added by Example Mod!"
+			DisabledExampleTip: "This tip will be added but then disabled by Example Mod."
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.TML.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Terraria.ModLoader;
+
+namespace Terraria.GameContent.UI
+{
+	public partial class GameTipsDisplay
+	{
+		internal List<GameTipData> vanillaTips {
+			get;
+			private set;
+		}
+		internal List<GameTipData> allTips;
+
+		internal void Initialize() {
+			vanillaTips = _tipsDefault.Concat(_tipsKeyboard).Concat(_tipsGamepad).Select(localizedText => new GameTipData(localizedText)).ToList();
+			allTips = vanillaTips.Select(tip => tip.Clone()).ToList();
+		}
+
+		internal void Reset() {
+			ClearTips();
+			allTips = vanillaTips.Select(tip => tip.Clone()).ToList();
+			_lastTip = null;
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.TML.cs
@@ -6,20 +6,16 @@ namespace Terraria.GameContent.UI
 {
 	public partial class GameTipsDisplay
 	{
-		internal List<GameTipData> vanillaTips {
-			get;
-			private set;
-		}
 		internal List<GameTipData> allTips;
 
 		internal void Initialize() {
-			vanillaTips = _tipsDefault.Concat(_tipsKeyboard).Concat(_tipsGamepad).Select(localizedText => new GameTipData(localizedText)).ToList();
-			allTips = vanillaTips.Select(tip => tip.Clone()).ToList();
+			allTips = _tipsDefault.Concat(_tipsKeyboard).Concat(_tipsGamepad).Select(localizedText => new GameTipData(localizedText)).ToList();
 		}
 
 		internal void Reset() {
 			ClearTips();
-			allTips = vanillaTips.Select(tip => tip.Clone()).ToList();
+			allTips = allTips.Where(tip => tip.Mod is null).ToList();
+			allTips.ForEach(tip => tip.isVisible = true);
 			_lastTip = null;
 		}
 	}

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
@@ -1,37 +1,24 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/GameTipsDisplay.cs
 +++ src/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs
-@@ -2,8 +_,10 @@
- using Microsoft.Xna.Framework.Graphics;
- using ReLogic.Graphics;
+@@ -4,11 +_,12 @@
  using System.Collections.Generic;
-+using System.Linq;
  using Terraria.GameInput;
  using Terraria.Localization;
 +using Terraria.ModLoader;
  using Terraria.UI.Chat;
  
  namespace Terraria.GameContent.UI
-@@ -56,6 +_,8 @@
- 			}
- 		}
- 
-+		internal readonly List<GameTipData> vanillaTips;
-+		internal List<GameTipData> allTips;
- 		private LocalizedText[] _tipsDefault;
- 		private LocalizedText[] _tipsGamepad;
- 		private LocalizedText[] _tipsKeyboard;
-@@ -67,6 +_,14 @@
+ {
+-	public class GameTipsDisplay
++	public partial class GameTipsDisplay
+ 	{
+ 		private class GameTip
+ 		{
+@@ -67,6 +_,7 @@
  			_tipsGamepad = Language.FindAll(Lang.CreateDialogFilter("LoadingTips_GamePad."));
  			_tipsKeyboard = Language.FindAll(Lang.CreateDialogFilter("LoadingTips_Keyboard."));
  			_lastTip = null;
-+			vanillaTips = _tipsDefault.Concat(_tipsKeyboard).Concat(_tipsGamepad).Select(localizedText => new GameTipData(localizedText)).ToList();
-+			allTips = new List<GameTipData>();
-+		}
-+
-+		internal void Reset() {
-+			ClearTips();
-+			allTips = new List<GameTipData>();
-+			_lastTip = null;
++			Initialize();
  		}
  
  		public void Update() {

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/GameTipsDisplay.cs
 +++ src/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs
-@@ -2,9 +_,12 @@
+@@ -2,8 +_,10 @@
  using Microsoft.Xna.Framework.Graphics;
  using ReLogic.Graphics;
  using System.Collections.Generic;
@@ -9,10 +9,8 @@
  using Terraria.Localization;
 +using Terraria.ModLoader;
  using Terraria.UI.Chat;
-+using Game = IL.Terraria.Server.Game;
  
  namespace Terraria.GameContent.UI
- {
 @@ -56,6 +_,8 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
@@ -38,9 +38,9 @@
 +			List<GameTipData> list = new List<GameTipData>();
 +			list.AddRange(allTips);
 +			if (PlayerInput.UsingGamepad)
-+				list.RemoveAll(tip => tip.Mod == "Terraria" && tip.TipText.Key.StartsWith("LoadingTips_Keyboard"));
++				list.RemoveAll(tip => tip.Mod is null && tip.TipText.Key.StartsWith("LoadingTips_Keyboard"));
 +			else
-+				list.RemoveAll(tip => tip.Mod == "Terraria" && tip.TipText.Key.StartsWith("LoadingTips_GamePad"));
++				list.RemoveAll(tip => tip.Mod is null && tip.TipText.Key.StartsWith("LoadingTips_GamePad"));
 +
 +			if (_lastTip != null)
 +				list.RemoveAll(tip => tip.TipText == _lastTip);

--- a/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs.patch
@@ -1,0 +1,69 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/GameTipsDisplay.cs
++++ src/tModLoader/Terraria/GameContent/UI/GameTipsDisplay.cs
+@@ -2,9 +_,12 @@
+ using Microsoft.Xna.Framework.Graphics;
+ using ReLogic.Graphics;
+ using System.Collections.Generic;
++using System.Linq;
+ using Terraria.GameInput;
+ using Terraria.Localization;
++using Terraria.ModLoader;
+ using Terraria.UI.Chat;
++using Game = IL.Terraria.Server.Game;
+ 
+ namespace Terraria.GameContent.UI
+ {
+@@ -56,6 +_,8 @@
+ 			}
+ 		}
+ 
++		internal readonly List<GameTipData> vanillaTips;
++		internal List<GameTipData> allTips;
+ 		private LocalizedText[] _tipsDefault;
+ 		private LocalizedText[] _tipsGamepad;
+ 		private LocalizedText[] _tipsKeyboard;
+@@ -67,6 +_,14 @@
+ 			_tipsGamepad = Language.FindAll(Lang.CreateDialogFilter("LoadingTips_GamePad."));
+ 			_tipsKeyboard = Language.FindAll(Lang.CreateDialogFilter("LoadingTips_Keyboard."));
+ 			_lastTip = null;
++			vanillaTips = _tipsDefault.Concat(_tipsKeyboard).Concat(_tipsGamepad).Select(localizedText => new GameTipData(localizedText)).ToList();
++			allTips = new List<GameTipData>();
++		}
++
++		internal void Reset() {
++			ClearTips();
++			allTips = new List<GameTipData>();
++			_lastTip = null;
+ 		}
+ 
+ 		public void Update() {
+@@ -137,6 +_,7 @@
+ 
+ 		private void AddNewTip(double currentTime) {
+ 			string textKey = "UI.Back";
++			/*
+ 			List<LocalizedText> list = new List<LocalizedText>();
+ 			list.AddRange(_tipsDefault);
+ 			if (PlayerInput.UsingGamepad)
+@@ -146,8 +_,20 @@
+ 
+ 			if (_lastTip != null)
+ 				list.Remove(_lastTip);
++			*/
++			List<GameTipData> list = new List<GameTipData>();
++			list.AddRange(allTips);
++			if (PlayerInput.UsingGamepad)
++				list.RemoveAll(tip => tip.Mod == "Terraria" && tip.TipText.Key.StartsWith("LoadingTips_Keyboard"));
++			else
++				list.RemoveAll(tip => tip.Mod == "Terraria" && tip.TipText.Key.StartsWith("LoadingTips_GamePad"));
++
++			if (_lastTip != null)
++				list.RemoveAll(tip => tip.TipText == _lastTip);
++
++			list.RemoveAll(tip => !tip.isVisible);
+ 
+-			string key = (_lastTip = ((list.Count != 0) ? list[Main.rand.Next(list.Count)] : LocalizedText.Empty)).Key;
++			string key = (_lastTip = ((list.Count != 0) ? list[Main.rand.Next(list.Count)].TipText : LocalizedText.Empty)).Key;
+ 			if (Language.Exists(key))
+ 				textKey = key;
+ 

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -14,38 +14,47 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// The name of the mod this GameTip belongs to.
-		/// For vanilla tips, this value is "Terraria"
+		/// The mod instance this tip belongs to. This value is null
+		/// for vanilla tips.
 		/// </summary>
-		public string Mod {
+		public Mod Mod {
 			get;
 			internal set;
 		}
 
 		/// <summary>
-		/// Retrieves the "short" key of this GameTip, excluding the beginning Mods.ModName.GameTips portion.
-		/// For example, if the key was "Mods.ExampleMod.GameTips.ExampleTip", this would return
-		/// "ExampleTip".
+		/// Retrieves the "name" of this GameTip, which is the Key excluding the beginning Mods.ModName.GameTips portion.
+		/// For example, if the key was "Mods.ExampleMod.GameTips.ExampleTip", this would return "ExampleTip".
 		/// </summary>
-		public string ShortKey {
+		public string Name {
+			get;
+			internal set;
+		}
+
+		/// <summary>
+		/// Retrieves the FULL "name" of this GameTip, which includes the Mod and this tip's Name.
+		/// For example, if this tip was from ExampleMod and was named "ExampleTip", this would
+		/// return "ExampleMod/ExampleTip"
+		/// </summary>
+		public string FullName {
 			get;
 			internal set;
 		}
 
 		internal bool isVisible = true;
 
-		public GameTipData(LocalizedText text, Mod mod) : this(text, mod.Name) { }
-
-		internal GameTipData(LocalizedText text, string mod) {
+		public GameTipData(LocalizedText text, Mod mod) {
 			TipText = text;
 			Mod = mod;
-			ShortKey = text.Key.Replace($"Mods.{mod}.GameTips.", "");
+			Name = text.Key.Replace($"Mods.{mod.Name}.GameTips.", "");
+			FullName = $"{Mod.Name}/{Name}";
 		}
 
 		internal GameTipData(LocalizedText text) {
 			TipText = text;
-			Mod = "Terraria";
-			ShortKey = text.Key;
+			Mod = null;
+			Name = text.Key;
+			FullName = $"Terraria/{Name}";
 		}
 
 		/// <summary>
@@ -53,13 +62,6 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public void Hide() {
 			isVisible = false;
-		}
-
-		/// <summary>
-		/// Returns a new object which is a clone of this object.
-		/// </summary>
-		public GameTipData Clone() {
-			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value), Mod);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -1,0 +1,51 @@
+﻿using Terraria.Localization;
+
+namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// Wrapper class for a LocalizedText and visibility field that has intended use with modification
+	/// of Game Tips.
+	/// </summary>
+	public sealed class GameTipData
+	{
+		public LocalizedText TipText {
+			get;
+			internal set;
+		}
+
+		/// <summary>
+		/// The name of the mod this GameTip belongs to.
+		/// For vanilla tips, this value is "Terraria"
+		/// </summary>
+		public string Mod {
+			get;
+			internal set;
+		}
+
+		internal bool isVisible = true;
+
+		public GameTipData(LocalizedText text, Mod mod) {
+			TipText = text;
+			Mod = mod.Name;
+		}
+
+		internal GameTipData(LocalizedText text) {
+			TipText = text;
+			Mod = "Terraria";
+		}
+
+		/// <summary>
+		/// Until reload, prevents this tip from ever appearing during loading screens.
+		/// </summary>
+		public void DisableVisibility() {
+			isVisible = false;
+		}
+
+		/// <summary>
+		/// Returns a new copy which is a clone of this object.
+		/// </summary>
+		public GameTipData Clone() {
+			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value));
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -34,12 +34,12 @@ namespace Terraria.ModLoader
 
 		internal bool isVisible = true;
 
-		public GameTipData(LocalizedText text, Mod mod) {
-			SetTipData(text, mod.Name);
-		}
+		public GameTipData(LocalizedText text, Mod mod) : this(text, mod.Name) { }
 
 		internal GameTipData(LocalizedText text, string mod) {
-			SetTipData(text, mod);
+			TipText = text;
+			Mod = mod;
+			ShortKey = text.Key.Replace($"Mods.{mod}.GameTips.", "");
 		}
 
 		internal GameTipData(LocalizedText text) {
@@ -51,7 +51,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// Until reload, prevents this tip from ever appearing during loading screens.
 		/// </summary>
-		public void DisableVisibility() {
+		public void Hide() {
 			isVisible = false;
 		}
 
@@ -60,12 +60,6 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public GameTipData Clone() {
 			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value), Mod);
-		}
-
-		internal void SetTipData(LocalizedText text, string mod) {
-			TipText = text;
-			Mod = mod;
-			ShortKey = text.Key.Replace($"Mods.{mod}.GameTips.", "");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -22,16 +22,30 @@ namespace Terraria.ModLoader
 			internal set;
 		}
 
+		/// <summary>
+		/// Retrieves the "short" key of this GameTip, excluding the beginning Mods.ModName.GameTip portion.
+		/// For example, if the key was "Mods.ExampleMod.GameTip.ExampleTip", this would return
+		/// "ExampleTip".
+		/// </summary>
+		public string ShortKey {
+			get;
+			internal set;
+		}
+
 		internal bool isVisible = true;
 
 		public GameTipData(LocalizedText text, Mod mod) {
-			TipText = text;
-			Mod = mod.Name;
+			SetTipData(text, mod.Name);
+		}
+
+		internal GameTipData(LocalizedText text, string mod) {
+			SetTipData(text, mod);
 		}
 
 		internal GameTipData(LocalizedText text) {
 			TipText = text;
 			Mod = "Terraria";
+			ShortKey = text.Key;
 		}
 
 		/// <summary>
@@ -45,7 +59,13 @@ namespace Terraria.ModLoader
 		/// Returns a new copy which is a clone of this object.
 		/// </summary>
 		public GameTipData Clone() {
-			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value));
+			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value), Mod);
+		}
+
+		internal void SetTipData(LocalizedText text, string mod) {
+			TipText = text;
+			Mod = mod;
+			ShortKey = text.Key.Replace($"Mods.{mod}.GameTips.", "");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -56,7 +56,7 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Returns a new copy which is a clone of this object.
+		/// Returns a new object which is a clone of this object.
 		/// </summary>
 		public GameTipData Clone() {
 			return new GameTipData(new LocalizedText(TipText.Key, TipText.Value), Mod);

--- a/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipData.cs
@@ -23,8 +23,8 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
-		/// Retrieves the "short" key of this GameTip, excluding the beginning Mods.ModName.GameTip portion.
-		/// For example, if the key was "Mods.ExampleMod.GameTip.ExampleTip", this would return
+		/// Retrieves the "short" key of this GameTip, excluding the beginning Mods.ModName.GameTips portion.
+		/// For example, if the key was "Mods.ExampleMod.GameTips.ExampleTip", this would return
 		/// "ExampleTip".
 		/// </summary>
 		public string ShortKey {

--- a/patches/tModLoader/Terraria/ModLoader/GameTipID.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipID.cs
@@ -349,7 +349,7 @@
 		/// <summary>
 		/// "Riding Minecarts is one of the best ways of getting around. You can build your own tracks, or find them Underground."
 		/// </summary>
-		public static readonly int MinecartCratingAndLocation = 68;
+		public static readonly int MinecartCraftingAndLocation = 68;
 
 		/// <summary>
 		/// "Life Crystals not enough for you? Eventually, Life Fruit will grow in the Jungle, and can give you an extra boost to your health."
@@ -384,7 +384,7 @@
 		/// <summary>
 		/// "Sometimes, enemies may even invade from other dimensions . . ."
 		/// </summary>
-		public static readonly int InterdimensionalInvasionWarning = 75;
+		public static readonly int OldOnesArmyInvasion = 75;
 
 		/// <summary>
 		/// "A Pumpkin Medallion can be used to summon the Pumpkin Moon. Spooky!"
@@ -429,7 +429,7 @@
 		/// <summary>
 		/// "If you need a new haircut, go check out a nearby Spider Biome. Stylists always end up lost in them!"
 		/// </summary>
-		public static readonly int StylistLocatio = 84;
+		public static readonly int StylistLocation = 84;
 
 		/// <summary>
 		/// "Regular Wood and Stone not vibrant enough for you? A Painter will move in and sell paints if enough townsfolk move in."
@@ -444,7 +444,7 @@
 		/// <summary>
 		/// "You could get a Witch Doctor to come to your World if you defeat the Queen Bee."
 		/// </summary>
-		public static readonly int WitchDoctorNeedsQUeenBeeToMoveIn = 87;
+		public static readonly int WitchDoctorNeedsQueenBeeToMoveIn = 87;
 
 		/// <summary>
 		/// "The Party Girl won't move in unless your World is full of other townsfolk. Afterall, what's a party without lots of guests?"

--- a/patches/tModLoader/Terraria/ModLoader/GameTipID.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GameTipID.cs
@@ -1,0 +1,665 @@
+﻿namespace Terraria.ModLoader
+{
+	/// <summary>
+	/// This class contains a more human-readable name for every single Game Tip created by Vanilla.
+	/// </summary>
+	public static class GameTipID
+	{
+
+		/// <summary>
+		/// "Other players can loot your chests! If you don't trust them, use a Safe or Piggy Bank; those items have storage that is exclusive to each player."
+		/// </summary>
+		public static readonly int UseSafeOrPiggyBank = 0;
+
+		/// <summary>
+		/// "Info accessories don't need to be equipped to provide you and nearby friends with useful information; you can just leave them in your Inventory."
+		/// </summary>
+		public static readonly int InfoAccessoriesInInventory = 1;
+
+		/// <summary>
+		/// "Rope can really help you get around while exploring caves. You can even craft it into a Rope Coil which can be thrown and automatically unfolds!"
+		/// </summary>
+		public static readonly int RopeAndRopeCoils = 2;
+
+		/// <summary>
+		/// "Mushroom Biomes can be grown above ground as well as below. Friendly Truffles will sometimes make themselves at home in Surface Mushroom Biomes."
+		/// </summary>
+		public static readonly int GlowingMushroomBiomeAndTruffles = 3;
+
+		/// <summary>
+		/// "You can change your spawn point by placing and using a bed."
+		/// </summary>
+		public static readonly int SpawnPointSettingWithBed = 4;
+
+		/// <summary>
+		/// "If you find a Magic Mirror, you can use it to teleport back to your spawn point."
+		/// </summary>
+		public static readonly int MagicMirror = 5;
+
+		/// <summary>
+		/// "There are Floating Islands in the sky."
+		/// </summary>
+		public static readonly int FloatingIslandsInSky = 6;
+
+		/// <summary>
+		/// "Sometimes you can find NPCs hidden around the World."
+		/// </summary>
+		public static readonly int BoundNPCsInWorld = 7;
+
+		/// <summary>
+		/// "During a Blood Moon, Zombies can open doors."
+		/// </summary>
+		public static readonly int BloodMoonZombieDoorOpening = 8;
+
+		/// <summary>
+		/// "Water will break your fall."
+		/// </summary>
+		public static readonly int WaterBreaksFall = 9;
+
+		/// <summary>
+		/// "Torches and Glowsticks can be a light for you in dark places when all other lights go out. Torches won't work underwater, but Glowsticks will."
+		/// </summary>
+		public static readonly int GlowsticksAndTorches = 10;
+
+		/// <summary>
+		/// "Don't fall into lava without drinking an Obsidian Skin Potion first!"
+		/// </summary>
+		public static readonly int LavaAndObsidianSkinPotion = 11;
+
+		/// <summary>
+		/// "You won't take falling damage if you have a Lucky Horseshoe. Look for them in chests underground."
+		/// </summary>
+		public static readonly int LuckyHorseshoeFallDamage = 12;
+
+		/// <summary>
+		/// "Walking on Hellstone and Meteorite can burn you! Protect yourself by equipping an Obsidian Skull or similar accessory."
+		/// </summary>
+		public static readonly int ObsidianSkullWithHellstoneOrMeteorite = 13;
+
+		/// <summary>
+		/// "Life Crystals are hidden around the World. Use them to increase your health."
+		/// </summary>
+		public static readonly int LifeCrystalsForLifeIncrease = 14;
+
+		/// <summary>
+		/// "Torches require Wood and Gel to craft. Gel can be obtained by defeating slimes."
+		/// </summary>
+		public static readonly int TorchesCrafting = 15;
+
+		/// <summary>
+		/// "Some ores require better pickaxes to mine."
+		/// </summary>
+		public static readonly int OrePickaxePowerRequirements = 16;
+
+		/// <summary>
+		/// "Bosses are easier to defeat with friends."
+		/// </summary>
+		public static readonly int BossesBetterWithFriends = 17;
+
+		/// <summary>
+		/// "Bows and guns require the proper ammo in your Ammo Slots."
+		/// </summary>
+		public static readonly int BowsAndGunsNeedAmmo = 18;
+
+		/// <summary>
+		/// "The Old Man at the Dungeon is a Clothier. If only someone could lift his curse..."
+		/// </summary>
+		public static readonly int OldManWithCurseIsClothier = 19;
+
+		/// <summary>
+		/// "Merchants love money. If you save up enough, one might move in!"
+		/// </summary>
+		public static readonly int MerchantsNeedMoneyToMoveIn = 20;
+
+		/// <summary>
+		/// "Keep an explosive in your inventory or a storage container to attract a Demolitionist to your house."
+		/// </summary>
+		public static readonly int DemolitionistNeedsExplosivesToMoveIn = 21;
+
+		/// <summary>
+		/// "Make sure you have valid housing with empty rooms, and you may attract new inhabitants to your World."
+		/// </summary>
+		public static readonly int NeedHousingForTownNPCs = 22;
+
+		/// <summary>
+		/// "When exploring, it helps to keep some Platforms on hand. They can be crafted from numerous materials such as Wood, Glass, or even Bones."
+		/// </summary>
+		public static readonly int PlatformsWhileExploring = 23;
+
+		/// <summary>
+		/// "Slay a boss to attract a Dryad to your house. She can tell you the state of Corruption, Crimson, and Hallow in your World."
+		/// </summary>
+		public static readonly int DryadNeedsBossToMoveIn = 24;
+
+		/// <summary>
+		/// "Advanced players may wish to remap their buttons; you can do this from the Controls Menu in Settings."
+		/// </summary>
+		public static readonly int ButtonRemappingInControlsMenu = 25;
+
+		/// <summary>
+		/// "Wear a Mining Helmet if you don't want to use Torches."
+		/// </summary>
+		public static readonly int MiningHelmet = 26;
+
+		/// <summary>
+		/// "You can wear Buckets on your head!"
+		/// </summary>
+		public static readonly int CanWearBucketsOnHead = 27;
+
+		/// <summary>
+		/// "Defeat the boss in The Underworld to change the World forever. Find a Guide Voodoo Doll and hurl it into the infernal lava to summon him."
+		/// </summary>
+		public static readonly int GuideVoodooDollToSummonWOF = 28;
+
+		/// <summary>
+		/// "Demon Altars and Crimson Altars can't be destroyed with a normal hammer. You have to pwn them."
+		/// </summary>
+		public static readonly int PwnHammerForAltars = 29;
+
+		/// <summary>
+		/// "Killing Bunnies is cruel. Period."
+		/// </summary>
+		public static readonly int BunnyKillingIsCruel = 30;
+
+		/// <summary>
+		/// "Falling Stars sometimes appear at night. Collect 5 of them to craft a Mana Crystal you can use to increase your Mana."
+		/// </summary>
+		public static readonly int ManaCrystalCrafting = 31;
+
+		/// <summary>
+		/// "Watch out for Meteorites!"
+		/// </summary>
+		public static readonly int WatchOutForMeteorites = 32;
+
+		/// <summary>
+		/// "A pet can be your best friend."
+		/// </summary>
+		public static readonly int PetsAreBestFriends = 33;
+
+		/// <summary>
+		/// "If you dig deep enough, you'll end up in The Underworld!"
+		/// </summary>
+		public static readonly int DigDeeperForUnderworld = 34;
+
+		/// <summary>
+		/// "Santa Claus is real. He comes to town after the Frost Legion is defeated (and 'tis the season)."
+		/// </summary>
+		public static readonly int SantaClausDuringChristmasSeason = 35;
+
+		/// <summary>
+		/// "Don't shake a Snow Globe unless you want to summon the Frost Legion."
+		/// </summary>
+		public static readonly int SnowGlobalSummonsFrostLegion = 36;
+
+		/// <summary>
+		/// "You can use Hallowed Seeds, Holy Water, or Pearlstone to make Hallow spread."
+		/// </summary>
+		public static readonly int SpredHallowWithSeedsOrWater = 37;
+
+		/// <summary>
+		/// "The Hallow is the only place where Corruption and Crimson cannot spread."
+		/// </summary>
+		public static readonly int CorruptionCantSpreadInHallow = 38;
+
+		/// <summary>
+		/// "The Corruption is full of chasms. Mind the gaps."
+		/// </summary>
+		public static readonly int CorruptionHasChasms = 39;
+
+		/// <summary>
+		/// "Time heals all wounds."
+		/// </summary>
+		public static readonly int TimeHealsWounds = 40;
+
+		/// <summary>
+		/// "You can plant Acorns to grow new trees."
+		/// </summary>
+		public static readonly int AcornsGrowTrees = 41;
+
+		/// <summary>
+		/// "Rocket science gave us Rocket Boots."
+		/// </summary>
+		public static readonly int RocketScienceAndBoots = 42;
+
+		/// <summary>
+		/// "The Cloud in a Bottle and Shiny Red Balloon accessories both improve your ability to jump. Combine them to make a Cloud in a Balloon."
+		/// </summary>
+		public static readonly int CloudInABalloonCrafting = 43;
+
+		/// <summary>
+		/// "If you store your Coins in a Chest or Piggy Bank, you will be less likely to lose them."
+		/// </summary>
+		public static readonly int StoreMoneyInBank = 44;
+
+		/// <summary>
+		/// "To craft potions, place a Bottle on a Table to make an Alchemy Station. Double, double, toil and trouble!"
+		/// </summary>
+		public static readonly int PotionCraftingWithBottle = 45;
+
+		/// <summary>
+		/// "If your house doesn't have background walls, monsters will be able to spawn inside."
+		/// </summary>
+		public static readonly int MonstersSpawnWithoutWalls = 46;
+
+		/// <summary>
+		/// "Wearing a full set of armor crafted from the same material gives you an extra bonus."
+		/// </summary>
+		public static readonly int ArmorSetBonus = 47;
+
+		/// <summary>
+		/// "Build a Furnace to craft metal bars out of ore."
+		/// </summary>
+		public static readonly int CreateMetalBarWithFurnace = 48;
+
+		/// <summary>
+		/// "You can harvest Cobwebs and turn them into Silk. You can use Silk to craft beds, sofas, and more!"
+		/// </summary>
+		public static readonly int SilkCrafting = 49;
+
+		/// <summary>
+		/// "You can buy Wires from the Mechanic and use them to create traps, pumping systems, or other elaborate devices."
+		/// </summary>
+		public static readonly int WiresFromMechanic = 50;
+
+		/// <summary>
+		/// "The Housing section of the Equipment Menu allows you to decide what rooms you want your NPCs to live in."
+		/// </summary>
+		public static readonly int HousingUIInEquipmentMenu = 51;
+
+		/// <summary>
+		/// "If you're sick of getting knocked around, try equipping a Cobalt Shield. You can find one in the Dungeon."
+		/// </summary>
+		public static readonly int CobaltShieldKnockback = 52;
+
+		/// <summary>
+		/// "Grappling Hooks are invaluable tools for exploration. Try crafting them with Hooks or gems."
+		/// </summary>
+		public static readonly int GrapplingHooksForExploration = 53;
+
+		/// <summary>
+		/// "A room in a house can have Wood Platforms as a floor or ceiling, but NPCs need at least one solid block to stand on."
+		/// </summary>
+		public static readonly int HousesCanHavePlatformFloors = 54;
+
+		/// <summary>
+		/// "You can destroy Shadow Orbs and Crimson Hearts with a hammer or explosives, but prepare yourself for the forces they unleash."
+		/// </summary>
+		public static readonly int ShadowOrbsDestruction = 55;
+
+		/// <summary>
+		/// "When dealing with a Goblin Army, crowd control is key."
+		/// </summary>
+		public static readonly int GoblinArmyCrowdControl = 56;
+
+		/// <summary>
+		/// "The best wizards around use Mana Flowers."
+		/// </summary>
+		public static readonly int WizardsUseManaFlowers = 57;
+
+		/// <summary>
+		/// "Use 'suspicious looking items' at your own risk!"
+		/// </summary>
+		public static readonly int SuspiciousItemWarning = 58;
+
+		/// <summary>
+		/// "Sand is overpowered."
+		/// </summary>
+		public static readonly int OverpoweredSand = 59;
+
+		/// <summary>
+		/// "The Goblin Tinkerer found in Underground Caverns will sell you many useful items, including a Tinkerer's Workshop."
+		/// </summary>
+		public static readonly int GoblinTinkererLocation = 60;
+
+		/// <summary>
+		/// "You can check if a room is valid housing from the Housing section of the Inventory Menu."
+		/// </summary>
+		public static readonly int ValidHousingCheckInHousingUI = 61;
+
+		/// <summary>
+		/// "Seeds can be used to grow a variety of useful ingredients for crafting potions."
+		/// </summary>
+		public static readonly int SeedsForPotionIngredients = 62;
+
+		/// <summary>
+		/// "If you get lost or need to find another player, open the World Map."
+		/// </summary>
+		public static readonly int UseMapWhenLost = 63;
+
+		/// <summary>
+		/// "If you need to remove background walls, craft a hammer!"
+		/// </summary>
+		public static readonly int CraftHammerToDestroyWalls = 64;
+
+		/// <summary>
+		/// "Got some extra walls or platforms? You can turn them back into their original materials!"
+		/// </summary>
+		public static readonly int ExtraPlatformOrWallConversion = 65;
+
+		/// <summary>
+		/// "Fishing is a fantastic source of crafting ingredients, accessories, and loot crates!"
+		/// </summary>
+		public static readonly int FishingIsLucrative = 66;
+
+		/// <summary>
+		/// "Nothing improves your mobility like Wings. Who wouldn't want to fly?"
+		/// </summary>
+		public static readonly int WingsAllowFlight = 67;
+
+		/// <summary>
+		/// "Riding Minecarts is one of the best ways of getting around. You can build your own tracks, or find them Underground."
+		/// </summary>
+		public static readonly int MinecartCratingAndLocation = 68;
+
+		/// <summary>
+		/// "Life Crystals not enough for you? Eventually, Life Fruit will grow in the Jungle, and can give you an extra boost to your health."
+		/// </summary>
+		public static readonly int LifeFruitLocation = 69;
+
+		/// <summary>
+		/// "Change your clothes in game at a Dresser or talk to the Stylist for a new hairdo."
+		/// </summary>
+		public static readonly int UseSylistForNewHair = 70;
+
+		/// <summary>
+		/// "Mounts grant the player increased mobility and a variety of useful abilities. Each one is unique!"
+		/// </summary>
+		public static readonly int MountMobilityAndUniqueness = 71;
+
+		/// <summary>
+		/// "Looking for a challenge? Try Expert mode!"
+		/// </summary>
+		public static readonly int ExpertModeChallenge = 72;
+
+		/// <summary>
+		/// "Be careful around Martian Probes. If they scan you, they'll summon a Martian Invasion!"
+		/// </summary>
+		public static readonly int MartianProbesSpawnInvasion = 73;
+
+		/// <summary>
+		/// "During a Solar Eclipse, be on the lookout for tons of strange and creepy monsters."
+		/// </summary>
+		public static readonly int SolarEclipseCreepyMonsters = 74;
+
+		/// <summary>
+		/// "Sometimes, enemies may even invade from other dimensions . . ."
+		/// </summary>
+		public static readonly int InterdimensionalInvasionWarning = 75;
+
+		/// <summary>
+		/// "A Pumpkin Medallion can be used to summon the Pumpkin Moon. Spooky!"
+		/// </summary>
+		public static readonly int PumpkingMoonStarting = 76;
+
+		/// <summary>
+		/// "Feeling up for the chill of winter? Use a Naughty Present to summon the Frost Moon!"
+		/// </summary>
+		public static readonly int FrostMoonStarting = 77;
+
+		/// <summary>
+		/// "When a Sandstorm hits, deserts can be very dangerous. New enemies, reduced visibility, and it can even be hard to move!"
+		/// </summary>
+		public static readonly int SandstormWarning = 78;
+
+		/// <summary>
+		/// "The Arms Dealer knows more about guns than anyone. If you find one, he might move in."
+		/// </summary>
+		public static readonly int ArmsDealerNeedsGunToMoveIn = 79;
+
+		/// <summary>
+		/// "The Mechanic got lost in the Dungeon. You'll have to help her out if you want her to move in."
+		/// </summary>
+		public static readonly int MechanicLocation = 80;
+
+		/// <summary>
+		/// "Once you use a Life Crystal, a Nurse might move in! Speak to her for healing at any time . . . for a price, of course."
+		/// </summary>
+		public static readonly int NurseNeedsLifeCrystalToMoveIn = 81;
+
+		/// <summary>
+		/// "If you ever want to get stylish, try dyes! The Dye Trader can help you turn some materials into new dye colors."
+		/// </summary>
+		public static readonly int DyesFromDyeTrader = 82;
+
+		/// <summary>
+		/// "The Tavernkeep is a guest from a faraway land called Etheria."
+		/// </summary>
+		public static readonly int TavernkeepOrigins = 83;
+
+		/// <summary>
+		/// "If you need a new haircut, go check out a nearby Spider Biome. Stylists always end up lost in them!"
+		/// </summary>
+		public static readonly int StylistLocatio = 84;
+
+		/// <summary>
+		/// "Regular Wood and Stone not vibrant enough for you? A Painter will move in and sell paints if enough townsfolk move in."
+		/// </summary>
+		public static readonly int PainterNeedsOtherNPCsToMoveIn = 85;
+
+		/// <summary>
+		/// "It's worth it to explore your Oceans. You can find treasure, dyes, and even sleeping fishermen."
+		/// </summary>
+		public static readonly int ExploreTheOceans = 86;
+
+		/// <summary>
+		/// "You could get a Witch Doctor to come to your World if you defeat the Queen Bee."
+		/// </summary>
+		public static readonly int WitchDoctorNeedsQUeenBeeToMoveIn = 87;
+
+		/// <summary>
+		/// "The Party Girl won't move in unless your World is full of other townsfolk. Afterall, what's a party without lots of guests?"
+		/// </summary>
+		public static readonly int PartyGirlNeedsOtherNPCsToMoveIn = 88;
+
+		/// <summary>
+		/// "The Wizard sells some useful magic artifacts, but he has a tendency to wander off Underground."
+		/// </summary>
+		public static readonly int WizardLocation = 89;
+
+		/// <summary>
+		/// "The Tax Collector spends his days wandering the Underworld as a Tortured Soul. If only there were a way to purify him . . ."
+		/// </summary>
+		public static readonly int TaxCollectorNeedsToBePurified = 90;
+
+		/// <summary>
+		/// "Pirates are so unpredictable. First they invade your world, and then they move into your houses!"
+		/// </summary>
+		public static readonly int PirateInvasionAndTownNPC = 91;
+
+		/// <summary>
+		/// "If you ever defeat any giant robots, a Steampunker might move in to your World."
+		/// </summary>
+		public static readonly int SteampunkerNeedsMechDeadToMoveIn = 92;
+
+		/// <summary>
+		/// "If you like rockets, the Cyborg may have some for sale."
+		/// </summary>
+		public static readonly int CyborgSellsRockets = 93;
+
+		/// <summary>
+		/// "The Traveling Merchant never stays in one place for long, but he always brings different wares when he visits!"
+		/// </summary>
+		public static readonly int TravellingMerchantStaysTemporarily = 94;
+
+		/// <summary>
+		/// "Not all Skeletons are evil. Some are even known to sell unique items to those that can find them."
+		/// </summary>
+		public static readonly int BoneMerchantLocation = 95;
+
+		/// <summary>
+		/// "Not sure what to do next? Take a look at the Achievement Guide for a clue!"
+		/// </summary>
+		public static readonly int UseAchievementGuideForHelp = 96;
+
+		/// <summary>
+		/// "If an enemy steals your money after you die in Expert Mode, hunt it down! If you defeat it, you can get your money back."
+		/// </summary>
+		public static readonly int MoneyStealingInExpertMode = 97;
+
+		/// <summary>
+		/// "With the Block Swap mechanic enabled, you can replace one block with another directly, rather than having to mine it first."
+		/// </summary>
+		public static readonly int BlockSwapUsage = 98;
+
+		/// <summary>
+		/// "Keep an eye out for Goodie Bags around Halloween. If you open them, you can find all sorts of spooky items.  Trick or Treat!"
+		/// </summary>
+		public static readonly int GoodieBagsDuringHalloween = 99;
+
+		/// <summary>
+		/// "Clouds are nice and soft, and you won't get hurt falling on them no matter how far you fall."
+		/// </summary>
+		public static readonly int CloudsPreventFallDamage = 100;
+
+		/// <summary>
+		/// "Did you know you can order your Summons to attack a specific target? While holding a Summoning Weapon, Right Click an enemy!"
+		/// </summary>
+		public static readonly int SummonerTargeting = 101;
+
+		/// <summary>
+		/// "Press the + and - keys to zoom in &amp; out! Focus on what matters!"
+		/// </summary>
+		public static readonly int CameraZoomFunctionality = 102;
+
+		/// <summary>
+		/// "Have something on the Map to show a friend? Double click on the Map to ping a location for everyone to see!"
+		/// </summary>
+		public static readonly int MapPinging = 103;
+
+		/// <summary>
+		/// "The Void Bag is a magical artifact that will store items for you when your inventory is full."
+		/// </summary>
+		public static readonly int VoidBagUsage = 104;
+
+		/// <summary>
+		/// "Enemies aren't the only danger when exploring Underground. Watch out for traps too!"
+		/// </summary>
+		public static readonly int TrapWarning = 105;
+
+		/// <summary>
+		/// "Find a cool new Material?  Want to know what you can make?  Check with your friendly neighborhood Guide!"
+		/// </summary>
+		public static readonly int AskGuideForCraftingRecipes = 106;
+
+		/// <summary>
+		/// "Have some NPCs perished?  Don't worry, they'll be back in the morning."
+		/// </summary>
+		public static readonly int NPCsWillRespawn = 107;
+
+		/// <summary>
+		/// "Explosives are dangerous!\n...and effective..."
+		/// </summary>
+		public static readonly int ExplosivesAreDangerous = 108;
+
+		/// <summary>
+		/// "You can continuously use some items by holding down the {InputTrigger_UseOrAttack} button."
+		/// </summary>
+		public static readonly int KeyboardAutoReuse = 109;
+
+		/// <summary>
+		/// "Press {InputTrigger_SmartCursor} to switch between Cursor Modes."
+		/// </summary>
+		public static readonly int KeyboardCursorMode = 110;
+
+		/// <summary>
+		/// "If your Inventory is full, you can press {InputTriggerUI_Trash} and {InputTrigger_UseOrAttack} to send items to the Trash."
+		/// </summary>
+		public static readonly int KeyboardTrash = 111;
+
+		/// <summary>
+		/// "When speaking to a vendor, you can sell items in your Inventory by pressing {InputTriggerUI_Trash} and {InputTrigger_UseOrAttack}."
+		/// </summary>
+		public static readonly int KeyboardQuickSelling = 112;
+
+		/// <summary>
+		/// "You can remove Torches with {InputTrigger_InteractWithTile} or with a pickaxe."
+		/// </summary>
+		public static readonly int KeyboardTorchRemoval = 113;
+
+		/// <summary>
+		/// "In your Inventory, you can press {InputTrigger_InteractWithTile} to equip items such as armor or accessories directly to a usable slot."
+		/// </summary>
+		public static readonly int KeyboardQuickEquip = 114;
+
+		/// <summary>
+		/// "Hold {InputTrigger_SmartSelect} to use Auto Select, a versatile feature that adapts to your environment. It will allow you to automatically hold your Torches in dark caves, Glowsticks when underwater, or even select the right tool for breaking something."
+		/// </summary>
+		public static readonly int KeyboardAutoSelect = 115;
+
+		/// <summary>
+		/// "Press {InputTriggerUI_FavoriteItem} and {InputTrigger_UseOrAttack} to Favorite an item. Favorited items can no longer be sold, thrown away, or dropped. No more accidentally losing your favorite items!"
+		/// </summary>
+		public static readonly int KeyboardFavoriting = 116;
+
+		/// <summary>
+		/// "You can assign your favorite items to the DPad for rapid use by enabling DPad Hotbar in Gamepad Settings!"
+		/// </summary>
+		public static readonly int GamePadDPadFavoriting = 117;
+
+		/// <summary>
+		/// "You can continuously use some items by holding down the {InputTrigger_UseOrAttack} button."
+		/// </summary>
+		public static readonly int GamePadAutoReuse = 118;
+
+		/// <summary>
+		/// "Press {InputTrigger_SmartCursor} to switch between Cursor Modes."
+		/// </summary>
+		public static readonly int GamePadCursorMode = 119;
+
+		/// <summary>
+		/// "If your Inventory is full, you can press {InputTriggerUI_Trash} to send items to the Trash."
+		/// </summary>
+		public static readonly int GamePadTrash = 120;
+
+		/// <summary>
+		/// "When speaking to a vendor, you can sell items in your Inventory by pressing {InputTriggerUI_SellItem}."
+		/// </summary>
+		public static readonly int GamePadQuickSelling = 121;
+
+		/// <summary>
+		/// "You can remove Torches with {InputTrigger_InteractWithTile} or with a pickaxe."
+		/// </summary>
+		public static readonly int GamePadTorchRemoval = 122;
+
+		/// <summary>
+		/// "In your Inventory, you can press {InputTrigger_QuickEquip} to equip items such as armor or accessories directly to a usable slot."
+		/// </summary>
+		public static readonly int GamePadQuickEquip = 123;
+
+		/// <summary>
+		/// "Hold {InputTrigger_SmartSelect} to use Auto Select, a versatile feature that adapts to your environment. It will allow you to automatically hold your Torches in dark caves, Glowsticks when underwater, or even select the right tool for breaking something."
+		/// </summary>
+		public static readonly int GamePadAutoSelect = 124;
+
+		/// <summary>
+		/// "Press {InputTriggerUI_FavoriteItem} to Favorite an item. Favorited items can no longer be sold, thrown away, or dropped. No more accidentally losing your favorite items!"
+		/// </summary>
+		public static readonly int GamePadFavoriting = 125;
+
+		/// <summary>
+		/// "While navigating your Inventory, press {InputTriggerUI_BuildFromInventory} while highlighting a tool or block to build directly from your Inventory."
+		/// </summary>
+		public static readonly int GamePadInventoryBuilding = 126;
+
+		/// <summary>
+		/// "Hold {InputTrigger_RadialQuickbar} and {InputTrigger_RadialHotbar} to bring up the Radial Quickbar and Radial Hotbar menus. These will allow you to quickly access potions, mounts, and the items in your hotbar."
+		/// </summary>
+		public static readonly int GamePadRadialHotbar = 127;
+
+		/// <summary>
+		/// "There are multiple Gamepad control layouts available in the menu. Choose from Redigit's Pick, Yoraiz0r's Pick, Xbox, Playstation, or even make your own Custom settings!"
+		/// </summary>
+		public static readonly int GamePadControlLayouts = 128;
+
+		/// <summary>
+		/// "If you select DPad Cursor Snap in the Gamepad settings, you can use the DPad for improved precision when mining or building."
+		/// </summary>
+		public static readonly int GamePadCursorSnap = 129;
+
+		/// <summary>
+		/// "When using Gamepad, you can lock on to enemies by pressing {InputTrigger_LockOn}. Locked on targets will be marked by a spinning reticle, and long range weapons will automatically aim at your target!"
+		/// </summary>
+		public static readonly int GamePadEnemyLockOn = 130;
+
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -60,6 +60,11 @@ namespace Terraria.ModLoader
 
 			foreach (var value in modTranslationDictionary.Values) {
 				AddTranslation(value);
+
+				//This must be manually added here, since we need to know what mod is added in order to add GameTipData.
+				if (value.Key.StartsWith($"Mods.{mod.Name}.GameTips.")) {
+					Main.gameTips.allTips.Add(new GameTipData(new LocalizedText(value.Key, value.GetDefault()), mod));
+				}
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -334,8 +334,8 @@ namespace Terraria.ModLoader
 
 			Main.player[255] = new Player();
 
-			Main.gameTips.allTips = SystemLoader.ModifyGameTips(Main.gameTips.vanillaTips);
 			LocalizationLoader.RefreshModLanguage(Language.ActiveCulture);
+			Main.gameTips.allTips = SystemLoader.ModifyGameTips(Main.gameTips.allTips);
 
 			MapLoader.SetupModMap();
 			PlantLoader.SetupPlants();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -334,6 +334,7 @@ namespace Terraria.ModLoader
 
 			Main.player[255] = new Player();
 
+			Main.gameTips.allTips = SystemLoader.ModifyGameTips(Main.gameTips.vanillaTips);
 			LocalizationLoader.RefreshModLanguage(Language.ActiveCulture);
 
 			MapLoader.SetupModMap();
@@ -492,6 +493,7 @@ namespace Terraria.ModLoader
 			CustomCurrencyManager.Initialize();
 			EffectsTracker.RemoveModEffects();
 			Main.MapIcons = new MapIconOverlay().AddLayer(new SpawnMapLayer()).AddLayer(new TeleportPylonsMapLayer()).AddLayer(Main.Pings);
+			Main.gameTips.Reset();
 
 			// ItemID.Search = IdDictionary.Create<ItemID, short>();
 			// NPCID.Search = IdDictionary.Create<NPCID, short>();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -335,7 +335,7 @@ namespace Terraria.ModLoader
 			Main.player[255] = new Player();
 
 			LocalizationLoader.RefreshModLanguage(Language.ActiveCulture);
-			Main.gameTips.allTips = SystemLoader.ModifyGameTipVisibility(Main.gameTips.allTips);
+			SystemLoader.ModifyGameTipVisibility(Main.gameTips.allTips);
 
 			MapLoader.SetupModMap();
 			PlantLoader.SetupPlants();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -335,7 +335,7 @@ namespace Terraria.ModLoader
 			Main.player[255] = new Player();
 
 			LocalizationLoader.RefreshModLanguage(Language.ActiveCulture);
-			Main.gameTips.allTips = SystemLoader.ModifyGameTips(Main.gameTips.allTips);
+			Main.gameTips.allTips = SystemLoader.ModifyGameTipVisibility(Main.gameTips.allTips);
 
 			MapLoader.SetupModMap();
 			PlantLoader.SetupPlants();

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -212,14 +212,11 @@ namespace Terraria.ModLoader
 		public virtual void ModifyInterfaceLayers(List<GameInterfaceLayer> layers) { }
 
 		/// <summary>
-		/// Allows you to set the visibility of any added gameTips as well as add your own. You can only disable GameTips; once one is disabled,
-		/// you cannot re-enable it.
+		/// Allows you to set the visibility of any added vanilla or modded GameTips. In order to add your OWN tips, add them in
+		/// your localization file, with the key prefix of "Mods.ModName.GameTips".
 		/// </summary>
 		/// <param name="gameTips"> The current list of all added game tips. </param>
-		/// <param name="newTips"> A list of all of the localized texts pertaining to the tips you wish to add. </param>
-		public virtual void ModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips) {
-			newTips = new List<LocalizedText>();
-		}
+		public virtual void ModifyGameTips(IReadOnlyList<GameTipData> gameTips) { }
 
 		/// <summary>
 		/// Called after interface is drawn but right before mouse and mouse hover text is drawn. Allows for drawing interface.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -216,7 +216,7 @@ namespace Terraria.ModLoader
 		/// your localization file, with the key prefix of "Mods.ModName.GameTips".
 		/// </summary>
 		/// <param name="gameTips"> The current list of all added game tips. </param>
-		public virtual void ModifyGameTips(IReadOnlyList<GameTipData> gameTips) { }
+		public virtual void ModifyGameTipVisibility(IReadOnlyList<GameTipData> gameTips) { }
 
 		/// <summary>
 		/// Called after interface is drawn but right before mouse and mouse hover text is drawn. Allows for drawing interface.

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -212,6 +212,16 @@ namespace Terraria.ModLoader
 		public virtual void ModifyInterfaceLayers(List<GameInterfaceLayer> layers) { }
 
 		/// <summary>
+		/// Allows you to set the visibility of any added gameTips as well as add your own. You can only disable GameTips; once one is disabled,
+		/// you cannot re-enable it.
+		/// </summary>
+		/// <param name="gameTips"> The current list of all added game tips. </param>
+		/// <param name="newTips"> A list of all of the localized texts pertaining to the tips you wish to add. </param>
+		public virtual void ModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips) {
+			newTips = new List<LocalizedText>();
+		}
+
+		/// <summary>
 		/// Called after interface is drawn but right before mouse and mouse hover text is drawn. Allows for drawing interface.
 		///
 		/// Note: This hook should no longer be used. It is better to use the ModifyInterfaceLayers hook.

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -55,6 +55,8 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateModifyLightingBrightness(ref float scale);
 
+		private delegate void DelegateModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips);
+
 		private delegate void DelegatePreDrawMapIconOverlay(IReadOnlyList<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext);
 
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
@@ -136,6 +138,8 @@ namespace Terraria.ModLoader
 		private static HookList HookPostUpdateEverything = AddHook<Action>(s => s.PostUpdateEverything);
 
 		private static HookList HookModifyInterfaceLayers = AddHook<Action<List<GameInterfaceLayer>>> (s => s.ModifyInterfaceLayers);
+
+		private static HookList HookModifyGameTips = AddHook<DelegateModifyGameTips>(s => s.ModifyGameTips);
 
 		private static HookList HookPostDrawInterface = AddHook<Action<SpriteBatch>>(s => s.PostDrawInterface);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -55,8 +55,6 @@ namespace Terraria.ModLoader
 
 		private delegate void DelegateModifyLightingBrightness(ref float scale);
 
-		private delegate void DelegateModifyGameTips(IReadOnlyList<GameTipData> gameTips, out List<LocalizedText> newTips);
-
 		private delegate void DelegatePreDrawMapIconOverlay(IReadOnlyList<IMapLayer> layers, MapOverlayDrawContext mapOverlayDrawContext);
 
 		private delegate void DelegatePostDrawFullscreenMap(ref string mouseText);
@@ -139,7 +137,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookModifyInterfaceLayers = AddHook<Action<List<GameInterfaceLayer>>> (s => s.ModifyInterfaceLayers);
 
-		private static HookList HookModifyGameTips = AddHook<DelegateModifyGameTips>(s => s.ModifyGameTips);
+		private static HookList HookModifyGameTips = AddHook<Action<IReadOnlyList<GameTipData>>>(s => s.ModifyGameTips);
 
 		private static HookList HookPostDrawInterface = AddHook<Action<SpriteBatch>>(s => s.PostDrawInterface);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -137,7 +137,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookModifyInterfaceLayers = AddHook<Action<List<GameInterfaceLayer>>> (s => s.ModifyInterfaceLayers);
 
-		private static HookList HookModifyGameTips = AddHook<Action<IReadOnlyList<GameTipData>>>(s => s.ModifyGameTips);
+		private static HookList HookModifyGameTipVisibility = AddHook<Action<IReadOnlyList<GameTipData>>>(s => s.ModifyGameTipVisibility);
 
 		private static HookList HookPostDrawInterface = AddHook<Action<SpriteBatch>>(s => s.PostDrawInterface);
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -336,13 +336,12 @@ namespace Terraria.ModLoader
 		}
 
 		public static List<GameTipData> ModifyGameTips(List<GameTipData> gameTips) {
-			List<GameTipData> tips = gameTips.Select(gameTipData => gameTipData.Clone()).ToList();
+			IReadOnlyList<GameTipData> tips = gameTips.Select(gameTipData => gameTipData.Clone()).ToList().AsReadOnly();
 			foreach (var system in HookModifyGameTips.arr) {
-				system.ModifyGameTips(tips.AsReadOnly(), out List<LocalizedText> newTips);
-				tips.AddRange(newTips.Select(localizedText => new GameTipData(localizedText)));
+				system.ModifyGameTips(tips);
 			}
 
-			return tips;
+			return tips.ToList();
 		}
 
 		public static void PostDrawInterface(SpriteBatch spriteBatch) {

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -335,10 +335,10 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static List<GameTipData> ModifyGameTips(List<GameTipData> gameTips) {
-			IReadOnlyList<GameTipData> tips = gameTips.Select(gameTipData => gameTipData.Clone()).ToList().AsReadOnly();
-			foreach (var system in HookModifyGameTips.arr) {
-				system.ModifyGameTips(tips);
+		public static List<GameTipData> ModifyGameTipVisibility(List<GameTipData> gameTips) {
+			IReadOnlyList<GameTipData> tips = gameTips.AsReadOnly();
+			foreach (var system in HookModifyGameTipVisibility.arr) {
+				system.ModifyGameTipVisibility(tips);
 			}
 
 			return tips.ToList();

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Terraria.Graphics;
 using Terraria.IO;
 using Terraria.Localization;
@@ -332,6 +333,16 @@ namespace Terraria.ModLoader
 			foreach (var system in HookModifyInterfaceLayers.arr) {
 				system.ModifyInterfaceLayers(layers);
 			}
+		}
+
+		public static List<GameTipData> ModifyGameTips(List<GameTipData> gameTips) {
+			List<GameTipData> tips = gameTips.Select(gameTipData => gameTipData.Clone()).ToList();
+			foreach (var system in HookModifyGameTips.arr) {
+				system.ModifyGameTips(tips.AsReadOnly(), out List<LocalizedText> newTips);
+				tips.AddRange(newTips.Select(localizedText => new GameTipData(localizedText)));
+			}
+
+			return tips;
 		}
 
 		public static void PostDrawInterface(SpriteBatch spriteBatch) {

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -335,13 +335,10 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static List<GameTipData> ModifyGameTipVisibility(List<GameTipData> gameTips) {
-			IReadOnlyList<GameTipData> tips = gameTips.AsReadOnly();
+		public static void ModifyGameTipVisibility(IReadOnlyList<GameTipData> tips) {
 			foreach (var system in HookModifyGameTipVisibility.arr) {
 				system.ModifyGameTipVisibility(tips);
 			}
-
-			return tips.ToList();
 		}
 
 		public static void PostDrawInterface(SpriteBatch spriteBatch) {


### PR DESCRIPTION
### What is the new feature?

The ability to hide vanilla game tips (which appear during loading screens), as well as the ability for mods to add their own. 

### Why should this be part of tModLoader?

Currently there is no way to add game tips or hide/remove vanilla tips without some kind of IL editing or detouring, which can become problematic if multiple mods attempt to do so.

### Are there alternative designs?

A system using a `bool?` value was discussed as a potential alternative, with similar capabilities.

### Sample usage for the new feature

Check ExampleMod's ExampleGameTipsSystem.cs
