### PR TITLE
Localization support for ModConfig

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Gib einen Befehl ein: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
 
 		// Interface
 		"BossBarStyle": "Bossleisten-Stil: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Gib eine Zahl ein, um zwischen aktiviert/deaktiviert zu wechseln",
 		"AskForCommand": "Gib einen Befehl ein: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Bossleisten-Stil: {0}",
 		"BossBarStyleNoOptions": "Keine Einstellungen",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Type a number to switch between enabled/disabled",
 		"AskForCommand": "Type a command: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Boss Bar Style: {0}",
 		"BossBarStyleNoOptions": "No Options",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Escribe un número para cambiar entre activado/desactivado",
 		"AskForCommand": "Escribe un comando: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Estilo de barra de jefes: {0}",
 		"BossBarStyleNoOptions": "Sin opciones",
@@ -143,7 +154,7 @@
 		"LoadErrorNotLoading": "Solo puede llamarse a Mod.AddContent durante la carga",
 		"LoadErrorDuplicateName": "No se pueden sumar dos {0} con el mismo nombre: {1}. Tal vez 2 clases compartan un nombre de clase, pero en diferentes espacios de nombres mientras se cargan automáticamente, o quizá has llamado a AddContent con 2 {0} del mismo nombre.",
 
-		"LoadErrorResourceNotFoundPathHint": "Recurso esperado no encontrado: \n	{0}\nSuposición más probable: ¿Hay un error de ortografía o de colocación de la carpeta?\n	{1}",
+		"LoadErrorResourceNotFoundPathHint": "Recurso esperado no encontrado: \n\t{0}\nSuposición más probable: ¿Hay un error de ortografía o de colocación de la carpeta?\n\t{1}",
 		"RuntimeErrorSilentlyCaughtException": "Excepción silenciosa: ",
 		"RuntimeErrorSeeLogsForFullTrace": "(abre {0} para ver el registro completo)",
 		"OpenLogs": "Abrir registros",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Escribe un comando: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
 
 		// Interface
 		"BossBarStyle": "Estilo de barra de jefes: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Tapez un nombre pour basculer entre activé/désactivé",
 		"AskForCommand": "Tapez une commande: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Style de Barre de Patron: {0}",
 		"BossBarStyleNoOptions": "Pas D'Options",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Tapez une commande: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
 
 		// Interface
 		"BossBarStyle": "Style de Barre de Patron: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -84,6 +84,17 @@
 		// "AskForModIndex": "Type a number to switch between enabled/disabled",
 		// "AskForCommand": "Type a command: ",
 
+		//Mod Config
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload"
+
 		// Interface
 		// "BossBarStyle": "Boss Bar Style: {0}",
 		// "BossBarStyleNoOptions": "No Options",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Wpisz komendę: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
 
 		// Interface
 		"BossBarStyle": "Styl Paska Bossa: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Wpisz liczbę, aby przełączać między włączonymi/wyłączonymi modami",
 		"AskForCommand": "Wpisz komendę: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Styl Paska Bossa: {0}",
 		"BossBarStyleNoOptions": "Bez Opcji",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Digite um número para alterar entre habilitado/desabilitado",
 		"AskForCommand": "Digite um comando: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Estilo da Barra de Chefe: {0}",
 		"BossBarStyleNoOptions": "Nenhuma Opção",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Digite um comando: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		//"ModConfigFilterOptions": "Filter Options",
+		//"ModConfigNotification": "Notification: ",
+		//"ModConfigModConfig": "Mod Config",
+		//"ModConfigSaveConfig": "Save Config",
+		//"ModConfigBack": "Back",
+		//"ModConfigRevertChanges": "Revert Changes",
+		//"ModConfigRestoreDefaults": "Restore Defaults",
+		//"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		//"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
 
 		// Interface
 		"BossBarStyle": "Estilo da Barra de Chefe: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -82,6 +82,17 @@
 		"AskForModIndex": "Введите номер для переключения Вкл/Выкл",
 		"AskForCommand": "Введите команду: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "Filter Options",
+		"ModConfigNotification": "Notification: ",
+		"ModConfigModConfig": "Mod Config",
+		"ModConfigSaveConfig": "Save Config",
+		"ModConfigBack": "Back",
+		"ModConfigRevertChanges": "Revert Changes",
+		"ModConfigRestoreDefaults": "Restore Defaults",
+		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+
 		// Interface
 		"BossBarStyle": "Стиль полоски здоровья босса: {0}",
 		"BossBarStyleNoOptions": "Нет настроек",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -83,15 +83,15 @@
 		"AskForCommand": "Введите команду: ",
 
 		//Mod Config
-		"ModConfigFilterOptions": "Filter Options",
-		"ModConfigNotification": "Notification: ",
-		"ModConfigModConfig": "Mod Config",
-		"ModConfigSaveConfig": "Save Config",
-		"ModConfigBack": "Back",
-		"ModConfigRevertChanges": "Revert Changes",
-		"ModConfigRestoreDefaults": "Restore Defaults",
-		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		"ModConfigFilterOptions": "Параметры фильтрации",
+		"ModConfigNotification": "Уведомление: ",
+		"ModConfigModConfig": "Конфигурация мода",
+		"ModConfigSaveConfig": "Сохранение конфигурации",
+		"ModConfigBack": "Назад",
+		"ModConfigRevertChanges": "Отменить Изменения",
+		"ModConfigRestoreDefaults": "Восстановление значений по умолчанию",
+		"ModConfigAskingServerToAcceptChanges": "Запрос сервера на принятие изменений...",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Не удается сохранить, потому что изменения потребуют перезагрузки",
 
 		// Interface
 		"BossBarStyle": "Стиль полоски здоровья босса: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -89,7 +89,7 @@
 		"ModConfigModConfig": "模组设置",
 		"ModConfigSaveConfig": "保存设置",
 		"ModConfigBack": "返回",
-		"ModConfigRevertChanges": "重置改动",
+		"ModConfigRevertChanges": "撤销改动",
 		"ModConfigRestoreDefaults": "重设为默认",
 		"ModConfigAskingServerToAcceptChanges": "正在请求服务器接受改动……",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "由于需要重载模组而无法保存改动（请从主菜单进入模组列表以调整配置）",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -92,7 +92,7 @@
 		"ModConfigRevertChanges": "重置改动",
 		"ModConfigRestoreDefaults": "重设为默认",
 		"ModConfigAskingServerToAcceptChanges": "正在请求服务器接受改动……",
-		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "由于需要重载模组而无法保存改动（请从主菜单进入模组列表，点击对应模组的齿轮图标以调整配置）",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "由于需要重载模组而无法保存改动（请从主菜单进入模组列表以调整配置）",
 
 		// Interface
 		"BossBarStyle": "Boss血条样式: {0}",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -83,6 +83,17 @@
 		"AskForModIndex": "输入模组序号以启用/禁用模组",
 		"AskForCommand": "请输入命令: ",
 
+		//Mod Config
+		"ModConfigFilterOptions": "筛选选项",
+		"ModConfigNotification": "通知：",
+		"ModConfigModConfig": "模组设置",
+		"ModConfigSaveConfig": "保存设置",
+		"ModConfigBack": "返回",
+		"ModConfigRevertChanges": "重置改动",
+		"ModConfigRestoreDefaults": "重设为默认",
+		"ModConfigAskingServerToAcceptChanges": "正在请求服务器接受改动……",
+		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "由于需要重载模组而无法保存改动（请从主菜单进入模组列表，点击对应模组的齿轮图标以调整配置）",
+
 		// Interface
 		"BossBarStyle": "Boss血条样式: {0}",
 		"BossBarStyleNoOptions": "无",

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -14,6 +14,7 @@ using Terraria.ID;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.UI.Gamepad;
+using Terraria.Localization;
 
 namespace Terraria.ModLoader.Config.UI
 {
@@ -64,7 +65,7 @@ namespace Terraria.ModLoader.Config.UI
 
 			UIPanel textBoxBackground = new UIPanel();
 			textBoxBackground.SetPadding(0);
-			filterTextField = new UIFocusInputTextField("Filter Options");
+			filterTextField = new UIFocusInputTextField(Language.GetText("tModLoader.ModConfigFilterOptions"));//"Filter Options"
 			textBoxBackground.Top.Set(2f, 0f);
 			textBoxBackground.Left.Set(-190, 1f);
 			textBoxBackground.Width.Set(180, 0f);
@@ -85,7 +86,7 @@ namespace Terraria.ModLoader.Config.UI
 			textBoxBackground.Append(filterTextField);
 
 			// TODO: ModConfig Localization support
-			message = new UITextPanel<string>("Notification: ");
+			message = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigNotification"));//"Notification: "
 			message.Width.Set(-80f, 1f);
 			message.Height.Set(20f, 0f);
 			message.HAlign = 0.5f;
@@ -109,7 +110,7 @@ namespace Terraria.ModLoader.Config.UI
 			uIPanel.Append(uIScrollbar);
 			mainConfigList.SetScrollbar(uIScrollbar);
 
-			headerTextPanel = new UITextPanel<string>("Mod Config", 0.8f, true);
+			headerTextPanel = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigModConfig"), 0.8f, true);//"Mod Config"
 			headerTextPanel.HAlign = 0.5f;
 			headerTextPanel.Top.Set(-50f, 0f);
 			headerTextPanel.SetPadding(15f);
@@ -133,7 +134,7 @@ namespace Terraria.ModLoader.Config.UI
 			nextConfigButton.OnClick += NextConfig;
 			//uIElement.Append(nextConfigButton);
 
-			saveConfigButton = new UITextPanel<string>("Save Config", 1f, false);
+			saveConfigButton = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigSaveConfig"), 1f, false);//"Save Config"
 			saveConfigButton.Width.Set(-10f, 1f / 4f);
 			saveConfigButton.Height.Set(25f, 0f);
 			saveConfigButton.Top.Set(-20f, 0f);
@@ -143,7 +144,7 @@ namespace Terraria.ModLoader.Config.UI
 			saveConfigButton.OnClick += SaveConfig;
 			//uIElement.Append(saveConfigButton);
 
-			backButton = new UITextPanel<string>("Back", 1f, false);
+			backButton = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigBack"), 1f, false);//"Back"
 			backButton.CopyStyle(saveConfigButton);
 			backButton.HAlign = 0;
 			backButton.WithFadedMouseOver();
@@ -158,7 +159,7 @@ namespace Terraria.ModLoader.Config.UI
 			backButton.OnClick += BackClick;
 			uIElement.Append(backButton);
 
-			revertConfigButton = new UITextPanel<string>("Revert Changes", 1f, false);
+			revertConfigButton = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigRevertChanges"), 1f, false);//"Revert Changes"
 			revertConfigButton.CopyStyle(saveConfigButton);
 			revertConfigButton.WithFadedMouseOver();
 			revertConfigButton.HAlign = 0.66f;
@@ -166,7 +167,7 @@ namespace Terraria.ModLoader.Config.UI
 			//uIElement.Append(revertConfigButton);
 
 			//float scale = Math.Min(1f, 130f/FontAssets.MouseText.Value.MeasureString("Restore Defaults").X);
-			restoreDefaultsConfigButton = new UITextPanel<string>("Restore Defaults", 1f, false);
+			restoreDefaultsConfigButton = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigRestoreDefaults"), 1f, false);//"Restore Defaults"
 			restoreDefaultsConfigButton.CopyStyle(saveConfigButton);
 			restoreDefaultsConfigButton.WithFadedMouseOver();
 			restoreDefaultsConfigButton.HAlign = 1f;
@@ -260,7 +261,7 @@ namespace Terraria.ModLoader.Config.UI
 				// If we are in game...
 				if (pendingConfig.Mode == ConfigScope.ServerSide && Main.netMode == NetmodeID.MultiplayerClient) {
 					// TODO: Too
-					SetMessage("Asking server to accept changes...", Color.Yellow);
+					SetMessage(Language.GetText("tModLoader.ModConfigAskingServerToAcceptChanges"), Color.Yellow); //"Asking server to accept changes..."
 
 					var requestChanges = new ModPacket(MessageID.InGameChangeConfig);
 					requestChanges.Write(pendingConfig.Mod.Name);
@@ -279,7 +280,7 @@ namespace Terraria.ModLoader.Config.UI
 
 				if (loadTimeConfig.NeedsReload(pendingConfig)) {
 					SoundEngine.PlaySound(SoundID.MenuClose);
-					SetMessage("Can't save because changes would require a reload.", Color.Red);
+					SetMessage(Language.GetText("tModLoader.ModConfigCantSaveBecauseChangesWouldRequireAReload"), Color.Red);//"Can't save because changes would require a reload."
 					return;
 				}
 				else {
@@ -327,7 +328,7 @@ namespace Terraria.ModLoader.Config.UI
 
 		public void SetMessage(string text, Color color) {
 			message.TextScale = 1f;
-			message.SetText("Notification: " + text);
+			message.SetText(Language.GetText("tModLoader.ModConfigNotification") + text);
 			float width = FontAssets.MouseText.Value.MeasureString(text).X;
 			if (width > 400) {
 				message.TextScale = 400 / width;
@@ -704,7 +705,7 @@ namespace Terraria.ModLoader.Config.UI
 			//uIPanel.Append(headingText);
 			//top += 40;
 
-			UITextPanel<string> back = new UITextPanel<string>("Back") {
+			UITextPanel<string> back = new UITextPanel<string>(Language.GetText("tModLoader.ModConfigBack")) {
 				HAlign = 1f
 			};
 


### PR DESCRIPTION
### What is the new feature?
-Localization support for ModConfig
-Chinese translation for ModConfig
### Why should this be part of tModLoader?
-It's considered as a TODO
-Localization helps those who are not English speakers to understand what are the features of ModConfig
### Are there alternative designs?
-Since other localizations are using the .json files in the Localization folder, I just did it in the same way
-I don't see any better design, but is there is, I'll be willing to change
### Sample usage for the new feature
-Localizers can easily add/modify the translations in corresponding .json files