### PR TITLE
Only log silently caught exceptions to console in servers.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
@@ -104,23 +104,23 @@ namespace Terraria.ModLoader
 						return;
 				}
 
-				previousException = args.Exception;
-				string msg = args.Exception.Message + " " + Language.GetTextValue("tModLoader.RuntimeErrorSeeLogsForFullTrace", Path.GetFileName(LogPath));
+				tML.Warn(Language.GetTextValue("tModLoader.RuntimeErrorSilentlyCaughtException") + '\n' + exString);
 
-				if (!Main.dedServ && ModCompile.activelyModding && !Main.gameMenu) {
-					AddChatMessage(msg);
-				}
-				else {
+				previousException = args.Exception;
+
+				string msg = args.Exception.Message + " " + Language.GetTextValue("tModLoader.RuntimeErrorSeeLogsForFullTrace", Path.GetFileName(LogPath));
+				if (Main.dedServ) { // TODO, sometimes console write fails on unix clients. Hopefully it doesn't happen on servers? System.IO.IOException: Input/output error at System.ConsolePal.Write
 					Console.ForegroundColor = ConsoleColor.DarkMagenta;
 					Console.WriteLine(msg);
 					Console.ResetColor();
 				}
-
-				tML.Warn(Language.GetTextValue("tModLoader.RuntimeErrorSilentlyCaughtException") + '\n' + exString);
+				else if (ModCompile.activelyModding && !Main.gameMenu) {
+					AddChatMessage(msg);
+				}
 
 				if (oom) {
 					string error = Language.GetTextValue("tModLoader.OutOfMemory");
-					Logging.tML.Fatal(error);
+					tML.Fatal(error);
 					Interface.MessageBoxShow(error);
 					Environment.Exit(1);
 				}


### PR DESCRIPTION
### What is the bug?
Writing to console can fail on unix for unknown reason. It doesn't appear to be a 'broken pipe' error, because those have a different exception message, and have been handled https://github.com/dotnet/runtime/issues/15587. Maybe it's something else?

**This actually prevents the game launching randomly for some linux users**

Either way, there's no reason to write the 'see logs for full trace' message to console on client.

[client (20).log](https://github.com/tModLoader/tModLoader/files/9006676/client.20.log)

### How did you fix the bug?
Only write 'see logs for full trace' message to console in servers. Also write the actual exception to the logs as early as possible, so it doesn't get consumed by a potential console exception.

### Are there alternatives to your fix?
Eh... different conditions for writing to console? More try-catch?
