### PR TITLE
Mod API proxying

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -242,6 +242,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Used for strongly-typed or duck-typed inter-mod communication. This allows you to interact with other mods without having to reference their types or namespaces, provided that they have implemented this method.<br/>
+		/// The <see href="https://github.com/tModLoader/tModLoader/wiki/Expert-Cross-Mod-Content">Expert Cross Mod Content Guide</see> explains how to use this hook to implement and utilize cross-mod capabilities.
+		/// </summary>
+		protected internal virtual object GetAPI()
+		{
+			return null;
+		}
+
+		/// <summary>
 		/// Creates a ModPacket object that you can write to and then send between servers and clients.
 		/// </summary>
 		/// <param name="capacity">The capacity.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -17,6 +17,8 @@ using Terraria.Initializers;
 using Terraria.ModLoader.Assets;
 using ReLogic.Content;
 using System.Runtime.CompilerServices;
+using Nanoray.Pintail;
+using System.Reflection.Emit;
 
 namespace Terraria.ModLoader
 {
@@ -48,6 +50,14 @@ namespace Terraria.ModLoader
 		public static string ModPath => ModOrganizer.modPath;
 
 		private static readonly IDictionary<string, Mod> modsByName = new Dictionary<string, Mod>(StringComparer.OrdinalIgnoreCase);
+		private static readonly Lazy<IProxyManager<string>> proxyManager = new(() => {
+			AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName($"Terraria.ModLoader.Proxies, Version={typeof(ModLoader).Assembly.GetName().Version}, Culture=neutral"), AssemblyBuilderAccess.Run);
+			ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("Terraria.ModLoader.Proxies");
+			return new ProxyManager<string>(moduleBuilder, new ProxyManagerConfiguration<string>(
+				proxyPrepareBehavior: ProxyManagerProxyPrepareBehavior.Eager,
+				proxyObjectInterfaceMarking: ProxyObjectInterfaceMarking.MarkerWithProperty
+			));
+		});
 
 		internal static readonly string modBrowserPublicKey = "<RSAKeyValue><Modulus>oCZObovrqLjlgTXY/BKy72dRZhoaA6nWRSGuA+aAIzlvtcxkBK5uKev3DZzIj0X51dE/qgRS3OHkcrukqvrdKdsuluu0JmQXCv+m7sDYjPQ0E6rN4nYQhgfRn2kfSvKYWGefp+kqmMF9xoAq666YNGVoERPm3j99vA+6EIwKaeqLB24MrNMO/TIf9ysb0SSxoV8pC/5P/N6ViIOk3adSnrgGbXnFkNQwD0qsgOWDks8jbYyrxUFMc4rFmZ8lZKhikVR+AisQtPGUs3ruVh4EWbiZGM2NOkhOCOM4k1hsdBOyX2gUliD0yjK5tiU3LBqkxoi2t342hWAkNNb4ZxLotw==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>";
 		internal static string modBrowserPassphrase = "";
@@ -82,6 +92,35 @@ namespace Terraria.ModLoader
 		/// <summary> Safely checks whether or not a mod with the specified internal name is currently loaded. </summary>
 		/// <returns> Whether or not a mod with the provided internal name has been found. </returns>
 		public static bool HasMod(string name) => modsByName.ContainsKey(name);
+
+		public static TInterface GetAPI<TInterface>(string name) where TInterface : class
+		{
+			// get mod
+			if (!TryGetMod(name, out Mod mod))
+				return null;
+
+			// get raw API
+			object api = mod.GetAPI();
+			if (api is null)
+				return null;
+
+			// validate mapping
+			if (!typeof(TInterface).IsInterface)
+			{
+				Logging.tML.Error($"Tried to map a mod-provided API to class '{typeof(TInterface).FullName}'; must be a public interface.");
+				return null;
+			}
+			if (!typeof(TInterface).IsPublic)
+			{
+				Logging.tML.Error($"Tried to map a mod-provided API to non-public interface '{typeof(TInterface).FullName}'; must be a public interface.");
+				return null;
+			}
+
+			// get API of type
+			return api is TInterface castApi
+				? castApi
+				: proxyManager.Value.ObtainProxy<string, TInterface>(api, targetContext: mod.GetType().Assembly.GetName().FullName, proxyContext: typeof(TInterface).Assembly.GetName().FullName);
+		}
 
 		internal static void EngineInit()
 		{

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -53,7 +53,7 @@
      <EmbeddedResource Include="GameContent/Creative/Content/*" />
      <EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
      <EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -46,18 +_,30 @@
+@@ -46,18 +_,31 @@
    <ItemGroup>
      <Compile Remove="Social/WeGame/AsyncTaskHelper.cs" />
      <Compile Remove="Social/WeGame/CurrentThreadRunner.cs" />
@@ -70,6 +70,7 @@
 +    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
 +    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
 +    <PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5 " />
++    <PackageReference Include="Pintail" Version="2.2.0" />
      <PackageReference Include="Steamworks.NET" Version="20.1.0" />
 +    <PackageReference Include="System.CodeDom" Version="6.0.0" />
 +    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />


### PR DESCRIPTION
Before anything else, I'll just say, that:
***~~I did not test this functionality with any tModLoader mods. I only checked if it builds.~~ I'm not exactly willing to come back for real to the Terraria modding scene, so I left it at that. The library that is leveraged here is already in use in a modding API for another game, Stardew Valley, and the related (super minimal) code was simply ported to tML.***

### What is the new feature?
This PR implements "mod API proxies". It leverages a library I created (called Pintail) to create proxies for arbitrary objects.

[Pintail's repository](https://github.com/Nanoray-pl/Pintail)

The library allows providing strongly-typed and/or duck-typed API (depending on the usage), without losing the benefit of not requiring the providing mod. The providing mod does not have to be referenced at all, not even as a weak dependency.

You provide an object you want to proxy, and a proxy interface type (it specifically has to be an interface). Pintail will generate a new type, that implements that interface, by delegating all of the method calls to the proxied object. The methods' bodies are built by emitting IL instructions.

The library is currently being used in the stable version of SMAPI, the modding API for Stardew Valley.
[SMAPI's website](https://smapi.io/)
[SMAPI's repository](https://github.com/Pathoschild/SMAPI)

Implementation in SMAPI:
[ModRegistryHelper.cs](https://github.com/Pathoschild/SMAPI/blob/a8a4d314dff1f80970090e9d364f36e787df73d6/src/SMAPI/Framework/ModHelpers/ModRegistryHelper.cs#L59-L101)
[InterfaceProxyFactory.cs](https://github.com/Pathoschild/SMAPI/blob/a8a4d314dff1f80970090e9d364f36e787df73d6/src/SMAPI/Framework/Reflection/InterfaceProxyFactory.cs)

Before Pintail was a thing, SMAPI used the same approach, but in a super simplified form (the APIs could only use types known by both parties) - I'm not sure for how long, but I've seen mods that are at least 2 years old, providing an API. This is the generally agreed upon standard in that community - it's either that or strong DLL references.

Nowadays, Pintail has been in use in stable builds for about 2 months I think, with barely any problems (one of those being a super edge case which only 1 mod ran into - fixed by now; the second of those was a minor problem which could be worked around on the mod side - also fixed already).

Actual usage of this feature looks like this:
* A providing mod returns some kind of object in its `Mod.GetAPI` method. It doesn't really matter what that object is - it can even be `this` (this happens a lot in the Stardew modding scene for the smaller mods). The important part is that only `public` methods can be proxied and accessed by other mods.
* A consuming mod that wants to access this API creates an interface, with methods matching the providing mod's API methods.
* The consuming mod calls `ModLoader.GetAPI<LatterMod.TheNewInterfaceWeJustMade>("<providing mod's name>")`
* The method returns null if the mod is not loaded or the proxy couldn't be created; otherwise it returns an `LatterMod.TheNewInterfaceWeJustMade` instance.
* The consuming mod can call any of the methods it defined. All the types that match get passed directly. Any other types get proxied.

Types and features that work with proxying (the ones I could at least remember about, I've probably forgotten about some):
* Any types both of the sides know (no proxying happening here)
* Types in "out" positions (result type, out parameters)
* Types in "in" positions (normal parameters)
* Types in "in/out" positions (ref parameters)
* Specialized enum handling - mapping enums by their `int` values (currently only enums with the `int` underlying type are supported, but this is the default, so not really a problem)
* Specialized array handling - they act kind of like an "in/out" position, but with special validation (they're still a pain in the ass to use though, I suggest using `IList<>` instead)
* Specialized "reconstructable" type handling - basically any type that has a Deconstruct method with a matching constructor - this makes Dictionary `KeyValuePair`s work with this system, which in turn also allows proxying `IDictionary<>`

Currently Pintail does not have any documentation, other than XML docs (which should be 100% complete for all public types).
There are a lot of unit tests, you can find them [here](https://github.com/Nanoray-pl/Pintail/tree/master/PintailTests).

### Why should this be part of tModLoader?

`Mod.Call` is a way of providing similar APIs right now, but it's super painful to use - both on the providing and consuming side. The providing side has to check what kind of call it received and cast the received arguments to proper types. This is error-prone and can cause exceptions to be thrown if anything doesn't match (types or number of arguments), or requires a lot of validation code. Additionally, the IDE cannot help you in any way, as it straight up doesn't know what's the correct type. The consuming side ALSO has to cast the result to the proper type, so same issues here.

### Are there alternative designs?

I don't know, you tell me

### Sample usage for the new feature

While I don't have any tML-specific examples, I can post several Stardew mod examples, that are already released and working without any issues.

[Project Fluent - main mod class](https://github.com/Shockah/Stardew-Valley-Mods/blob/2415c38f2d238444b473308096d3a83107c6459f/ProjectFluent/ProjectFluent.cs#L81)
[Project Fluent - the type whose instance we proxy in this case](https://github.com/Shockah/Stardew-Valley-Mods/blob/master/ProjectFluent/FluentApi.cs)
[Project Fluent - the interface on the API provider's side](https://github.com/Shockah/Stardew-Valley-Mods/blob/master/ProjectFluent/PublicAPI/IFluentApi.cs) (+ some other types in the same directory)
[Predictable Retaining Soil - the interface blueprint for which to create the proxy](https://github.com/Shockah/Stardew-Valley-Mods/blob/712f586a42e451216dd4e1c66f3725a67fd72be0/PredictableRetainingSoil/APIs/IFluentApi.cs)
[Predictable Retaining Soil - usage on the API consumer's side](https://github.com/Shockah/Stardew-Valley-Mods/blob/712f586a42e451216dd4e1c66f3725a67fd72be0/PredictableRetainingSoil/PredictableRetainingSoil.cs#L75-L76)
Note that the interface on the API provider's side is completely optional - it is only provided for the ease of use by potential consumers (just copy over the interface to your own mod's code and you can use it).

### ExampleMod updates
~~I did not update the ExampleMod.~~
The next comment has relevant links.