### PR TITLE
Remove GlobalRecipe

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalRecipe.cs
@@ -1,39 +1,10 @@
-﻿namespace Terraria.ModLoader
+﻿using System;
+
+namespace Terraria.ModLoader
 {
-	/// <summary>
-	/// This class provides hooks that control all recipes in the game.
-	/// </summary>
-	public abstract class GlobalRecipe : ModType
+	// class left in for tModPorter
+	[Obsolete("Use Recipe.AddCondition/AddConsumeItemCallback/AddOnCraftCallback or GlobalItem.OnCreate", true)]
+	public class GlobalRecipe
 	{
-		protected sealed override void Register() {
-			ModTypeLookup<GlobalRecipe>.Register(this);
-			RecipeLoader.Add(this);
-		}
-
-		public sealed override void SetupContent() => SetStaticDefaults();
-
-		/// <summary>
-		/// Whether or not the conditions are met for the given recipe to be available for the player to use. This hook can be used for conditions unrelated to items or tiles (for example, biome or time).
-		/// </summary>
-		public virtual bool RecipeAvailable(Recipe recipe) {
-			return true;
-		}
-
-		/// <summary>
-		/// Allows you to make anything happen when the player uses the given recipe. The item parameter is the item the player has just crafted.
-		/// </summary>
-		/// <param name="item">The item created.</param>
-		/// <param name="recipe">The recipe used to create the item.</param>
-		public virtual void OnCraft(Item item, Recipe recipe) {
-		}
-
-		/// <summary>
-		/// Allows to edit the amount of item the player uses in a recipe.
-		/// </summary>
-		/// <param name="recipe">The recipe used for the craft.</param>
-		/// <param name="type">Type of the ingredient.</param>
-		/// <param name="amount">Modifiable amount of the item consumed.</param>
-		public virtual void ConsumeItem(Recipe recipe, int type, ref int amount) {
-		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -12,7 +12,6 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public static class RecipeLoader
 	{
-		internal static readonly IList<GlobalRecipe> globalRecipes = new List<GlobalRecipe>();
 		internal static Recipe[] FirstRecipeForItem = new Recipe[ItemID.Count];
 
 		/// <summary>
@@ -25,12 +24,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		internal static Mod CurrentMod { get; private set; }
 
-		internal static void Add(GlobalRecipe globalRecipe) {
-			globalRecipes.Add(globalRecipe);
-		}
-
 		internal static void Unload() {
-			globalRecipes.Clear();
 			setupRecipes = false;
 			FirstRecipeForItem = new Recipe[Recipe.maxRecipes];
 		}
@@ -148,7 +142,7 @@ namespace Terraria.ModLoader
 		/// <param name="recipe">The recipe to check.</param>
 		/// <returns>Whether or not the conditions are met for this recipe.</returns>
 		public static bool RecipeAvailable(Recipe recipe) {
-			return recipe.Conditions.All(c => c.RecipeAvailable(recipe)) && globalRecipes.All(globalRecipe => globalRecipe.RecipeAvailable(recipe));
+			return recipe.Conditions.All(c => c.RecipeAvailable(recipe));
 		}
 
 		/// <summary>
@@ -158,10 +152,6 @@ namespace Terraria.ModLoader
 		/// <param name="recipe">The recipe used to craft the item.</param>
 		public static void OnCraft(Item item, Recipe recipe) {
 			recipe.OnCraftHooks?.Invoke(recipe, item);
-
-			foreach (GlobalRecipe globalRecipe in globalRecipes) {
-				globalRecipe.OnCraft(item, recipe);
-			}
 		}
 
 		/// <summary>
@@ -172,10 +162,6 @@ namespace Terraria.ModLoader
 		/// <param name="amount">Modifiable amount of the item consumed.</param>
 		public static void ConsumeItem(Recipe recipe, int type, ref int amount) {
 			recipe.ConsumeItemHooks?.Invoke(recipe, type, ref amount);
-
-			foreach (GlobalRecipe globalRecipe in globalRecipes) {
-				globalRecipe.ConsumeItem(recipe, type, ref amount);
-			}
 		}
 	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.Expected.cs
@@ -1,0 +1,17 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+#if COMPILE_ERROR
+public abstract class GlobalRecipeTest : GlobalRecipe
+{
+	public override bool RecipeAvailable(Recipe recipe)/* tModPorter Note: Removed. Use Recipe.AddCondition */ {
+		return true;
+	}
+
+	public override void OnCraft(Item item, Recipe recipe)/* tModPorter Note: Removed. Use Recipe.AddOnCraftCallback or GlobalItem.OnCreate */ {
+	}
+
+	public override void ConsumeItem(Recipe recipe, int type, ref int amount)/* tModPorter Note: Removed. Use Recipe.AddConsumeItemCallback */ {
+	}
+}
+#endif

--- a/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalRecipeTest.cs
@@ -1,0 +1,17 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+#if COMPILE_ERROR
+public abstract class GlobalRecipeTest : GlobalRecipe
+{
+	public override bool RecipeAvailable(Recipe recipe) {
+		return true;
+	}
+
+	public override void OnCraft(Item item, Recipe recipe) {
+	}
+
+	public override void ConsumeItem(Recipe recipe, int type, ref int amount) {
+	}
+}
+#endif

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -173,10 +173,13 @@ public static partial class Config
 		HookRemoved("Terraria.ModLoader.ModItem",		"DrawHair",		"In SetStaticDefaults, use ArmorIDs.Head.Sets.DrawFullHair[Item.headSlot] = true if you had drawHair set to true, and ArmorIDs.Head.Sets.DrawHatHair[Item.headSlot] = true if you had drawAltHair set to true");
 		HookRemoved("Terraria.ModLoader.GlobalItem",	"DrawHair",		"In SetStaticDefaults, use ArmorIDs.Head.Sets.DrawFullHair[head] = true if you had drawHair set to true, and ArmorIDs.Head.Sets.DrawHatHair[head] = true if you had drawAltHair set to true");
 
-		HookRemoved("Terraria.ModLoader.ModItem",	"IgnoreDamageModifiers","If you returned true, consider leaving Item.DamageType as DamageClass.Default, or make a custom DamageClass which returns StatInheritanceData.None in GetModifierInheritance");
-		HookRemoved("Terraria.ModLoader.ModItem",	"OnlyShootOnSwing",		"If you returned true, set Item.useTime to a multiple of Item.useAnimation");
-		HookRemoved("Terraria.ModLoader.ModGore",	"DrawBehind",			"Use GoreID.Sets.DrawBehind[Type] in SetStaticDefaults");
-		HookRemoved("Terraria.ModLoader.ModTile",	"SaplingGrowthType",	"Use ModTree.SaplingGrowthType");
+		HookRemoved("Terraria.ModLoader.ModItem",		"IgnoreDamageModifiers","If you returned true, consider leaving Item.DamageType as DamageClass.Default, or make a custom DamageClass which returns StatInheritanceData.None in GetModifierInheritance");
+		HookRemoved("Terraria.ModLoader.ModItem",		"OnlyShootOnSwing",		"If you returned true, set Item.useTime to a multiple of Item.useAnimation");
+		HookRemoved("Terraria.ModLoader.ModGore",		"DrawBehind",			"Use GoreID.Sets.DrawBehind[Type] in SetStaticDefaults");
+		HookRemoved("Terraria.ModLoader.ModTile",		"SaplingGrowthType",	"Use ModTree.SaplingGrowthType");
+		HookRemoved("Terraria.ModLoader.GlobalRecipe",	"RecipeAvailable",		"Use Recipe.AddCondition");
+		HookRemoved("Terraria.ModLoader.GlobalRecipe",	"OnCraft",				"Use Recipe.AddOnCraftCallback or GlobalItem.OnCreate");
+		HookRemoved("Terraria.ModLoader.GlobalRecipe",	"ConsumeItem",			"Use Recipe.AddConsumeItemCallback");
 
 		HookRemoved("Terraria.ModLoader.ModSurfaceBackgroundStyle",		"ChooseBgStyle", "Create a ModBiome (or ModSceneEffect) class and override SurfaceBackgroundStyle property to return this object through Mod/ModContent.Find, then move this code into IsBiomeActive (or IsSceneEffectActive)");
 		HookRemoved("Terraria.ModLoader.ModUndergroundBackgroundStyle",	"ChooseBgStyle", "Create a ModBiome (or ModSceneEffect) class and override UndergroundBackgroundStyle property to return this object through Mod/ModContent.Find, then move this code into IsBiomeActive (or IsSceneEffectActive)");


### PR DESCRIPTION
### What is the new feature?
`GlobalRecipe` is removed. 

### Why should this be part of tModLoader?
- All functionality can be achieved elsewhere
- Less code to maintain, less ways of doing the same thing
- Can tell when a recipe has `Conditions` or `ConsumeItemHooks`
  - Makes advanced recipe features easier, because the availability of 'simple' recipes can be cached. (Helps with #2602)

### Are there alternative designs?
No

### Sample usage for the new feature
Edit the recipes you want to edit in `ModSystem.PostAddRecipes` to add callbacks/custom conditions. 

Consider `Main.hidePlayerCraftingMenu` (previously added by tML) if you want to disable crafting.

### ExampleMod updates
None, it didn't have any `GlobalRecipe` examples.

