### PR TITLE
Support ARM Dedicated Servers

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -108,7 +109,11 @@ namespace Terraria.Social.Steam
 
 				File.WriteAllText(apptxt, thisApp.ToString());
 
-				if (GameServer.Init(0x7f000001, 7775, 7774, EServerMode.eServerModeNoAuthentication, "0.11.9.0")) {
+				if (RuntimeInformation.ProcessArchitecture is Architecture.Arm or Architecture.Arm64) {
+					Logging.tML.Warn("Steam Game Server currently unsupported on ARM");
+					SteamAvailable = false;
+				}
+				else if (GameServer.Init(0x7f000001, 7775, 7774, EServerMode.eServerModeNoAuthentication, "0.11.9.0")) {
 					SteamGameServer.SetGameDescription("tModLoader Mod Browser");
 					SteamGameServer.SetProduct(thisApp.ToString());
 					SteamGameServer.LogOnAnonymous();


### PR DESCRIPTION
## This fix is incomplete. 
Depends on #2496

An ARM64 or AnyCPU Steamworks.NET.dll is required.

<details>
<summary>I managed to build one with the following patches to https://github.com/rlabrecque/Steamworks.NET</summary>

```patch
 Standalone/BuildPackages.targets          |  3 +++
 Standalone/Steamworks.NET.Standard.csproj | 11 ++++++++++-
 2 files changed, 13 insertions(+), 1 deletion(-)

diff --git a/Standalone/BuildPackages.targets b/Standalone/BuildPackages.targets
index eba41e7..c0c86fc 100644
--- a/Standalone/BuildPackages.targets
+++ b/Standalone/BuildPackages.targets
@@ -39,6 +39,9 @@
 			<ToBuilt Include="Steamworks.NET.Standard.csproj">
 				<Properties>Platform=x86;Configuration=OSX-Linux;PackagingBuild=true</Properties>
 			</ToBuilt>
+			<ToBuilt Include="Steamworks.NET.Standard.csproj">
+				<Properties>Platform=arm64;Configuration=OSX-Linux;PackagingBuild=true</Properties>
+			</ToBuilt>
 			<ToBuilt Include="Steamworks.NET.Standard.csproj">
 				<Properties>
 					Platform=x64;
diff --git a/Standalone/Steamworks.NET.Standard.csproj b/Standalone/Steamworks.NET.Standard.csproj
index 9a7cce6..7f7eb5a 100644
--- a/Standalone/Steamworks.NET.Standard.csproj
+++ b/Standalone/Steamworks.NET.Standard.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<RootNamespace>Steamworks</RootNamespace>
 		<AssemblyName>Steamworks.NET</AssemblyName>
-		<Platforms>x64;x86</Platforms>
+		<Platforms>x64;x86;arm64</Platforms>
 		<Configurations>Windows;OSX-Linux</Configurations>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<RepositoryType>git</RepositoryType>
@@ -59,6 +59,15 @@
 		<ErrorReport>prompt</ErrorReport>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX-Linux|arm64'">
+		<OutputPath>bin\arm64\OSX-Linux\</OutputPath>
+		<DefineConstants>TRACE;STEAMWORKS_LIN_OSX;STEAMWORKS_X64</DefineConstants>
+		<Optimize>true</Optimize>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<PlatformTarget>arm64</PlatformTarget>
+		<ErrorReport>prompt</ErrorReport>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<Compile Include="../com.rlabrecque.steamworks.net/Runtime/**/*.cs" />
 	</ItemGroup>
```

But this breaks the simple nuget dep we have. I think a better option is to fork and build our own AnyCPU version.
We can figure out the `steamapi/steamapi_64` mismatch fairly easily which seems to be the only reason for platform dependent compilation.

</details>

### What is the bug?
Can't run dedicated servers on ARM, due to Steamworks.NET failure.

### How did you fix the bug?
Add bailout on ARM before actually calling Steamworks functions.

### Are there alternatives to your fix?

