### PR TITLE
fix NoSync mods potentially crashing the client during mod sync

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModNet.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNet.cs
@@ -399,12 +399,12 @@ namespace Terraria.ModLoader
 
 				list.Add(mod);
 
-				if (mod != null) //nosync mod that doesn't exist on the client
+				if (mod != null) // NoSync mod that doesn't exist on the client
 					mod.netID = i;
 			}
 
 			netMods = list.ToArray();
-			SetModNetDiagnosticsUI(netMods); // When client receives netMods, assign a new UI
+			SetModNetDiagnosticsUI(netMods.Where(mod => mod != null)); // When client receives netMods, exclude NoSync mods that aren't on the client, and assign a new UI
 
 			ItemLoader.ReadNetGlobalOrder(reader);
 			SystemLoader.ReadNetSystemOrder(reader);


### PR DESCRIPTION
### What is the bug?
NoSync mods which don't exist on the client, but do on the server, will cause the client to crash during mod sync

### How did you fix the bug?
exclude NoSync mods which don't exist on client from the ModNetDiagnosticsUI initialization

### Are there alternatives to your fix?
Figure out why `null` mods are added to `netMods` in the first place, if there is no valid reason, exclude them, making this fix redundant
