### PR TITLE
[1.4] NPC Dialogue Fixes Followup

### DIFF
--- a/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatManager.cs.patch
@@ -1,18 +1,20 @@
 --- src/TerrariaNetCore/Terraria/UI/Chat/ChatManager.cs
 +++ src/tModLoader/Terraria/UI/Chat/ChatManager.cs
-@@ -256,6 +_,12 @@
- 			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
- 		}
+@@ -253,7 +_,13 @@
  
+ 		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, TextSnippet[] snippets, Vector2 position, float rotation, Color color, Vector2 origin, Vector2 baseScale, out int hoveredSnippet, float maxWidth = -1f, float spread = 2f) {
+ 			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, Color.Black, rotation, origin, baseScale, maxWidth, spread);
+-			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
++			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
++		}
++
 +		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
 +		public static Vector2 DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, TextSnippet[] snippets, Vector2 position, float rotation, Color color, Color shadowColor, Vector2 origin, Vector2 baseScale, out int hoveredSnippet, float maxWidth = -1f, float spread = 2f) {
 +			DrawColorCodedStringShadow(spriteBatch, font, snippets, position, shadowColor, rotation, origin, baseScale, maxWidth, spread);
-+			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
-+		}
-+
++			return DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
+ 		}
+ 
  		public static void DrawColorCodedStringShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, string text, Vector2 position, Color baseColor, float rotation, Vector2 origin, Vector2 baseScale, float maxWidth = -1f, float spread = 2f) {
- 			for (int i = 0; i < ShadowDirections.Length; i++) {
- 				DrawColorCodedString(spriteBatch, font, text, position + ShadowDirections[i] * spread, baseColor, rotation, origin, baseScale, maxWidth, ignoreColors: true);
 @@ -327,6 +_,15 @@
  			TextSnippet[] snippets = ParseMessage(text, baseColor).ToArray();
  			ConvertNormalSnippets(snippets);


### PR DESCRIPTION
Followup PR to #2629.  This PR fixes color tags (e.g. `[c/ff0000:Hello!]`) being ignored by the ChatManager methods.