### PR TITLE
Gamepad icons overlap fix

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2410,6 +2410,19 @@
  		}
  
  		protected void DrawFPS() {
+@@ -15890,10 +_,10 @@
+ 				float num2 = 1f;
+ 				Vector2 baseScale = new Vector2(num2);
+ 				if (gameMenu)
+-					num = 55f;
++					num = 90f;
+ 
+ 				if (menuMode == 0)
+-					num += 32f;
++					num += 55f;
+ 
+ 				Vector2 stringSize = ChatManager.GetStringSize(FontAssets.MouseText.Value, text, new Vector2(1f));
+ 				float t = num2;
 @@ -16070,9 +_,14 @@
  			TilesRenderer.ClearCachedTileDraws(solidLayer: true);
  		}


### PR DESCRIPTION
### What is the bug?
The gamepad icons overlap with the text and link buttons tModLoader added
![dotnet_ezrGDfHiAt](https://user-images.githubusercontent.com/35227653/175862235-23dba511-1a18-4b64-b1af-d8cbaba3ca49.png)
![dotnet_PMKG4EsFhT](https://user-images.githubusercontent.com/35227653/175862266-cad62e5a-c1f6-4da6-9b6c-637e56688544.png)

### How did you fix the bug?
In `Main.DrawGamepadInstructions()` method:
```
if (gameMenu)
	num = 55f;
if (menuMode == 0)
	num += 32f;
```
I simply changed it into:
```
if (gameMenu)
	num = 90f;
if (menuMode == 0)
	num += 55f;
```
And the problem is solved
![dotnet_kQWVcaaENy](https://user-images.githubusercontent.com/35227653/175862485-a75b85f1-17c0-4fda-acad-1f71d3e0f19f.png)
![dotnet_TxrZyIgKnb](https://user-images.githubusercontent.com/35227653/175862488-61c43bce-d414-4d8f-b23a-b3f4479a8ce0.png)