### PR TITLE
Better fix for docker in non-interactive mode

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -831,14 +831,18 @@
  			}
  
  			YouCanSleepNow();
-@@ -4538,8 +_,15 @@
+@@ -4538,8 +_,19 @@
  
  		public static void startDedInputCallBack() {
  			while (!Netplay.Disconnect) {
 -				Console.Write(": ");
  				string text = Console.ReadLine();
-+				if (text != null) // Fix for #2644 where Docker would steal lines from the active console.
-+					ExecuteCommand(text, new ConsoleCommandCaller());
++				if (text == null) { // Fix for #2644 where Docker would steal lines from the active console.
++					Logging.tML.Warn("Console input not connected, ignoring...");
++					break;
++				}
++
++				ExecuteCommand(text, new ConsoleCommandCaller());
 +			}
 +		}
 +


### PR DESCRIPTION
### What is the bug?

The fix for #2672 will cause a background thread to spin forever, wasting CPU and raising core contention.

### How did you fix the bug?

If input returns null, it's not coming back. Exit with a message.

### Are there alternatives to your fix?

Try multiple times? Sleep between retries? Doubt this would make any difference.

