### PR TITLE
Vanilla Documentation & Publicize some methods

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
@@ -2,7 +2,11 @@ namespace Terraria.GameContent.Drawing
 {
 	public partial class TileDrawing
 	{
+		/// <summary>
+		/// The wind grid used to exert wind effects on tiles.
+		/// </summary>
 		public WindGrid Wind => _windGrid;
+
 		/// <summary>
 		/// Checks if a tile at the given coordinates counts towards tile coloring from the Dangersense buff.
 		/// <br/>Vanilla only uses Main.LocalPlayer for <paramref name="player"/>

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
@@ -2,6 +2,7 @@ namespace Terraria.GameContent.Drawing
 {
 	public partial class TileDrawing
 	{
+		public WindGrid Wind => _windGrid;
 		/// <summary>
 		/// Checks if a tile at the given coordinates counts towards tile coloring from the Dangersense buff.
 		/// <br/>Vanilla only uses Main.LocalPlayer for <paramref name="player"/>

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -536,27 +536,40 @@
  				if (tileLight.R < 200)
  					tileLight.R = 200;
  
-@@ -5755,7 +_,15 @@
+@@ -5755,7 +_,17 @@
  			}
  		}
  
 +		/// <summary>
-+		/// Determines how much wind should affect a theoretical tile at the given location on the current update tick.
++		/// Determines how much wind should affect a theoretical tile at the target location on the current update tick.
 +		/// </summary>
 +		/// <param name="i">The X coordinate of the theoretical target tile.</param>
 +		/// <param name="j">The Y coordinate of the theoretical target tile.</param>
 +		/// <param name="pushAnimationTimeTotal">The total amount of time, in ticks, that a wind push cycle for the theoretical target tile should last for.</param>
 +		/// <param name="pushForcePerFrame">The amount which wind should affect the theoretical target tile per frame.</param>
-+		/// <returns></returns>
++		/// <returns>
++		/// The degree to which wind should affect the theoretical target tile, represented as a float.
++		/// </returns>
 -		private float GetWindGridPush(int i, int j, int pushAnimationTimeTotal, float pushForcePerFrame) {
 +		public float GetWindGridPush(int i, int j, int pushAnimationTimeTotal, float pushForcePerFrame) {
  			_windGrid.GetWindTime(i, j, pushAnimationTimeTotal, out int windTimeLeft, out int direction);
  			if (windTimeLeft >= pushAnimationTimeTotal / 2)
  				return (float)(pushAnimationTimeTotal - windTimeLeft) * pushForcePerFrame * (float)direction;
-@@ -5763,7 +_,7 @@
+@@ -5763,7 +_,18 @@
  			return (float)windTimeLeft * pushForcePerFrame * (float)direction;
  		}
  
++		/// <summary>
++		/// Determines how much wind should affect a theoretical tile at the target location on the current update tick.<br/>
++		/// More complex version of <see cref="GetWindGridPush"/>.
++		/// </summary>
++		/// <param name="i">The X coordinate of the theoretical target tile.</param>
++		/// <param name="j">The Y coordinate of the theoretical target tile.</param>
++		/// <param name="pushAnimationTimeTotal">The total amount of time, in ticks, that a wind push cycle for the theoretical target tile should last for.</param>
++		/// <param name="totalPushForce"></param>
++		/// <param name="loops"></param>
++		/// <param name="flipDirectionPerLoop"></param>
++		/// <returns></returns>
 -		private float GetWindGridPushComplex(int i, int j, int pushAnimationTimeTotal, float totalPushForce, int loops, bool flipDirectionPerLoop) {
 +		public float GetWindGridPushComplex(int i, int j, int pushAnimationTimeTotal, float totalPushForce, int loops, bool flipDirectionPerLoop) {
  			_windGrid.GetWindTime(i, j, pushAnimationTimeTotal, out int windTimeLeft, out int direction);

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -16,15 +16,6 @@
  	{
  		private enum TileCounterType
  		{
-@@ -70,7 +_,7 @@
- 		private double _grassWindCounter;
- 		private double _sunflowerWindCounter;
- 		private double _vineWindCounter;
--		private WindGrid _windGrid = new WindGrid();
-+		public WindGrid _windGrid = new WindGrid();
- 		private bool _shouldShowInvisibleBlocks;
- 		private List<Point> _vineRootsPositions = new List<Point>();
- 		private List<Point> _reverseVineRootsPositions = new List<Point>();
 @@ -142,11 +_,11 @@
  					if (tile == null)
  						continue;

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -16,6 +16,15 @@
  	{
  		private enum TileCounterType
  		{
+@@ -70,7 +_,7 @@
+ 		private double _grassWindCounter;
+ 		private double _sunflowerWindCounter;
+ 		private double _vineWindCounter;
+-		private WindGrid _windGrid = new WindGrid();
++		public WindGrid _windGrid = new WindGrid();
+ 		private bool _shouldShowInvisibleBlocks;
+ 		private List<Point> _vineRootsPositions = new List<Point>();
+ 		private List<Point> _reverseVineRootsPositions = new List<Point>();
 @@ -142,11 +_,11 @@
  					if (tile == null)
  						continue;
@@ -347,6 +356,47 @@
  			_specialTileX[_specialTilesCount] = x;
  			_specialTileY[_specialTilesCount] = y;
  			_specialTilesCount++;
+@@ -5026,12 +_,26 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Emits a single living tree leaf or other gore instance directly below the target tile.<br/>
++		/// With a 50% chance, also emits a second leaf or other gore instance directly to the side of the target tile, dependent on wind direction.<br/>
++		/// Used by vanilla's two types of Living Trees, from which this method and its two submethods get their collective name.<br/>
++		/// </summary>
++		/// <param name="i">The X coordinate of the target tile.</param>
++		/// <param name="j">The Y coordinate of the target tile.</param>
++		/// <param name="leafGoreType">The numerical ID of the leaf or other gore instance that should be spawned.</param>
+-		private void EmitLivingTreeLeaf(int i, int j, int leafGoreType) {
++		public void EmitLivingTreeLeaf(int i, int j, int leafGoreType) {
+ 			EmitLivingTreeLeaf_Below(i, j, leafGoreType);
+ 			if (_rand.Next(2) == 0)
+ 				EmitLivingTreeLeaf_Sideways(i, j, leafGoreType);
+ 		}
+ 
++		/// <summary>
++		/// Emits a single living tree leaf or other gore instance directly below the target tile.<br/>
++		/// </summary>
++		/// <param name="x">The X coordinate of the target tile.</param>
++		/// <param name="y">The Y coordinate of the target tile.</param>
++		/// <param name="leafGoreType">The numerical ID of the leaf or other gore instance that should be spawned.</param>
+ 		private void EmitLivingTreeLeaf_Below(int x, int y, int leafGoreType) {
+ 			Tile tile = Main.tile[x, y + 1];
+ 			if (!WorldGen.SolidTile(tile) && tile.liquid <= 0) {
+@@ -5041,6 +_,12 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Emits a single living tree leaf or other gore instance directly to the side of the target tile, dependent on wind direction.<br/>
++		/// </summary>
++		/// <param name="x">The X coordinate of the target tile.</param>
++		/// <param name="y">The Y coordinate of the target tile.</param>
++		/// <param name="leafGoreType">The numerical ID of the leaf or other gore instance that should be spawned.</param>
+ 		private void EmitLivingTreeLeaf_Sideways(int x, int y, int leafGoreType) {
+ 			int num = 0;
+ 			if (Main.WindForVisuals > 0.2f)
 @@ -5096,6 +_,8 @@
  			int type = 706;
  			if (Main.waterStyle == 12)
@@ -355,6 +405,49 @@
 +				type = LoaderManager.Get<WaterStylesLoader>().Get(Main.waterStyle).GetDropletGore();
  			else if (Main.waterStyle > 1)
  				type = 706 + Main.waterStyle - 1;
+ 
+@@ -5121,7 +_,17 @@
+ 			_gore[num2].velocity *= 0f;
+ 		}
+ 
++		/// <summary>
++		/// Fetches the degree to which wind would/should affect a tile at the given location.
++		/// </summary>
++		/// <param name="x">The X coordinate of the theoretical target tile.</param>
++		/// <param name="y">The Y coordinate of the theoretical target tile.</param>
++		/// <param name="windCounter"></param>
++		/// <returns>
++		/// If <see cref="Main.SettingsEnabled_TilesSwayInWind"/> is false or the tile is below surface level, 0.<br/>
++		/// Otherwise, returns a value from 0.08f to 0.18f.
++		/// </returns>
+-		private float GetWindCycle(int x, int y, double windCounter) {
++		public float GetWindCycle(int x, int y, double windCounter) {
+ 			if (!Main.SettingsEnabled_TilesSwayInWind)
+ 				return 0f;
+ 
+@@ -5136,7 +_,22 @@
+ 			return 0f;
+ 		}
+ 
++		/// <summary>
++		/// Determines whether or not the tile at the given location should be able to sway in the wind.
++		/// </summary>
++		/// <param name="x">The X coordinate of the given tile.</param>
++		/// <param name="y">The Y coordinate of the given tile.</param>
++		/// <param name="tileCache">The tile to determine the sway-in-wind-ability of.</param>
++		/// <returns>
++		/// False if something dictates that the tile should NOT be able to sway in the wind; returns true by default.<br/>
++		/// Vanilla conditions that prevent wind sway are, in this order:<br/>
++		/// - if <see cref="Main.SettingsEnabled_TilesSwayInWind"/> is false<br/>
++		/// - if <see cref="TileID.Sets.SwaysInWindBasic"/> is false for the tile type of <paramref name="tileCache"/><br/>
++		/// - if the tile is an Orange Bloodroot
++		/// - if the tile is a Pink Prickly Pear on any vanilla cactus variant
++		/// </returns>
++		// TO-DO: add TileLoader hookset
+-		private bool ShouldSwayInWind(int x, int y, Tile tileCache) {
++		public bool ShouldSwayInWind(int x, int y, Tile tileCache) {
+ 			if (!Main.SettingsEnabled_TilesSwayInWind)
+ 				return false;
  
 @@ -5423,6 +_,8 @@
  
@@ -443,3 +536,29 @@
  				if (tileLight.R < 200)
  					tileLight.R = 200;
  
+@@ -5755,7 +_,15 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Determines how much wind should affect a theoretical tile at the given location on the current update tick.
++		/// </summary>
++		/// <param name="i">The X coordinate of the theoretical target tile.</param>
++		/// <param name="j">The Y coordinate of the theoretical target tile.</param>
++		/// <param name="pushAnimationTimeTotal">The total amount of time, in ticks, that a wind push cycle for the theoretical target tile should last for.</param>
++		/// <param name="pushForcePerFrame">The amount which wind should affect the theoretical target tile per frame.</param>
++		/// <returns></returns>
+-		private float GetWindGridPush(int i, int j, int pushAnimationTimeTotal, float pushForcePerFrame) {
++		public float GetWindGridPush(int i, int j, int pushAnimationTimeTotal, float pushForcePerFrame) {
+ 			_windGrid.GetWindTime(i, j, pushAnimationTimeTotal, out int windTimeLeft, out int direction);
+ 			if (windTimeLeft >= pushAnimationTimeTotal / 2)
+ 				return (float)(pushAnimationTimeTotal - windTimeLeft) * pushForcePerFrame * (float)direction;
+@@ -5763,7 +_,7 @@
+ 			return (float)windTimeLeft * pushForcePerFrame * (float)direction;
+ 		}
+ 
+-		private float GetWindGridPushComplex(int i, int j, int pushAnimationTimeTotal, float totalPushForce, int loops, bool flipDirectionPerLoop) {
++		public float GetWindGridPushComplex(int i, int j, int pushAnimationTimeTotal, float totalPushForce, int loops, bool flipDirectionPerLoop) {
+ 			_windGrid.GetWindTime(i, j, pushAnimationTimeTotal, out int windTimeLeft, out int direction);
+ 			float num = (float)windTimeLeft / (float)pushAnimationTimeTotal;
+ 			int num2 = (int)(num * (float)loops);

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -22,34 +22,220 @@
  	{
  		private string _nameOverride;
  		public const int luckPotionDuration1 = 10800;
-@@ -51,18 +_,24 @@
+@@ -33,43 +_,210 @@
+ 		private readonly int eclipsePrice = sellPrice(0, 7, 50);
+ 		private readonly int eclipsePostPlanteraPrice = sellPrice(0, 10);
+ 		private readonly int eclipseMothronPrice = sellPrice(0, 12, 50);
++		/// <summary>
++		/// The number of cached item spawns by type.<br/>
++		/// A value of -1 means that an item type is not being cached.<br/>
++		/// See <see cref="StartCachingType"/> and <see cref= "DropCache" /> for more info.<br/>
++		/// Indexed by <see cref="type"/>.Defaults to -1.<br/>
++		/// </summary>
+ 		public static int[] cachedItemSpawnsByType = ItemID.Sets.Factory.CreateIntSet(-1);
++		/// <summary>
++		/// The default cooldown, in ticks, of most healing items.<br/>
++		/// This value is never changed. For creating a Philosopher's Stone-like item, see <see cref="Player.pStone"/> or <see cref="Player.potionDelayTime"/>.<br/>
++		/// </summary>
+ 		public static int potionDelay = 3600;
++		/// <summary>
++		/// The default cooldown, in ticks, of Restoration Potions.<br/>
++		/// This value is never changed. For creating a Philosopher's Stone-like item, see <see cref="Player.pStone"/> or <see cref="Player.restorationDelayTime"/>.<br/>
++		/// </summary>
+ 		public static int restorationDelay = 2700;
++		/// <summary>
++		/// The default cooldown, in ticks, of Mushrooms.<br/>
++		/// This value is never changed. For creating a Philosopher's Stone-like item, see <see cref="Player.pStone"/> or <see cref="Player.mushroomDelayTime"/>.<br/>
++		/// </summary>
+ 		public static int mushroomDelay = 1800;
++		/// <summary>
++		/// If true, categorizes the given item as a quest fish.<br/>
++		/// Quest fish get a special tooltip, their own category in the Research Menu, and cannot be auto-moved to the Void Vault when picked up.<br/>
++		/// If you'd like to make a quest fish, see <see cref="DefaultToQuestFish"/>.<br/>
++		/// If you'd just like to emulate the one-per-inventory behavior of quest fish, see <see cref="uniqueStack"/>.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public bool questItem;
++		/// <summary>
++		/// An array for converting an <see cref="headSlot"/> value into a <see cref="type"/> value.<br/>
++		/// Indexed by <see cref="headSlot"/>. Defaults to 0.<br/>
++		/// </summary>
+ 		public static int[] headType = new int[277];
++		/// <summary>
++		/// An array for converting an <see cref="bodySlot"/> value into a <see cref="type"/> value.<br/>
++		/// Indexed by <see cref="bodySlot"/>. Defaults to 0.<br/>
++		/// </summary>
+ 		public static int[] bodyType = new int[246];
++		/// <summary>
++		/// An array for converting an <see cref="legSlot"/> value into a <see cref="type"/> value.<br/>
++		/// Indexed by <see cref="legSlot"/>. Defaults to 0.<br/>
++		/// </summary>
+ 		public static int[] legType = new int[234];
++		/// <summary>
++		/// If true, categorizes the given item type as a staff.<br/>
++		/// Staffs are held differently when their <see cref="useStyle"/> is <see cref="ItemUseStyleID.Shoot"/>, but are otherwise no different than any other item.<br/>
++		/// Indexed by <see cref="type"/>. Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public static bool[] staff = new bool[5125];
++		/// <summary>
++		/// If true, categorizes the given item type as a claw.<br/>
++		/// Claws are held differently when their <see cref="useStyle"/> is <see cref="ItemUseStyleID.Swing"/>, but are otherwise no different than any other item.<br/>
++		/// Used exclusively by the Bladed Glove in vanilla.<br/>
++		/// Indexed by <see cref="type"/>. Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public static bool[] claw = new bool[5125];
+ 		public bool flame;
++		/// <summary>
++		/// If true, then the given item will show all placed wires and actuators when held.<br/>
++		/// This item will also be grouped with other items with <c>mech</c> set to <see langword="true"/> when the inventory is sorted.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public bool mech;
++		/// <summary>
++		/// The delay, in ticks, before players can pick up this item.<br/>
++		/// Usually set to 100 (approximately 1.666... seconds) whenever an item is dropped.<br/>
++		/// Set to 0 whenever an item drops from a projectile.<br/>
++		/// </summary>
+ 		public int noGrabDelay;
++		/// <summary>
++		/// If true, then this item is currently being grabbed by a player.<br/>
++		/// Items being grabbed by the player cannot combine with nearby items, be picked up by enemies, burn in lava, or despawn.<br/>
++		/// </summary>
+ 		public bool beingGrabbed;
++		/// <summary>
++		/// A value that increases every tick an item is in the world.<br/>
++		/// Defaults to the value in <see cref="ItemID.Sets.NewItemSpawnPriority"/> when an item is created, and increases by <see cref="ItemID.Sets.ItemSpawnDecaySpeed"/> every tick.<br/>
++		/// When creating new items, items with a high <c>timeSinceItemSpawned</c> value will be replaced if no empty item slots are available.<br/>
++		/// </summary>
+ 		public int timeSinceItemSpawned;
++		/// <summary>
++		/// The numerical ID of the item this item consumes when used.<br/>
++		/// If greater than 0, this item cannot be used unless the player has the item type <c>tileWand</c> is set to. The item also gains a counter for said item type.<br/>
++		/// Defaults to -1.<br/>
++		/// </summary>
  		public int tileWand = -1;
++		/// <summary>
++		/// If true, then this item is in the local player's armor slots.<br/>
++		/// This causes the item to gain the set bonus tooltip if <see cref="Player.setBonus"/> isn't an empty string.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// </summary>
  		public bool wornArmor;
++		/// <summary>
++		/// The context in which this item's tooltip is being drawn.<br/>
++		/// See <see cref="ItemSlot.Context"/> for more details.<br/>
++		/// Defaults to -1.<br/>
++		/// </summary>
  		public int tooltipContext = -1;
 -		public byte dye;
++		/// <summary>
++		/// The numerical ID of the armor shader in <see cref="GameShaders.Armor"/> this item activates when worn in a dye slot.<br/>
++		/// If greater than 0, then this item can be equipped into dye slots.<br/>
++		/// Defaults to -1.<br/>
++		/// </summary>
 +		public int dye; //TML: Changed from byte to int.
++		/// <summary>
++		/// The numerical value this item adds to a player's fishing skill when held.<br/>
++		/// If greater than 0, categorizes this item as a fishing pole.<br/>
++		/// Fishing poles can be placed into weapon racks, have a counter for the bait the player is carrying, and are held out when a bobber is active.<br/>
++		/// Defaults to 0.<br/>
++		/// </summary>
  		public int fishingPole = 1;
++		/// <summary>
++		/// The numerical value this item adds to a player's fishing skill when used as bait.<br/>
++		/// If greater than 0, categorizes this item as bait.<br/>
++		/// Bait can be put into ammo slots and is consumed when fishing.<br/>
++		/// The higher the value of <c>bait</c>, the lower the chance the bait is consumed.<br/>
++		/// Defaults to 0.<br/>
++		/// </summary>
  		public int bait;
++		/// <summary>
++		/// The additional distance, in pixels, that coins may be grabbed from if the player has the Gold Ring or its upgrades (<see cref="Player.goldRing"/>).<br/>
++		/// Applies to <see cref="ItemID.CopperCoin"/>, <see cref="ItemID.SilverCoin"/>, <see cref="ItemID.GoldCoin"/>, and <see cref="ItemID.PlatinumCoin"/>.<br/>
++		/// </summary>
  		public static int coinGrabRange = 350;
++		/// <summary>
++		/// The additional distance, in pixels, that mana stars may be grabbed from if the player has the Celestial Magnet or its upgrades (<see cref="Player.manaMagnet"/>).<br/>
++		/// Applies to <see cref="ItemID.Star"/>, <see cref="ItemID.SoulCake"/>, and <see cref="ItemID.SugarPlum"/>.<br/>
++		/// </summary>
  		public static int manaGrabRange = 300;
++		/// <summary>
++		/// The additional distance, in pixels, that mana stars may be grabbed from if the player has consumed a Heartreach Potion (<see cref="Player.lifeMagnet"/>).<br/>
++		/// Applies to <see cref="ItemID.Heart"/>, <see cref="ItemID.CandyApple"/>, and <see cref="ItemID.CandyCane"/>.<br/>
++		/// </summary>
  		public static int lifeGrabRange = 250;
++		/// <summary>
++		/// The additional distance, in pixels, that items may be grabbed from if the player has equipped a Treasure Magnet (<see cref="Player.treasureMagnet"/>).<br/>
++		/// </summary>
  		public static int treasureGrabRange = 150;
 -		public short makeNPC;
 +		/// <summary>
-+		/// The numerical ID of the NPC that this item creates when used.<br></br>
++		/// The numerical ID of the NPC that this item creates when used.<br/>
 +		/// Mainly used for caught critters as items so that they can be released into the world.
 +		/// </summary>
 +		public int makeNPC; // tML: changed to int for convenience and consistency purposes
++		/// <summary>
++		/// If true, then the given item's effects only function in Expert Mode or higher (<see cref="Main.expertMode"/>).<br/>
++		/// Specifically, any equipped, Expert-only accessory will not update, any Expert-only minecart will not be used when riding minecart tracks, and an 'X' will be drawn over the item when equipped.<br/>
++		/// Unused in vanilla.<br/>
++		/// </summary>
  		public bool expertOnly;
++		/// <summary>
++		/// If true, then the given item is automatically given the Expert rarity, causing its name to be drawn in rainbow text.<br/>
++		/// It also adds the "Expert" tooltip. To use the Expert rarity without adding this tooltip, see <see cref="ItemRarityID.Expert"/>.<br/>
++		/// </summary>
  		public bool expert;
++		/// <summary>
++		/// If true, then the given item's effects only function in Master Mode or higher (<see cref="Main.masterMode"/>).<br/>
++		/// Specifically, any equipped, Master-only accessory will not update, any Master-only minecart will not be used when riding minecart tracks, and an 'X' will be drawn over the item when equipped.<br/>
++		/// Unused in vanilla.<br/>
++		/// </summary>
 +		public bool masterOnly;
++		/// <summary>
++		/// If true, then the given item is automatically given the Master rarity, causing its name to be drawn in red-orange text.<br/>
++		/// It also adds the "Master" tooltip. To use the Master rarity without adding this tooltip, see <see cref="ItemRarityID.Master"/>.<br/>
++		/// </summary>
 +		public bool master;
++		/// <summary>
++		/// If true, then the given item is being sold in a shop.<br/>
++		/// Shop items display their price. See <see cref="value"/>.<br/>
++		/// </summary>
  		public bool isAShopItem;
 -		public short hairDye = -1;
 +		public int hairDye = -1; //TML: Changed from short to int.
++		/// <summary>
++		/// The numerical ID of the paint applied by this item when used with a paint brush or paint roller.<br/>
++		/// For conversion into a shader index, see <see cref="Main.ConvertPaintIdToTileShaderIndex"/>.<br/>
++		/// For more details regarding paint, see <see cref="Tile.TileColor"/> and <see cref="Tile.WallColor"/>.<br/>
++		/// Defaults to 0.<br/>
++		/// </summary>
  		public byte paint;
++		/// <summary>
++		/// If true, then the given item is instanced per-client.<br/>
++		/// Instanced items only appear on the client they were spawned on and are less likely to be replaced if a new item is spawned.<br/>
++		/// Instanced items do not exist on servers.<br/>
++		/// Vanilla uses this field for treasure bags and Defender Medals. tModLoader automatically handles this for modded treasure bags.<br/>
++		/// If you would like to make an instanced item, see any one of the following for examples:<br/>
++		/// - <see cref="NPC.DropItemInstanced"/><br/>
++		/// - <see cref="GameContent.ItemDropRules.CommonCode.DropItemLocalPerClientAndSetNPCMoneyTo0"/><br/>
++		/// - <see cref="MessageID.InstancedItem"/><br/>
++		/// Defaults to false.<br/>
++		/// </summary>
  		public bool instanced;
  		public int ownIgnore = -1;
+ 		public int ownTime;
+ 		public int keepTime;
+ 		public int timeLeftInWhichTheItemCannotBeTakenByEnemies;
+ 		public int type;
++		/// <summary>
++		/// If true, then the given item is favorited.<br/>
++		/// Favorited items cannot be dropped, automatically moved into chests, placed in any kind of item rack, sold, trashed, or sorted.<br/>
++		/// Favorited items can still be dropped if the player has no inventory space and will still drop on death on Mediumcore or higher difficulties.<br/>
++		/// An item becomes unfavorited if removed from the player's inventory, including if the item is move to any equipment slot.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public bool favorited;
+ 		public int holdStyle;
+ 		public int useStyle;
 @@ -98,7 +_,7 @@
  		public int alpha;
  		public short glowMask;
@@ -59,7 +245,34 @@
  		public int defense;
  		public int headSlot = -1;
  		public int bodySlot = -1;
-@@ -148,11 +_,44 @@
+@@ -142,17 +_,71 @@
+ 		public int buffTime;
+ 		public int mountType = -1;
+ 		public bool cartTrack;
++		/// <summary>
++		/// Players cannot pick up a <c>uniqueStack</c> item if they have an item with the same <see cref="type"/> in their inventory.<br/>
++		/// This does not apply to equipped items, nor does it apply to items held with the mouse (<see cref="Main.mouseItem"/>).<br/>
++		/// This field only prevents picking items up: Multiple <c>uniqueStack</c> items may still be transferred into the player's inventory from chests.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// </summary>
+ 		public bool uniqueStack;
++		/// <summary>
++		/// The numerical ID of the special currency this item is bought using.<br/>
++		/// To make an item bought using Defender Medals, set this to <see cref="CustomCurrencyID.DefenderMedals"/>.<br/>
++		/// Defaults to -1, which means an item is bought using coins.<br/>
++		/// </summary>
+ 		public int shopSpecialCurrency = -1;
++		/// <summary>
++		/// If not <see langword="null"/>, the custom value of the given item when being bought from a shop.<br/>
++		/// Used for assigning a non-default price to an item in shops.<br/>
++		/// To get the raw price of an item, use <see cref="GetStoreValue"/>.<br/>
++		/// To get the price of an item after discounts, use <see cref="Player.GetItemExpectedPrice"/>.<br/>
++		/// Defaults to <see langword="null"/>.<br/>
++		/// </summary>
+ 		public int? shopCustomPrice;
++		/// <summary>
++		/// 
++		/// </summary>
  		public bool DD2Summon;
  		public int netID;
  		public int crit;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -245,7 +245,7 @@
  		public int defense;
  		public int headSlot = -1;
  		public int bodySlot = -1;
-@@ -142,17 +_,71 @@
+@@ -142,17 +_,74 @@
  		public int buffTime;
  		public int mountType = -1;
  		public bool cartTrack;
@@ -271,7 +271,10 @@
 +		/// </summary>
  		public int? shopCustomPrice;
 +		/// <summary>
-+		/// 
++		/// If true, the given item is categorized as a Dungeon Defenders 2 summon item.<br/>
++		/// DD2 summon items get a counter for how much Etherian Mana is in the player's inventory.<br/>
++		/// <b>This field being set does not make the item consume Etherian Mana.</b> Etherian Mana consumption is handled manually per-type.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
 +		/// </summary>
  		public bool DD2Summon;
  		public int netID;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -117,6 +117,47 @@
  		public static float iS = 1f;
  		public static bool render;
  		public static int qaStyle;
+@@ -528,12 +_,40 @@
+ 		public static bool[] projHostile = new bool[972];
+ 		public static bool[] projHook = new bool[972];
+ 		public static bool[] pvpBuff = new bool[338];
++		/// <summary>
++		/// Allows status effects for which this is set to true to persist after the afflicted player's death.<br/>
++		/// Defaults to false; all vanilla flask effects have their entries here set to true.<br/>
++		/// </summary>
+ 		public static bool[] persistentBuff = new bool[338];
++		/// <summary>
++		/// Categorizes status effects for which this is set to true as being from vanity pets, preventing them from overlapping with other vanity pet status effects.<br/>
++		/// Defaults to false; all vanilla vanity pets have their entries here set to true.<br/>
++		/// </summary>
+ 		public static bool[] vanityPet = new bool[338];
++		/// <summary>
++		/// Categorizes status effects for which this is set to true as being tied to a light pet, preventing them from overlapping with other light pet status effects.<br/>
++		/// Defaults to false; all vanilla light pets have their entries here set to true.<br/>
++		/// </summary>
+ 		public static bool[] lightPet = new bool[338];
++		/// <summary>
++		/// Categorizes status effects for which this is set to true as being from flasks, preventing them from overlapping with other flask status effects.<br/>
++		/// Defaults to false; all vanilla flask effects have their entries here set to true.<br/>
++		/// </summary>
+ 		public static bool[] meleeBuff = new bool[338];
++		/// <summary>
++		/// Categorizes status effects for which this is set to true as being debuffs instead of buffs.<br/>
++		/// This has multiple effects on gameplay:<br/>
++		/// - the Nurse can remove the status effect when healing the afflicted player (to prevent this, refer to <see cref="BuffID.Sets.NurseCannotRemoveDebuff"/>)<br/>
++		/// - the status effect cannot be cleared from overflowing the status effect cap (buffs will be cleared instead)<br/>
++		/// - the status effect cannot be cleared by right-clicking it (which can be done for all other status effect types)<br/>
++		/// Defaults to false; all vanilla debuffs have their entries here set to true.<br/>
++		/// </summary>
+ 		public static bool[] debuff = new bool[338];
+ 		public static bool[] buffNoSave = new bool[338];
++		/// <summary>
++		/// Prevents status effects which have their entries set to true from displaying the amount of time they have left.<br/>
++		/// Defaults to false; most, if not all, status effects which have their entries set to true here are related to mounts, pets, and summons.
++		/// </summary>
+ 		public static bool[] buffNoTimeDisplay = new bool[338];
+ 		public static bool[] buffDoubleApply = new bool[338];
+ 		public static int maxMP = 10;
 @@ -545,7 +_,7 @@
  		public static int instantBGTransitionCounter = 2;
  		public static int bgDelay;
@@ -3373,7 +3414,7 @@
  			}
  		}
  
-@@ -32294,6 +_,13 @@
+@@ -32294,6 +_,14 @@
  			return text;
  		}
  
@@ -3384,6 +3425,7 @@
 +		/// <param name="buffSlotOnPlayer">The index for buffType and buffTime</param>
 +		/// <param name="buffTimeValue">The "remaining time" in ticks</param>
 +		/// <returns><see langword="true"/> if <paramref name="buffTimeValue"/> is set, otherwise <see langword="false"/></returns>
++		// TO-DO: add a hook for drawing time left probably?
  		public static bool TryGetBuffTime(int buffSlotOnPlayer, out int buffTimeValue) {
  			int num = player[myPlayer].buffType[buffSlotOnPlayer];
  			buffTimeValue = 0;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -153,7 +153,7 @@
  		public static bool[] buffNoSave = new bool[338];
 +		/// <summary>
 +		/// Prevents status effects which have their entries set to true from displaying the amount of time they have left.<br/>
-+		/// Defaults to false; most, if not all, status effects which have their entries set to true here are related to mounts, pets, and summons.
++		/// Defaults to false; most, if not all, status effects which have their entries set to true here are related to mounts, pets, and summons.<br/>
 +		/// </summary>
  		public static bool[] buffNoTimeDisplay = new bool[338];
  		public static bool[] buffDoubleApply = new bool[338];
@@ -398,14 +398,14 @@
  		public static Matrix Transform => GameViewMatrix.TransformationMatrix;
  
 +		/// <summary>
-+		/// Fetches the position of the mouse cursor on the screen.
-+		/// Useful for making things visually happen near the cursor.
++		/// Fetches the position of the mouse cursor on the screen.<br/>
++		/// Useful for making things visually happen near the cursor.<br/>
 +		/// </summary>
  		public static Vector2 MouseScreen => new Vector2(mouseX, mouseY);
  
 +		/// <summary>
-+		/// Fetches the position of the mouse cursor in the world.
-+		/// Useful for making things functionally happen near the cursor, such as projectile or NPC spawns.
++		/// Fetches the position of the mouse cursor in the world.<br/>
++		/// Useful for making things functionally happen near the cursor, such as projectile or NPC spawns.<br/>
 +		/// </summary>
  		public static Vector2 MouseWorld {
  			get {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -393,6 +393,23 @@
  		private static bool _canShowMeteorFall;
  		private static bool _isResizingAndRemakingTargets = false;
  
+@@ -2250,8 +_,16 @@
+ 		[Old("Transform is deprecated. Please use GameViewMatrix & GUIViewMatrix")]
+ 		public static Matrix Transform => GameViewMatrix.TransformationMatrix;
+ 
++		/// <summary>
++		/// Fetches the position of the mouse cursor on the screen.
++		/// Useful for making things visually happen near the cursor.
++		/// </summary>
+ 		public static Vector2 MouseScreen => new Vector2(mouseX, mouseY);
+ 
++		/// <summary>
++		/// Fetches the position of the mouse cursor in the world.
++		/// Useful for making things functionally happen near the cursor, such as projectile or NPC spawns.
++		/// </summary>
+ 		public static Vector2 MouseWorld {
+ 			get {
+ 				Vector2 result = MouseScreen + screenPosition;
 @@ -2283,7 +_,7 @@
  
  		public static int npcShop {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -263,6 +263,18 @@
  		public static bool allChestStackHover;
  		public static bool inventorySortMouseOver;
  		public static float GraveyardVisualIntensity;
+@@ -961,6 +_,11 @@
+ 		public static int[] grasshopperCageFrameCounter = new int[cageFrames];
+ 		public static bool[] tileSand = new bool[625];
+ 		public static bool[] tileFlame = new bool[625];
++		/// <summary>
++		/// Used to denote an NPC as being catchable by bug nets and similar.<br/>
++		/// Contrary to its name, this array isn't actually used for catching logic at all.<br/>
++		/// It is instead used to determine if an NPC can be released back into the world after being caught.<br/>
++		/// </summary>
+ 		public static bool[] npcCatchable = new bool[670];
+ 		public static int[] tileFrame = new int[625];
+ 		public static int[] tileFrameCounter = new int[625];
 @@ -971,7 +_,7 @@
  		public static HairstyleUnlocksHelper Hairstyles = new HairstyleUnlocksHelper();
  		public static bool tilesLoaded = false;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -27,6 +27,17 @@
  		public short releaseOwner = 255;
  		public int rarity;
  		public static bool taxCollector = false;
+@@ -90,6 +_,10 @@
+ 		public static int crimsonBoss = -1;
+ 		public int netSkip;
+ 		public bool netAlways;
++		/// <summary>
++		/// Stores the index of a single NPC. This NPC will then share a health pool with that NPC.<br/>
++		/// Used for the Destroyer's various segments and the Wall of Flesh's eyes and mouth.<br/>
++		/// </summary>
+ 		public int realLife = -1;
+ 		private string _givenName = "";
+ 		public static int sWidth = 1920;
 @@ -104,14 +_,14 @@
  		private static int townRangeY = sHeight;
  		public float npcSlots = 1f;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -197,8 +197,22 @@
  		public static bool downedMechBoss3 = false;
  		public static bool[] npcsFoundForCheckActive = new bool[670];
  		public static int[] lazyNPCOwnedProjectileSearchArray = new int[200];
-@@ -218,8 +_,8 @@
+@@ -212,14 +_,22 @@
+ 		public bool justHit;
+ 		public int timeLeft;
+ 		public int target = -1;
++		/// <summary>
++		/// The amount of contact damage this NPC deals.<br/>
++		/// Changing this WILL NOT change the amount of damage done by projectiles.<br/>
++		/// </summary>
+ 		public int damage;
+ 		public int defense;
+ 		public int defDamage;
  		public int defDefense;
++		/// <summary>
++		/// Denotes whether or not this NPC counts as dealing cold damage for the purposes of the Warmth Potion.<br/>
++		/// Defaults to false.
++		/// </summary>
  		public bool coldDamage;
  		public bool trapImmune;
 -		public LegacySoundStyle HitSound;
@@ -208,11 +222,16 @@
  		public int life;
  		public int lifeMax;
  		public Rectangle targetRect;
-@@ -389,7 +_,13 @@
+@@ -389,8 +_,26 @@
  
  		public int WhoAmIToTargettingIndex => whoAmI + 300;
  
 -		public string TypeName => Lang.GetNPCNameValue(netID);
++		/// <summary>
++		/// The TYPE name of this NPC.<br/>
++		/// Type names are the base titles given to any NPC, and are typically shared amongst all instances of an NPC. For example, the Stylist's type name will always be "Stylist".<br/>
++		/// To modify the type name of a specific NPC, make use of the ModifyTypeName hooks in <see cref="GlobalNPC"/> and <see cref="ModLoader.ModNPC"/>, according to your needs.<br/>
++		/// </summary>
 +		public string TypeName {
 +			get {
 +				string typeName = Lang.GetNPCNameValue(netID);
@@ -221,8 +240,43 @@
 +			}
 +		}
  
++		/// <summary>
++		/// The FULL name of this NPC.<br/>
++		/// If the NPC doesn't have a given name, this will just return the type name. A Stylist without a given name will always return "Stylist" here.<br/>
++		/// If the NPC does have a given name, this will return the NPC's full name; given name first, then type name.<br/>
++		/// Full name with a given name is given in the format of "X the Y", where X is their given name and Y is their type name.<br/>
++		/// For example, a Stylist might return "Scarlett the Stylist" here; with Scarlett being her given name, and Stylist being her type name.<br/>
++		/// </summary>
  		public string FullName {
  			get {
+ 				if (!HasGivenName)
+@@ -400,8 +_,14 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Whether or not this NPC has a given name.<br/>
++		/// </summary>
+ 		public bool HasGivenName => _givenName.Length != 0;
+ 
++		/// <summary>
++		/// If this NPC has a given name, returns their given name; otherwise, returns their type name.<br/>
++		/// </summary>
+ 		public string GivenOrTypeName {
+ 			get {
+ 				if (!HasGivenName)
+@@ -411,6 +_,11 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// The GIVEN name of this NPC. Can be set directly.<br/>
++		/// Given names are unique to each NPC, though two NPCs can have the same given name.<br/>
++		/// Some vanilla examples of given names are Andrew (for the Guide), Yorai (for the Princess), Whitney (for the Steampunker), or Scarlett (for the Stylist).<br/>
++		/// </summary>
+ 		public string GivenName {
+ 			get {
+ 				return _givenName;
 @@ -458,7 +_,7 @@
  
  		public bool isLikeATownNPC {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -55,6 +55,148 @@
  		public bool midas;
  		public bool ichor;
  		public bool onFire;
+@@ -153,33 +_,119 @@
+ 		public static bool boughtCat = false;
+ 		public static bool boughtDog = false;
+ 		public static bool boughtBunny = false;
++		/// <summary>
++		/// Denotes whether or not Advanced Combat Techniques has been used in the current world.
++		/// </summary>
+ 		public static bool combatBookWasUsed = false;
++		/// <summary>
++		/// Denotes whether or not the Eye of Cthulhu has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedBoss1 = false;
++		/// <summary>
++		/// Denotes whether or not the Eater of Worlds OR the Brain of Cthulhu have been defeated at least once in the current world.<br/>
++		/// This does NOT track the two of them separately; you will need to establish your own fields in a <see cref="ModSystem"/> for that.<br/>
++		/// </summary>
+ 		public static bool downedBoss2 = false;
++		/// <summary>
++		/// Denotes whether or not Skeletron has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedBoss3 = false;
++		/// <summary>
++		/// Denotes whether or not at least one Queen Bee has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedQueenBee = false;
++		/// <summary>
++		/// Denotes whether or not King Slime has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedSlimeKing = false;
++		/// <summary>
++		/// Denotes whether or not at least one Goblin Army has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedGoblins = false;
++		/// <summary>
++		/// Denotes whether or not the Frost Legion has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedFrost = false;
++		/// <summary>
++		/// Denotes whether or not at least one Pirate Invasion has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedPirates = false;
++		/// <summary>
++		/// Denotes whether or not at least one Clown has been killed in the current world.<br/>
++		/// Only used to make the Clothier sell the Clown set once at least one has been killed.
++		/// </summary>
+ 		public static bool downedClown = false;
++		/// <summary>
++		/// Denotes whether or not Plantera has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedPlantBoss = false;
++		/// <summary>
++		/// Denotes whether or not Golem has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedGolemBoss = false;
++		/// <summary>
++		/// Denotes whether or not at least one Martian Madness event has been cleared in the current world.
++		/// </summary>
+ 		public static bool downedMartians = false;
++		/// <summary>
++		/// Denotes whether or not Duke Fishron has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedFishron = false;
++		/// <summary>
++		/// Denotes whether or not at least one Mourning Wood has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedHalloweenTree = false;
++		/// <summary>
++		/// Denotes whether or not at least one Pumpking has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedHalloweenKing = false;
++		/// <summary>
++		/// Denotes whether or not at least one Ice Queen has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedChristmasIceQueen = false;
++		/// <summary>
++		/// Denotes whether or not at least one Everscream has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedChristmasTree = false;
++		/// <summary>
++		/// Denotes whether or not at least one Santa-NK1 has been defeated in the current world.
++		/// </summary>
+ 		public static bool downedChristmasSantank = false;
++		/// <summary>
++		/// Denotes whether or not the Lunatic Cultist has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedAncientCultist = false;
++		/// <summary>
++		/// Denotes whether or not the Moon Lord has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedMoonlord = false;
++		/// <summary>
++		/// Denotes whether or not the Solar Pillar has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedTowerSolar = false;
++		/// <summary>
++		/// Denotes whether or not the Vortex Pillar has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedTowerVortex = false;
++		/// <summary>
++		/// Denotes whether or not the Nebula Pillar has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedTowerNebula = false;
++		/// <summary>
++		/// Denotes whether or not the Stardust Pillar has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedTowerStardust = false;
++		/// <summary>
++		/// Denotes whether or not the Empress of Light has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedEmpressOfLight = false;
++		/// <summary>
++		/// Denotes whether or not Queen Slime has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedQueenSlime = false;
++		/// <summary>
++		/// Denotes whether or not the Deerclops has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedDeerclops = false;
+ 		public static int ShieldStrengthTowerSolar = 0;
+ 		public static int ShieldStrengthTowerVortex = 0;
+@@ -192,9 +_,21 @@
+ 		public static bool TowerActiveNebula = false;
+ 		public static bool TowerActiveStardust = false;
+ 		public static bool LunarApocalypseIsUp = false;
++		/// <summary>
++		/// Denotes whether or not ANY Mechanical Boss has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedMechBossAny = false;
++		/// <summary>
++		/// Denotes whether or not the Destroyer has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedMechBoss1 = false;
++		/// <summary>
++		/// Denotes whether or not the Twins have been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedMechBoss2 = false;
++		/// <summary>
++		/// Denotes whether or not Skeletron Prime has been defeated at least once in the current world.
++		/// </summary>
+ 		public static bool downedMechBoss3 = false;
+ 		public static bool[] npcsFoundForCheckActive = new bool[670];
+ 		public static int[] lazyNPCOwnedProjectileSearchArray = new int[200];
 @@ -218,8 +_,8 @@
  		public int defDefense;
  		public bool coldDamage;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3344,6 +3344,20 @@
  							PullItem_Pickup(item, 12f, 5);
  						else if (lifeMagnet && (item.type == 58 || item.type == 1734 || item.type == 1867))
  							PullItem_Pickup(item, 15f, 5);
+@@ -24905,7 +_,12 @@
+ 			return itemToPickUp;
+ 		}
+ 
++		/// <summary>
++		/// Heals the player for a certain amount.
++		/// </summary>
++		/// <param name="player">The player to heal.</param>
++		/// <param name="amount">The amount to heal the player by.</param>
+-		private void Heal(int amount) {
++		public void Heal(int amount) {
+ 			statLife += amount;
+ 			if (Main.myPlayer == whoAmI)
+ 				HealEffect(amount);
 @@ -25347,7 +_,7 @@
  		public void AdjTiles() {
  			int num = 4;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -77,6 +77,42 @@
  		public static int crystalLeafDamage = 100;
  		public static int crystalLeafKB = 10;
  		public float basiliskCharge;
+@@ -516,10 +_,35 @@
+ 		public int ropeCount;
+ 		public int manaRegenBonus;
+ 		public int manaRegenDelayBonus;
++		/// <summary>
++		/// The current vanilla dash that the player is using.<br/>
++		/// The following values correspond to vanilla dashes:<br/>
++		/// 1 => Tabi / Master Ninja Gear<br/>
++		/// 2 => Shield of Cthulhu<br/>
++		/// 3 => Solar Flare armor set bonus<br/>
++		/// 4 => Unused, though a dash for this value DOES exist<br/>
++		/// 5 => Crystal Assassin set bonus<br/>
++		/// </summary>
+ 		public int dashType;
++		/// <summary>
++		/// The current vanilla dash that the player is VISIBLY using.<br/>
++		/// Unlike <see cref="dashType"/>, this does not update if a dash cannot currently be input.<br/>
++		/// </summary>
+ 		public int dash;
++		/// <summary>
++		/// The amount of time this player has left, in ticks, to input the second keystroke of a standard dash input (double-tap left/right).<br/>
++		/// For vanilla dashes, this window is 15 ticks, or a quarter of a second, in total.<br/>
++		/// </summary>
+ 		public int dashTime;
++		/// <summary>
++		/// The amount of time that has passed, in ticks, since this player last performed a dash.
++		/// </summary>
+ 		public int timeSinceLastDashStarted;
++		/// <summary>
++		/// The amount of time that has to pass, in ticks, before a new dash input will be registered.<br/>
++		/// For the first frame of any given dash, this is set to -1. After that frame has passsed, it is set to 20 ticks, or 1/3 of a second.<br/>
++		/// For the Tabi dash, and when dashing into an enemy with the Shield of Cthulhu, this is set to 30 ticks, or 1/2 of a second, instead.<br/>
++		/// </summary>
+ 		public int dashDelay;
+ 		public int eocDash;
+ 		public int eocHit;
 @@ -528,6 +_,23 @@
  		public int gem = -1;
  		public int gemCount;
@@ -2619,6 +2655,22 @@
  							crit2 = true;
  
  						int direction = base.direction;
+@@ -15361,6 +_,15 @@
+ 			solarDashConsumedFlare = false;
+ 		}
+ 
++		/*
++		TO-DO:
++		- make public, as it has little reason to be private and could be of great help to those makin' modded dashes
++		- properly explain how to use this in the context of programmin' a modded dash (use ExampleShield for this; see below)
++		- make ExampleShield use this, and simplify it accordingly (it currently has way too many movin' parts that require extra upkeep, for way too little payoff)
++
++		I'll do all this in an upcomin' PR if nobody else does
++		-thomas
++		*/
+ 		private void DoCommonDashHandle(out int dir, out bool dashing, DashStartAction dashStartAction = null) {
+ 			dir = 0;
+ 			dashing = false;
 @@ -15654,8 +_,10 @@
  				float num5 = 0.1f;
  				if (wingsLogic == 26) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -77,6 +77,27 @@
  		public static int crystalLeafDamage = 100;
  		public static int crystalLeafKB = 10;
  		public float basiliskCharge;
+@@ -528,6 +_,20 @@
+ 		public int gem = -1;
+ 		public int gemCount;
+ 		public BitsByte ownedLargeGems;
++		/// <summary>
++		/// The vanilla flask effect which the player currently has active; these affect all melee weapons and whips.<br/>
++		/// Defaults to 0, which denotes that the player does not currently have a flask active.<br/>
++		/// The following values correspond to vanilla flasks:<br/>
++		/// 1 => Flask of Venom (affected weapons proc Acid Venom on hit)<br/>
++		/// 2 => Flask of Cursed Flames (affected weapons proc Cursed Inferno on hit)<br/>
++		/// 3 => Flask of Fire (affected weapons proc On Fire! on hit)<br/>
++		/// 4 => Flask of Gold (affected weapons proc Midas on hit)<br/>
++		/// 5 => Flask of Ichor (affected weapons proc Ichor on hit)<br/>
++		/// 6 => Flask of Nanites (affected weapons proc Confused on hit)<br/>
++		/// 7 => Flask of Party (affected weapons sometimes release confetti explosions on hit)<br/>
++		/// 8 => Flask of Poison (affected weapons proc Poisoned on hit)<br/>
++		/// </summary>
++		// TO-DO: transform to int later, make proper flask effect system maybe?
+ 		public byte meleeEnchant;
+ 		public byte pulleyDir;
+ 		public bool pulley;
 @@ -539,7 +_,13 @@
  		public int snowBallLauncherInteractionCooldown;
  		public bool iceSkate;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -77,7 +77,7 @@
  		public static int crystalLeafDamage = 100;
  		public static int crystalLeafKB = 10;
  		public float basiliskCharge;
-@@ -528,6 +_,20 @@
+@@ -528,6 +_,23 @@
  		public int gem = -1;
  		public int gemCount;
  		public BitsByte ownedLargeGems;
@@ -94,7 +94,10 @@
 +		/// 7 => Flask of Party (affected weapons sometimes release confetti explosions on hit)<br/>
 +		/// 8 => Flask of Poison (affected weapons proc Poisoned on hit)<br/>
 +		/// </summary>
-+		// TO-DO: transform to int later, make proper flask effect system maybe?
++		// TO-DO:
++		// transform to int later, make proper flask effect system maybe?
++		// concrete use cases exist. just gotta find a way to make a system for 'em intuitive
++		// -thomas
  		public byte meleeEnchant;
  		public byte pulleyDir;
  		public bool pulley;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -77,6 +77,21 @@
  		public static int crystalLeafDamage = 100;
  		public static int crystalLeafKB = 10;
  		public float basiliskCharge;
+@@ -539,7 +_,13 @@
+ 		public int snowBallLauncherInteractionCooldown;
+ 		public bool iceSkate;
+ 		public bool carpet;
+-		public int spikedBoots;
++		/// <summary>
++		/// Used by the Shoe Spikes and Climbing Claws to allow for holding onto walls (of tiles, not to be confused with actual walls).<br/>
++		/// Defaults to 0. Any value higher than 0 allows the player to wall-jump.<br/>
++		/// A value of 1 causes the player to slowly slide down them while holding onto them.<br/>
++		/// A value of 2 or more doesn't give this limitation, allowing the player to stay holding onto a wall indefinitely.
++		/// </summary>
++		public int spikedBoots; // tML: documentation added because this field can be a little tricky to understand at first glance
+ 		public int carpetFrame = -1;
+ 		public float carpetFrameCounter;
+ 		public bool canCarpet;
 @@ -564,7 +_,7 @@
  		public byte oldLuckPotion;
  		public float endurance;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3309,7 +3309,7 @@
  		}
  
  		public Color ChatColor() {
-@@ -24778,11 +_,22 @@
+@@ -24778,11 +_,21 @@
  				if (!item.active || item.noGrabDelay != 0 || item.playerIndexTheItemIsReservedFor != i || !CanAcceptItemIntoInventory(item))
  					continue;
  
@@ -3317,7 +3317,6 @@
 +					continue;
 +
  				int itemGrabRange = GetItemGrabRange(item);
-+				ItemLoader.GrabRange(Main.item[j], this, ref itemGrabRange);
  				Rectangle hitbox = item.Hitbox;
  				if (base.Hitbox.Intersects(hitbox)) {
 -					if (i == Main.myPlayer && (inventory[selectedItem].type != 0 || itemAnimation <= 0))
@@ -3358,6 +3357,29 @@
  			statLife += amount;
  			if (Main.myPlayer == whoAmI)
  				HealEffect(amount);
+@@ -24914,7 +_,13 @@
+ 				statLife = statLifeMax2;
+ 		}
+ 
++		/// <summary>
++		/// Fetches the range at which the given item begins to gravitate towards the player.<br/>
++		/// This range, referred to as item grab range, is measured in pixels.
++		/// </summary>
++		/// <param name="item">The item whose grab range is being evaluated.</param>
++		/// <returns>The item grab range of the player, in pixels.</returns>
+-		private int GetItemGrabRange(Item item) {
++		public int GetItemGrabRange(Item item) {
+ 			int num = defaultItemGrabRange;
+ 			if (goldRing && item.IsACoin)
+ 				num += Item.coinGrabRange;
+@@ -24937,6 +_,7 @@
+ 			if (ItemID.Sets.NebulaPickup[item.type])
+ 				num += 100;
+ 
++			ItemLoader.GrabRange(item, this, ref num);
+ 			return num;
+ 		}
+ 
 @@ -25347,7 +_,7 @@
  		public void AdjTiles() {
  			int num = 4;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -959,6 +959,21 @@
  								int num = damage;
  								position = base.Center;
  								int num2 = 0;
+@@ -28874,6 +_,14 @@
+ 			return result;
+ 		}
+ 
++		/// <summary>
++		/// Finds the closest NPC to this projectile which can be targeted and which it has line of sight to.
++		/// </summary>
++		/// <param name="maxRange">
++		/// The maximum range at which this projectile should search out a target, measured in pixels.<br/>
++		/// Defaults to 800 (50 tiles). Each tile, for reference, measures out to be 16x16 pixels.
++		/// </param>
++		/// <returns>The index, in <see cref="Main.npc"/>, of the closest targetable NPC.</returns>
+ 		public int FindTargetWithLineOfSight(float maxRange = 800f) {
+ 			float num = maxRange;
+ 			int result = -1;
 @@ -29210,7 +_,7 @@
  			if (flag2 && player.channel && player.itemAnimation < num)
  				player.SetDummyItemTime(num);

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1410,7 +1410,7 @@
  			if (num4 != 2 && num4 != type && ((Main.tile[i, j].frameX == 0 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 22 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 44 && Main.tile[i, j].frameY <= 130)))
  				KillTile(i, j);
  
-@@ -35125,6 +_,52 @@
+@@ -35125,6 +_,57 @@
  			}
  		}
  
@@ -1460,6 +1460,11 @@
 +		/// This optional parameter, which defaults to 4, determines the "radius" of that square in tiles, counting outward from the central tile.<br/>
 +		/// Set to 0 if you only want to convert a single tile. In other cases, use this parameter wisely.
 +		/// </param>
++		/*
++		TO-DO:
++		- ConvertTIle utility method which consolidates the three lines used for most conversions into a single call
++		- modder-friendliness extension; see #2738
++		*/
  		public static void Convert(int i, int j, int conversionType, int size = 4) {
  			for (int k = i - size; k <= i + size; k++) {
  				for (int l = j - size; l <= j + size; l++) {
@@ -1492,31 +1497,6 @@
  								if (WallID.Sets.Conversion.Grass[wall] && wall != 69) {
  									Main.tile[k, l].wall = 69;
  									SquareWallFrame(k, l);
-@@ -35532,6 +_,24 @@
- 						if (Main.netMode == 1)
- 							NetMessage.SendData(17, -1, -1, null, 0, k, l);
- 					}
-+
-+					/*
-+					tML:
-+					I'm writin' this at the end of the method here as opposed to the top so I don't separate the method header and body too badly
-+					(the documentation for this method is already supremo fat and I really don't wanna keep people from the code at hand further)
-+
-+					this seriously needs updates to be extensible for additional conversion types. approaches to this are...more than a bit limited
-+					without core changes, unfortunately. in the future, I may consider the implementation of a hook or something similar to allow
-+					for more extensive conversion definitions. this way, modders could not only register their tile types effectively for conversion
-+					to vanilla biomes, but also allow conversions to and from their own biomes easily and in a way that supports vanilla stuff.
-+					alternatives are quite welcome, but...at the moment, this isn't significant enough to warrant makin' an issue (and it'll never
-+					be addressed in a reasonable timeframe regardless), so it's really just a note to myself
-+
-+					tl;dr this is way too hardcoded and I hate it.
-+					can (and, more importantly, should) we see about improvin' it at some point?
-+					and, if we do end up lookin' for a better way, what'll it be?
-+					-thomas
-+					*/
- 				}
- 			}
- 		}
 @@ -35730,7 +_,7 @@
  			if (num3 / 255 > cactusWaterLimit)
  				return;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1410,6 +1410,59 @@
  			if (num4 != 2 && num4 != type && ((Main.tile[i, j].frameX == 0 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 22 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 44 && Main.tile[i, j].frameY <= 130)))
  				KillTile(i, j);
  
+@@ -35125,6 +_,52 @@
+ 			}
+ 		}
+ 
++		/// <summary>
++		/// Allows easy conversion of eligible tiles to and from their variants for vanilla spreading biomes.<br/>
++		/// Please view the <paramref name="conversionType"/> parameter's description for more details on what biomes are supported.<br/>
++		/// This method, by default, converts a 9x9 square. Please view the <paramref name="size"/> parameter's description for info on how to adjust this behavior.
++		/// </summary>
++		/// <remarks>
++		/// For an easily-viewable example of the method's usage, you may refer to the code for projectile AI style 31 (the AI style used for the Clentaminator's solutions).<br/>
++		/// <br/>
++		/// The following tile and wall types can be converted by this method.<br/>
++		/// <br/>
++		/// For Corruption, Crimson, and Hallow conversions:<br/>
++		/// - Grass (+ wall)<br/>
++		/// - Stone (+ wall, also clears moss on stone tiles)<br/>
++		/// - Ice<br/>
++		/// - Sand<br/>
++		/// - Hardened Sand (+ wall)<br/>
++		/// - Sandstone (+ wall)<br/>
++		/// - Various cave wall types, which will not be listed off individually on account of there simply being too goddamn many of them<br/>
++		/// <br/>
++		/// For Corruption and Crimson conversions specifically, thorns, should they exist, will be converted to their evil counterparts<br/>
++		/// For Hallow conversions specifically:<br/>
++		/// - Thorns are removed entirely<br/>
++		/// - Conversion of grass tiles can also safely convert mowed grass<br/>
++		/// <br/>
++		/// For Mushroom biome conversions:<br/>
++		/// - Jungle Grass (+ wall)<br/>
++		/// - Mud Wall<br/>
++		/// - Thorns are removed entirely<br/>
++		/// <br/>
++		/// "Cleansing" conversions (conversion type 0) affect all listed tile and wall types.
++		/// </remarks>
++		/// <param name="i">The X coordinate of the target tile.</param>
++		/// <param name="j">The Y coordinate of the target tile.</param>
++		/// <param name="conversionType">
++		/// Denotes the biome that you wish to convert to. The following biomes are supported:<br/>
++		/// 1 => The Corruption.<br/>
++		/// 2 => The Hallow.<br/>
++		/// 3 => Mushroom biome.<br/>
++		/// 4 => The Crimson.<br/>
++		/// Setting this to 0 returns affected tiles to their default states (e.g. Ebonstone, Crimstone, and Pearlstone will be converted back into normal Stone Blocks).<br/>
++		/// </param>
++		/// <param name="size">
++		/// When using this method to convert tiles, a square centered on the target tile is converted into those of the target biome.<br/>
++		/// This optional parameter, which defaults to 4, determines the "radius" of that square in tiles, counting outward from the central tile.<br/>
++		/// Set to 0 if you only want to convert a single tile. In other cases, use this parameter wisely.
++		/// </param>
+ 		public static void Convert(int i, int j, int conversionType, int size = 4) {
+ 			for (int k = i - size; k <= i + size; k++) {
+ 				for (int l = j - size; l <= j + size; l++) {
 @@ -35135,7 +_,7 @@
  					int wall = Main.tile[k, l].wall;
  					switch (conversionType) {
@@ -1439,6 +1492,31 @@
  								if (WallID.Sets.Conversion.Grass[wall] && wall != 69) {
  									Main.tile[k, l].wall = 69;
  									SquareWallFrame(k, l);
+@@ -35532,6 +_,24 @@
+ 						if (Main.netMode == 1)
+ 							NetMessage.SendData(17, -1, -1, null, 0, k, l);
+ 					}
++
++					/*
++					tML:
++					I'm writin' this at the end of the method here as opposed to the top so I don't separate the method header and body too badly
++					(the documentation for this method is already supremo fat and I really don't wanna keep people from the code at hand further)
++
++					this seriously needs updates to be extensible for additional conversion types. approaches to this are...more than a bit limited
++					without core changes, unfortunately. in the future, I may consider the implementation of a hook or something similar to allow
++					for more extensive conversion definitions. this way, modders could not only register their tile types effectively for conversion
++					to vanilla biomes, but also allow conversions to and from their own biomes easily and in a way that supports vanilla stuff.
++					alternatives are quite welcome, but...at the moment, this isn't significant enough to warrant makin' an issue (and it'll never
++					be addressed in a reasonable timeframe regardless), so it's really just a note to myself
++
++					tl;dr this is way too hardcoded and I hate it.
++					can (and, more importantly, should) we see about improvin' it at some point?
++					and, if we do end up lookin' for a better way, what'll it be?
++					-thomas
++					*/
+ 				}
+ 			}
+ 		}
 @@ -35730,7 +_,7 @@
  			if (num3 / 255 > cactusWaterLimit)
  				return;


### PR DESCRIPTION
## OVERVIEW
there are a lot of things that aren't properly documented or made reasonably accessible by tModLoader, both from vanilla and from tML. this little mission of mine is the first part of a long, *long*, _**long**_ overdue attempt to resolve that problem
expect multiple PRs over multiple months as I work away at this, piece by piece

as this PR is the first of its kind, but certainly won't be the last, feel free to yell at me on Discord (ThomasThePencil#4448) if you have any methods, fields, properties, or what have you that you want to see clarified better by the mod loader, rather than havin' to sift through the Amazon Jungle corollary that is vanilla code

## THINGS IMPROVED UPON
I'll keep this as brief as possible, as a LOT of things got publicized and documented here. please refer to the actual in-API documentation on these things, as such documentation now exists and this summary would be way too long if each thing was explained individually
### `Main`
- `MouseWorld` and `MouseScreen`
- `persistentBuff`, `vanityPet`, `lightPet`, `meleeBuff`, `debuff`, and `buffNoTimeDisplay*`
- `isCatchable` (despite what its name may suggest, it isn't used for catchin' at all)

### `Player`
- `spikedBoots`
- `dashType`, `dash`, `dashTimd`, `timeSinceLastDashStarted`, and `dashDelay`*
- `meleeEnchant*`
- `Heal` method (publicated)
- `GetItemGrabRange` method (publicated)
  - additionally now includes `ItemLoader.GrabRange` (it didn't previously)

### `Item`
- `cachedSpawnsByItemType`
- `potionDelay`, `restorationDelay`, and `mushroomDelay`
- `questItem`
- `headType`, `bodyType`, and `legType`
- `staff` and `claw`
- `mech`
- `noGrabDelay` and `beingGrabbed`
- `timeSinceItemSpawned`
- `tileWand`
- `wormArmor`
- `tooltipContext`
- `dye`
- `fishingPole` and `bait`
- `coinGrabRange`, `manaGrabRange`, `lifeGrabRange`, and `treasureGrabRange`
- `expert`, `expertOnly`, `master`, and `masterOnly`
- `isAShopItem`
- `paint`
- `instanced`
- `favorited`
- `uniqueStack`
- `shopSpecialCurrency` and `shopCustomPrice`
- `DD2Summon`

### `Projectile`
- `FindTargetWithLineOfSight`

### `NPC`
- `damage`
- `coldDamage`
- every single downed bool now tells you (in the added documentation) what boss, miniboss, or event it's for
- `realLife`
- all NPC name-related fields and properties

### `TileDrawing`
this class has so much private stuff it's not even funny. seriously, who made all this private? there's a ton of useful stuff here! therefore, I'll give a little more info on each thing here
- `_windGrid` (technically publicated)
  - the wind grid. the wind. wind. you need reflection to access this at the moment, as well as a bunch of useful stuff related to it!...I don't know how else to explain this. somebody else can figure out better, more thorough documentation later...hopefully
  - can now be accessed freely through the `Wind` property, which has a simple explanation attached
- `EmitLivingTreeLeaf` and its two submethods (publicated)
  - can be useful for spawnin' a given gore type from a tile; again, useful for custom things to be given a bit more flair, such as custom Living Trees
- `GetWindCycle` method (publicated)
  - self-explanatory. helps with keepin' track of the degree to which wind should affect a given tile location at the given time
- `ShouldSwayInWind`* method (publicated)
  - this is probably the second most useful thing to publicize here, behind the wind grid itself. why should one NOT be able to check if a given tile can sway in the wind?
- `GetWindGridPush` and `GetWindGridPushComplex` methods (publicated)
  - methods used for figurin' out how much force to exert on a given tile based on the wind grid's current state. suffice to say, these'll be useful for those makin' their own stuff affected by wind

### `WorldGen`
- `Convert`*

entries with a `*` next to them also include a note of something to return to later