### PR TITLE
Modernize PlayerLoader, support custom ModPlayer hooks.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/FilteredEnumerator.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/FilteredEnumerator.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Terraria.ModLoader.Core
+{
+	// split into two classes, because the span version is slow. Keep an eye on https://github.com/dotnet/runtime/issues/68797 and check disassembly periodically
+	// or https://github.com/dotnet/runtime/issues/9977
+	// and my issue https://github.com/dotnet/runtime/issues/71510
+	public ref struct FilteredArrayEnumerator<T>
+	{
+		// T[] current produces much better code-gen than `ReadOnlySpan<T>`
+		private readonly T[] arr;
+		private readonly int[] inds;
+
+		private T current;
+		private int i;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public FilteredArrayEnumerator(T[] arr, int[] inds) {
+			this.arr = arr;
+			this.inds = inds;
+			current = default;
+			i = 0;
+		}
+
+		public T Current => current;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool MoveNext() {
+			if (i >= inds.Length)
+				return false;
+
+			current = arr[inds[i++]];
+			return true;
+		}
+
+		public FilteredArrayEnumerator<T> GetEnumerator() => this;
+	}
+
+	public ref struct FilteredSpanEnumerator<T>
+	{
+		private readonly ReadOnlySpan<T> arr;
+		private readonly int[] inds;
+
+		private T current;
+		private int i;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public FilteredSpanEnumerator(ReadOnlySpan<T> arr, int[] inds) {
+			this.arr = arr;
+			this.inds = inds;
+			current = default;
+			i = 0;
+		}
+
+		public T Current => current;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public bool MoveNext() {
+			if (i >= inds.Length)
+				return false;
+
+			current = arr[inds[i++]];
+			return true;
+		}
+
+		public FilteredSpanEnumerator<T> GetEnumerator() => this;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
@@ -79,8 +79,8 @@ namespace Terraria.ModLoader.Core
 		public InstanceEnumerator Enumerate(Instanced<T>[] instances)
 			=> new(instances, indices);
 
-		public void Update<U>(IList<U> instances) where U : GlobalType {
-			indices = instances.WhereMethodIsOverridden(method).Select(g => (int)g.index).ToArray();
+		public void Update<U>(IList<U> instances) where U : IIndexed {
+			indices = instances.WhereMethodIsOverridden(method).Select(g => (int)g.Index).ToArray();
 		}
 
 		public static HookList<T> Create<F>(Expression<Func<T, F>> expr) where F : Delegate

--- a/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
@@ -68,6 +68,36 @@ namespace Terraria.ModLoader.Core
 			public InstanceEnumerator GetEnumerator() => this;
 		}
 
+		public ref struct FilteredEnumerator
+		{
+			private readonly T[] arr;
+			private readonly int[] inds;
+
+			private T current;
+			private int i;
+
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
+			public FilteredEnumerator(T[] arr, int[] inds) {
+				this.arr = arr;
+				this.inds = inds;
+				current = default;
+				i = 0;
+			}
+
+			public T Current => current;
+
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
+			public bool MoveNext() {
+				if (i >= inds.Length)
+					return false;
+
+				current = arr[inds[i++]];
+				return true;
+			}
+
+			public FilteredEnumerator GetEnumerator() => this;
+		}
+
 		public readonly MethodInfo method;
 
 		private int[] indices = Array.Empty<int>();
@@ -77,6 +107,9 @@ namespace Terraria.ModLoader.Core
 		}
 		
 		public InstanceEnumerator Enumerate(Instanced<T>[] instances)
+			=> new(instances, indices);
+
+		public FilteredEnumerator Enumerate(T[] instances)
 			=> new(instances, indices);
 
 		public void Update<U>(IList<U> instances) where U : IIndexed {

--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -96,7 +96,7 @@ namespace Terraria.ModLoader.Core
 				int j = 0;
 				foreach (var g in set) {
 					if (g != null)
-						entityGlobals[j++] = new(g.index, g);
+						entityGlobals[j++] = new(g.Index, g);
 				}
 			}
 			else {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -30,14 +30,14 @@ namespace Terraria.ModLoader
 		protected sealed override void Register() {
 			ModTypeLookup<GlobalItem>.Register(this);
 
-			index = (ushort)ItemLoader.globalItems.Count;
+			Index = (ushort)ItemLoader.globalItems.Count;
 
 			ItemLoader.globalItems.Add(this);
 		}
 
 		public sealed override void SetupContent() => SetStaticDefaults();
 
-		public GlobalItem Instance(Item item) => Instance(item.globalItems, index);
+		public GlobalItem Instance(Item item) => Instance(item.globalItems, Index);
 
 		/// <summary>
 		/// Allows you to set the properties of any and every item that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -18,14 +18,14 @@ namespace Terraria.ModLoader
 
 			ModTypeLookup<GlobalNPC>.Register(this);
 
-			index = (ushort)NPCLoader.globalNPCs.Count;
+			Index = (ushort)NPCLoader.globalNPCs.Count;
 
 			NPCLoader.globalNPCs.Add(this);
 		}
 
 		public sealed override void SetupContent() => SetStaticDefaults();
 
-		public GlobalNPC Instance(NPC npc) => Instance(npc.globalNPCs, index);
+		public GlobalNPC Instance(NPC npc) => Instance(npc.globalNPCs, Index);
 
 		/// <summary>
 		/// Allows you to set the properties of any and every NPC that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -16,14 +16,14 @@ namespace Terraria.ModLoader
 
 			ModTypeLookup<GlobalProjectile>.Register(this);
 
-			index = (ushort)ProjectileLoader.globalProjectiles.Count;
+			Index = (ushort)ProjectileLoader.globalProjectiles.Count;
 
 			ProjectileLoader.globalProjectiles.Add(this);
 		}
 
 		public sealed override void SetupContent() => SetStaticDefaults();
 
-		public GlobalProjectile Instance(Projectile projectile) => Instance(projectile.globalProjectiles, index);
+		public GlobalProjectile Instance(Projectile projectile) => Instance(projectile.globalProjectiles, Index);
 
 		/// <summary>
 		/// Allows you to set the properties of any and every projectile that gets created.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -6,9 +6,9 @@ using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader
 {
-	public abstract class GlobalType : ModType
+	public abstract class GlobalType : ModType, IIndexed
 	{
-		internal ushort index;
+		public ushort Index { get; internal set; }
 
 		/// <summary>
 		/// Whether to create a new instance of this Global for every entity that exists.
@@ -54,7 +54,7 @@ namespace Terraria.ModLoader
 				return false;
 			}
 
-			result = Instance(globals, baseInstance.index) as TResult;
+			result = Instance(globals, baseInstance.Index) as TResult;
 			return result != null;
 		}
 
@@ -125,7 +125,7 @@ namespace Terraria.ModLoader
 
 			var inst = (TGlobal)Activator.CreateInstance(GetType());
 			inst.Mod = Mod;
-			inst.index = index;
+			inst.Index = Index;
 			return inst;
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/IIndexed.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IIndexed.cs
@@ -1,0 +1,7 @@
+﻿namespace Terraria.ModLoader
+{
+	public interface IIndexed
+	{
+		ushort Index { get; }
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -166,9 +166,7 @@ namespace Terraria.ModLoader.IO
 
 			var saveData = new TagCompound();
 
-			foreach (var instanced in player.modPlayers) {
-				var modPlayer = instanced.Instance;
-
+			foreach (var modPlayer in player.modPlayers) {
 				modPlayer.SaveData(saveData);
 
 				if (saveData.Count == 0)

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -166,7 +166,9 @@ namespace Terraria.ModLoader.IO
 
 			var saveData = new TagCompound();
 
-			foreach (var modPlayer in player.modPlayers) {
+			foreach (var instanced in player.modPlayers) {
+				var modPlayer = instanced.Instance;
+
 				modPlayer.SaveData(saveData);
 
 				if (saveData.Count == 0)

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -30,7 +30,6 @@ namespace Terraria.ModLoader
 		internal static readonly int[] vanillaWings = new int[Main.maxWings];
 
 		private static int nextItem = ItemID.Count;
-		private static Instanced<GlobalItem>[] globalItemsArray = new Instanced<GlobalItem>[0];
 
 		private static readonly List<HookList> hooks = new List<HookList>();
 		private static readonly List<HookList> modHooks = new List<HookList>();
@@ -121,10 +120,6 @@ namespace Terraria.ModLoader
 					.ToArray();
 
 			FindVanillaWings();
-
-			globalItemsArray = globalItems
-				.Select(g => new Instanced<GlobalItem>(g.Index, g))
-				.ToArray();
 
 			NetGlobals = globalItems.WhereMethodIsOverridden<GlobalItem, Action<Item, BinaryWriter>>(g => g.NetSend).ToArray();
 
@@ -1135,7 +1130,7 @@ namespace Terraria.ModLoader
 			if (legs.ModItem != null && legs.ModItem.IsArmorSet(head, body, legs))
 				legs.ModItem.UpdateArmorSet(player);
 
-			foreach (GlobalItem globalItem in HookUpdateArmorSet.Enumerate(globalItemsArray)) {
+			foreach (GlobalItem globalItem in HookUpdateArmorSet.Enumerate(globalItems)) {
 				string set = globalItem.IsArmorSet(head, body, legs);
 				if (!string.IsNullOrEmpty(set))
 					globalItem.UpdateArmorSet(player, set);
@@ -1161,7 +1156,7 @@ namespace Terraria.ModLoader
 			if (legTexture != null && legTexture.IsVanitySet(player.head, player.body, player.legs))
 				legTexture.PreUpdateVanitySet(player);
 
-			foreach (GlobalItem globalItem in HookPreUpdateVanitySet.Enumerate(globalItemsArray)) {
+			foreach (GlobalItem globalItem in HookPreUpdateVanitySet.Enumerate(globalItems)) {
 				string set = globalItem.IsVanitySet(player.head, player.body, player.legs);
 				if (!string.IsNullOrEmpty(set))
 					globalItem.PreUpdateVanitySet(player, set);
@@ -1187,7 +1182,7 @@ namespace Terraria.ModLoader
 			if (legTexture != null && legTexture.IsVanitySet(player.head, player.body, player.legs))
 				legTexture.UpdateVanitySet(player);
 
-			foreach (GlobalItem globalItem in HookUpdateVanitySet.Enumerate(globalItemsArray)) {
+			foreach (GlobalItem globalItem in HookUpdateVanitySet.Enumerate(globalItems)) {
 				string set = globalItem.IsVanitySet(player.head, player.body, player.legs);
 				if (!string.IsNullOrEmpty(set))
 					globalItem.UpdateVanitySet(player, set);
@@ -1213,7 +1208,7 @@ namespace Terraria.ModLoader
 			if (legTexture != null && legTexture.IsVanitySet(player.head, player.body, player.legs))
 				legTexture.ArmorSetShadows(player);
 
-			foreach (GlobalItem globalItem in HookArmorSetShadows.Enumerate(globalItemsArray)) {
+			foreach (GlobalItem globalItem in HookArmorSetShadows.Enumerate(globalItems)) {
 				string set = globalItem.IsVanitySet(player.head, player.body, player.legs);
 				if (!string.IsNullOrEmpty(set))
 					globalItem.ArmorSetShadows(player, set);
@@ -1231,7 +1226,7 @@ namespace Terraria.ModLoader
 
 			texture?.SetMatch(male, ref equipSlot, ref robes);
 
-			foreach (var g in HookSetMatch.Enumerate(globalItemsArray)) {
+			foreach (var g in HookSetMatch.Enumerate(globalItems)) {
 				g.SetMatch(armorSlot, type, male, ref equipSlot, ref robes);
 			}
 		}
@@ -1313,7 +1308,7 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static bool PreOpenVanillaBag(string context, Player player, int arg) {
 			bool result = true;
-			foreach (var g in HookPreOpenVanillaBag.Enumerate(globalItemsArray)) {
+			foreach (var g in HookPreOpenVanillaBag.Enumerate(globalItems)) {
 				result &= g.PreOpenVanillaBag(context, player, arg);
 			}
 
@@ -1331,7 +1326,7 @@ namespace Terraria.ModLoader
 		/// Calls all GlobalItem.OpenVanillaBag hooks.
 		/// </summary>
 		public static void OpenVanillaBag(string context, Player player, int arg) {
-			foreach (var g in HookOpenVanillaBag.Enumerate(globalItemsArray)) {
+			foreach (var g in HookOpenVanillaBag.Enumerate(globalItems)) {
 				g.OpenVanillaBag(context, player, arg);
 			}
 		}
@@ -1346,7 +1341,7 @@ namespace Terraria.ModLoader
 			if (item1.prefix != item2.prefix) // TML: #StackablePrefixWeapons
 				return false;
 
-			foreach (var g in HookCanStack.Enumerate(globalItemsArray)) {
+			foreach (var g in HookCanStack.Enumerate(globalItems)) {
 				if (!g.CanStack(item1, item2))
 					return false;
 			}
@@ -1360,7 +1355,7 @@ namespace Terraria.ModLoader
 		/// Calls all GlobalItem.CanStackInWorld hooks until one returns false then ModItem.CanStackInWorld. Returns whether any of the hooks returned false.
 		/// </summary>
 		public static bool CanStackInWorld(Item item1, Item item2) {
-			foreach (var g in HookCanStackInWorld.Enumerate(globalItemsArray)) {
+			foreach (var g in HookCanStackInWorld.Enumerate(globalItems)) {
 				if (!g.CanStackInWorld(item1, item2))
 					return false;
 			}
@@ -1428,7 +1423,7 @@ namespace Terraria.ModLoader
 			EquipTexture texture = EquipLoader.GetEquipTexture(type, slot);
 			texture?.DrawArmorColor(drawPlayer, shadow, ref color, ref glowMask, ref glowMaskColor);
 
-			foreach (var g in HookDrawArmorColor.Enumerate(globalItemsArray)) {
+			foreach (var g in HookDrawArmorColor.Enumerate(globalItems)) {
 				g.DrawArmorColor(type, slot, drawPlayer, shadow, ref color, ref glowMask, ref glowMaskColor);
 			}
 		}
@@ -1444,7 +1439,7 @@ namespace Terraria.ModLoader
 
 			texture?.ArmorArmGlowMask(drawPlayer, shadow, ref glowMask, ref color);
 
-			foreach (var g in HookArmorArmGlowMask.Enumerate(globalItemsArray)) {
+			foreach (var g in HookArmorArmGlowMask.Enumerate(globalItems)) {
 				g.ArmorArmGlowMask(slot, drawPlayer, shadow, ref glowMask, ref color);
 			}
 		}
@@ -1537,7 +1532,7 @@ namespace Terraria.ModLoader
 			EquipTexture texture = EquipLoader.GetEquipTexture(EquipType.Wings, player.wings);
 			bool? retVal = texture?.WingUpdate(player, inUse);
 
-			foreach (var g in HookWingUpdate.Enumerate(globalItemsArray)) {
+			foreach (var g in HookWingUpdate.Enumerate(globalItems)) {
 				retVal |= g.WingUpdate(player.wings, player, inUse);
 			}
 
@@ -1753,7 +1748,7 @@ namespace Terraria.ModLoader
 				}
 			}
 
-			foreach (var g in HookHoldoutOffset.Enumerate(globalItemsArray)) {
+			foreach (var g in HookHoldoutOffset.Enumerate(globalItems)) {
 				Vector2? modOffset = g.HoldoutOffset(type);
 
 				if (modOffset.HasValue) {
@@ -1828,7 +1823,7 @@ namespace Terraria.ModLoader
 		public static void ExtractinatorUse(ref int resultType, ref int resultStack, int extractType) {
 			GetItem(extractType)?.ExtractinatorUse(ref resultType, ref resultStack);
 
-			foreach (var g in HookExtractinatorUse.Enumerate(globalItemsArray)) {
+			foreach (var g in HookExtractinatorUse.Enumerate(globalItems)) {
 				g.ExtractinatorUse(extractType, ref resultType, ref resultStack);
 			}
 		}
@@ -1851,7 +1846,7 @@ namespace Terraria.ModLoader
 			if (modItem != null)
 				notAvailable |= !modItem.IsAnglerQuestAvailable();
 
-			foreach (var g in HookIsAnglerQuestAvailable.Enumerate(globalItemsArray)) {
+			foreach (var g in HookIsAnglerQuestAvailable.Enumerate(globalItems)) {
 				notAvailable |= !g.IsAnglerQuestAvailable(itemID);
 			}
 		}
@@ -1864,7 +1859,7 @@ namespace Terraria.ModLoader
 			string catchLocation = "";
 			GetItem(type)?.AnglerQuestChat(ref chat, ref catchLocation);
 
-			foreach (var g in HookAnglerChat.Enumerate(globalItemsArray)) {
+			foreach (var g in HookAnglerChat.Enumerate(globalItems)) {
 				g.AnglerChat(type, ref chat, ref catchLocation);
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -123,7 +123,7 @@ namespace Terraria.ModLoader
 			FindVanillaWings();
 
 			globalItemsArray = globalItems
-				.Select(g => new Instanced<GlobalItem>(g.index, g))
+				.Select(g => new Instanced<GlobalItem>(g.Index, g))
 				.ToArray();
 
 			NetGlobals = globalItems.WhereMethodIsOverridden<GlobalItem, Action<Item, BinaryWriter>>(g => g.NetSend).ToArray();

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -20,12 +20,20 @@ namespace Terraria.ModLoader
 		public Player Player => Entity;
 
 		public ushort Index { get; internal set; }
+		
+		protected override Player CreateTemplateEntity() => null;
+
+		public override ModPlayer NewInstance(Player entity) {
+			var inst = base.NewInstance(entity);
+			
+			inst.Index = Index;
+
+			return inst;
+		}
 
 		public bool TypeEquals(ModPlayer other) {
 			return Mod == other.Mod && Name == other.Name;
 		}
-
-		protected override Player CreateTemplateEntity() => null;
 
 		protected override void ValidateType() {
 			base.ValidateType();

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -14,13 +14,13 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	{
+		public ushort Index { get; internal set; }
+
 		/// <summary>
 		/// The Player instance that this ModPlayer instance is attached to.
 		/// </summary>
 		public Player Player => Entity;
 
-		public ushort Index { get; internal set; }
-		
 		protected override Player CreateTemplateEntity() => null;
 
 		public override ModPlayer NewInstance(Player entity) {

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -12,16 +12,12 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// A ModPlayer instance represents an extension of a Player instance. You can store fields in the ModPlayer classes, much like how the Player class abuses field usage, to keep track of mod-specific information on the player that a ModPlayer instance represents. It also contains hooks to insert your code into the Player class.
 	/// </summary>
-	public abstract class ModPlayer : ModType<Player, ModPlayer>
+	public abstract class ModPlayer : GlobalType<Player, ModPlayer>
 	{
 		/// <summary>
 		/// The Player instance that this ModPlayer instance is attached to.
 		/// </summary>
-		public Player Player => Entity;
-
-		internal ushort index;
-
-		protected override Player CreateTemplateEntity() => null;
+		public Player Player { get; private set; }
 
 		public override ModPlayer NewInstance(Player entity) {
 			var inst = base.NewInstance(entity);

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -12,22 +12,20 @@ namespace Terraria.ModLoader
 	/// <summary>
 	/// A ModPlayer instance represents an extension of a Player instance. You can store fields in the ModPlayer classes, much like how the Player class abuses field usage, to keep track of mod-specific information on the player that a ModPlayer instance represents. It also contains hooks to insert your code into the Player class.
 	/// </summary>
-	public abstract class ModPlayer : GlobalType<Player, ModPlayer>
+	public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	{
 		/// <summary>
 		/// The Player instance that this ModPlayer instance is attached to.
 		/// </summary>
-		public Player Player { get; private set; }
+		public Player Player => Entity;
 
-		public override ModPlayer NewInstance(Player entity) {
-			var inst = base.NewInstance(entity);
-			inst.index = index;
-			return inst;
-		}
+		public ushort Index { get; internal set; }
 
 		public bool TypeEquals(ModPlayer other) {
 			return Mod == other.Mod && Name == other.Name;
 		}
+
+		protected override Player CreateTemplateEntity() => null;
 
 		protected override void ValidateType() {
 			base.ValidateType();

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -36,7 +36,6 @@ namespace Terraria.ModLoader
 		/// </summary>
 		public static readonly IList<int> blockLoot = new List<int>();
 
-		private static Instanced<GlobalNPC>[] globalNPCsArray = new Instanced<GlobalNPC>[0];
 		private static readonly List<HookList> hooks = new List<HookList>();
 		private static readonly List<HookList> modHooks = new List<HookList>();
 
@@ -129,10 +128,6 @@ namespace Terraria.ModLoader
 				Main.npcFrameCount[k] = 1;
 				Lang._npcNameCache[k] = LocalizedText.Empty;
 			}
-
-			globalNPCsArray = globalNPCs
-				.Select(g => new Instanced<GlobalNPC>(g.Index, g))
-				.ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(globalNPCs);
@@ -441,7 +436,7 @@ namespace Terraria.ModLoader
 
 		private static HookList HookModifyGlobalLoot = AddHook<Action<GlobalLoot>>(g => g.ModifyGlobalLoot);
 		public static void ModifyGlobalLoot(GlobalLoot globalLoot) {
-			foreach (GlobalNPC g in HookModifyGlobalLoot.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookModifyGlobalLoot.Enumerate(globalNPCs)) {
 				g.ModifyGlobalLoot(globalLoot);
 			}
 		}
@@ -839,7 +834,7 @@ namespace Terraria.ModLoader
 		private static HookList HookEditSpawnRate = AddHook<DelegateEditSpawnRate>(g => g.EditSpawnRate);
 
 		public static void EditSpawnRate(Player player, ref int spawnRate, ref int maxSpawns) {
-			foreach (GlobalNPC g in HookEditSpawnRate.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookEditSpawnRate.Enumerate(globalNPCs)) {
 				g.EditSpawnRate(player, ref spawnRate, ref maxSpawns);
 			}
 		}
@@ -850,7 +845,7 @@ namespace Terraria.ModLoader
 
 		public static void EditSpawnRange(Player player, ref int spawnRangeX, ref int spawnRangeY,
 			ref int safeRangeX, ref int safeRangeY) {
-			foreach (GlobalNPC g in HookEditSpawnRange.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookEditSpawnRange.Enumerate(globalNPCs)) {
 				g.EditSpawnRange(player, ref spawnRangeX, ref spawnRangeY, ref safeRangeX, ref safeRangeY);
 			}
 		}
@@ -869,7 +864,7 @@ namespace Terraria.ModLoader
 					pool[npc.NPC.type] = weight;
 				}
 			}
-			foreach (GlobalNPC g in HookEditSpawnPool.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookEditSpawnPool.Enumerate(globalNPCs)) {
 				g.EditSpawnPool(pool, spawnInfo);
 			}
 			float totalWeight = 0f;
@@ -926,7 +921,7 @@ namespace Terraria.ModLoader
 		public static void ModifyNPCHappiness(NPC npc, int primaryPlayerBiome, ShopHelper shopHelperInstance, bool[] nearbyNPCsByType) {
 			npc.ModNPC?.ModifyNPCHappiness(primaryPlayerBiome, shopHelperInstance, nearbyNPCsByType);
 
-			foreach (GlobalNPC g in HookModifyNPCHappiness.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookModifyNPCHappiness.Enumerate(globalNPCs)) {
 				g.Instance(npc).ModifyNPCHappiness(npc, primaryPlayerBiome, shopHelperInstance, nearbyNPCsByType);
 			}
 		}
@@ -1066,7 +1061,7 @@ namespace Terraria.ModLoader
 			else {
 				GetNPC(type)?.SetupShop(shop, ref nextSlot);
 			}
-			foreach (GlobalNPC g in HookSetupShop.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookSetupShop.Enumerate(globalNPCs)) {
 				g.SetupShop(type, shop, ref nextSlot);
 			}
 		}
@@ -1075,7 +1070,7 @@ namespace Terraria.ModLoader
 		private static HookList HookSetupTravelShop = AddHook<DelegateSetupTravelShop>(g => g.SetupTravelShop);
 
 		public static void SetupTravelShop(int[] shop, ref int nextSlot) {
-			foreach (GlobalNPC g in HookSetupTravelShop.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookSetupTravelShop.Enumerate(globalNPCs)) {
 				g.SetupTravelShop(shop, ref nextSlot);
 			}
 		}
@@ -1112,7 +1107,7 @@ namespace Terraria.ModLoader
 		private static HookList HookBuffTownNPC = AddHook<DelegateBuffTownNPC>(g => g.BuffTownNPC);
 
 		public static void BuffTownNPC(ref float damageMult, ref int defense) {
-			foreach (GlobalNPC g in HookBuffTownNPC.Enumerate(globalNPCsArray)) {
+			foreach (GlobalNPC g in HookBuffTownNPC.Enumerate(globalNPCs)) {
 				g.BuffTownNPC(ref damageMult, ref defense);
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -131,7 +131,7 @@ namespace Terraria.ModLoader
 			}
 
 			globalNPCsArray = globalNPCs
-				.Select(g => new Instanced<GlobalNPC>(g.index, g))
+				.Select(g => new Instanced<GlobalNPC>(g.Index, g))
 				.ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -21,11 +21,20 @@ namespace Terraria.ModLoader
 	{
 		private static readonly List<ModPlayer> players = new();
 		private static readonly List<HookList> hooks = new();
+		private static readonly List<HookList> modHooks = new();
 
 		private static HookList AddHook<F>(Expression<Func<ModPlayer, F>> func) where F : Delegate {
 			var hook = HookList.Create(func);
 
 			hooks.Add(hook);
+
+			return hook;
+		}
+
+		public static T AddModHook<T>(T hook) where T : HookList {
+			hook.Update(players);
+
+			modHooks.Add(hook);
 
 			return hook;
 		}
@@ -36,7 +45,7 @@ namespace Terraria.ModLoader
 		}
 
 		internal static void RebuildHooks() {
-			foreach (var hook in hooks) {
+			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(players);
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -9,6 +9,7 @@ using Terraria.DataStructures;
 using Terraria.GameInput;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Default;
+using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.ModPlayer>;
 
 namespace Terraria.ModLoader
 {
@@ -18,23 +19,14 @@ namespace Terraria.ModLoader
 	/// </summary>
 	public static class PlayerLoader
 	{
-		private static readonly IList<ModPlayer> players = new List<ModPlayer>();
-
-		private class HookList
-		{
-			public int[] arr = new int[0];
-			public readonly MethodInfo method;
-
-			public HookList(MethodInfo method) {
-				this.method = method;
-			}
-		}
-
-		private static List<HookList> hooks = new List<HookList>();
+		private static readonly List<ModPlayer> players = new();
+		private static readonly List<HookList> hooks = new();
 
 		private static HookList AddHook<F>(Expression<Func<ModPlayer, F>> func) where F : Delegate {
-			var hook = new HookList(func.ToMethodInfo());
+			var hook = HookList.Create(func);
+
 			hooks.Add(hook);
+
 			return hook;
 		}
 
@@ -45,7 +37,7 @@ namespace Terraria.ModLoader
 
 		internal static void RebuildHooks() {
 			foreach (var hook in hooks) {
-				hook.arr = players.WhereMethodIsOverridden(hook.method).Select(p => (int)p.index).ToArray();
+				hook.Update(players);
 			}
 		}
 
@@ -54,27 +46,28 @@ namespace Terraria.ModLoader
 		}
 
 		private static HookList HookInitialize = AddHook<Action>(p => p.Initialize);
-		internal static void SetupPlayer(Player player) {
-			player.modPlayers = players.Select(modPlayer => modPlayer.NewInstance(player)).ToArray();
 
-			foreach (int index in HookInitialize.arr) {
-				player.modPlayers[index].Initialize();
+		internal static void SetupPlayer(Player player) {
+			LoaderUtils.InstantiateGlobals(player, players, ref player.modPlayers, () => { });
+
+			foreach (var modPlayer in HookInitialize.Enumerate(player.ModPlayers.array)) {
+				modPlayer.Initialize();
 			}
 		}
 
 		private static HookList HookResetEffects = AddHook<Action>(p => p.ResetEffects);
 
 		public static void ResetEffects(Player player) {
-			foreach (int index in HookResetEffects.arr) {
-				player.modPlayers[index].ResetEffects();
+			foreach (var modPlayer in HookResetEffects.Enumerate(player.modPlayers)) {
+				modPlayer.ResetEffects();
 			}
 		}
 
 		private static HookList HookUpdateDead = AddHook<Action>(p => p.UpdateDead);
 
 		public static void UpdateDead(Player player) {
-			foreach (int index in HookUpdateDead.arr) {
-				player.modPlayers[index].UpdateDead();
+			foreach (var modPlayer in HookUpdateDead.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateDead();
 			}
 		}
 
@@ -102,56 +95,56 @@ namespace Terraria.ModLoader
 		private static HookList HookPreSavePlayer = AddHook<Action>(p => p.PreSavePlayer);
 
 		public static void PreSavePlayer(Player player) {
-			foreach (int index in HookPreSavePlayer.arr) {
-				player.modPlayers[index].PreSavePlayer();
+			foreach (var modPlayer in HookPreSavePlayer.Enumerate(player.modPlayers)) {
+				modPlayer.PreSavePlayer();
 			}
 		}
 
 		private static HookList HookPostSavePlayer = AddHook<Action>(p => p.PostSavePlayer);
 
 		public static void PostSavePlayer(Player player) {
-			foreach (int index in HookPostSavePlayer.arr) {
-				player.modPlayers[index].PostSavePlayer();
+			foreach (var modPlayer in HookPostSavePlayer.Enumerate(player.modPlayers)) {
+				modPlayer.PostSavePlayer();
 			}
 		}
 
 		private static HookList HookClientClone = AddHook<Action<ModPlayer>>(p => p.clientClone);
 
 		public static void clientClone(Player player, Player clientClone) {
-			foreach (int index in HookClientClone.arr) {
-				player.modPlayers[index].clientClone(clientClone.modPlayers[index]);
+			foreach (var modPlayer in HookClientClone.Enumerate(player.modPlayers)) {
+				modPlayer.clientClone(clientClone.modPlayers[modPlayer.index].Instance);
 			}
 		}
 
 		private static HookList HookSyncPlayer = AddHook<Action<int, int, bool>>(p => p.SyncPlayer);
 
 		public static void SyncPlayer(Player player, int toWho, int fromWho, bool newPlayer) {
-			foreach (int index in HookSyncPlayer.arr) {
-				player.modPlayers[index].SyncPlayer(toWho, fromWho, newPlayer);
+			foreach (var modPlayer in HookSyncPlayer.Enumerate(player.modPlayers)) {
+				modPlayer.SyncPlayer(toWho, fromWho, newPlayer);
 			}
 		}
 
 		private static HookList HookSendClientChanges = AddHook<Action<ModPlayer>>(p => p.SendClientChanges);
 
 		public static void SendClientChanges(Player player, Player clientPlayer) {
-			foreach (int index in HookSendClientChanges.arr) {
-				player.modPlayers[index].SendClientChanges(clientPlayer.modPlayers[index]);
+			foreach (var modPlayer in HookSendClientChanges.Enumerate(player.modPlayers)) {
+				modPlayer.SendClientChanges(clientPlayer.modPlayers[modPlayer.index].Instance);
 			}
 		}
 
 		private static HookList HookUpdateBadLifeRegen = AddHook<Action>(p => p.UpdateBadLifeRegen);
 
 		public static void UpdateBadLifeRegen(Player player) {
-			foreach (int index in HookUpdateBadLifeRegen.arr) {
-				player.modPlayers[index].UpdateBadLifeRegen();
+			foreach (var modPlayer in HookUpdateBadLifeRegen.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateBadLifeRegen();
 			}
 		}
 
 		private static HookList HookUpdateLifeRegen = AddHook<Action>(p => p.UpdateLifeRegen);
 
 		public static void UpdateLifeRegen(Player player) {
-			foreach (int index in HookUpdateLifeRegen.arr) {
-				player.modPlayers[index].UpdateLifeRegen();
+			foreach (var modPlayer in HookUpdateLifeRegen.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateLifeRegen();
 			}
 		}
 
@@ -159,48 +152,48 @@ namespace Terraria.ModLoader
 		private static HookList HookNaturalLifeRegen = AddHook<DelegateNaturalLifeRegen>(p => p.NaturalLifeRegen);
 
 		public static void NaturalLifeRegen(Player player, ref float regen) {
-			foreach (int index in HookNaturalLifeRegen.arr) {
-				player.modPlayers[index].NaturalLifeRegen(ref regen);
+			foreach (var modPlayer in HookNaturalLifeRegen.Enumerate(player.modPlayers)) {
+				modPlayer.NaturalLifeRegen(ref regen);
 			}
 		}
 
 		private static HookList HookUpdateAutopause = AddHook<Action>(p => p.UpdateAutopause);
 
 		public static void UpdateAutopause(Player player) {
-			foreach (int index in HookUpdateAutopause.arr) {
-				player.modPlayers[index].UpdateAutopause();
+			foreach (var modPlayer in HookUpdateAutopause.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateAutopause();
 			}
 		}
 
 		private static HookList HookPreUpdate = AddHook<Action>(p => p.PreUpdate);
 
 		public static void PreUpdate(Player player) {
-			foreach (int index in HookPreUpdate.arr) {
-				player.modPlayers[index].PreUpdate();
+			foreach (var modPlayer in HookPreUpdate.Enumerate(player.modPlayers)) {
+				modPlayer.PreUpdate();
 			}
 		}
 
 		private static HookList HookSetControls = AddHook<Action>(p => p.SetControls);
 
 		public static void SetControls(Player player) {
-			foreach (int index in HookSetControls.arr) {
-				player.modPlayers[index].SetControls();
+			foreach (var modPlayer in HookSetControls.Enumerate(player.modPlayers)) {
+				modPlayer.SetControls();
 			}
 		}
 
 		private static HookList HookPreUpdateBuffs = AddHook<Action>(p => p.PreUpdateBuffs);
 
 		public static void PreUpdateBuffs(Player player) {
-			foreach (int index in HookPreUpdateBuffs.arr) {
-				player.modPlayers[index].PreUpdateBuffs();
+			foreach (var modPlayer in HookPreUpdateBuffs.Enumerate(player.modPlayers)) {
+				modPlayer.PreUpdateBuffs();
 			}
 		}
 
 		private static HookList HookPostUpdateBuffs = AddHook<Action>(p => p.PostUpdateBuffs);
 
 		public static void PostUpdateBuffs(Player player) {
-			foreach (int index in HookPostUpdateBuffs.arr) {
-				player.modPlayers[index].PostUpdateBuffs();
+			foreach (var modPlayer in HookPostUpdateBuffs.Enumerate(player.modPlayers)) {
+				modPlayer.PostUpdateBuffs();
 			}
 		}
 
@@ -208,80 +201,80 @@ namespace Terraria.ModLoader
 		private static HookList HookUpdateEquips = AddHook<DelegateUpdateEquips>(p => p.UpdateEquips);
 
 		public static void UpdateEquips(Player player) {
-			foreach (int index in HookUpdateEquips.arr) {
-				player.modPlayers[index].UpdateEquips();
+			foreach (var modPlayer in HookUpdateEquips.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateEquips();
 			}
 		}
 
 		private static HookList HookPostUpdateEquips = AddHook<Action>(p => p.PostUpdateEquips);
 
 		public static void PostUpdateEquips(Player player) {
-			foreach (int index in HookPostUpdateEquips.arr) {
-				player.modPlayers[index].PostUpdateEquips();
+			foreach (var modPlayer in HookPostUpdateEquips.Enumerate(player.modPlayers)) {
+				modPlayer.PostUpdateEquips();
 			}
 		}
 
 		private static HookList HookUpdateVisibleAccessories = AddHook<Action>(p => p.UpdateVisibleAccessories);
 
 		public static void UpdateVisibleAccessories(Player player) {
-			foreach (int index in HookUpdateVisibleAccessories.arr) {
-				player.modPlayers[index].UpdateVisibleAccessories();
+			foreach (var modPlayer in HookUpdateVisibleAccessories.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateVisibleAccessories();
 			}
 		}
 
 		private static HookList HookUpdateVisibleVanityAccessories = AddHook<Action>(p => p.UpdateVisibleVanityAccessories);
 
 		public static void UpdateVisibleVanityAccessories(Player player) {
-			foreach (int index in HookUpdateVisibleVanityAccessories.arr) {
-				player.modPlayers[index].UpdateVisibleVanityAccessories();
+			foreach (var modPlayer in HookUpdateVisibleVanityAccessories.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateVisibleVanityAccessories();
 			}
 		}
 
 		private static HookList HookUpdateDyes = AddHook<Action>(p => p.UpdateDyes);
 
 		public static void UpdateDyes(Player player) {
-			foreach (int index in HookUpdateDyes.arr) {
-				player.modPlayers[index].UpdateDyes();
+			foreach (var modPlayer in HookUpdateDyes.Enumerate(player.modPlayers)) {
+				modPlayer.UpdateDyes();
 			}
 		}
 
 		private static HookList HookPostUpdateMiscEffects = AddHook<Action>(p => p.PostUpdateMiscEffects);
 
 		public static void PostUpdateMiscEffects(Player player) {
-			foreach (int index in HookPostUpdateMiscEffects.arr) {
-				player.modPlayers[index].PostUpdateMiscEffects();
+			foreach (var modPlayer in HookPostUpdateMiscEffects.Enumerate(player.modPlayers)) {
+				modPlayer.PostUpdateMiscEffects();
 			}
 		}
 
 		private static HookList HookPostUpdateRunSpeeds = AddHook<Action>(p => p.PostUpdateRunSpeeds);
 
 		public static void PostUpdateRunSpeeds(Player player) {
-			foreach (int index in HookPostUpdateRunSpeeds.arr) {
-				player.modPlayers[index].PostUpdateRunSpeeds();
+			foreach (var modPlayer in HookPostUpdateRunSpeeds.Enumerate(player.modPlayers)) {
+				modPlayer.PostUpdateRunSpeeds();
 			}
 		}
 
 		private static HookList HookPreUpdateMovement = AddHook<Action>(p => p.PreUpdateMovement);
 
 		public static void PreUpdateMovement(Player player) {
-			foreach (int index in HookPreUpdateMovement.arr) {
-				player.modPlayers[index].PreUpdateMovement();
+			foreach (var modPlayer in HookPreUpdateMovement.Enumerate(player.modPlayers)) {
+				modPlayer.PreUpdateMovement();
 			}
 		}
 
 		private static HookList HookPostUpdate = AddHook<Action>(p => p.PostUpdate);
 
 		public static void PostUpdate(Player player) {
-			foreach (int index in HookPostUpdate.arr) {
-				player.modPlayers[index].PostUpdate();
+			foreach (var modPlayer in HookPostUpdate.Enumerate(player.modPlayers)) {
+				modPlayer.PostUpdate();
 			}
 		}
 
 		private static HookList HookFrameEffects = AddHook<Action>(p => p.FrameEffects);
 
 		public static void FrameEffects(Player player) {
-			foreach (int index in HookFrameEffects.arr) {
-				player.modPlayers[index].FrameEffects();
+			foreach (var modPlayer in HookFrameEffects.Enumerate(player.modPlayers)) {
+				modPlayer.FrameEffects();
 			}
 		}
 
@@ -292,8 +285,8 @@ namespace Terraria.ModLoader
 		public static bool PreHurt(Player player, bool pvp, bool quiet, ref int damage, ref int hitDirection,
 			ref bool crit, ref bool customDamage, ref bool playSound, ref bool genGore, ref PlayerDeathReason damageSource) {
 			bool flag = true;
-			foreach (int index in HookPreHurt.arr) {
-				if (!player.modPlayers[index].PreHurt(pvp, quiet, ref damage, ref hitDirection, ref crit, ref customDamage,
+			foreach (var modPlayer in HookPreHurt.Enumerate(player.modPlayers)) {
+				if (!modPlayer.PreHurt(pvp, quiet, ref damage, ref hitDirection, ref crit, ref customDamage,
 						ref playSound, ref genGore, ref damageSource)) {
 					flag = false;
 				}
@@ -304,16 +297,16 @@ namespace Terraria.ModLoader
 		private static HookList HookHurt = AddHook<Action<bool, bool, double, int, bool>>(p => p.Hurt);
 
 		public static void Hurt(Player player, bool pvp, bool quiet, double damage, int hitDirection, bool crit) {
-			foreach (int index in HookHurt.arr) {
-				player.modPlayers[index].Hurt(pvp, quiet, damage, hitDirection, crit);
+			foreach (var modPlayer in HookHurt.Enumerate(player.modPlayers)) {
+				modPlayer.Hurt(pvp, quiet, damage, hitDirection, crit);
 			}
 		}
 
 		private static HookList HookPostHurt = AddHook<Action<bool, bool, double, int, bool>>(p => p.PostHurt);
 
 		public static void PostHurt(Player player, bool pvp, bool quiet, double damage, int hitDirection, bool crit) {
-			foreach (int index in HookPostHurt.arr) {
-				player.modPlayers[index].PostHurt(pvp, quiet, damage, hitDirection, crit);
+			foreach (var modPlayer in HookPostHurt.Enumerate(player.modPlayers)) {
+				modPlayer.PostHurt(pvp, quiet, damage, hitDirection, crit);
 			}
 		}
 
@@ -324,8 +317,8 @@ namespace Terraria.ModLoader
 		public static bool PreKill(Player player, double damage, int hitDirection, bool pvp, ref bool playSound,
 			ref bool genGore, ref PlayerDeathReason damageSource) {
 			bool flag = true;
-			foreach (int index in HookPreKill.arr) {
-				if (!player.modPlayers[index].PreKill(damage, hitDirection, pvp, ref playSound, ref genGore, ref damageSource)) {
+			foreach (var modPlayer in HookPreKill.Enumerate(player.modPlayers)) {
+				if (!modPlayer.PreKill(damage, hitDirection, pvp, ref playSound, ref genGore, ref damageSource)) {
 					flag = false;
 				}
 			}
@@ -335,8 +328,8 @@ namespace Terraria.ModLoader
 		private static HookList HookKill = AddHook<Action<double, int, bool, PlayerDeathReason>>(p => p.Kill);
 
 		public static void Kill(Player player, double damage, int hitDirection, bool pvp, PlayerDeathReason damageSource) {
-			foreach (int index in HookKill.arr) {
-				player.modPlayers[index].Kill(damage, hitDirection, pvp, damageSource);
+			foreach (var modPlayer in HookKill.Enumerate(player.modPlayers)) {
+				modPlayer.Kill(damage, hitDirection, pvp, damageSource);
 			}
 		}
 
@@ -345,8 +338,8 @@ namespace Terraria.ModLoader
 
 		public static bool PreModifyLuck(Player player, ref float luck) {
 			bool flag = true;
-			foreach (int index in HookPreModifyLuck.arr) {
-				if (!player.modPlayers[index].PreModifyLuck(ref luck)) {
+			foreach (var modPlayer in HookPreModifyLuck.Enumerate(player.modPlayers)) {
+				if (!modPlayer.PreModifyLuck(ref luck)) {
 					flag = false;
 				}
 			}
@@ -357,8 +350,8 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyLuck = AddHook<DelegateModifyLuck>(p => p.ModifyLuck);
 
 		public static void ModifyLuck(Player player, ref float luck) {
-			foreach (int index in HookModifyLuck.arr) {
-				player.modPlayers[index].ModifyLuck(ref luck);
+			foreach (var modPlayer in HookModifyLuck.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyLuck(ref luck);
 			}
 		}
 
@@ -366,8 +359,8 @@ namespace Terraria.ModLoader
 
 		public static bool PreItemCheck(Player player) {
 			bool result = true;
-			foreach (int index in HookPreItemCheck.arr) {
-				result &= player.modPlayers[index].PreItemCheck();
+			foreach (var modPlayer in HookPreItemCheck.Enumerate(player.modPlayers)) {
+				result &= modPlayer.PreItemCheck();
 			}
 			return result;
 		}
@@ -375,8 +368,8 @@ namespace Terraria.ModLoader
 		private static HookList HookPostItemCheck = AddHook<Action>(p => p.PostItemCheck);
 
 		public static void PostItemCheck(Player player) {
-			foreach (int index in HookPostItemCheck.arr) {
-				player.modPlayers[index].PostItemCheck();
+			foreach (var modPlayer in HookPostItemCheck.Enumerate(player.modPlayers)) {
+				modPlayer.PostItemCheck();
 			}
 		}
 
@@ -388,8 +381,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return multiplier;
 
-			foreach (int index in HookUseTimeMultiplier.arr) {
-				multiplier *= player.modPlayers[index].UseTimeMultiplier(item);
+			foreach (var modPlayer in HookUseTimeMultiplier.Enumerate(player.modPlayers)) {
+				multiplier *= modPlayer.UseTimeMultiplier(item);
 			}
 
 			return multiplier;
@@ -403,8 +396,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return multiplier;
 
-			foreach (int index in HookUseAnimationMultiplier.arr) {
-				multiplier *= player.modPlayers[index].UseAnimationMultiplier(item);
+			foreach (var modPlayer in HookUseAnimationMultiplier.Enumerate(player.modPlayers)) {
+				multiplier *= modPlayer.UseAnimationMultiplier(item);
 			}
 
 			return multiplier;
@@ -418,8 +411,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return multiplier;
 
-			foreach (int index in HookUseSpeedMultiplier.arr) {
-				multiplier *= player.modPlayers[index].UseSpeedMultiplier(item);
+			foreach (var modPlayer in HookUseSpeedMultiplier.Enumerate(player.modPlayers)) {
+				multiplier *= modPlayer.UseSpeedMultiplier(item);
 			}
 
 			return multiplier;
@@ -432,8 +425,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookGetHealLife.arr) {
-				player.modPlayers[index].GetHealLife(item, quickHeal, ref healValue);
+			foreach (var modPlayer in HookGetHealLife.Enumerate(player.modPlayers)) {
+				modPlayer.GetHealLife(item, quickHeal, ref healValue);
 			}
 		}
 
@@ -444,8 +437,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookGetHealMana.arr) {
-				player.modPlayers[index].GetHealMana(item, quickHeal, ref healValue);
+			foreach (var modPlayer in HookGetHealMana.Enumerate(player.modPlayers)) {
+				modPlayer.GetHealMana(item, quickHeal, ref healValue);
 			}
 		}
 
@@ -456,8 +449,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookModifyManaCost.arr) {
-				player.modPlayers[index].ModifyManaCost(item, ref reduce, ref mult);
+			foreach (var modPlayer in HookModifyManaCost.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyManaCost(item, ref reduce, ref mult);
 			}
 		}
 
@@ -467,8 +460,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookOnMissingMana.arr) {
-				player.modPlayers[index].OnMissingMana(item, manaNeeded);
+			foreach (var modPlayer in HookOnMissingMana.Enumerate(player.modPlayers)) {
+				modPlayer.OnMissingMana(item, manaNeeded);
 			}
 		}
 
@@ -478,8 +471,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookOnConsumeMana.arr) {
-				player.modPlayers[index].OnConsumeMana(item, manaConsumed);
+			foreach (var modPlayer in HookOnConsumeMana.Enumerate(player.modPlayers)) {
+				modPlayer.OnConsumeMana(item, manaConsumed);
 			}
 		}
 
@@ -492,16 +485,16 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookModifyWeaponDamage.arr) {
-				player.modPlayers[index].ModifyWeaponDamage(item, ref damage);
+			foreach (var modPlayer in HookModifyWeaponDamage.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyWeaponDamage(item, ref damage);
 			}
 		}
 
 		private static HookList HookProcessTriggers = AddHook<Action<TriggersSet>>(p => p.ProcessTriggers);
 
 		public static void ProcessTriggers(Player player, TriggersSet triggersSet) {
-			foreach (int index in HookProcessTriggers.arr) {
-				player.modPlayers[index].ProcessTriggers(triggersSet);
+			foreach (var modPlayer in HookProcessTriggers.Enumerate(player.modPlayers)) {
+				modPlayer.ProcessTriggers(triggersSet);
 			}
 		}
 
@@ -512,8 +505,8 @@ namespace Terraria.ModLoader
 			if (item.IsAir)
 				return;
 
-			foreach (int index in HookModifyWeaponKnockback.arr) {
-				player.modPlayers[index].ModifyWeaponKnockback(item, ref knockback);
+			foreach (var modPlayer in HookModifyWeaponKnockback.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyWeaponKnockback(item, ref knockback);
 			}
 		}
 
@@ -522,16 +515,16 @@ namespace Terraria.ModLoader
 
 		public static void ModifyWeaponCrit(Player player, Item item, ref float crit) {
 			if (item.IsAir) return;
-			foreach (int index in HookModifyWeaponCrit.arr) {
-				player.modPlayers[index].ModifyWeaponCrit(item, ref crit);
+			foreach (var modPlayer in HookModifyWeaponCrit.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyWeaponCrit(item, ref crit);
 			}
 		}
 
 		private static HookList HookCanConsumeAmmo = AddHook<Func<Item, Item, bool>>(p => p.CanConsumeAmmo);
 
 		public static bool CanConsumeAmmo(Player player, Item weapon, Item ammo) {
-			foreach (int index in HookCanConsumeAmmo.arr) {
-				if (!player.modPlayers[index].CanConsumeAmmo(weapon, ammo)) {
+			foreach (var modPlayer in HookCanConsumeAmmo.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanConsumeAmmo(weapon, ammo)) {
 					return false;
 				}
 			}
@@ -541,15 +534,15 @@ namespace Terraria.ModLoader
 		private static HookList HookOnConsumeAmmo = AddHook<Action<Item, Item>>(p => p.OnConsumeAmmo);
 
 		public static void OnConsumeAmmo(Player player, Item weapon, Item ammo) {
-			foreach (int index in HookOnConsumeAmmo.arr)
-				player.modPlayers[index].OnConsumeAmmo(weapon, ammo);
+			foreach (var modPlayer in HookOnConsumeAmmo.Enumerate(player.modPlayers))
+				modPlayer.OnConsumeAmmo(weapon, ammo);
 		}
 
 		private static HookList HookCanShoot = AddHook<Func<Item, bool>>(p => p.CanShoot);
 
 		public static bool CanShoot(Player player, Item item) {
-			foreach (int index in HookCanShoot.arr) {
-				if (!player.modPlayers[index].CanShoot(item))
+			foreach (var modPlayer in HookCanShoot.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanShoot(item))
 					return false;
 			}
 
@@ -560,8 +553,8 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyShootStats = AddHook<DelegateModifyShootStats>(p => p.ModifyShootStats);
 
 		public static void ModifyShootStats(Player player, Item item, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback) {
-			foreach (int index in HookModifyShootStats.arr) {
-				player.modPlayers[index].ModifyShootStats(item, ref position, ref velocity, ref type, ref damage, ref knockback);
+			foreach (var modPlayer in HookModifyShootStats.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyShootStats(item, ref position, ref velocity, ref type, ref damage, ref knockback);
 			}
 		}
 
@@ -570,8 +563,8 @@ namespace Terraria.ModLoader
 		public static bool Shoot(Player player, Item item, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {
 			bool defaultResult = true;
 
-			foreach (int index in HookShoot.arr) {
-				defaultResult &= player.modPlayers[index].Shoot(item, source, position, velocity, type, damage, knockback);
+			foreach (var modPlayer in HookShoot.Enumerate(player.modPlayers)) {
+				defaultResult &= modPlayer.Shoot(item, source, position, velocity, type, damage, knockback);
 			}
 
 			return defaultResult;
@@ -580,8 +573,8 @@ namespace Terraria.ModLoader
 		private static HookList HookMeleeEffects = AddHook<Action<Item, Rectangle>>(p => p.MeleeEffects);
 
 		public static void MeleeEffects(Player player, Item item, Rectangle hitbox) {
-			foreach (int index in HookMeleeEffects.arr) {
-				player.modPlayers[index].MeleeEffects(item, hitbox);
+			foreach (var modPlayer in HookMeleeEffects.Enumerate(player.modPlayers)) {
+				modPlayer.MeleeEffects(item, hitbox);
 			}
 		}
 
@@ -589,8 +582,8 @@ namespace Terraria.ModLoader
 
 		public static bool? CanCatchNPC(Player player, NPC target, Item item) {
 			bool? returnValue = null;
-			foreach (int index in HookCanCatchNPC.arr) {
-				bool? canCatch = player.modPlayers[index].CanCatchNPC(target, item);
+			foreach (var modPlayer in HookCanCatchNPC.Enumerate(player.modPlayers)) {
+				bool? canCatch = modPlayer.CanCatchNPC(target, item);
 				if (canCatch.HasValue) {
 					if (!canCatch.Value)
 						return false;
@@ -604,8 +597,8 @@ namespace Terraria.ModLoader
 		private static HookList HookOnCatchNPC = AddHook<Action<NPC, Item, bool>>(p => p.OnCatchNPC);
 
 		public static void OnCatchNPC(Player player, NPC target, Item item, bool failed) {
-			foreach (int index in HookOnCatchNPC.arr) {
-				player.modPlayers[index].OnCatchNPC(target, item, failed);
+			foreach (var modPlayer in HookOnCatchNPC.Enumerate(player.modPlayers)) {
+				modPlayer.OnCatchNPC(target, item, failed);
 			}
 		}
 
@@ -613,16 +606,16 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyItemScale = AddHook<DelegateModifyItemScale>(p => p.ModifyItemScale);
 
 		public static void ModifyItemScale(Player player, Item item, ref float scale) {
-			foreach (int index in HookModifyItemScale.arr) {
-				player.modPlayers[index].ModifyItemScale(item, ref scale);
+			foreach (var modPlayer in HookModifyItemScale.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyItemScale(item, ref scale);
 			}
 		}
 
 		private static HookList HookOnHitAnything = AddHook<Action<float, float, Entity>>(p => p.OnHitAnything);
 
 		public static void OnHitAnything(Player player, float x, float y, Entity victim) {
-			foreach (int index in HookOnHitAnything.arr) {
-				player.modPlayers[index].OnHitAnything(x, y, victim);
+			foreach (var modPlayer in HookOnHitAnything.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitAnything(x, y, victim);
 			}
 		}
 
@@ -631,8 +624,8 @@ namespace Terraria.ModLoader
 		public static bool? CanHitNPC(Player player, Item item, NPC target) {
 			bool? flag = null;
 
-			foreach (int index in HookCanHitNPC.arr) {
-				bool? canHit = player.modPlayers[index].CanHitNPC(item, target);
+			foreach (var modPlayer in HookCanHitNPC.Enumerate(player.modPlayers)) {
+				bool? canHit = modPlayer.CanHitNPC(item, target);
 
 				if (canHit.HasValue) {
 					if (!canHit.Value) {
@@ -650,16 +643,16 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyHitNPC = AddHook<DelegateModifyHitNPC>(p => p.ModifyHitNPC);
 
 		public static void ModifyHitNPC(Player player, Item item, NPC target, ref int damage, ref float knockback, ref bool crit) {
-			foreach (int index in HookModifyHitNPC.arr) {
-				player.modPlayers[index].ModifyHitNPC(item, target, ref damage, ref knockback, ref crit);
+			foreach (var modPlayer in HookModifyHitNPC.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitNPC(item, target, ref damage, ref knockback, ref crit);
 			}
 		}
 
 		private static HookList HookOnHitNPC = AddHook<Action<Item, NPC, int, float, bool>>(p => p.OnHitNPC);
 
 		public static void OnHitNPC(Player player, Item item, NPC target, int damage, float knockback, bool crit) {
-			foreach (int index in HookOnHitNPC.arr) {
-				player.modPlayers[index].OnHitNPC(item, target, damage, knockback, crit);
+			foreach (var modPlayer in HookOnHitNPC.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitNPC(item, target, damage, knockback, crit);
 			}
 		}
 
@@ -671,8 +664,8 @@ namespace Terraria.ModLoader
 			}
 			Player player = Main.player[proj.owner];
 			bool? flag = null;
-			foreach (int index in HookCanHitNPCWithProj.arr) {
-				bool? canHit = player.modPlayers[index].CanHitNPCWithProj(proj, target);
+			foreach (var modPlayer in HookCanHitNPCWithProj.Enumerate(player.modPlayers)) {
+				bool? canHit = modPlayer.CanHitNPCWithProj(proj, target);
 				if (canHit.HasValue && !canHit.Value) {
 					return false;
 				}
@@ -691,8 +684,8 @@ namespace Terraria.ModLoader
 				return;
 			}
 			Player player = Main.player[proj.owner];
-			foreach (int index in HookModifyHitNPCWithProj.arr) {
-				player.modPlayers[index].ModifyHitNPCWithProj(proj, target, ref damage, ref knockback, ref crit, ref hitDirection);
+			foreach (var modPlayer in HookModifyHitNPCWithProj.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitNPCWithProj(proj, target, ref damage, ref knockback, ref crit, ref hitDirection);
 			}
 		}
 
@@ -703,16 +696,16 @@ namespace Terraria.ModLoader
 				return;
 			}
 			Player player = Main.player[proj.owner];
-			foreach (int index in HookOnHitNPCWithProj.arr) {
-				player.modPlayers[index].OnHitNPCWithProj(proj, target, damage, knockback, crit);
+			foreach (var modPlayer in HookOnHitNPCWithProj.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitNPCWithProj(proj, target, damage, knockback, crit);
 			}
 		}
 
 		private static HookList HookCanHitPvp = AddHook<Func<Item, Player, bool>>(p => p.CanHitPvp);
 
 		public static bool CanHitPvp(Player player, Item item, Player target) {
-			foreach (int index in HookCanHitPvp.arr) {
-				if (!player.modPlayers[index].CanHitPvp(item, target)) {
+			foreach (var modPlayer in HookCanHitPvp.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanHitPvp(item, target)) {
 					return false;
 				}
 			}
@@ -723,16 +716,16 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyHitPvp = AddHook<DelegateModifyHitPvp>(p => p.ModifyHitPvp);
 
 		public static void ModifyHitPvp(Player player, Item item, Player target, ref int damage, ref bool crit) {
-			foreach (int index in HookModifyHitPvp.arr) {
-				player.modPlayers[index].ModifyHitPvp(item, target, ref damage, ref crit);
+			foreach (var modPlayer in HookModifyHitPvp.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitPvp(item, target, ref damage, ref crit);
 			}
 		}
 
 		private static HookList HookOnHitPvp = AddHook<Action<Item, Player, int, bool>>(p => p.OnHitPvp);
 
 		public static void OnHitPvp(Player player, Item item, Player target, int damage, bool crit) {
-			foreach (int index in HookOnHitPvp.arr) {
-				player.modPlayers[index].OnHitPvp(item, target, damage, crit);
+			foreach (var modPlayer in HookOnHitPvp.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitPvp(item, target, damage, crit);
 			}
 		}
 
@@ -740,8 +733,8 @@ namespace Terraria.ModLoader
 
 		public static bool CanHitPvpWithProj(Projectile proj, Player target) {
 			Player player = Main.player[proj.owner];
-			foreach (int index in HookCanHitPvpWithProj.arr) {
-				if (!player.modPlayers[index].CanHitPvpWithProj(proj, target)) {
+			foreach (var modPlayer in HookCanHitPvpWithProj.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanHitPvpWithProj(proj, target)) {
 					return false;
 				}
 			}
@@ -753,8 +746,8 @@ namespace Terraria.ModLoader
 
 		public static void ModifyHitPvpWithProj(Projectile proj, Player target, ref int damage, ref bool crit) {
 			Player player = Main.player[proj.owner];
-			foreach (int index in HookModifyHitPvpWithProj.arr) {
-				player.modPlayers[index].ModifyHitPvpWithProj(proj, target, ref damage, ref crit);
+			foreach (var modPlayer in HookModifyHitPvpWithProj.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitPvpWithProj(proj, target, ref damage, ref crit);
 			}
 		}
 
@@ -762,8 +755,8 @@ namespace Terraria.ModLoader
 
 		public static void OnHitPvpWithProj(Projectile proj, Player target, int damage, bool crit) {
 			Player player = Main.player[proj.owner];
-			foreach (int index in HookOnHitPvpWithProj.arr) {
-				player.modPlayers[index].OnHitPvpWithProj(proj, target, damage, crit);
+			foreach (var modPlayer in HookOnHitPvpWithProj.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitPvpWithProj(proj, target, damage, crit);
 			}
 		}
 
@@ -771,8 +764,8 @@ namespace Terraria.ModLoader
 		private static HookList HookCanBeHitByNPC = AddHook<DelegateCanBeHitByNPC>(p => p.CanBeHitByNPC);
 
 		public static bool CanBeHitByNPC(Player player, NPC npc, ref int cooldownSlot) {
-			foreach (int index in HookCanBeHitByNPC.arr) {
-				if (!player.modPlayers[index].CanBeHitByNPC(npc, ref cooldownSlot)) {
+			foreach (var modPlayer in HookCanBeHitByNPC.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanBeHitByNPC(npc, ref cooldownSlot)) {
 					return false;
 				}
 			}
@@ -783,24 +776,24 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyHitByNPC = AddHook<DelegateModifyHitByNPC>(p => p.ModifyHitByNPC);
 
 		public static void ModifyHitByNPC(Player player, NPC npc, ref int damage, ref bool crit) {
-			foreach (int index in HookModifyHitByNPC.arr) {
-				player.modPlayers[index].ModifyHitByNPC(npc, ref damage, ref crit);
+			foreach (var modPlayer in HookModifyHitByNPC.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitByNPC(npc, ref damage, ref crit);
 			}
 		}
 
 		private static HookList HookOnHitByNPC = AddHook<Action<NPC, int, bool>>(p => p.OnHitByNPC);
 
 		public static void OnHitByNPC(Player player, NPC npc, int damage, bool crit) {
-			foreach (int index in HookOnHitByNPC.arr) {
-				player.modPlayers[index].OnHitByNPC(npc, damage, crit);
+			foreach (var modPlayer in HookOnHitByNPC.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitByNPC(npc, damage, crit);
 			}
 		}
 
 		private static HookList HookCanBeHitByProjectile = AddHook<Func<Projectile, bool>>(p => p.CanBeHitByProjectile);
 
 		public static bool CanBeHitByProjectile(Player player, Projectile proj) {
-			foreach (int index in HookCanBeHitByProjectile.arr) {
-				if (!player.modPlayers[index].CanBeHitByProjectile(proj)) {
+			foreach (var modPlayer in HookCanBeHitByProjectile.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanBeHitByProjectile(proj)) {
 					return false;
 				}
 			}
@@ -811,16 +804,16 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyHitByProjectile = AddHook<DelegateModifyHitByProjectile>(p => p.ModifyHitByProjectile);
 
 		public static void ModifyHitByProjectile(Player player, Projectile proj, ref int damage, ref bool crit) {
-			foreach (int index in HookModifyHitByProjectile.arr) {
-				player.modPlayers[index].ModifyHitByProjectile(proj, ref damage, ref crit);
+			foreach (var modPlayer in HookModifyHitByProjectile.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyHitByProjectile(proj, ref damage, ref crit);
 			}
 		}
 
 		private static HookList HookOnHitByProjectile = AddHook<Action<Projectile, int, bool>>(p => p.OnHitByProjectile);
 
 		public static void OnHitByProjectile(Player player, Projectile proj, int damage, bool crit) {
-			foreach (int index in HookOnHitByProjectile.arr) {
-				player.modPlayers[index].OnHitByProjectile(proj, damage, crit);
+			foreach (var modPlayer in HookOnHitByProjectile.Enumerate(player.modPlayers)) {
+				modPlayer.OnHitByProjectile(proj, damage, crit);
 			}
 		}
 
@@ -828,8 +821,8 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyFishingAttempt = AddHook<DelegateModifyFishingAttempt>(p => p.ModifyFishingAttempt);
 
 		public static void ModifyFishingAttempt(Player player, ref FishingAttempt attempt) {
-			foreach (int index in HookModifyFishingAttempt.arr) {
-				player.modPlayers[index].ModifyFishingAttempt(ref attempt);
+			foreach (var modPlayer in HookModifyFishingAttempt.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyFishingAttempt(ref attempt);
 			}
 
 			attempt.rolledItemDrop = attempt.rolledEnemySpawn = 0; // Reset, modders need to use CatchFish for this 
@@ -839,8 +832,8 @@ namespace Terraria.ModLoader
 		private static HookList HookCatchFish = AddHook<DelegateCatchFish>(p => p.CatchFish);
 
 		public static void CatchFish(Player player, FishingAttempt attempt, ref int itemDrop, ref int enemySpawn, ref AdvancedPopupRequest sonar, ref Vector2 sonarPosition) {
-			foreach (int index in HookCatchFish.arr) {
-				player.modPlayers[index].CatchFish(attempt, ref itemDrop, ref enemySpawn, ref sonar, ref sonarPosition);
+			foreach (var modPlayer in HookCatchFish.Enumerate(player.modPlayers)) {
+				modPlayer.CatchFish(attempt, ref itemDrop, ref enemySpawn, ref sonar, ref sonarPosition);
 			}
 		}
 
@@ -848,8 +841,8 @@ namespace Terraria.ModLoader
 		private static HookList HookCaughtFish = AddHook<DelegateModifyCaughtFish>(p => p.ModifyCaughtFish);
 
 		public static void ModifyCaughtFish(Player player, Item fish) {
-			foreach (int index in HookCaughtFish.arr) {
-				player.modPlayers[index].ModifyCaughtFish(fish);
+			foreach (var modPlayer in HookCaughtFish.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyCaughtFish(fish);
 			}
 		}
 
@@ -858,8 +851,8 @@ namespace Terraria.ModLoader
 
 		public static bool? CanConsumeBait(Player player, Item bait) {
 			bool? ret = null;
-			foreach (int index in HookCaughtFish.arr) {
-				if (player.modPlayers[index].CanConsumeBait(bait) is bool b)
+			foreach (var modPlayer in HookCaughtFish.Enumerate(player.modPlayers)) {
+				if (modPlayer.CanConsumeBait(bait) is bool b)
 					ret = (ret ?? true) && b;
 			}
 			return ret;
@@ -869,24 +862,24 @@ namespace Terraria.ModLoader
 		private static HookList HookGetFishingLevel = AddHook<DelegateGetFishingLevel>(p => p.GetFishingLevel);
 
 		public static void GetFishingLevel(Player player, Item fishingRod, Item bait, ref float fishingLevel) {
-			foreach (int index in HookGetFishingLevel.arr) {
-				player.modPlayers[index].GetFishingLevel(fishingRod, bait, ref fishingLevel);
+			foreach (var modPlayer in HookGetFishingLevel.Enumerate(player.modPlayers)) {
+				modPlayer.GetFishingLevel(fishingRod, bait, ref fishingLevel);
 			}
 		}
 
 		private static HookList HookAnglerQuestReward = AddHook<Action<float, List<Item>>>(p => p.AnglerQuestReward);
 
 		public static void AnglerQuestReward(Player player, float rareMultiplier, List<Item> rewardItems) {
-			foreach (int index in HookAnglerQuestReward.arr) {
-				player.modPlayers[index].AnglerQuestReward(rareMultiplier, rewardItems);
+			foreach (var modPlayer in HookAnglerQuestReward.Enumerate(player.modPlayers)) {
+				modPlayer.AnglerQuestReward(rareMultiplier, rewardItems);
 			}
 		}
 
 		private static HookList HookGetDyeTraderReward = AddHook<Action<List<int>>>(p => p.GetDyeTraderReward);
 
 		public static void GetDyeTraderReward(Player player, List<int> rewardPool) {
-			foreach (int index in HookGetDyeTraderReward.arr) {
-				player.modPlayers[index].GetDyeTraderReward(rewardPool);
+			foreach (var modPlayer in HookGetDyeTraderReward.Enumerate(player.modPlayers)) {
+				modPlayer.GetDyeTraderReward(rewardPool);
 			}
 		}
 
@@ -894,9 +887,10 @@ namespace Terraria.ModLoader
 		private static HookList HookDrawEffects = AddHook<DelegateDrawEffects>(p => p.DrawEffects);
 
 		public static void DrawEffects(PlayerDrawSet drawInfo, ref float r, ref float g, ref float b, ref float a, ref bool fullBright) {
-			ModPlayer[] modPlayers = drawInfo.drawPlayer.modPlayers;
-			foreach (int index in HookDrawEffects.arr) {
-				modPlayers[index].DrawEffects(drawInfo, ref r, ref g, ref b, ref a, ref fullBright);
+			var player = drawInfo.drawPlayer;
+
+			foreach (var modPlayer in HookDrawEffects.Enumerate(player.modPlayers)) {
+				modPlayer.DrawEffects(drawInfo, ref r, ref g, ref b, ref a, ref fullBright);
 			}
 		}
 
@@ -904,33 +898,41 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyDrawInfo = AddHook<DelegateModifyDrawInfo>(p => p.ModifyDrawInfo);
 
 		public static void ModifyDrawInfo(ref PlayerDrawSet drawInfo) {
-			ModPlayer[] modPlayers = drawInfo.drawPlayer.modPlayers;
-			foreach (int index in HookModifyDrawInfo.arr) {
-				modPlayers[index].ModifyDrawInfo(ref drawInfo);
+			var player = drawInfo.drawPlayer;
+
+			foreach (var modPlayer in HookModifyDrawInfo.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyDrawInfo(ref drawInfo);
 			}
 		}
 
 		private static HookList HookModifyDrawLayerOrdering = AddHook<Action<IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position>>>(p => p.ModifyDrawLayerOrdering);
 
 		public static void ModifyDrawLayerOrdering(IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position> positions) {
-			foreach (int index in HookModifyDrawLayerOrdering.arr) {
-				players[index].ModifyDrawLayerOrdering(positions);
+			//TODO: Make Enumerate(players) work?
+			/*foreach (var modPlayer in HookModifyDrawLayerOrdering.Enumerate(players)) {
+				modPlayer.ModifyDrawLayerOrdering(positions);
+			}*/
+
+			foreach (var modPlayer in players) {
+				modPlayer.ModifyDrawLayerOrdering(positions);
 			}
 		}
 
 		private static HookList HookModifyDrawLayers = AddHook<Action<PlayerDrawSet>>(p => p.HideDrawLayers);
 
 		public static void HideDrawLayers(PlayerDrawSet drawInfo) {
-			foreach (int index in HookModifyDrawLayers.arr) {
-				drawInfo.drawPlayer.modPlayers[index].HideDrawLayers(drawInfo);
+			var player = drawInfo.drawPlayer;
+
+			foreach (var modPlayer in HookModifyDrawLayers.Enumerate(player.modPlayers)) {
+				modPlayer.HideDrawLayers(drawInfo);
 			}
 		}
 
 		private static HookList HookModifyScreenPosition = AddHook<Action>(p => p.ModifyScreenPosition);
 
 		public static void ModifyScreenPosition(Player player) {
-			foreach (int index in HookModifyScreenPosition.arr) {
-				player.modPlayers[index].ModifyScreenPosition();
+			foreach (var modPlayer in HookModifyScreenPosition.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyScreenPosition();
 			}
 		}
 
@@ -938,8 +940,8 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyZoom = AddHook<DelegateModifyZoom>(p => p.ModifyZoom);
 
 		public static void ModifyZoom(Player player, ref float zoom) {
-			foreach (int index in HookModifyZoom.arr) {
-				player.modPlayers[index].ModifyZoom(ref zoom);
+			foreach (var modPlayer in HookModifyZoom.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyZoom(ref zoom);
 			}
 		}
 
@@ -947,8 +949,8 @@ namespace Terraria.ModLoader
 
 		public static void PlayerConnect(int playerIndex) {
 			var player = Main.player[playerIndex];
-			foreach (int index in HookPlayerConnect.arr) {
-				player.modPlayers[index].PlayerConnect(player);
+			foreach (var modPlayer in HookPlayerConnect.Enumerate(player.modPlayers)) {
+				modPlayer.PlayerConnect(player);
 			}
 		}
 
@@ -956,8 +958,8 @@ namespace Terraria.ModLoader
 
 		public static void PlayerDisconnect(int playerIndex) {
 			var player = Main.player[playerIndex];
-			foreach (int index in HookPlayerDisconnect.arr) {
-				player.modPlayers[index].PlayerDisconnect(player);
+			foreach (var modPlayer in HookPlayerDisconnect.Enumerate(player.modPlayers)) {
+				modPlayer.PlayerDisconnect(player);
 			}
 		}
 
@@ -966,24 +968,24 @@ namespace Terraria.ModLoader
 		// Do NOT hook into the Player.Hooks.OnEnterWorld event
 		public static void OnEnterWorld(int playerIndex) {
 			var player = Main.player[playerIndex];
-			foreach (int index in HookOnEnterWorld.arr) {
-				player.modPlayers[index].OnEnterWorld(player);
+			foreach (var modPlayer in HookOnEnterWorld.Enumerate(player.modPlayers)) {
+				modPlayer.OnEnterWorld(player);
 			}
 		}
 
 		private static HookList HookOnRespawn = AddHook<Action<Player>>(p => p.OnRespawn);
 
 		public static void OnRespawn(Player player) {
-			foreach (int index in HookOnRespawn.arr) {
-				player.modPlayers[index].OnRespawn(player);
+			foreach (var modPlayer in HookOnRespawn.Enumerate(player.modPlayers)) {
+				modPlayer.OnRespawn(player);
 			}
 		}
 
 		private static HookList HookShiftClickSlot = AddHook<Func<Item[], int, int, bool>>(p => p.ShiftClickSlot);
 
 		public static bool ShiftClickSlot(Player player, Item[] inventory, int context, int slot) {
-			foreach (int index in HookShiftClickSlot.arr) {
-				if (player.modPlayers[index].ShiftClickSlot(inventory, context, slot)) {
+			foreach (var modPlayer in HookShiftClickSlot.Enumerate(player.modPlayers)) {
+				if (modPlayer.ShiftClickSlot(inventory, context, slot)) {
 					return true;
 				}
 			}
@@ -993,8 +995,8 @@ namespace Terraria.ModLoader
 		private static HookList HookPostSellItem = AddHook<Action<NPC, Item[], Item>>(p => p.PostSellItem);
 
 		public static void PostSellItem(Player player, NPC npc, Item[] shopInventory, Item item) {
-			foreach (int index in HookPostSellItem.arr) {
-				player.modPlayers[index].PostSellItem(npc, shopInventory, item);
+			foreach (var modPlayer in HookPostSellItem.Enumerate(player.modPlayers)) {
+				modPlayer.PostSellItem(npc, shopInventory, item);
 			}
 		}
 
@@ -1002,8 +1004,8 @@ namespace Terraria.ModLoader
 
 		// TODO: GlobalNPC and ModNPC hooks for Buy/Sell hooks as well.
 		public static bool CanSellItem(Player player, NPC npc, Item[] shopInventory, Item item) {
-			foreach (int index in HookCanSellItem.arr) {
-				if (!player.modPlayers[index].CanSellItem(npc, shopInventory, item))
+			foreach (var modPlayer in HookCanSellItem.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanSellItem(npc, shopInventory, item))
 					return false;
 			}
 			return true;
@@ -1012,16 +1014,16 @@ namespace Terraria.ModLoader
 		private static HookList HookPostBuyItem = AddHook<Action<NPC, Item[], Item>>(p => p.PostBuyItem);
 
 		public static void PostBuyItem(Player player, NPC npc, Item[] shopInventory, Item item) {
-			foreach (int index in HookPostBuyItem.arr) {
-				player.modPlayers[index].PostBuyItem(npc, shopInventory, item);
+			foreach (var modPlayer in HookPostBuyItem.Enumerate(player.modPlayers)) {
+				modPlayer.PostBuyItem(npc, shopInventory, item);
 			}
 		}
 
 		private static HookList HookCanBuyItem = AddHook<Func<NPC, Item[], Item, bool>>(p => p.CanBuyItem);
 
 		public static bool CanBuyItem(Player player, NPC npc, Item[] shopInventory, Item item) {
-			foreach (int index in HookCanBuyItem.arr) {
-				if (!player.modPlayers[index].CanBuyItem(npc, shopInventory, item))
+			foreach (var modPlayer in HookCanBuyItem.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanBuyItem(npc, shopInventory, item))
 					return false;
 			}
 			return true;
@@ -1030,8 +1032,8 @@ namespace Terraria.ModLoader
 		private static HookList HookCanUseItem = AddHook<Func<Item, bool>>(p => p.CanUseItem);
 
 		public static bool CanUseItem(Player player, Item item) {
-			foreach (int index in HookCanUseItem.arr) {
-				if (!player.modPlayers[index].CanUseItem(item))
+			foreach (var modPlayer in HookCanUseItem.Enumerate(player.modPlayers)) {
+				if (!modPlayer.CanUseItem(item))
 					return false;
 			}
 
@@ -1043,8 +1045,8 @@ namespace Terraria.ModLoader
 		public static bool? CanAutoReuseItem(Player player, Item item) {
 			bool? flag = null;
 
-			foreach (int index in HookCanAutoReuseItem.arr) {
-				bool? allow = player.modPlayers[index].CanAutoReuseItem(item);
+			foreach (var modPlayer in HookCanAutoReuseItem.Enumerate(player.modPlayers)) {
+				bool? allow = modPlayer.CanAutoReuseItem(item);
 
 				if (allow.HasValue) {
 					if (!allow.Value) {
@@ -1059,30 +1061,32 @@ namespace Terraria.ModLoader
 		}
 
 		private delegate bool DelegateModifyNurseHeal(NPC npc, ref int health, ref bool removeDebuffs, ref string chatText);
-		private static HookList HookModifyNurseHeal = AddHook<DelegateModifyNurseHeal>(p => p.ModifyNurseHeal);
+		
+		private static readonly HookList HookModifyNurseHeal = AddHook<DelegateModifyNurseHeal>(p => p.ModifyNurseHeal);
 
-		public static bool ModifyNurseHeal(Player p, NPC npc, ref int health, ref bool removeDebuffs, ref string chat) {
-			foreach (int index in HookModifyNurseHeal.arr) {
-				if (!p.modPlayers[index].ModifyNurseHeal(npc, ref health, ref removeDebuffs, ref chat))
+		public static bool ModifyNurseHeal(Player player, NPC npc, ref int health, ref bool removeDebuffs, ref string chat) {
+			foreach (var modPlayer in HookModifyNurseHeal.Enumerate(player.modPlayers)) {
+				if (!modPlayer.ModifyNurseHeal(npc, ref health, ref removeDebuffs, ref chat))
 					return false;
 			}
+
 			return true;
 		}
 
 		private delegate void DelegateModifyNursePrice(NPC npc, int health, bool removeDebuffs, ref int price);
 		private static HookList HookModifyNursePrice = AddHook<DelegateModifyNursePrice>(p => p.ModifyNursePrice);
 
-		public static void ModifyNursePrice(Player p, NPC npc, int health, bool removeDebuffs, ref int price) {
-			foreach (int index in HookModifyNursePrice.arr) {
-				p.modPlayers[index].ModifyNursePrice(npc, health, removeDebuffs, ref price);
+		public static void ModifyNursePrice(Player player, NPC npc, int health, bool removeDebuffs, ref int price) {
+			foreach (var modPlayer in HookModifyNursePrice.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyNursePrice(npc, health, removeDebuffs, ref price);
 			}
 		}
 
 		private static HookList HookPostNurseHeal = AddHook<Action<NPC, int, bool, int>>(p => p.PostNurseHeal);
 
 		public static void PostNurseHeal(Player player, NPC npc, int health, bool removeDebuffs, int price) {
-			foreach (int index in HookPostNurseHeal.arr) {
-				player.modPlayers[index].PostNurseHeal(npc, health, removeDebuffs, price);
+			foreach (var modPlayer in HookPostNurseHeal.Enumerate(player.modPlayers)) {
+				modPlayer.PostNurseHeal(npc, health, removeDebuffs, price);
 			}
 		}
 
@@ -1090,17 +1094,16 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyStartingInventory = AddHook<Action<IReadOnlyDictionary<string, List<Item>>, bool>>(p => p.ModifyStartingInventory);
 
 		public static List<Item> GetStartingItems(Player player, IEnumerable<Item> vanillaItems, bool mediumCoreDeath = false) {
-			var itemsByMod = new Dictionary<string, List<Item>>();
+			var itemsByMod = new Dictionary<string, List<Item>> {
+				["Terraria"] = vanillaItems.ToList()
+			};
 
-			itemsByMod["Terraria"] = vanillaItems.ToList();
-
-			foreach (int index in HookAddStartingItems.arr) {
-				ModPlayer modPlayer = player.modPlayers[index];
+			foreach (var modPlayer in HookAddStartingItems.Enumerate(player.modPlayers)) {
 				itemsByMod[modPlayer.Mod.Name] = modPlayer.AddStartingItems(mediumCoreDeath).ToList();
 			}
 
-			foreach (int index in HookModifyStartingInventory.arr) {
-				player.modPlayers[index].ModifyStartingInventory(itemsByMod, mediumCoreDeath);
+			foreach (var modPlayer in HookModifyStartingInventory.Enumerate(player.modPlayers)) {
+				modPlayer.ModifyStartingInventory(itemsByMod, mediumCoreDeath);
 			}
 
 			return itemsByMod

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -52,6 +52,7 @@ namespace Terraria.ModLoader
 
 		internal static void Unload() {
 			players.Clear();
+			modHooks.Clear();
 		}
 
 		private static HookList HookInitialize = AddHook<Action>(p => p.Initialize);

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -923,12 +923,7 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyDrawLayerOrdering = AddHook<Action<IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position>>>(p => p.ModifyDrawLayerOrdering);
 
 		public static void ModifyDrawLayerOrdering(IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position> positions) {
-			//TODO: Make Enumerate(players) work?
-			/*foreach (var modPlayer in HookModifyDrawLayerOrdering.Enumerate(players)) {
-				modPlayer.ModifyDrawLayerOrdering(positions);
-			}*/
-
-			foreach (var modPlayer in players) {
+			foreach (var modPlayer in HookModifyDrawLayerOrdering.Enumerate(players)) {
 				modPlayer.ModifyDrawLayerOrdering(positions);
 			}
 		}
@@ -955,7 +950,7 @@ namespace Terraria.ModLoader
 		private static HookList HookModifyZoom = AddHook<DelegateModifyZoom>(p => p.ModifyZoom);
 
 		public static void ModifyZoom(Player player, ref float zoom) {
-			foreach (var modPlayer in HookModifyZoom.Enumerate(player.modPlayers)) {
+			foreach (var modPlayer in HookModifyZoom.Enumerate(player.modPlayers.ToList())) {
 				modPlayer.ModifyZoom(ref zoom);
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -59,7 +59,7 @@ namespace Terraria.ModLoader
 		internal static void SetupPlayer(Player player) {
 			player.modPlayers = players.Select(modPlayer => new Instanced<ModPlayer>(modPlayer.Index, modPlayer.NewInstance(player))).ToArray();
 
-			foreach (var modPlayer in HookInitialize.Enumerate(player.ModPlayers.array)) {
+			foreach (var modPlayer in HookInitialize.Enumerate(player.modPlayers)) {
 				modPlayer.Initialize();
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -40,7 +40,7 @@ namespace Terraria.ModLoader
 		}
 
 		internal static void Add(ModPlayer player) {
-			player.index = (ushort)players.Count;
+			player.Index = (ushort)players.Count;
 			players.Add(player);
 		}
 
@@ -57,7 +57,7 @@ namespace Terraria.ModLoader
 		private static HookList HookInitialize = AddHook<Action>(p => p.Initialize);
 
 		internal static void SetupPlayer(Player player) {
-			LoaderUtils.InstantiateGlobals(player, players, ref player.modPlayers, () => { });
+			player.modPlayers = players.Select(modPlayer => new Instanced<ModPlayer>(modPlayer.Index, modPlayer.NewInstance(player))).ToArray();
 
 			foreach (var modPlayer in HookInitialize.Enumerate(player.ModPlayers.array)) {
 				modPlayer.Initialize();
@@ -121,7 +121,7 @@ namespace Terraria.ModLoader
 
 		public static void clientClone(Player player, Player clientClone) {
 			foreach (var modPlayer in HookClientClone.Enumerate(player.modPlayers)) {
-				modPlayer.clientClone(clientClone.modPlayers[modPlayer.index].Instance);
+				modPlayer.clientClone(clientClone.modPlayers[modPlayer.Index].Instance);
 			}
 		}
 
@@ -137,7 +137,7 @@ namespace Terraria.ModLoader
 
 		public static void SendClientChanges(Player player, Player clientPlayer) {
 			foreach (var modPlayer in HookSendClientChanges.Enumerate(player.modPlayers)) {
-				modPlayer.SendClientChanges(clientPlayer.modPlayers[modPlayer.index].Instance);
+				modPlayer.SendClientChanges(clientPlayer.modPlayers[modPlayer.Index].Instance);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -25,9 +25,8 @@ namespace Terraria.ModLoader
 		internal static readonly List<GlobalProjectile> globalProjectiles = new();
 
 		private static int nextProjectile = ProjectileID.Count;
-		private static readonly List<HookList> hooks = new List<HookList>();
-		private static readonly List<HookList> modHooks = new List<HookList>();
-		private static Instanced<GlobalProjectile>[] globalProjectilesArray = new Instanced<GlobalProjectile>[0];
+		private static readonly List<HookList> hooks = new();
+		private static readonly List<HookList> modHooks = new();
 
 		private static HookList AddHook<F>(Expression<Func<GlobalProjectile, F>> func) where F : Delegate {
 			var hook = HookList.Create(func);
@@ -87,10 +86,6 @@ namespace Terraria.ModLoader
 			for (int i = 0; i < nextProjectile; i++) {
 				Projectile.perIDStaticNPCImmunity[i] = new uint[200];
 			}
-
-			globalProjectilesArray = globalProjectiles
-				.Select(g => new Instanced<GlobalProjectile>(g.Index, g))
-				.ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {
 				hook.Update(globalProjectiles);
@@ -649,7 +644,7 @@ namespace Terraria.ModLoader
 		public static bool? CanUseGrapple(int type, Player player) {
 			bool? flag = GetProjectile(type)?.CanUseGrapple(player);
 
-			foreach (GlobalProjectile g in HookCanUseGrapple.Enumerate(globalProjectilesArray)) {
+			foreach (GlobalProjectile g in HookCanUseGrapple.Enumerate(globalProjectiles)) {
 				bool? canGrapple = g.CanUseGrapple(type, player);
 
 				if (canGrapple.HasValue) {
@@ -665,7 +660,7 @@ namespace Terraria.ModLoader
 		public static bool? SingleGrappleHook(int type, Player player) {
 			bool? flag = GetProjectile(type)?.SingleGrappleHook(player);
 
-			foreach (GlobalProjectile g in HookSingleGrappleHook.Enumerate(globalProjectilesArray)) {
+			foreach (GlobalProjectile g in HookSingleGrappleHook.Enumerate(globalProjectiles)) {
 				bool? singleHook = g.SingleGrappleHook(type, player);
 
 				if (singleHook.HasValue) {
@@ -682,7 +677,7 @@ namespace Terraria.ModLoader
 		public static void UseGrapple(Player player, ref int type) {
 			GetProjectile(type)?.UseGrapple(player, ref type);
 
-			foreach (GlobalProjectile g in HookUseGrapple.Enumerate(globalProjectilesArray)) {
+			foreach (GlobalProjectile g in HookUseGrapple.Enumerate(globalProjectiles)) {
 				g.UseGrapple(player, ref type);
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -89,7 +89,7 @@ namespace Terraria.ModLoader
 			}
 
 			globalProjectilesArray = globalProjectiles
-				.Select(g => new Instanced<GlobalProjectile>(g.index, g))
+				.Select(g => new Instanced<GlobalProjectile>(g.Index, g))
 				.ToArray();
 
 			foreach (var hook in hooks.Union(modHooks)) {

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -13,8 +13,11 @@ namespace Terraria
 	public partial class Player
 	{
 		internal IList<string> usedMods;
-		internal ModPlayer[] modPlayers = Array.Empty<ModPlayer>();
+		internal Instanced<ModPlayer>[] modPlayers = Array.Empty<Instanced<ModPlayer>>();
+
 		public Item equippedWings = null;
+
+		public RefReadOnlyArray<Instanced<ModPlayer>> ModPlayers => new(modPlayers);
 
 		public HashSet<int> NearbyModTorch { get; private set; } = new HashSet<int>();
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -34,7 +34,7 @@ namespace Terraria
 		/// <exception cref="IndexOutOfRangeException"/>
 		/// <exception cref="NullReferenceException"/>
 		public T GetModPlayer<T>(T baseInstance) where T : ModPlayer
-			=> modPlayers[baseInstance.index] as T ?? throw new KeyNotFoundException($"Instance of '{typeof(T).Name}' does not exist on the current player.");
+			=> modPlayers[baseInstance.Index] as T ?? throw new KeyNotFoundException($"Instance of '{typeof(T).Name}' does not exist on the current player.");
 
 		// TryGet
 
@@ -45,13 +45,13 @@ namespace Terraria
 		/// <summary> Safely attempts to get the local instance of the type of the specified ModPlayer instance. </summary>
 		/// <returns> Whether or not the requested instance has been found. </returns>
 		public bool TryGetModPlayer<T>(T baseInstance, out T result) where T : ModPlayer {
-			if (baseInstance == null || baseInstance.index < 0 || baseInstance.index >= modPlayers.Length) {
+			if (baseInstance == null || baseInstance.Index < 0 || baseInstance.Index >= modPlayers.Length) {
 				result = default;
 
 				return false;
 			}
 
-			result = modPlayers[baseInstance.index] as T;
+			result = modPlayers[baseInstance.Index] as T;
 
 			return result != null;
 		}

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -13,11 +13,11 @@ namespace Terraria
 	public partial class Player
 	{
 		internal IList<string> usedMods;
-		internal Instanced<ModPlayer>[] modPlayers = Array.Empty<Instanced<ModPlayer>>();
+		internal ModPlayer[] modPlayers = Array.Empty<ModPlayer>();
 
 		public Item equippedWings = null;
 
-		public RefReadOnlyArray<Instanced<ModPlayer>> ModPlayers => new(modPlayers);
+		public RefReadOnlyArray<ModPlayer> ModPlayers => new(modPlayers);
 
 		public HashSet<int> NearbyModTorch { get; private set; } = new HashSet<int>();
 


### PR DESCRIPTION
PR does the following:
- Makes `PlayerLoader` use `Terraria.ModLoader.Core.HookList<T>`, instead of its old-old nested class.
- Adds `PlayerLoader.AddModHook` method, in line with `ItemLoader`, `NPCLoader`, and `ProjectileLoader` classes.
- Since `ModPlayer` is something in-between `ModType<,>` and `GlobalType<,>`, and those classes appear as a proof of past mistakes, I had to add `IIndexed` interface with `ushort Index { get; }` in it, and put that on `ModPlayer` and `GlobalType<,>` to allow the former to be used with some `HookList<T>` methods.
- Most of the changes is the replacement of `GlobalType.index` field with the `Index` auto-property. Ignore.