### PR TITLE
Remove `Read/WriteVarInt` extensions

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -96,7 +96,7 @@
  
  						player8.name = reader.ReadString().Trim().Trim();
 -						player8.hairDye = reader.ReadByte();
-+						player8.hairDye = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.ReadVarInt();
++						player8.hairDye = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt();
  						BitsByte bitsByte6 = reader.ReadByte();
  						for (int num91 = 0; num91 < 8; num91++) {
  							player8.hideVisibleAccessory[num91] = bitsByte6[num91];
@@ -213,8 +213,8 @@
  						Vector2 velocity6 = reader.ReadVector2();
 -						int stack7 = reader.ReadInt16();
 -						int pre3 = reader.ReadByte();
-+						int stack7 = ModNet.AllowVanillaClients ? reader.ReadInt16() : reader.ReadVarInt();
-+						int pre3 = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.ReadVarInt();
++						int stack7 = ModNet.AllowVanillaClients ? reader.ReadInt16() : reader.Read7BitEncodedInt();
++						int pre3 = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt();
  						int num182 = reader.ReadByte();
  						int num183 = reader.ReadInt16();
  						if (Main.netMode == 1) {
@@ -359,11 +359,11 @@
  											NetMessage.TrySendData(34, whoAmI, -1, null, b4, num26, num27, num28, num30);
  											Item.NewItem(new EntitySource_TileBreak(num26, num27), num26 * 16, num27 * 16, 32, 32, Chest.chestItemSpawn[num28], 1, noBroadcast: true);
 +											*/
-+											
++
 +											NetMessage.TrySendData(34, whoAmI, -1, null, b4, num26, num27, num28, num30, modType);
-+											
++
 +											int itemSpawn = b4 < 100 ? Chest.chestItemSpawn[num28] : TileLoader.GetTile(modType).ChestDrop;
-+											
++
 +											if (itemSpawn > 0)
 +												Item.NewItem(new EntitySource_TileBreak(num26, num27), num26 * 16, num27 * 16, 32, 32, itemSpawn, 1, noBroadcast: true);
  										}
@@ -399,9 +399,9 @@
 +											*/
 +
 +											NetMessage.TrySendData(34, whoAmI, -1, null, b4, num26, num27, num28, num31, modType);
-+											
++
 +											int itemSpawn = b4 < 100 ? Chest.dresserItemSpawn[num28] : TileLoader.GetTile(modType).DresserDrop;
-+											
++
 +											if (itemSpawn > 0)
 +												Item.NewItem(new EntitySource_TileBreak(num26, num27), num26 * 16, num27 * 16, 32, 32, itemSpawn, 1, noBroadcast: true);
  										}
@@ -555,7 +555,7 @@
 +						}
 +						else {
 +							item = ItemIO.Receive(reader);
-+							item.stack = reader.ReadVarInt();
++							item.stack = reader.Read7BitEncodedInt();
 +						}
 +
 +						TEItemFrame.TryPlacing(x12, y12, item, item.stack);
@@ -600,7 +600,7 @@
  						int stack6 = reader.ReadInt16();
  						TEWeaponsRack.TryPlacing(x9, y9, netid2, prefix2, stack6);
 +						*/
-+						
++
 +						Item item;
 +
 +						if (ModNet.AllowVanillaClients) {
@@ -612,7 +612,7 @@
 +						}
 +						else {
 +							item = ItemIO.Receive(reader);
-+							item.stack = reader.ReadVarInt();
++							item.stack = reader.Read7BitEncodedInt();
 +						}
 +
 +						TEWeaponsRack.TryPlacing(x9, y9, item, item.stack);
@@ -662,7 +662,7 @@
 +						}
 +						else {
 +							item = ItemIO.Receive(reader);
-+							item.stack = reader.ReadVarInt();
++							item.stack = reader.Read7BitEncodedInt();
 +						}
 +
 +						TEWeaponsRack.TryPlacing(x5, y5, item, item.stack);

--- a/patches/tModLoader/Terraria/ModLoader/IO/BinaryIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BinaryIO.cs
@@ -5,48 +5,16 @@ namespace Terraria.ModLoader.IO
 {
 	public static class BinaryIO
 	{
-		//copied from BinaryWriter.Read7BitEncodedInt
-		public static void WriteVarInt(this BinaryWriter writer, int value) {
-			// Write out an int 7 bits at a time.  The high bit of the byte,
-			// when on, tells reader to continue reading more bytes.
-			uint v = (uint)value;   // support negative numbers
-			while (v >= 0x80) {
-				writer.Write((byte)(v | 0x80));
-				v >>= 7;
-			}
-			writer.Write((byte)v);
-		}
-
-		//copied from BinaryReader.Read7BitEncodedInt
-		public static int ReadVarInt(this BinaryReader reader) {
-			// Read out an Int32 7 bits at a time.  The high bit
-			// of the byte when on means to continue reading more bytes.
-			int count = 0;
-			int shift = 0;
-			byte b;
-			do {
-				// Check for a corrupted stream.  Read a max of 5 bytes.
-				if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
-					throw new FormatException("variable length int with more than 32 bits");
-
-				// ReadByte handles end of stream cases for us.
-				b = reader.ReadByte();
-				count |= (b & 0x7F) << shift;
-				shift += 7;
-			} while ((b & 0x80) != 0);
-			return count;
-		}
-
 		public static void SafeWrite(this BinaryWriter writer, Action<BinaryWriter> write) {
 			var ms = new MemoryStream();//memory thrash should be fine here
 			write(new BinaryWriter(ms));
-			writer.WriteVarInt((int)ms.Length);
+			writer.Write7BitEncodedInt((int)ms.Length);
 			ms.Position = 0;
 			ms.CopyTo(writer.BaseStream);
 		}
 
 		public static void SafeRead(this BinaryReader reader, Action<BinaryReader> read) {
-			int length = reader.ReadVarInt();
+			int length = reader.Read7BitEncodedInt();
 			var ms = new MemoryStream(reader.ReadBytes(length));
 			read(new BinaryReader(ms));
 			if (ms.Position != length)

--- a/patches/tModLoader/Terraria/ModLoader/IO/BinaryIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BinaryIO.cs
@@ -5,6 +5,12 @@ namespace Terraria.ModLoader.IO
 {
 	public static class BinaryIO
 	{
+		[Obsolete("Use Write7BitEncodedInt", true)]
+		public static void WriteVarInt(this BinaryWriter writer, int value) => writer.Write7BitEncodedInt(value);
+
+		[Obsolete("Use Read7BitEncodedInt", true)]
+		public static int ReadVarInt(this BinaryReader reader) => reader.Read7BitEncodedInt();
+
 		public static void SafeWrite(this BinaryWriter writer, Action<BinaryWriter> write) {
 			var ms = new MemoryStream();//memory thrash should be fine here
 			write(new BinaryWriter(ms));

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitReader.cs
@@ -11,7 +11,7 @@ namespace Terraria.ModLoader.IO
 		public int BitsRead { get; private set; }
 
 		public BitReader(BinaryReader reader) {
-			MaxBits = reader.ReadVarInt();
+			MaxBits = reader.Read7BitEncodedInt();
 
 			int byteCount = MaxBits / 8;
 			if (MaxBits % 8 != 0)

--- a/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/BitWriter.cs
@@ -22,7 +22,7 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public void Flush(BinaryWriter w) {
-			w.WriteVarInt(bytes.Count * 8 + i);
+			w.Write7BitEncodedInt(bytes.Count * 8 + i);
 
 			if (i > 0) {
 				bytes.Add(cur);

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -167,11 +167,11 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public static void Send(Item item, BinaryWriter writer, bool writeStack = false, bool writeFavorite = false) {
-			writer.WriteVarInt(item.netID);
-			writer.WriteVarInt(item.prefix);
+			writer.Write7BitEncodedInt(item.netID);
+			writer.Write7BitEncodedInt(item.prefix);
 
 			if (writeStack)
-				writer.WriteVarInt(item.stack);
+				writer.Write7BitEncodedInt(item.stack);
 
 			if (writeFavorite)
 				writer.Write(item.favorited);
@@ -180,11 +180,11 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public static void Receive(Item item, BinaryReader reader, bool readStack = false, bool readFavorite = false) {
-			item.netDefaults(reader.ReadVarInt());
-			item.Prefix(ModNet.AllowVanillaClients ? reader.ReadByte() : reader.ReadVarInt());
+			item.netDefaults(reader.Read7BitEncodedInt());
+			item.Prefix(ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt());
 
 			if (readStack)
-				item.stack = reader.ReadVarInt();
+				item.stack = reader.Read7BitEncodedInt();
 
 			if (readFavorite)
 				item.favorited = reader.ReadBoolean();

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -58,7 +58,7 @@
 +								PlayerIO.WriteByteVanillaHairDye(player5.hairDye, writer);
 +							else
 -							writer.Write(player5.hairDye);
-+								writer.WriteVarInt(player5.hairDye);
++								writer.Write7BitEncodedInt(player5.hairDye);
 +
  							BitsByte bb6 = (byte)0;
  							for (int num14 = 0; num14 < 8; num14++) {
@@ -114,8 +114,8 @@
 +								ItemIO.WriteByteVanillaPrefix(item7, writer);
 +							}
 +							else {
-+								writer.WriteVarInt(item7.stack);
-+								writer.WriteVarInt(item7.prefix);
++								writer.Write7BitEncodedInt(item7.stack);
++								writer.Write7BitEncodedInt(item7.prefix);
 +							}
 +
  							writer.Write((byte)number2);
@@ -259,7 +259,7 @@
 +							}
 +							else {
 +								ItemIO.Send(item3, writer);
-+								writer.WriteVarInt(number5);
++								writer.Write7BitEncodedInt(number5);
 +							}
 +
  							break;
@@ -292,7 +292,7 @@
 +							}
 +							else {
 +								ItemIO.Send(item2, writer);
-+								writer.WriteVarInt(number5);
++								writer.Write7BitEncodedInt(number5);
 +							}
 +
  							break;
@@ -313,7 +313,7 @@
 +							}
 +							else {
 +								ItemIO.Send(item, writer);
-+								writer.WriteVarInt(number5);
++								writer.Write7BitEncodedInt(number5);
 +							}
 +
  							break;

--- a/tModPorter/tModPorter.Tests/TestData/BinaryIOVarInt.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/BinaryIOVarInt.Expected.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class BinaryIOVarInt : ModSystem
+	{
+		public static int Value1 = 1;
+		public static int Value2 => 2;
+		public static int Value3() => 3;
+
+		public override void NetSend(BinaryWriter writer) {
+			writer.Write7BitEncodedInt(Value1);
+			writer.Write7BitEncodedInt(Value2);
+			writer.Write7BitEncodedInt(Value3());
+			writer.Write7BitEncodedInt(4);
+		}
+
+		public override void NetReceive(BinaryReader reader) {
+			int value1 = reader.Read7BitEncodedInt();
+			int value2 = reader.Read7BitEncodedInt();
+			int value3 = reader.Read7BitEncodedInt();
+			int value4 = reader.Read7BitEncodedInt();
+		}
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/BinaryIOVarInt.cs
+++ b/tModPorter/tModPorter.Tests/TestData/BinaryIOVarInt.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using Terraria.ModLoader;
+
+namespace tModPorter.Tests.TestData
+{
+	public class BinaryIOVarInt : ModSystem
+	{
+		public static int Value1 = 1;
+		public static int Value2 => 2;
+		public static int Value3() => 3;
+
+		public override void NetSend(BinaryWriter writer) {
+			writer.WriteVarInt(Value1);
+			writer.WriteVarInt(Value2);
+			writer.WriteVarInt(Value3());
+			writer.WriteVarInt(4);
+		}
+
+		public override void NetReceive(BinaryReader reader) {
+			int value1 = reader.ReadVarInt();
+			int value2 = reader.ReadVarInt();
+			int value3 = reader.ReadVarInt();
+			int value4 = reader.ReadVarInt();
+		}
+	}
+}

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -4,6 +4,7 @@ using static tModPorter.Rewriters.MemberUseRewriter;
 using static tModPorter.Rewriters.HookRewriter;
 using static tModPorter.Rewriters.AddComment;
 using System;
+using System.IO;
 
 namespace tModPorter;
 
@@ -304,6 +305,8 @@ public static partial class Config
 		RefactorInstanceMethodCall("Terraria.ModLoader.Mod", "AddEquipTexture",		ConvertAddEquipTexture);
 		RefactorInstanceMethodCall("Terraria.ModLoader.Mod", "CreateRecipe",		ToStaticMethodCall("Terraria.Recipe",								"Create",				targetBecomesFirstArg: false));
 
+		RenameMethod("System.IO.BinaryReader",			from: "ReadVarInt",		to: "Read7BitEncodedInt");
+		RenameMethod("System.IO.BinaryWriter",			from: "WriteVarInt",	to: "Write7BitEncodedInt");
 		RenameMethod("Terraria.ModLoader.Mod",			from: "TextureExists",	to: "HasAsset");
 		RenameMethod("Terraria.ModLoader.ModContent",	from: "TextureExists",	to: "HasAsset");
 


### PR DESCRIPTION
### What is the new feature?
Removal of `ReadVarInt`/`WriteVarInt` extensions for `BinaryReader`/`BinaryWriter`

### Why should this be part of tModLoader?
The extensions are copies of `Read7BitEncodedInt`/`Write7BitEncodedInt` methods in `BinaryReader`/`BinaryWriter`.
They were made because `Read7BitEncodedInt` and `Write7BitEncodedInt` were `protected` in .NET Framework.

These methods are public since .NET 5, and thus we can remove our copies of them.

### Are there alternative designs?
Keep our copies
Redirect our extensions to the now public methods

### ExampleMod updates
None
