### PR TITLE
OnConsumeItem() callback

### DIFF
--- a/ExampleMod/Common/GlobalItems/ExampleExperienceItem.cs
+++ b/ExampleMod/Common/GlobalItems/ExampleExperienceItem.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader.IO;
+
+namespace ExampleMod.Common.GlobalItems
+{
+	public class ExampleExperienceItem : GlobalItem {
+		public int experience;
+		public int level;
+		public static int experiencePerLevel = 100;
+
+		public override bool InstancePerEntity => true;
+
+		public override bool AppliesToEntity(Item entity, bool lateInstantiation) {
+			//Apply this GlobalItem to all swords
+			return entity.DamageType == DamageClass.Melee && entity.noMelee == false && entity.useStyle == ItemUseStyleID.Swing;
+		}
+
+		public override GlobalItem Clone(Item item, Item itemClone) {
+			//Overriding clone is required for GlobalItems that set InstancePerEntity to true.
+			//It is expremely important to include complex fields and properties such as arrays, lists and dictionaries in the Clone method.
+			//If they are not included, they will act like static fields or properties.
+			ExampleExperienceItem clone = (ExampleExperienceItem)base.Clone(item, itemClone);
+			clone.experience = experience;
+			return clone;
+		}
+
+		public override void LoadData(Item item, TagCompound tag) {
+			experience = tag.Get<int>("experience");//Load experience tag
+			item.value += experience * 5;
+			UpdateLevel();
+		}
+		public override void SaveData(Item item, TagCompound tag) {
+			tag["experience"] = experience;//Save experience tag
+		}
+
+		public override void OnHitNPC(Item item, Player player, NPC target, int damage, float knockBack, bool crit) {
+			//The sword gains experience when damaging an npc.
+			int xp = damage;
+			experience += xp;
+			item.value += xp * 5;
+			UpdateLevel();
+		}
+
+		public void UpdateLevel() {
+			level = experience / experiencePerLevel;
+		}
+
+		public override void ModifyTooltips(Item item, List<TooltipLine> tooltips) {
+			if (experience > 0) {
+				UpdateLevel();
+				tooltips.Add(new TooltipLine(Mod, "level", $"Level: {level}") { OverrideColor = Color.LightGreen });
+				string levelString = $" ({(level + 1) * experiencePerLevel - experience} to next level)";
+				tooltips.Add(new TooltipLine(Mod, "experience", $"Experience: {experience}{levelString}") { OverrideColor = Color.White });
+			}
+		}
+
+		public static void SpawnCoins(Item item) {
+			int coinValue = item.value / 5;//The unmodified sell price is 1/5 of an item's value.
+			int valuePerCoin = 1000000;//Starting with value of 1 platinum coin.
+			for(int i = 3; i >= 0; i--) {
+				int coins = coinValue / valuePerCoin;
+				coinValue %= valuePerCoin;
+				valuePerCoin /= 100;
+				if(coins > 0)
+					Main.LocalPlayer.QuickSpawnItem(Main.LocalPlayer.GetSource_GiftOrReward(), ItemID.CopperCoin + i, coins);
+			}
+		}
+	}
+}

--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -1,4 +1,8 @@
+using ExampleMod.Common.GlobalItems;
+using System.Collections.Generic;
+using Terraria;
 using Terraria.GameContent.UI;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace ExampleMod
@@ -9,6 +13,8 @@ namespace ExampleMod
 		public const string AssetPath = $"{nameof(ExampleMod)}/Assets/";
 
 		public static int ExampleCustomCurrencyId;
+
+		public static List<Item> consumedItems = new();
 
 		public override void Load() {
 			// Registers a new custom currency
@@ -23,6 +29,59 @@ namespace ExampleMod
 
 			// NOTE: When writing unload code - be sure use 'defensive programming'. Or, in other words, you should always assume that everything in the mod you're unloading might've not even been initialized yet.
 			// NOTE: There is rarely a need to null-out values of static fields, since TML aims to completely dispose mod assemblies in-between mod reloads.
+		}
+
+		public override void PostAddRecipes() {
+			for (int i = 0; i < Main.recipe.Length; i++) {
+				foreach(Item ingredient in Main.recipe[i].requiredItem) {
+					//Checks if any ingredient meets the conditions for ExampleExperienceItem by trying to get global item
+					//If at least one does, add the OnConsueItemCallback to the recipe.
+					//The "conditions" reffering to ExampleExperienceItem's AppliesToEntity() method.
+					if (ingredient.TryGetGlobalItem(out ExampleExperienceItem ingredientGlobal)) {
+						//OnConsumeItemCallback gives access to the item that is about to be consumed while crafting.
+						Recipe.OnConsumeItemCallback consumeCallback = (Recipe recipe, Item item, ref int amountRemaining) => {
+							//Because recipies can have multiple ingredients, some that dont meet the conditions of ExampleExperienceItem,
+							//We need to try getting the global item again inside the OnConsumeItemCallback.
+							if (item.TryGetGlobalItem(out ExampleExperienceItem exampleExperienceItem)) {
+								//The return value determines if the vanilla code for consuming this specific item will be ran.
+								//If trying to prevent an item being consumed, either set amountRemaining = 0 or return false;
+								//Note: retruning false will prevent the item being consumed, however the craft has already begun and will not stop.
+								//If the ammountRemaining is > 0, it will continue looking for the same item type to consume.
+								//It would generally be best to reduce the amountRemaining by the item.stack
+								//	or setting amountRemaining to 0 when prevening an item from being consumed.
+								if (exampleExperienceItem.experience < 1000) {
+									ExampleExperienceItem.SpawnCoins(item);
+									consumedItems.Add(item.Clone());
+									return true;
+								}
+								else {
+									exampleExperienceItem.experience -= 1000;
+									amountRemaining -= item.stack;
+									return false;
+								}
+							}
+							//If the ingredient, item, does not meet the conditions of ExampleExperienceItem,
+							//Return true to allow the vanilla consume item code to run.
+							return true;
+						};
+						Main.recipe[i].AddOnConsumeItemCallback(consumeCallback);
+
+						Recipe.OnCraftCallback craftCallback = (Recipe recipe, Item item) => {
+							if(item.TryGetGlobalItem(out ExampleExperienceItem itemGlobal)) {
+								foreach (Item consumedItem in consumedItems) {
+									itemGlobal.experience += consumedItem.GetGlobalItem<ExampleExperienceItem>().experience;
+									itemGlobal.UpdateLevel();
+								}
+							}
+							consumedItems.Clear();
+						};
+						Main.recipe[i].AddOnCraftCallback(craftCallback);
+						//We only want to add the callback to a recipe once, so if we find one ingredient that meets the conditions
+						//of ExampleExperienceItem, stop checking the ingredients from that recipe with break.
+						break;
+					}
+				}
+			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -163,5 +163,26 @@ namespace Terraria.ModLoader
 		public static void ConsumeItem(Recipe recipe, int type, ref int amount) {
 			recipe.ConsumeItemHooks?.Invoke(recipe, type, ref amount);
 		}
+
+		/// <summary>
+		/// Allows to edit the amount of item the player uses in a recipe.
+		/// </summary>
+		/// <param name="recipe">The recipe used for the craft.</param>
+		/// <param name="item">The item to be consumed.</param>
+		/// <param name="amountRemaining">Modifiable remaining amount of the item to be consumed.</param>
+		/// <returns>Return false to prevent vanilla code from consuming this item and reducing the ammountRemaining.  Returns true by default.</returns>
+		public static bool OnConsumeItem(Recipe recipe, Item item, ref int amountRemaining) {
+			recipe.OnConsumeItemHooks?.Invoke(recipe, item, ref amountRemaining);
+			/* Doesn't work
+
+			Recipe.OnConsumeItemCallback hooks = recipe.OnConsumeItemHooks;
+			bool returnValue = true;
+			foreach (var hook in hooks) {
+				if (!hook(recipe, item, ref amountRemaining))
+					returnValue = false;
+			}
+			return returnValue;
+			*/
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -172,17 +172,12 @@ namespace Terraria.ModLoader
 		/// <param name="amountRemaining">Modifiable remaining amount of the item to be consumed.</param>
 		/// <returns>Return false to prevent vanilla code from consuming this item and reducing the ammountRemaining.  Returns true by default.</returns>
 		public static bool OnConsumeItem(Recipe recipe, Item item, ref int amountRemaining) {
-			recipe.OnConsumeItemHooks?.Invoke(recipe, item, ref amountRemaining);
-			/* Doesn't work
-
-			Recipe.OnConsumeItemCallback hooks = recipe.OnConsumeItemHooks;
 			bool returnValue = true;
-			foreach (var hook in hooks) {
-				if (!hook(recipe, item, ref amountRemaining))
+			foreach(Recipe.OnConsumeItemCallback onConsumeItemCallback in recipe.OnConsumeItemHooks.GetInvocationList()) {
+				if (onConsumeItemCallback?.Invoke(recipe, item, ref amountRemaining) == false)
 					returnValue = false;
 			}
 			return returnValue;
-			*/
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -100,9 +100,11 @@ namespace Terraria
 
 		public delegate void OnCraftCallback(Recipe recipe, Item item);
 		public delegate void ConsumeItemCallback(Recipe recipe, int type, ref int amount);
+		public delegate bool OnConsumeItemCallback(Recipe recipe, Item item, ref int ammountRemaining);
 
 		internal OnCraftCallback OnCraftHooks { get; private set; }
 		internal ConsumeItemCallback ConsumeItemHooks { get; private set; }
+		internal OnConsumeItemCallback OnConsumeItemHooks { get; private set; }
 
 		private void AddGroup(int id) {
 			acceptedGroups.Add(id);
@@ -298,6 +300,17 @@ namespace Terraria
 			return this;
 		}
 
+		/// <summary>
+		/// Sets a callback that will allow you to make anything happen when the recipe is used to consume an item.
+		/// </summary>
+		public Recipe AddOnConsumeItemCallback(OnConsumeItemCallback callback) {
+			OnConsumeItemHooks += callback;
+			
+			return this;
+		}
+
+
+
 		#region Ordering
 
 		/// <summary>
@@ -392,6 +405,7 @@ namespace Terraria
 
 			clone.OnCraftHooks = OnCraftHooks;
 			clone.ConsumeItemHooks = ConsumeItemHooks;
+			clone.OnConsumeItemHooks = OnConsumeItemHooks;
 			foreach (Condition condition in Conditions) {
 				clone.AddCondition(condition);
 			}

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -153,6 +153,68 @@
  				if (num <= 0)
  					continue;
  
+@@ -138,13 +_,16 @@
+ 						break;
+ 
+ 					if (item.IsTheSameAs(item2) || useWood(item.type, item2.type) || useSand(item.type, item2.type) || useFragment(item.type, item2.type) || useIronBar(item.type, item2.type) || usePressurePlate(item.type, item2.type) || AcceptedByItemGroups(item.type, item2.type)) {
++						bool doVanillaConsumeItem = RecipeLoader.OnConsumeItem(this, item, ref num);
++						if (doVanillaConsumeItem) {
+-						if (item.stack > num) {
++							if (item.stack > num) {
+-							item.stack -= num;
++								item.stack -= num;
+-							num = 0;
++								num = 0;
+-						}
++							}
+-						else {
++							else {
+-							num -= item.stack;
++								num -= item.stack;
+-							array[k] = new Item();
++								array[k] = new Item();
++							}
+ 						}
+ 					}
+ 				}
+@@ -170,20 +_,23 @@
+ 
+ 					if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
+ 						continue;
+-
+-					if (item.stack > num) {
+-						item.stack -= num;
+-						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
+-							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
+-
+-						num = 0;
+-					}
+-					else {
+-						num -= item.stack;
+-						array[l] = new Item();
+-						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
+-							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
+-					}
++					int stack = item.stack;
++					bool doVanillaConsumeItem = RecipeLoader.OnConsumeItem(this, item, ref num);
++					
++					if (doVanillaConsumeItem) {
++						if (item.stack > num) {
++							item.stack -= num;
++
++							num = 0;
++						}
++						else {
++							num -= item.stack;
++							array[l] = new Item();
++						}
++					}
++
++					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
++						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
+ 				}
+ 			}
+ 
 @@ -192,7 +_,7 @@
  			FindRecipes();
  		}

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -195,7 +195,7 @@
 -						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
 -							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
 -					}
-+					int stack = item.stack;
++					
 +					bool doVanillaConsumeItem = RecipeLoader.OnConsumeItem(this, item, ref num);
 +					
 +					if (doVanillaConsumeItem) {


### PR DESCRIPTION
### What is the new feature?
Add an OnConsumeItem() callback to RecipeLoader.  This would occur slightly after the ConsumeItem() callback that exists.  

### Why should this be part of tModLoader?
RecipeLoader.ConsumeItem(Recipe recipe, int type, ref int amount) only gives access to the item's type and amount.  The main thigs this cuts us off from is item fields/properties that have been changed and more importantly, GlobalItem fields/properties.
RecipeLoader.OnConsumeItem(Recipe recipe, Item item, ref int amountRemaining) would give more options discussed in sample usage.

### Are there alternative designs?
ConsumeItem could be moved instead of creating a different callback, but I think it would be more beneficial to have both.  
ConsumeItem allows you to affect the total amount of items needed.
OnConsumeItem would allow you to affect the remaining amount needed based on the specific item being looked at.

Note: These can be accomplished with IL edits (I have), but the IL edits get missed my other mods that affect crafting such as Magic Storage and Better Crafting, causing incompatibilities.

### Sample usage for the new feature
1: Transfer values from an ingredient's GlobalItem to the result item's GlobalItem.  (This would require tracking the values by the modder, but that would be relatively easy.)
     Example: True Night's edge with 500 experience + True Excalibur with 300 experience -> Terra Blade with 800 experience.

2: Allow a specific instance of an item to be non-consumable from crafting.  Lets say you have an item in your mod called an infinity stone (cuz I'm creative) that can be installed on onto an item to make it so you can use it infinitely in crafting.  They would set the amountRemaining to 0 and return false to prevent the vanilla consume item code from running.

3: Allow other things to happen when consuming a specific item based on its GlobalItem fields or modified stats.  An example from my mod:  enchantment items are stored in an Item[] (max of 5) in the GlobalItem.  When crafting items with multiple ingredients, they could each have up to 5 enchantments.  I quickspawn the extra ones that don't fit.

### Summary
Many of these are examples from my mod, but in general, this would give modders more options to interact with crafting in unique ways.