### PR TITLE
Object Oriented Packet System (ModCustomPacket)

### DIFF
--- a/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
@@ -73,11 +73,10 @@ namespace ExampleMod.Content.Items.Consumables
 		}
 
 		public override void SyncPlayer(int toWho, int fromWho, bool newPlayer) {
-			ModPacket packet = Mod.GetPacket();
-			packet.Write((byte)ExampleMod.MessageType.ExamplePlayerSyncPlayer);
-			packet.Write((byte)Player.whoAmI);
-			packet.Write(exampleLifeFruits);
-			packet.Send(toWho, fromWho);
+			new ExampleSyncPlayerPacket {
+				ExampleLifeFruitPlayer = this,
+				ExampleLifeFruits = exampleLifeFruits
+			}.Send(toWho, fromWho);
 		}
 
 		// NOTE: The tag instance provided here is always empty by default.
@@ -88,6 +87,23 @@ namespace ExampleMod.Content.Items.Consumables
 
 		public override void LoadData(TagCompound tag) {
 			exampleLifeFruits = (int) tag["exampleLifeFruits"];
+		}
+	}
+
+	public class ExampleSyncPlayerPacket : ModCustomPacket
+	{
+		// This type is automatically correctly serialized!
+		public ExampleLifeFruitPlayer ExampleLifeFruitPlayer { get; init; }
+		public int ExampleLifeFruits { get; init; }
+
+		protected override void SetDefaults() {
+			// Here we don't need to set any defaults because we're including all properties in every call
+			// If we weren't, we'd want to set their default values here to make sure that no old values were mistakenly
+			// used from previously received packets
+		}
+
+		public override void HandlePacket() {
+			ExampleLifeFruitPlayer.exampleLifeFruits = ExampleLifeFruits;
 		}
 	}
 }

--- a/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleLifeFruit.cs
@@ -74,8 +74,7 @@ namespace ExampleMod.Content.Items.Consumables
 
 		public override void SyncPlayer(int toWho, int fromWho, bool newPlayer) {
 			new ExampleSyncPlayerPacket {
-				ExampleLifeFruitPlayer = this,
-				ExampleLifeFruits = exampleLifeFruits
+				ExampleLifeFruitPlayer = this, ExampleLifeFruits = exampleLifeFruits
 			}.Send(toWho, fromWho);
 		}
 
@@ -86,21 +85,19 @@ namespace ExampleMod.Content.Items.Consumables
 		}
 
 		public override void LoadData(TagCompound tag) {
-			exampleLifeFruits = (int) tag["exampleLifeFruits"];
+			exampleLifeFruits = (int)tag["exampleLifeFruits"];
 		}
 	}
 
 	public class ExampleSyncPlayerPacket : ModCustomPacket
 	{
-		// This type is automatically correctly serialized!
+		/// <summary>
+		/// This type is automatically correctly serialized! <see cref="ModPlayerPropertySerializer"/>
+		/// </summary>
 		public ExampleLifeFruitPlayer ExampleLifeFruitPlayer { get; init; }
-		public int ExampleLifeFruits { get; init; }
 
-		protected override void SetDefaults() {
-			// Here we don't need to set any defaults because we're including all properties in every call
-			// If we weren't, we'd want to set their default values here to make sure that no old values were mistakenly
-			// used from previously received packets
-		}
+		// "init" just means that your code can only set this when creating the object and not afterward
+		public int ExampleLifeFruits { get; init; }
 
 		public override void HandlePacket() {
 			ExampleLifeFruitPlayer.exampleLifeFruits = ExampleLifeFruits;

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -302,15 +302,10 @@ namespace ExampleMod.Content.NPCs
 
 		// Make something happen when the npc teleports to a statue. Since this method only runs server side, any visual effects like dusts or gores have to be synced across all clients manually.
 		public override void OnGoToStatue(bool toKingStatue) {
-			if (Main.netMode == NetmodeID.Server) {
-				ModPacket packet = Mod.GetPacket();
-				packet.Write((byte)ExampleMod.MessageType.ExampleTeleportToStatue);
-				packet.Write((byte)NPC.whoAmI);
-				packet.Send();
-			}
-			else {
-				StatueTeleport();
-			}
+			// HandleForAll will ensure the effects of the packet will be applied to all clients and the server, whether playing singleplayer or multiplayer
+			new ExampleTeleportToStatuePacket {
+				NPC = this
+			}.HandleForAll();
 		}
 
 		// Create a square of pixels around the NPC on teleport.
@@ -374,5 +369,14 @@ namespace ExampleMod.Content.NPCs
 		}
 
 		public int GetHeadTextureIndex(NPC npc) => ModContent.GetModHeadSlot("ExampleMod/Content/NPCs/ExamplePerson_Head");
+	}
+
+	public class ExampleTeleportToStatuePacket : ModCustomPacket
+	{
+		public ExamplePerson NPC { get; init; }
+
+		public override void HandlePacket() {
+			NPC.StatueTeleport();
+		}
 	}
 }

--- a/ExampleMod/ExampleMod.Networking.cs
+++ b/ExampleMod/ExampleMod.Networking.cs
@@ -1,5 +1,6 @@
 using ExampleMod.Content.Items.Consumables;
 using System.IO;
+using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
 namespace ExampleMod

--- a/ExampleMod/ExampleMod.Networking.cs
+++ b/ExampleMod/ExampleMod.Networking.cs
@@ -1,21 +1,25 @@
 using ExampleMod.Content.Items.Consumables;
-using ExampleMod.Content.NPCs;
 using System.IO;
-using Terraria;
+using Terraria.ModLoader.IO;
 
 namespace ExampleMod
 {
 	// This is a partial class, meaning some of its parts were split into other files. See ExampleMod.*.cs for other portions.
 	partial class ExampleMod
 	{
-		internal enum MessageType : byte
+		public override void HandlePacket(BinaryReader reader, int whoAmI) {
+			if (!ModCustomPacket.Handle(this, reader, whoAmI, out int packetType)) {
+				// Can still interact with packets in the old way here using the packetType
+			}
+		}
+
+		/*internal enum MessageType : byte
 		{
 			ExamplePlayerSyncPlayer,
 			ExampleTeleportToStatue
 		}
 
 		// Override this method to handle network packets sent for this mod.
-		//TODO: Introduce OOP packets into tML, to avoid this god-class level hardcode.
 		public override void HandlePacket(BinaryReader reader, int whoAmI) {
 			MessageType msgType = (MessageType)reader.ReadByte();
 
@@ -37,6 +41,6 @@ namespace ExampleMod
 					Logger.WarnFormat("ExampleMod: Unknown Message type: {0}", msgType);
 					break;
 			}
-		}
+		}*/
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/IO/CustomPacketSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/CustomPacketSerializer.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 namespace Terraria.ModLoader.IO;
 
 /// <summary>
-/// A class that holds the required info to serialize a custom packet type
+/// A class that holds the required info to serialize all the properties of a custom packet type
 /// </summary>
 internal abstract class CustomPacketSerializer
 {

--- a/patches/tModLoader/Terraria/ModLoader/IO/CustomPacketSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/CustomPacketSerializer.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Terraria.ModLoader.IO;
+
+/// <summary>
+/// A class that holds the required info to serialize a custom packet type
+/// </summary>
+internal abstract class CustomPacketSerializer
+{
+	public Mod Mod { get; private set; }
+	public int Type { get; private set; }
+
+	public static CustomPacketSerializer Create(ModCustomPacket packet) {
+		var serializationType = typeof(CustomPacketSerializer<>).MakeGenericType(packet.GetType());
+		var serializer = ((CustomPacketSerializer)Activator.CreateInstance(serializationType))!;
+		serializer.Mod = packet.Mod;
+		serializer.Type = packet.type;
+		serializer.Init(packet.GetType());
+
+		return serializer;
+	}
+
+	protected abstract void Init(Type packetType);
+
+	public abstract int PropertyCount { get; }
+
+	/// <summary>
+	/// Reads all information from the binary reader and stores it in the custom packet
+	/// </summary>
+	/// <param name="reader"></param>
+	/// <param name="modCustomPacket"></param>
+	public abstract void Deserialize(BinaryReader reader, ModCustomPacket modCustomPacket);
+
+	/// <summary>
+	/// Writes all custom information from the custom packet into the ModPacket
+	/// </summary>
+	/// <param name="packet"></param>
+	/// <param name="modCustomPacket"></param>
+	public abstract void Serialize(ModPacket packet, ModCustomPacket modCustomPacket);
+}
+
+/// <inheritdoc cref="CustomPacketSerializer"/>
+/// <typeparam name="T">The ModCustomPacket this serializes</typeparam>
+internal class CustomPacketSerializer<T> : CustomPacketSerializer where T : ModCustomPacket
+{
+	private List<PacketPropertySerializer<T>> serializers;
+
+	public override int PropertyCount => serializers.Count;
+
+	protected override void Init(Type packetType) {
+		var properties = packetType.GetProperties(BindingFlags.Public |
+		                                          BindingFlags.NonPublic |
+		                                          BindingFlags.DeclaredOnly |
+		                                          BindingFlags.Instance);
+
+		serializers = properties
+			.Where(info => info.CanRead && info.CanWrite)
+			.Select(PacketPropertySerializer.Create<T>)
+			.OrderBy(serializer => serializer.PropertyType.Name)
+			.ToList();
+	}
+
+	public override void Deserialize(BinaryReader reader, ModCustomPacket modCustomPacket) {
+		if (modCustomPacket is not T) {
+			Mod.Logger.Error(
+				$"CustomPacket tried to deserialize as wrong type, was {modCustomPacket.GetType().Name} but expected {typeof(T).Name}");
+			return;
+		}
+
+		serializers.ForEach(s => s.Deserialize(reader, modCustomPacket as T));
+	}
+
+	public override void Serialize(ModPacket packet, ModCustomPacket modCustomPacket) {
+		if (modCustomPacket is not T) {
+			Mod.Logger.Error(
+				$"CustomPacket tried to serialize as wrong type, was {modCustomPacket.GetType().Name} but expected {typeof(T).Name}");
+			return;
+		}
+
+		serializers.ForEach(s => s.Serialize(packet, modCustomPacket as T));
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/ModPropertySerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ModPropertySerializer.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Terraria.ModLoader.IO;
+
+/// <summary>
+/// A ModType representing a way to serialize and deserialize a certain type between a BinaryReader and a ModPacket
+/// <br/>
+/// Mods can add their own custom property serializers if they want
+/// </summary>
+public abstract class ModPropertySerializer : ModType
+{
+	internal static Dictionary<Type, ModPropertySerializer> propertySerializers;
+
+	public abstract Type Type { get; }
+
+	public sealed override void Load() {
+		propertySerializers ??= new Dictionary<Type, ModPropertySerializer>();
+	}
+
+	/// <summary>
+	/// Signifies that this is capable of serializing not just it's exact matching type, but types that descend from it
+	/// as well, e.g. ModPlayer
+	/// </summary>
+	public virtual bool AffectSubClasses => false;
+
+	public sealed override void SetupContent() {
+	}
+
+	public override void SetStaticDefaults() {
+	}
+
+	public sealed override void Unload() {
+		propertySerializers = null;
+	}
+
+	protected sealed override void Register() {
+		if (propertySerializers.ContainsKey(Type)) {
+			Mod.Logger.Warn($"A ModPropertySerializer for type {Type.FullName}, not overwriting");
+		}
+		else {
+			propertySerializers[Type] = this;
+		}
+	}
+
+	public abstract T Read<T>(BinaryReader reader);
+	public abstract void Write<T>(ModPacket packet, T value);
+
+	/// <summary>
+	/// Gets the element of the array at the given index, or null/default if the index is negative or out of bounds
+	/// </summary>
+	protected static T GetOrDefault<T>(T[] array, int index) =>
+		index < 0 || index >= array.Length ? default : array[index];
+}
+
+public abstract class ModPropertySerializer<TType> : ModPropertySerializer
+{
+	public override Type Type => typeof(TType);
+
+	public override T Read<T>(BinaryReader reader) {
+		return Read(reader) switch {
+			T t => t,
+			null => default,
+			_ => throw new SerializationException(
+				$"Result was of type {Read(reader).GetType().Name} when expected {typeof(T).Name} in serializer {GetType().Name}")
+		};
+	}
+
+	public override void Write<T>(ModPacket packet, T value) {
+		switch (value) {
+			case TType t:
+				Write(packet, t);
+				return;
+			case null:
+				Write(packet, default);
+				return;
+			default:
+				throw new SerializationException(
+					$"Could not write value of type {value.GetType().Name} to packet when expected {typeof(TType).Name} in serializer {GetType().Name}");
+		}
+	}
+
+	protected abstract TType Read(BinaryReader reader);
+	protected abstract void Write(ModPacket packet, TType value);
+}
+
+#region Simple Types
+
+public class BytePropertySerializer : ModPropertySerializer<byte>
+{
+	protected override byte Read(BinaryReader reader) => reader.ReadByte();
+	protected override void Write(ModPacket packet, byte value) => packet.Write(value);
+}
+
+public class BoolPropertySerializer : ModPropertySerializer<bool>
+{
+	protected override bool Read(BinaryReader reader) => reader.ReadBoolean();
+	protected override void Write(ModPacket packet, bool value) => packet.Write(value);
+}
+
+public class ShortPropertySerializer : ModPropertySerializer<short>
+{
+	protected override short Read(BinaryReader reader) => reader.ReadInt16();
+	protected override void Write(ModPacket packet, short value) => packet.Write(value);
+}
+
+public class IntPropertySerializer : ModPropertySerializer<int>
+{
+	protected override int Read(BinaryReader reader) => reader.ReadInt32();
+	protected override void Write(ModPacket packet, int value) => packet.Write(value);
+}
+
+public class LongPropertySerializer : ModPropertySerializer<long>
+{
+	protected override long Read(BinaryReader reader) => reader.ReadInt64();
+	protected override void Write(ModPacket packet, long value) => packet.Write(value);
+}
+
+public class StringPropertySerializer : ModPropertySerializer<string>
+{
+	protected override string Read(BinaryReader reader) => reader.ReadString();
+	protected override void Write(ModPacket packet, string value) => packet.Write(value ?? "");
+}
+
+public class CharPropertySerializer : ModPropertySerializer<char>
+{
+	protected override char Read(BinaryReader reader) => reader.ReadChar();
+	protected override void Write(ModPacket packet, char value) => packet.Write(value);
+}
+
+#endregion
+
+#region Complex Types
+
+public class PlayerPropertySerializer : ModPropertySerializer<Player>
+{
+	protected override Player Read(BinaryReader reader) => GetOrDefault(Main.player, reader.ReadInt32());
+
+	protected override void Write(ModPacket packet, Player value) => packet.Write(value?.whoAmI ?? -1);
+}
+
+public class NPCPropertySerializer : ModPropertySerializer<NPC>
+{
+	protected override NPC Read(BinaryReader reader) => GetOrDefault(Main.npc, reader.ReadInt32());
+	protected override void Write(ModPacket packet, NPC value) => packet.Write(value?.whoAmI ?? -1);
+}
+
+public class ProjectilePropertySerializer : ModPropertySerializer<Projectile>
+{
+	protected override Projectile Read(BinaryReader reader) => GetOrDefault(Main.projectile, reader.ReadInt32());
+	protected override void Write(ModPacket packet, Projectile value) => packet.Write(value?.whoAmI ?? -1);
+}
+
+public class ModPlayerPropertySerializer : ModPropertySerializer<ModPlayer>
+{
+	public override bool AffectSubClasses => true;
+
+	protected override ModPlayer Read(BinaryReader reader) {
+		var playerIndex = reader.ReadInt32();
+		if (playerIndex == -1) return null;
+
+		var modPlayerIndex = reader.ReadUInt16();
+
+		return Main.player[playerIndex].modPlayers[modPlayerIndex];
+	}
+
+	protected override void Write(ModPacket packet, ModPlayer value) {
+		packet.Write(value?.Player.whoAmI ?? -1);
+		if (value != null) {
+			packet.Write(value.index);
+		}
+	}
+}
+
+public class ModProjectilePropertySerializer : ModPropertySerializer<ModProjectile>
+{
+	public override bool AffectSubClasses => true;
+
+	protected override ModProjectile Read(BinaryReader reader) =>
+		GetOrDefault(Main.projectile, reader.ReadInt32())?.ModProjectile;
+
+	protected override void Write(ModPacket packet, ModProjectile value) =>
+		packet.Write(value?.Projectile.whoAmI ?? -1);
+}
+
+public class ModNPCPropertySerializer : ModPropertySerializer<ModNPC>
+{
+	public override bool AffectSubClasses => true;
+
+	protected override ModNPC Read(BinaryReader reader) => GetOrDefault(Main.npc, reader.ReadInt32())?.ModNPC;
+
+	protected override void Write(ModPacket packet, ModNPC value) => packet.Write(value?.NPC.whoAmI ?? -1);
+}
+
+#endregion

--- a/patches/tModLoader/Terraria/ModLoader/IO/ModPropertySerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ModPropertySerializer.cs
@@ -14,6 +14,9 @@ public abstract class ModPropertySerializer : ModType
 {
 	internal static Dictionary<Type, ModPropertySerializer> propertySerializers;
 
+	/// <summary>
+	/// The type of the property
+	/// </summary>
 	public abstract Type Type { get; }
 
 	public sealed override void Load() {
@@ -38,14 +41,21 @@ public abstract class ModPropertySerializer : ModType
 
 	protected sealed override void Register() {
 		if (propertySerializers.ContainsKey(Type)) {
-			Mod.Logger.Warn($"A ModPropertySerializer for type {Type.FullName}, not overwriting");
+			Mod.Logger.Warn($"A ModPropertySerializer for type {Type.Name} already exists, not overwriting");
 		}
 		else {
 			propertySerializers[Type] = this;
 		}
 	}
 
+	/// <summary>
+	/// Reads/parses the desired type from the BinaryReader
+	/// </summary>
 	public abstract T Read<T>(BinaryReader reader);
+
+	/// <summary>
+	/// Parses/writes the desired type to the ModPacket
+	/// </summary>
 	public abstract void Write<T>(ModPacket packet, T value);
 
 	/// <summary>
@@ -82,7 +92,9 @@ public abstract class ModPropertySerializer<TType> : ModPropertySerializer
 		}
 	}
 
+	/// <inheritdoc cref="Read{T}"/>
 	protected abstract TType Read(BinaryReader reader);
+	/// <inheritdoc cref="Write{T}"/>
 	protected abstract void Write(ModPacket packet, TType value);
 }
 
@@ -153,6 +165,9 @@ public class ProjectilePropertySerializer : ModPropertySerializer<Projectile>
 	protected override void Write(ModPacket packet, Projectile value) => packet.Write(value?.whoAmI ?? -1);
 }
 
+/// <summary>
+/// This is maybe a little overkill for ease of serialization, but there's no harm to it
+/// </summary>
 public class ModPlayerPropertySerializer : ModPropertySerializer<ModPlayer>
 {
 	public override bool AffectSubClasses => true;

--- a/patches/tModLoader/Terraria/ModLoader/IO/PacketPropertySerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PacketPropertySerializer.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Terraria.ModLoader.IO;
+
+/// <summary>
+/// An object that holds a getter and setter for serializing a specific Property within a custom packet without
+/// repeated reflection
+/// </summary>
+internal abstract class PacketPropertySerializer
+{
+	public abstract Type PropertyType { get; }
+
+	/// <summary>
+	/// Creates a new PacketPropertySerializer for a given property
+	/// </summary>
+	/// <param name="info"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public static PacketPropertySerializer<T> Create<T>(PropertyInfo info) where T : ModCustomPacket {
+		var propertyType = info.PropertyType;
+		if (!ModPropertySerializer.propertySerializers.TryGetValue(propertyType, out var propertySerializer)) {
+			propertySerializer = ModContent.GetContent<ModPropertySerializer>()
+				.Where(serializer => serializer.AffectSubClasses)
+				.FirstOrDefault(serializer => serializer.Type.IsAssignableFrom(propertyType));
+		}
+
+		if (propertySerializer == null) {
+			throw new SerializationException(
+				$"Can't create serializer for property {info.Name} with type {propertyType.Name} in ModCustomPacket {typeof(T).Name}.");
+		}
+
+		var serializer = Activator.CreateInstance(typeof(PacketPropertySerializer<,>)
+			.MakeGenericType(typeof(T), propertyType)) as PacketPropertySerializer<T>;
+		serializer!.Init(info, propertySerializer);
+		return serializer;
+	}
+
+	protected abstract void Init(PropertyInfo property, ModPropertySerializer serializer);
+}
+
+/// <inheritdoc cref="PacketPropertySerializer"/>
+/// <typeparam name="T">The packet type that this is for</typeparam>
+internal abstract class PacketPropertySerializer<T> : PacketPropertySerializer where T : ModCustomPacket
+{
+	/// <summary>
+	/// Reads information from the binary reader and stores it in the packet
+	/// </summary>
+	/// <param name="reader"></param>
+	/// <param name="customPacket"></param>
+	public virtual void Deserialize(BinaryReader reader, T customPacket) {
+	}
+
+	/// <summary>
+	/// Gets the information from the packet and writes it into the ModPacket
+	/// </summary>
+	/// <param name="packet"></param>
+	/// <param name="customPacket"></param>
+	public virtual void Serialize(ModPacket packet, T customPacket) {
+	}
+}
+
+/// <inheritdoc cref="PacketPropertySerializer"/>
+/// <typeparam name="TPacket">The packet type that this is for</typeparam>
+/// <typeparam name="TType">The property type this is for</typeparam>
+internal class PacketPropertySerializer<TPacket, TType> : PacketPropertySerializer<TPacket>
+	where TPacket : ModCustomPacket
+{
+	private ModPropertySerializer serializer;
+	private Action<TPacket, TType> setter;
+	private Func<TPacket, TType> getter;
+
+	public override Type PropertyType => typeof(TType);
+
+	protected sealed override void Init(PropertyInfo property, ModPropertySerializer tSerializer) {
+		serializer = tSerializer;
+		setter = (Action<TPacket, TType>)
+			Delegate.CreateDelegate(typeof(Action<TPacket, TType>), null, property.GetSetMethod(true)!);
+		getter = (Func<TPacket, TType>)
+			Delegate.CreateDelegate(typeof(Func<TPacket, TType>), null, property.GetGetMethod(true)!);
+	}
+
+	public sealed override void Deserialize(BinaryReader reader, TPacket customPacket) =>
+		setter(customPacket, serializer.Read<TType>(reader));
+
+	public sealed override void Serialize(ModPacket packet, TPacket customPacket) =>
+		serializer.Write(packet, getter(customPacket));
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/PacketPropertySerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PacketPropertySerializer.cs
@@ -17,9 +17,9 @@ internal abstract class PacketPropertySerializer
 	/// <summary>
 	/// Creates a new PacketPropertySerializer for a given property
 	/// </summary>
-	/// <param name="info"></param>
-	/// <typeparam name="T"></typeparam>
-	/// <returns></returns>
+	/// <param name="info">The property info</param>
+	/// <typeparam name="T">The custom packet type</typeparam>
+	/// <returns>A serializer for the property within the packet</returns>
 	public static PacketPropertySerializer<T> Create<T>(PropertyInfo info) where T : ModCustomPacket {
 		var propertyType = info.PropertyType;
 		if (!ModPropertySerializer.propertySerializers.TryGetValue(propertyType, out var propertySerializer)) {
@@ -39,6 +39,9 @@ internal abstract class PacketPropertySerializer
 		return serializer;
 	}
 
+	/// <summary>
+	/// Creates the getter/setter for the property and specifies that it use the given ModPropertySerializer
+	/// </summary>
 	protected abstract void Init(PropertyInfo property, ModPropertySerializer serializer);
 }
 
@@ -49,16 +52,12 @@ internal abstract class PacketPropertySerializer<T> : PacketPropertySerializer w
 	/// <summary>
 	/// Reads information from the binary reader and stores it in the packet
 	/// </summary>
-	/// <param name="reader"></param>
-	/// <param name="customPacket"></param>
 	public virtual void Deserialize(BinaryReader reader, T customPacket) {
 	}
 
 	/// <summary>
-	/// Gets the information from the packet and writes it into the ModPacket
+	/// Gets the information from the custom packet and writes it into the ModPacket
 	/// </summary>
-	/// <param name="packet"></param>
-	/// <param name="customPacket"></param>
 	public virtual void Serialize(ModPacket packet, T customPacket) {
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModCustomPacket.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCustomPacket.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Terraria.ID;
+using Terraria.ModLoader.Core;
+
+namespace Terraria.ModLoader.IO;
+
+/// <summary>
+/// A definable ModType for a specific set of information that's send-able in multiplayer via packets, and the effect
+/// that should happen based on that information
+/// </summary>
+public abstract class ModCustomPacket : ModType
+{
+	private static Dictionary<Type, CustomPacketSerializer> packetSerializers;
+	private static Dictionary<Mod, List<ModCustomPacket>> packets;
+	internal int type;
+
+	public sealed override void Load() {
+		packetSerializers ??= new Dictionary<Type, CustomPacketSerializer>();
+		packets ??= new Dictionary<Mod, List<ModCustomPacket>>();
+		base.Load();
+	}
+
+	public sealed override void Unload() {
+		base.Unload();
+		packetSerializers = null;
+		packets = null;
+	}
+
+	/// <summary>
+	/// Applies the effects of this packet
+	/// </summary>
+	public abstract void HandlePacket();
+
+	/// <summary>
+	/// If you have optional properties, initialize their default values here to avoid packets accidentally using the
+	/// values from previously received packets
+	/// </summary>
+	protected virtual void SetDefaults() {
+	}
+
+	protected sealed override void Register() {
+		if (!packets.ContainsKey(Mod)) {
+			packets[Mod] = new List<ModCustomPacket>();
+		}
+
+		packets[Mod].Add(this);
+		type = -packets[Mod].Count;
+		ModTypeLookup<ModCustomPacket>.Register(this);
+	}
+
+
+	public sealed override void SetupContent() {
+		// Doing this here because it's definitely after all the ModPropertySerializers have been loaded
+		var packetType = GetType();
+		var serialization = CustomPacketSerializer.Create(this);
+		packetSerializers[packetType] = serialization;
+		Mod.Logger.Info(
+			$"Registered CustomPacket {Name} with type {type} and {serialization.PropertyCount} total properties");
+
+		SetStaticDefaults();
+	}
+
+	public sealed override void SetStaticDefaults() {
+		// No static defaults need to be set for custom packets?
+	}
+
+	private void Receive(BinaryReader reader, int sender) {
+		if (packetSerializers.TryGetValue(GetType(), out var serializer)) {
+			if (ModCompile.DeveloperMode) { // TODO remove these debug comments
+				Mod.Logger.Info($"Receiving packet {GetType().Name} on netMode {Main.netMode}");
+			}
+
+			SetDefaults();
+			serializer.Deserialize(reader, this);
+			if (Main.netMode == NetmodeID.Server) {
+				Send(-1, sender);
+			}
+
+			HandlePacket();
+
+			if (ModCompile.DeveloperMode) {
+				Mod.Logger.Info($"Handled packet {GetType().Name} on netMode {Main.netMode}");
+			}
+		}
+		else {
+			Mod.Logger.Error($"Failed receiving packet {GetType().Name} because packet info is wrong type");
+		}
+	}
+
+	/// <summary>
+	/// Serializes the information in this ModCustomPacket and then sends it using the same format as <see cref="ModPacket.Send"/>
+	/// </summary>
+	/// <param name="toClient">The toClient param of <see cref="ModPacket.Send"/></param>
+	/// <param name="ignoreClient">The ignoreClient param of <see cref="ModPacket.Send"/></param>
+	public void Send(int toClient = -1, int ignoreClient = -1) {
+		if (packetSerializers.TryGetValue(GetType(), out var serializer)) {
+			if (ModCompile.DeveloperMode) {
+				serializer.Mod.Logger.Info(
+					$"Sending packet {GetType().Name} on netMode {Main.netMode} with type {serializer.Type}");
+			}
+
+			var packet = serializer.Mod.GetPacket();
+			packet.Write(serializer.Type);
+			serializer.Serialize(packet, this);
+			packet.Send(toClient, ignoreClient);
+		}
+		else {
+			Mod?.Logger.Error($"Failed sending packet {GetType().Name} because packet info is wrong type");
+		}
+	}
+
+	/// <summary>
+	/// Causes all clients and the server to handle the results of this packet
+	/// <br />
+	/// Works for single-player or multiplayer
+	/// </summary>
+	public void HandleForAll() {
+		switch (Main.netMode) {
+			case NetmodeID.MultiplayerClient:
+				Send(-1, Main.myPlayer);
+				break;
+			case NetmodeID.Server:
+				Send();
+				break;
+		}
+
+		HandlePacket();
+	}
+
+
+	/// <summary>
+	/// Reads an Int32 from the BinaryReader and treats it as the packet's type, Handling it as a ModCustomPacket from
+	/// the given Mod and returning true if it is negative, otherwise returning false and passing the packetType out
+	/// </summary>
+	/// <param name="mod">The Mod that the ModCustomPacket would be a part of</param>
+	/// <param name="reader">The BinaryReader read in <see cref="Mod.HandlePacket"/></param>
+	/// <param name="whoAmI">The int whoAmI in <see cref="Mod.HandlePacket"/></param>
+	/// <param name="packetType">The packet type, > 0 when this returns false</param>
+	/// <returns>Whether the packetType was for a ModCustomPacket</returns>
+	public static bool Handle(Mod mod, BinaryReader reader, int whoAmI, out int packetType) {
+		packetType = reader.ReadInt32();
+		if (packetType < 0 && packets.TryGetValue(mod, out var customPackets)) {
+			var packetIndex = -packetType - 1;
+			if (packetIndex < customPackets.Count) {
+				customPackets[packetIndex].Receive(reader, whoAmI);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Reads an Int32 from the BinaryReader and treats it as the packet's type, Handling it as a ModCustomPacket from
+	/// the given Mod
+	/// </summary>
+	/// <param name="mod">The Mod that the ModCustomPacket would be a part of</param>
+	/// <param name="reader">The BinaryReader read in <see cref="Mod.HandlePacket"/></param>
+	/// <param name="whoAmI">The int whoAmI in <see cref="Mod.HandlePacket"/></param>
+	public static void Handle(Mod mod, BinaryReader reader, int whoAmI) {
+		Handle(mod, reader, whoAmI, out _);
+	}
+
+	/// <summary>
+	/// Reads an Int32 from the BinaryReader and treats it as the packet's type, Handling it as a ModCustomPacket from
+	/// the given Mod and returning true if it is negative, otherwise returning false and passing the packetType out as
+	/// the given Enum
+	/// </summary>
+	/// <param name="mod">The Mod that the ModCustomPacket would be a part of</param>
+	/// <param name="reader">The BinaryReader read in <see cref="Mod.HandlePacket"/></param>
+	/// <param name="whoAmI">The int whoAmI in <see cref="Mod.HandlePacket"/></param>
+	/// <param name="packetType">The packet type, > 0 when this returns false</param>
+	/// <returns>Whether the packetType was for a ModCustomPacket</returns>
+	public static bool Handle<T>(Mod mod, BinaryReader reader, int whoAmI, out T packetType) where T : Enum {
+		var result = Handle(mod, reader, whoAmI, out var packetId);
+		if (result) {
+			packetType = default;
+		}
+		else {
+			packetType = (T)(packetId as object);
+		}
+
+		return result;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModCustomPacket.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCustomPacket.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using Terraria.ID;
 using Terraria.ModLoader.Core;
+using Terraria.ModLoader.IO;
 
-namespace Terraria.ModLoader.IO;
+namespace Terraria.ModLoader;
 
 /// <summary>
 /// A definable ModType for a specific set of information that's send-able in multiplayer via packets, and the effect
@@ -19,7 +20,6 @@ public abstract class ModCustomPacket : ModType
 	public sealed override void Load() {
 		packetSerializers ??= new Dictionary<Type, CustomPacketSerializer>();
 		packets ??= new Dictionary<Mod, List<ModCustomPacket>>();
-		base.Load();
 	}
 
 	public sealed override void Unload() {
@@ -34,8 +34,7 @@ public abstract class ModCustomPacket : ModType
 	public abstract void HandlePacket();
 
 	/// <summary>
-	/// If you have optional properties, initialize their default values here to avoid packets accidentally using the
-	/// values from previously received packets
+	/// If you want to alter the default values of the packet before the deserialized data is written to it
 	/// </summary>
 	protected virtual void SetDefaults() {
 	}
@@ -46,7 +45,7 @@ public abstract class ModCustomPacket : ModType
 		}
 
 		packets[Mod].Add(this);
-		type = -packets[Mod].Count;
+		type = -packets[Mod].Count; // Using negative types counting downwards to allow for 0+ to easily come from Enums
 		ModTypeLookup<ModCustomPacket>.Register(this);
 	}
 
@@ -63,12 +62,13 @@ public abstract class ModCustomPacket : ModType
 	}
 
 	public sealed override void SetStaticDefaults() {
-		// No static defaults need to be set for custom packets?
+		// TODO No one would need to set static defaults for their custom packets?
 	}
 
 	private void Receive(BinaryReader reader, int sender) {
 		if (packetSerializers.TryGetValue(GetType(), out var serializer)) {
-			if (ModCompile.DeveloperMode) { // TODO remove these debug comments
+			if (ModCompile.DeveloperMode) {
+				// TODO remove these debug comments?
 				Mod.Logger.Info($"Receiving packet {GetType().Name} on netMode {Main.netMode}");
 			}
 


### PR DESCRIPTION
### What is the new feature?

A system for Object Oriented packets utilizing the built-in tModLoader ModType system: `ModCustomPacket`

All Properties (with both a getter and a setter) within the class will be able to be automatically serialized to and from existing ModPackets / BinaryReaders.

### Why should this be part of tModLoader?

The current ways of Sending and Handling ModPackets is all through a "god-class level hardcode" (as the TODO comment in ExampleMod.Networking.cs put it) in the Mod file, and usually leads to modders all creating their own Enums / IDs to handle packets. 
There's also some not-always-intuitive patterns with dealing with client vs server code execution that can be real gotchas to newer modders. 
This system seeks to improve those situations.

### Are there alternative designs?

The current way to handle packets is obviously still functional, and modders would be able to 100% keep using it if they wanted.

As far as alternative OOP packet systems, I went through a couple iterations and this was the best one, mainly because it's got:

- Minimal reflection overhead; the `Delegate.CreateDelegate` calls create cached delegates that have [great performance](https://www.c-sharpcorner.com/article/boosting-up-the-reflection-performance-in-c-sharp/) getting and setting stuff
- Extensible custom serialization through creating new `ModPropertySerializer` types
- Compatibility with existing Enum/number types systems because the IDs start at -1 and count downward, leaving 0 and up open for easy Enum values

Since this started as a feature in my own separate mod, there may be additional/better ways to interact with the Terraria/tModLoader source code itself that I haven't taken advantage of.

### Sample usage for the new feature

A mod wanting to opt-in to custom packets would make their mod's `Mod.HandlePacket(BinaryReader, int)` method look something like:
```csharp
public override void HandlePacket(BinaryReader reader, int whoAmI) => ModCustomPacket.Handle(this, reader, whoAmI);
```
or
```csharp
public override void HandlePacket(BinaryReader reader, int whoAmI) {
	if (!ModCustomPacket.Handle(this, reader, whoAmI, out int packetType)) {
		// Can still interact with non-ModCustomPackets sent in the old way here using the packetType
	}
}
```

They'd then create a class that extends from `ModCustomPacket`, e.g.
```csharp
public class ExampleSyncPlayerPacket : ModCustomPacket
{
    /// <summary>
    /// This complex type is automatically correctly serialized (by reference)! <see cref="ModPlayerPropertySerializer"/>
    /// </summary>
    public ExampleLifeFruitPlayer ExampleLifeFruitPlayer { get; init; }
    
    // "init" just means that your code can only set this when creating the object and not afterward
    public int ExampleLifeFruits { get; init; }

    public override void HandlePacket() {
        ExampleLifeFruitPlayer.exampleLifeFruits = ExampleLifeFruits;
    }
}
```

Then, wherever they wanted to send the packet they could do so via:

```csharp
...
new ExampleSyncPlayerPacket {
    ExampleLifeFruitPlayer = this, ExampleLifeFruits = exampleLifeFruits
}.Send(toWho, fromWho);
...
```

Or, instead of sending the packet that traditional way, they could simplify things and do this:
```csharp
...
// HandleForAll will ensure the effects of the packet will be applied to all clients and the server, whether playing singleplayer or multiplayer
new ExampleTeleportToStatuePacket {
    NPC = this
}.HandleForAll();
...
```

### ExampleMod updates

`ExampleMod.Networking.cs`: Commented out the old stuff to show the new `ModCustomPacket.Handle` way

`ExamplePerson.cs`: Turning the existing packet interactions into a new `ExampleTeleportToStatuePacket`

`ExampleLifeFruit.cs`: Turning the existing packet interactions into a new `ExampleSyncPlayerPacket`


### Extra

I originally just made this for my own personal use, but it seemed like something that enough people could utilize that I decided to clean it up and PR it here. 

I also admit that I didn't do much research into any existing in-progress implementations of something like this, so if I've reinvented the wheel here or gone in a way different direction that y'all planned then RIP, so it goes lol. Still useful to myself in the interim at least :)

If this is could actually be useful to you guys though, you can also ping me in the tModLoader discord @doombubbles#1701 with questions/concerns. Also let me know if I should've gone with different naming conventions / namespaces for stuff.

P.S. I've tested this more extensively with my own mods than just the Examples in ExampleMod so far