### PR TITLE
Fix modpacks not saving for duplicate configs

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
@@ -141,7 +141,8 @@ namespace Terraria.ModLoader.UI
 					if (!config.Contains(enabled))
 						continue;
 
-					File.Copy(config, Path.Combine(configsPath, Path.GetFileName(config)));
+					// Overwrite existing config file to fix config collisions (#2661)
+					File.Copy(config, Path.Combine(configsPath, Path.GetFileName(config)), true);
 				}
 
 				// Prep work for export workshop mods to a download manager list


### PR DESCRIPTION
### What is the bug?
Modpack creation will fail when multiple mods use the same configuration file. This is most notable in Fargo's mutant and souls mod which target the same config file (#2661).

### How did you fix the bug?
Added a third parameter to `File.Copy` that forces an existing modpack config file to be overwritten

### Are there alternatives to your fix?
A check could be added to see if the config file already exists in the modpack (which may be a better long-term solution) but it's not necessary since config files can only come from one directory (and therefore shouldn't ever override any file except itself)
