### PR TITLE
Reformat ModPylon PR comments to fit tML convention

### DIFF
--- a/ExampleMod/Common/GlobalPylons/ExampleGlobalPylon.cs
+++ b/ExampleMod/Common/GlobalPylons/ExampleGlobalPylon.cs
@@ -15,34 +15,34 @@ namespace ExampleMod.Common.GlobalPylons
 	public class ExampleGlobalPylon : GlobalPylon
 	{
 		public override bool? ValidTeleportCheck_PreNPCCount(TeleportPylonInfo pylonInfo, ref int defaultNecessaryNPCCount) {
-			//Since we have the capabilities, we can allow players to teleport to any pylon even if there are no NPCs there during the night time.
+			// Since we have the capabilities, we can allow players to teleport to any pylon even if there are no NPCs there during the night time.
 			if (!Main.dayTime) {
 				defaultNecessaryNPCCount = 0;
 			}
 
-			//Since we aren't preventing anything and just changing the NPC count, we can just return what the default method returns, which is null (AKA vanilla behavior)
+			// Since we aren't preventing anything and just changing the NPC count, we can just return what the default method returns, which is null (AKA vanilla behavior)
 			return base.ValidTeleportCheck_PreNPCCount(pylonInfo, ref defaultNecessaryNPCCount);
 		}
 
 		public override bool PreDrawMapIcon(ref MapOverlayDrawContext context, ref string mouseOverText, ref TeleportPylonInfo pylonInfo, ref bool isNearPylon, ref Color drawColor, ref float deselectedScale, ref float selectedScale) {
-			//What if we want to change the color of all of the map icons?
-			//If we aren't near a pylon, we're going to shift the color of all pylon icons to being more red
+			// What if we want to change the color of all of the map icons?
+			// If we aren't near a pylon, we're going to shift the color of all pylon icons to being more red
 			if (!isNearPylon) {
 				drawColor = Color.Lerp(drawColor, Color.Red, 0.75f);
 			}
 
-			//Since we aren't actually preventing the drawing of any map icons, we can just return the default value, which in this case is null (AKA vanilla behavior)
+			// Since we aren't actually preventing the drawing of any map icons, we can just return the default value, which in this case is null (AKA vanilla behavior)
 			return base.PreDrawMapIcon(ref context, ref mouseOverText, ref pylonInfo, ref isNearPylon, ref drawColor, ref deselectedScale, ref selectedScale);
 		}
 
 		public override bool? PreCanPlacePylon(int x, int y, int tileType, TeleportPylonType pylonType) {
-			//What if we want to override the functionality for pylon placement?
-			//For example, let's always allow the players to place universal pylons, even if they already exist in the world:
+			// What if we want to override the functionality for pylon placement?
+			// For example, let's always allow the players to place universal pylons, even if they already exist in the world:
 			if (pylonType == TeleportPylonType.Victory) {
 				return true;
 			}
-			//What if we wanted to change something for a modded type? If you have strong reference to the modded pylon in question,
-			//you can simply use the class:
+			// What if we wanted to change something for a modded type? If you have strong reference to the modded pylon in question,
+			// you can simply use the class:
 			if (pylonType == ModContent.PylonType<ExamplePylonTileAdvanced>()) {
 				return null; //We don't want to *actually* change any functionality of the advanced pylon, so we return null.
 				//Obviously, if you wanted to actually change something about the modded pylon, you'd return something other than null here.
@@ -52,12 +52,12 @@ namespace ExampleMod.Common.GlobalPylons
 		}
 
 		public override bool? ValidTeleportCheck_PreBiomeRequirements(TeleportPylonInfo pylonInfo, SceneMetrics sceneData) {
-			//What if we want to do something based on the type of pylon in particular? Well all we have to do is check the pylon's type!
-			//Let's allow the Jungle Pylon to work in the snow, for example:
+			// What if we want to do something based on the type of pylon in particular? Well all we have to do is check the pylon's type!
+			// Let's allow the Jungle Pylon to work in the snow, for example:
 			if (pylonInfo.TypeOfPylon == TeleportPylonType.Jungle) {
-				//If another mod tries to mess with Jungle pylons, we don't want to return a forceful false, if applicable. If Jungle AND snow
-				//are both false, we will return null to allow for other mods to try and change things based on the Jungle pylon.
-				//Granted that no other mod does anything to change the null value, the teleportation process will fail, under the above circumstances.
+				// If another mod tries to mess with Jungle pylons, we don't want to return a forceful false, if applicable. If Jungle AND snow
+				// are both false, we will return null to allow for other mods to try and change things based on the Jungle pylon.
+				// Granted that no other mod does anything to change the null value, the teleportation process will fail, under the above circumstances.
 				return sceneData.EnoughTilesForJungle || sceneData.EnoughTilesForSnow ? true : null;
 			}
 
@@ -65,11 +65,11 @@ namespace ExampleMod.Common.GlobalPylons
 		}
 
 		public override void PostValidTeleportCheck(TeleportPylonInfo destinationPylonInfo, TeleportPylonInfo nearbyPylonInfo, ref bool destinationPylonValid, ref bool validNearbyPylonFound, ref string errorKey) {
-			//Since there is not an explicit hook for it (since it's too specific), what if we wanted to nullify vanilla's check to prevent accessing the Lihzahrd Temple early with a pylon?
+			// Since there is not an explicit hook for it (since it's too specific), what if we wanted to nullify vanilla's check to prevent accessing the Lihzahrd Temple early with a pylon?
 
-			//We just need to check that to see if the Lihzahrd Temple check is the actual error we got (not some other error) which in this case is done by checking the error key.
-			//We also do another quick check to make sure that we are still near a valid pylon.
-			//If that is true, we can set destinationPylonValid to true, overriding the teleportation prevention.
+			// We just need to check that to see if the Lihzahrd Temple check is the actual error we got (not some other error) which in this case is done by checking the error key.
+			// We also do another quick check to make sure that we are still near a valid pylon.
+			// If that is true, we can set destinationPylonValid to true, overriding the teleportation prevention.
 			if (validNearbyPylonFound && errorKey == "Net.CannotTeleportToPylonBecauseAccessingLihzahrdTempleEarly") {
 				destinationPylonValid = true;
 			}

--- a/ExampleMod/Content/Items/Placeable/ExamplePylonItem.cs
+++ b/ExampleMod/Content/Items/Placeable/ExamplePylonItem.cs
@@ -5,17 +5,17 @@ using Terraria.ModLoader;
 namespace ExampleMod.Content.Items.Placeable
 {
 	/// <summary>
-	/// The coupled item that placed the Example Pylon tile. For more information on the Pylon tile itself,
+	/// The coupled item that places the Example Pylon tile. For more information on said tile,
 	/// see <seealso cref="ExamplePylonTile"/>.
 	/// </summary>
 	public class ExamplePylonItem : ModItem
 	{
 		public override void SetDefaults() {
-			//Basically, this a just a shorthand method that will set all default values necessary to place
-			//the passed in tile type; in this case, the Example Pylon tile.
+			// Basically, this a just a shorthand method that will set all default values necessary to place
+			// the passed in tile type; in this case, the Example Pylon tile.
 			Item.DefaultToPlaceableTile(ModContent.TileType<ExamplePylonTile>());
 
-			//Another shorthand method that will set the rarity and how much the item is worth.
+			// Another shorthand method that will set the rarity and how much the item is worth.
 			Item.SetShopValues(ItemRarityColor.Blue1, Terraria.Item.buyPrice(gold: 10));
 		}
 	}

--- a/ExampleMod/Content/Items/Placeable/ExamplePylonItemAdvanced.cs
+++ b/ExampleMod/Content/Items/Placeable/ExamplePylonItemAdvanced.cs
@@ -5,17 +5,17 @@ using Terraria.ModLoader;
 namespace ExampleMod.Content.Items.Placeable
 {
 	/// <summary>
-	/// The coupled item that placed the Example Pylon tile. For more information on the Pylon tile itself,
+	/// The coupled item that places the Advanced Example Pylon tile. For more information on said tile,
 	/// see <seealso cref="ExamplePylonTileAdvanced"/>.
 	/// </summary>
 	public class ExamplePylonItemAdvanced : ModItem
 	{
 		public override void SetDefaults() {
-			//Basically, this a just a shorthand method that will set all default values necessary to place
-			//the passed in tile type; in this case, the Example Pylon tile.
+			// Basically, this a just a shorthand method that will set all default values necessary to place
+			// the passed in tile type; in this case, the Advanced Example Pylon tile.
 			Item.DefaultToPlaceableTile(ModContent.TileType<ExamplePylonTileAdvanced>());
 
-			//Another shorthand method that will set the rarity and how much the item is worth.
+			// Another shorthand method that will set the rarity and how much the item is worth.
 			Item.SetShopValues(ItemRarityColor.LightRed4, Terraria.Item.buyPrice(gold: 20));
 		}
 	}

--- a/ExampleMod/Content/TileEntities/AdvancedPylonTileEntity.cs
+++ b/ExampleMod/Content/TileEntities/AdvancedPylonTileEntity.cs
@@ -17,19 +17,19 @@ namespace ExampleMod.Content.TileEntities
 	/// </summary>
 	public class AdvancedPylonTileEntity : TEModdedPylon
 	{
-		//This is the main crux of this TileEntity; its pylon functionality will only work when this boolean is true.
+		// This is the main crux of this TileEntity; its pylon functionality will only work when this boolean is true.
 		public bool isActive;
 
 		public override void OnNetPlace() {
-			//This hook is only ever called on the server; its purpose is to give more freedom in terms of syncing FROM the server to clients, which we take advantage of
-			//by making sure to sync whenever this hook is called:
+			// This hook is only ever called on the server; its purpose is to give more freedom in terms of syncing FROM the server to clients, which we take advantage of
+			// by making sure to sync whenever this hook is called:
 			NetMessage.SendData(MessageID.TileEntitySharing, number: ID, number2: Position.X, number3: Position.Y);
 		}
 
 		public override void NetSend(BinaryWriter writer) {
-			//We want to make sure that our data is synced properly across clients and server.
-			//NetSend is called whenever a TileEntitySharing message is sent, so the game will handle this automatically for us,
-			//granted that we send a message when we need to.
+			// We want to make sure that our data is synced properly across clients and server.
+			// NetSend is called whenever a TileEntitySharing message is sent, so the game will handle this automatically for us,
+			// granted that we send a message when we need to.
 			writer.Write(isActive);
 		}
 
@@ -38,13 +38,13 @@ namespace ExampleMod.Content.TileEntities
 		}
 
 		public override void Update() {
-			//Update is only ever called on the Server or in SinglePlayer, so our randomness will be in that frame of reference
-			//Every tick, there will be a 1/180 chance that the active state of this pylon will swap (ON to OFF or vice versa)
+			// Update is only ever called on the Server or in SinglePlayer, so our randomness will be in that frame of reference
+			// Every tick, there will be a 1/180 chance that the active state of this pylon will swap (ON to OFF or vice versa)
 			if (!Main.rand.NextBool(180)) {
 				return;
 			}
 
-			//Granted that the check passes, we change the active state, and if this is on the server, we sync it with the server:
+			// Granted that the check passes, we change the active state, and if this is on the server, we sync it with the server:
 			isActive = !isActive;
 			if (Main.netMode == NetmodeID.Server) {
 				NetMessage.SendData(MessageID.TileEntitySharing, number: ID, number2: Position.X, number3: Position.Y);

--- a/ExampleMod/Content/Tiles/ExamplePylonTile.cs
+++ b/ExampleMod/Content/Tiles/ExamplePylonTile.cs
@@ -5,20 +5,14 @@ using ExampleMod.Content.TileEntities;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
-using System;
 using Terraria;
-using Terraria.Audio;
 using Terraria.DataStructures;
 using Terraria.GameContent;
-using Terraria.GameContent.ObjectInteractions;
-using Terraria.GameInput;
 using Terraria.ID;
-using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Default;
 using Terraria.ObjectData;
-using Terraria.UI;
 
 namespace ExampleMod.Content.Tiles
 {
@@ -41,7 +35,7 @@ namespace ExampleMod.Content.Tiles
 		public Asset<Texture2D> mapIcon;
 
 		public override void Load() {
-			//We'll need these textures for later, it's best practice to cache them on load instead of continually requesting every draw call.
+			// We'll need these textures for later, it's best practice to cache them on load instead of continually requesting every draw call.
 			crystalTexture = ModContent.Request<Texture2D>(Texture + "_Crystal");
 			mapIcon = ModContent.Request<Texture2D>(Texture + "_MapIcon");
 		}
@@ -54,8 +48,8 @@ namespace ExampleMod.Content.Tiles
 			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.DrawYOffset = 2;
 			TileObjectData.newTile.StyleHorizontal = true;
-			//These definitions allow for vanilla's pylon TileEntities to be placed. If you want to use your own TileEntities, do NOT add these lines!
-			//tModLoader has a built in Tile Entity specifically for modded pylons, which we must extend (see SimplePylonTileEntity)
+			// These definitions allow for vanilla's pylon TileEntities to be placed. If you want to use your own TileEntities, do NOT add these lines!
+			// tModLoader has a built in Tile Entity specifically for modded pylons, which we must extend (see SimplePylonTileEntity)
 			TEModdedPylon moddedPylon = ModContent.GetInstance<SimplePylonTileEntity>();
 			TileObjectData.newTile.HookCheckIfCanPlace = new PlacementHook(moddedPylon.PlacementPreviewHook_CheckIfCanPlace, 1, 0, true);
 			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(moddedPylon.Hook_AfterPlacement, -1, 0, false);
@@ -65,7 +59,7 @@ namespace ExampleMod.Content.Tiles
 			TileID.Sets.InteractibleByNPCs[Type] = true;
 			TileID.Sets.PreventsSandfall[Type] = true;
 
-			//Adds functionality for proximity of pylons; if this is true, then being near this tile will count as being near a pylon for the teleportation process.
+			// Adds functionality for proximity of pylons; if this is true, then being near this tile will count as being near a pylon for the teleportation process.
 			AddToArray(ref TileID.Sets.CountsAsPylon);
 
 			ModTranslation pylonName = CreateMapEntryName(); //Name is in the localization file
@@ -73,8 +67,8 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override int? IsPylonForSale(int npcType, Player player, bool isNPCHappyEnough) {
-			//Let's say that our pylon is for sale no matter what for any NPC under all circumstances, granted that the NPC
-			//is in the Example Surface/Underground Biome.
+			// Let's say that our pylon is for sale no matter what for any NPC under all circumstances, granted that the NPC
+			// is in the Example Surface/Underground Biome.
 			return ModContent.GetInstance<ExampleSurfaceBiome>().IsBiomeActive(player) || ModContent.GetInstance<ExampleUndergroundBiome>().IsBiomeActive(player)
 				? ModContent.ItemType<ExamplePylonItem>()
 				: null;
@@ -82,41 +76,41 @@ namespace ExampleMod.Content.Tiles
 
 
 		public override void MouseOver(int i, int j) {
-			//Show a little pylon icon on the mouse indicating we are hovering over it.
+			// Show a little pylon icon on the mouse indicating we are hovering over it.
 			Main.LocalPlayer.cursorItemIconEnabled = true;
 			Main.LocalPlayer.cursorItemIconID = ModContent.ItemType<ExamplePylonItem>();
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			//We need to clean up after ourselves, since this is still a "unique" tile, separate from Vanilla Pylons, so we must kill the TileEntity.
+			// We need to clean up after ourselves, since this is still a "unique" tile, separate from Vanilla Pylons, so we must kill the TileEntity.
 			ModContent.GetInstance<SimplePylonTileEntity>().Kill(i, j);
 
-			//Also, like other pylons, breaking it simply drops the item once again. Pretty straight-forward.
+			// Also, like other pylons, breaking it simply drops the item once again. Pretty straight-forward.
 			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 2, 3, ModContent.ItemType<ExamplePylonItem>());
 		}
 
 		public override bool ValidTeleportCheck_NPCCount(TeleportPylonInfo pylonInfo, int defaultNecessaryNPCCount) {
-			//Let's say for fun sake that no NPCs need to be nearby in order for this pylon to function. If you want your pylon to function just like vanilla,
-			//you don't need to override this method at all.
+			// Let's say for fun sake that no NPCs need to be nearby in order for this pylon to function. If you want your pylon to function just like vanilla,
+			// you don't need to override this method at all.
 			return true;
 		}
 
 		public override bool ValidTeleportCheck_BiomeRequirements(TeleportPylonInfo pylonInfo, SceneMetrics sceneData) {
-			//Right before this hook is called, the sceneData parameter exports its information based on wherever the destination pylon is,
-			//and by extension, it will call ALL ModSystems that use the TileCountsAvailable method. This means, that if you determine biomes
-			//based off of tile count, when this hook is called, you can simply check the tile threshold, like we do here. In the context of ExampleMod,
-			//something is considered within the Example Surface/Underground biome if there are 40 or more example blocks at that location.
+			// Right before this hook is called, the sceneData parameter exports its information based on wherever the destination pylon is,
+			// and by extension, it will call ALL ModSystems that use the TileCountsAvailable method. This means, that if you determine biomes
+			// based off of tile count, when this hook is called, you can simply check the tile threshold, like we do here. In the context of ExampleMod,
+			// something is considered within the Example Surface/Underground biome if there are 40 or more example blocks at that location.
 
 			return ModContent.GetInstance<ExampleBiomeTileCount>().exampleBlockCount >= 40;
 		}
 
 		public override void SpecialDraw(int i, int j, SpriteBatch spriteBatch) {
-			//We want to draw the pylon crystal the exact same way vanilla does, so we can use this built in method in ModPylon for default crystal drawing:
+			// We want to draw the pylon crystal the exact same way vanilla does, so we can use this built in method in ModPylon for default crystal drawing:
 			DefaultDrawPylonCrystal(spriteBatch, i, j, crystalTexture, Color.White, CrystalFrameHeight, CrystalHorizontalFrameCount, CrystalVerticalFrameCount);
 		}
 
 		public override void DrawMapIcon(ref MapOverlayDrawContext context, ref string mouseOverText, TeleportPylonInfo pylonInfo, bool isNearPylon, Color drawColor, float deselectedScale, float selectedScale) {
-			//Just like in SpecialDraw, we want things to be handled the EXACT same way vanilla would handle it, which ModPylon also has built in methods for:
+			// Just like in SpecialDraw, we want things to be handled the EXACT same way vanilla would handle it, which ModPylon also has built in methods for:
 			bool mouseOver = DefaultDrawMapIcon(ref context, mapIcon, pylonInfo.PositionInTiles.ToVector2() + new Vector2(1.5f, 2f), drawColor, deselectedScale, selectedScale);
 			DefaultMapClickHandle(mouseOver, pylonInfo, "Mods.ExampleMod.ItemName.ExamplePylonItem", ref mouseOverText);
 		}

--- a/ExampleMod/Content/Tiles/ExamplePylonTileAdvanced.cs
+++ b/ExampleMod/Content/Tiles/ExamplePylonTileAdvanced.cs
@@ -35,7 +35,7 @@ namespace ExampleMod.Content.Tiles
 		public Asset<Texture2D> mapIcon;
 
 		public override void Load() {
-			//We'll still use the other Example Pylon's sprites, but we need to adjust the texture values first to do so.
+			// We'll still use the other Example Pylon's sprites, but we need to adjust the texture values first to do so.
 			crystalTexture = ModContent.Request<Texture2D>(Texture.Replace("Advanced", "") + "_Crystal");
 			mapIcon = ModContent.Request<Texture2D>(Texture.Replace("Advanced", "") + "_MapIcon");
 		}
@@ -44,14 +44,14 @@ namespace ExampleMod.Content.Tiles
 			Main.tileLighted[Type] = true;
 			Main.tileFrameImportant[Type] = true;
 
-			//This time around, we'll have a tile that is 2x3 instead of 3x4.
+			// This time around, we'll have a tile that is 2x3 instead of 3x4.
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2xX);
 			TileObjectData.newTile.Height = 3;
 			TileObjectData.newTile.Origin = new Point16(0, 2);
 			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.DrawYOffset = 2;
 			TileObjectData.newTile.StyleHorizontal = true;
-			//Since we are going to need more in-depth functionality, we can't use vanilla's Pylon TE's OnPlace or CanPlace:
+			// Since we are going to need more in-depth functionality, we can't use vanilla's Pylon TE's OnPlace or CanPlace:
 			AdvancedPylonTileEntity advancedEntity = ModContent.GetInstance<AdvancedPylonTileEntity>();
 			TileObjectData.newTile.HookCheckIfCanPlace = new PlacementHook(advancedEntity.PlacementPreviewHook_CheckIfCanPlace, 1, 0, true);
 			TileObjectData.newTile.HookPostPlaceMyPlayer = new PlacementHook(advancedEntity.Hook_AfterPlacement, -1, 0, false);
@@ -68,7 +68,7 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override int? IsPylonForSale(int npcType, Player player, bool isNPCHappyEnough) {
-			//Let's say that our pylon is for sale no matter what for any NPC under all circumstances.
+			// Let's say that our pylon is for sale no matter what for any NPC under all circumstances.
 			return ModContent.ItemType<ExamplePylonItemAdvanced>();
 		}
 
@@ -93,7 +93,7 @@ namespace ExampleMod.Content.Tiles
 			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 3, 4, ModContent.ItemType<ExamplePylonItemAdvanced>());
 		}
 
-		//For the sake of example, we will allow this pylon to always be teleported to as long as it is on, so we make sure these two checks return true.
+		// For the sake of example, we will allow this pylon to always be teleported to as long as it is on, so we make sure these two checks return true.
 		public override bool ValidTeleportCheck_NPCCount(TeleportPylonInfo pylonInfo, int defaultNecessaryNPCCount) {
 			return true;
 		}
@@ -102,14 +102,14 @@ namespace ExampleMod.Content.Tiles
 			return true;
 		}
 
-		//These two steps below are simply determining whether or not either side of the coin is valid, which is to say:
-		//Is the destination pylon (the pylon clicked on the map) a valid pylon, and is the pylon the player standing near (the nearby pylon)
-		//a valid pylon? If either one of these checks fail, a errorKey wil be set to a custom localization key and a message will go to the player with
-		//said text (after its been localized, of course).
+		// These two steps below are simply determining whether or not either side of the coin is valid, which is to say:
+		// Is the destination pylon (the pylon clicked on the map) a valid pylon, and is the pylon the player standing near (the nearby pylon)
+		// a valid pylon? If either one of these checks fail, a errorKey wil be set to a custom localization key and a message will go to the player with
+		// said text (after its been localized, of course).
 		public override void ValidTeleportCheck_DestinationPostCheck(TeleportPylonInfo destinationPylonInfo, ref bool destinationPylonValid, ref string errorKey) {
-			//If you are unfamiliar with pattern matching notation, all this is asking is:
-			//1) The Tile Entity at the given position is an AdvancedPylonTileEntity (AKA not null or something else)
-			//2) The Tile Entity's isActive value is false
+			// If you are unfamiliar with pattern matching notation, all this is asking is:
+			// 1) The Tile Entity at the given position is an AdvancedPylonTileEntity (AKA not null or something else)
+			// 2) The Tile Entity's isActive value is false
 			if (TileEntity.ByPosition[destinationPylonInfo.PositionInTiles] is AdvancedPylonTileEntity { isActive: false }) {
 				//Given that both of these things are true, set the error key to our own special message (check the localization file), and make the destination value invalid (false)
 				destinationPylonValid = false;
@@ -118,7 +118,7 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override void ValidTeleportCheck_NearbyPostCheck(TeleportPylonInfo nearbyPylonInfo, ref bool destinationPylonValid, ref bool anyNearbyValidPylon, ref string errorKey) {
-			//The next check is determining whether or not the nearby pylon is potentially unstable, and if so, if it's not active, we also prevent teleportation.
+			// The next check is determining whether or not the nearby pylon is potentially unstable, and if so, if it's not active, we also prevent teleportation.
 			if (TileEntity.ByPosition[nearbyPylonInfo.PositionInTiles] is AdvancedPylonTileEntity { isActive: false }) {
 				destinationPylonValid = false;
 				errorKey = "Mods.ExampleMod.MessageInfo.NearbyUnstablePylonIsOff";
@@ -126,28 +126,28 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {
-			//This time, we'll ONLY draw the crystal if the pylon is active
-			//We need to check the framing here in order to guarantee we that we are trying to grab the TE ONLY when in the top left corner, where it is
-			//located. If we don't do this check, we will be attempting to grab the TE in position where it doesn't exist, throwing errors and causing
-			//loads of visual bugs.
+			// This time, we'll ONLY draw the crystal if the pylon is active
+			// We need to check the framing here in order to guarantee we that we are trying to grab the TE ONLY when in the top left corner, where it is
+			// located. If we don't do this check, we will be attempting to grab the TE in position where it doesn't exist, throwing errors and causing
+			// loads of visual bugs.
 			if (drawData.tileFrameX % 36 == 0 && drawData.tileFrameY == 0 && TileEntity.ByPosition[new Point16(i, j)] is AdvancedPylonTileEntity { isActive: true }) {
 				Main.instance.TilesRenderer.AddSpecialLegacyPoint(i, j);
 			}
 		}
 
 		public override void SpecialDraw(int i, int j, SpriteBatch spriteBatch) {
-			//This code is essentially identical to how it is in the basic example, but this time the crystal color is the disco (rainbow) color instead.
+			// This code is essentially identical to how it is in the basic example, but this time the crystal color is the disco (rainbow) color instead.
 			DefaultDrawPylonCrystal(spriteBatch, i, j, crystalTexture, Main.DiscoColor, CrystalFrameHeight, CrystalHorizontalFrameCount, CrystalVerticalFrameCount);
 		}
 
 		public override void DrawMapIcon(ref MapOverlayDrawContext context, ref string mouseOverText, TeleportPylonInfo pylonInfo, bool isNearPylon, Color drawColor, float deselectedScale, float selectedScale) {
 			if (!TileEntity.ByPosition.TryGetValue(pylonInfo.PositionInTiles, out var te) || te is not AdvancedPylonTileEntity entity) {
-				//If for some reason we don't find the tile entity, we won't draw anything.
+				// If for some reason we don't find the tile entity, we won't draw anything.
 				return;
 			}
 
-			//Depending on the whether or not the pylon is active, the color of the icon will change;
-			//otherwise, it acts as normal.
+			// Depending on the whether or not the pylon is active, the color of the icon will change;
+			// otherwise, it acts as normal.
 			drawColor = !entity.isActive ? Color.Gray * 0.5f : drawColor;
 			bool mouseOver = DefaultDrawMapIcon(ref context, mapIcon, pylonInfo.PositionInTiles.ToVector2() + new Vector2(1, 1.5f), drawColor, deselectedScale, selectedScale);
 			DefaultMapClickHandle(mouseOver, pylonInfo, "Mods.ExampleMod.ItemName.ExamplePylonItemAdvanced", ref mouseOverText);

--- a/patches/tModLoader/Terraria/ModLoader/Default/TEModdedPylon.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/TEModdedPylon.cs
@@ -36,7 +36,7 @@ namespace Terraria.ModLoader.Default
 			}
 		}
 
-		//Acts exactly like vanilla's TE does the placing process, except we tack on updating the pylon system.
+		// Acts exactly like vanilla's TE does the placing process, except we tack on updating the pylon system.
 		public new int Place(int i, int j) {
 			int ID = base.Place(i, j);
 
@@ -44,7 +44,7 @@ namespace Terraria.ModLoader.Default
 			return ID;
 		}
 
-		//Acts exactly like vanilla's TE does the killing process, except we tack on updating the pylon system.
+		// Acts exactly like vanilla's TE does the killing process, except we tack on updating the pylon system.
 		public new void Kill(int x, int y) {
 			base.Kill(x, y);
 
@@ -54,7 +54,7 @@ namespace Terraria.ModLoader.Default
 		public override string ToString() => Position.X + "x  " + Position.Y + "y";
 
 		public override bool IsTileValidForEntity(int x, int y) {
-			//This is the default check that vanilla does for vanilla pylons. Feel free to override this if you use a differently sized pylon, or use a multi-framed pylon.
+			// This is the default check that vanilla does for vanilla pylons. Feel free to override this if you use a differently sized pylon, or use a multi-framed pylon.
 			TileObjectData tileData = TileObjectData.GetTileData(Main.tile[x, y]);
 			return Main.tile[x, y].active() && TileID.Sets.CountsAsPylon.Contains(Main.tile[x, y].type) && Main.tile[x, y].frameY == 0 && Main.tile[x, y].frameX % tileData.CoordinateFullWidth == 0;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/ModPylon.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPylon.cs
@@ -197,20 +197,20 @@ namespace Terraria.ModLoader
 		public virtual void DrawMapIcon(ref MapOverlayDrawContext context, ref string mouseOverText, TeleportPylonInfo pylonInfo, bool isNearPylon, Color drawColor, float deselectedScale, float selectedScale) { }
 
 		public override bool RightClick(int i, int j) {
-			//Vanilla has a very handy function we can use that automatically opens the map, closes the inventory, plays a sound, etc:
+			// Vanilla has a very handy function we can use that automatically opens the map, closes the inventory, plays a sound, etc:
 			Main.LocalPlayer.TryOpeningFullscreenMap();
 			return true;
 		}
 
-		//Must be true in order for our highlight texture to work.
+		// Must be true in order for our highlight texture to work.
 		public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) {
 			return true;
 		}
 
 		public override void DrawEffects(int i, int j, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {
-			//Basically, we only want the crystal to be drawn once, based off the top left corner, which is what this check is.
-			//The top left corner of a Pylon will have its FrameX divisible by its full pixel width,
-			//and its FrameY will be 0, since it's at the top of the tile sheet.
+			// Basically, we only want the crystal to be drawn once, based off the top left corner, which is what this check is.
+			// The top left corner of a Pylon will have its FrameX divisible by its full pixel width,
+			// and its FrameY will be 0, since it's at the top of the tile sheet.
 			if (drawData.tileFrameX % TileObjectData.GetTileData(drawData.tileCache).CoordinateFullWidth == 0 && drawData.tileFrameY == 0) {
 				//This method call basically says "Run SpecialDraw once at this position"
 				Main.instance.TilesRenderer.AddSpecialLegacyPoint(i, j);
@@ -230,13 +230,13 @@ namespace Terraria.ModLoader
 		/// <param name="crystalHorizontalFrameCount">The total frames wide the crystal texture has. </param>
 		/// <param name="crystalVerticalFrameCount"> The total frames high the crystal texture has. </param>
 		public void DefaultDrawPylonCrystal(SpriteBatch spriteBatch, int i, int j, Asset<Texture2D> crystalTexture, Color crystalDrawColor, int frameHeight, int crystalHorizontalFrameCount, int crystalVerticalFrameCount) {
-			//This is lighting-mode specific, always include this if you draw tiles manually
+			// This is lighting-mode specific, always include this if you draw tiles manually
 			Vector2 offScreen = new Vector2(Main.offScreenRange);
 			if (Main.drawToScreen) {
 				offScreen = Vector2.Zero;
 			}
 
-			//Take the tile, check if it actually exists
+			// Take the tile, check if it actually exists
 			Point pos = new Point(i, j);
 			Tile tile = Main.tile[pos.X, pos.Y];
 			if (tile == null || !tile.HasTile) {
@@ -244,19 +244,19 @@ namespace Terraria.ModLoader
 			}
 			TileObjectData tileData = TileObjectData.GetTileData(tile);
 
-			//Here, lots of framing takes place. 
+			// Here, lots of framing takes place. 
 			Texture2D vanillaPylonCrystals = TextureAssets.Extra[181].Value; //The default textures for vanilla pylons, containing a "sheen" texture we need
-			int frameY = (Main.tileFrameCounter[TileID.TeleportationPylon] + pos.X + pos.Y) % frameHeight / crystalVerticalFrameCount; //Get the current frameY. All pylons share the same frameCounter
-			//Next, frame the actual crystal texture, it's highlight texture, and the sheen texture, in that order.
+			int frameY = (Main.tileFrameCounter[TileID.TeleportationPylon] + pos.X + pos.Y) % frameHeight / crystalVerticalFrameCount; // Get the current frameY. All pylons share the same frameCounter
+			// Next, frame the actual crystal texture, it's highlight texture, and the sheen texture, in that order.
 			Rectangle crystalFrame = crystalTexture.Frame(crystalHorizontalFrameCount, crystalVerticalFrameCount, 0, frameY); 
 			Rectangle highlightFrame = crystalTexture.Frame(crystalHorizontalFrameCount, crystalVerticalFrameCount, 1, frameY);
 			vanillaPylonCrystals.Frame(crystalHorizontalFrameCount, crystalVerticalFrameCount, 0, frameY);
-			//Calculate positional values in order to determine where to actually draw the pylon
+			// Calculate positional values in order to determine where to actually draw the pylon
 			Vector2 origin = crystalFrame.Size() / 2f;
 			Vector2 centerPos = pos.ToWorldCoordinates(0f, 0f) + new Vector2(tileData.Width / 2f * 16f, (tileData.Height / 2f + 1.5f) * 16f);
 			float centerDisplacement = (float)Math.Sin(Main.GlobalTimeWrappedHourly * ((float)Math.PI * 2f) / 5f);
 			Vector2 drawPos = centerPos + offScreen + new Vector2(0f, -40f) + new Vector2(0f, centerDisplacement * 4f);
-			//Randomly spawn dust, granted that the game is open an active
+			// Randomly spawn dust, granted that the game is open an active
 			if (!Main.gamePaused && Main.instance.IsActive && Main.rand.NextBool(40)) {
 				Rectangle dustBox = Utils.CenteredRectangle(drawPos, crystalFrame.Size());
 
@@ -265,21 +265,21 @@ namespace Terraria.ModLoader
 				Main.dust[dustIndex].velocity.Y -= 0.2f;
 			}
 
-			//Next, calculate the color of the crystal and draw it. The color is determined by how lit the tile is at that position.
+			// Next, calculate the color of the crystal and draw it. The color is determined by how lit the tile is at that position.
 			Color crystalColor = Color.Lerp(Lighting.GetColor(pos.X, pos.Y), crystalDrawColor, 0.8f) ;
 			spriteBatch.Draw(crystalTexture.Value, drawPos - Main.screenPosition, crystalFrame, crystalColor * 0.7f, 0f, origin, 1f, SpriteEffects.None, 0f);
 
-			//Next, calculate the color of the sheen texture and its scale, then draw it.
+			// Next, calculate the color of the sheen texture and its scale, then draw it.
 			float scale = (float)Math.Sin(Main.GlobalTimeWrappedHourly * (Math.PI * 2f) / 1f) * 0.2f + 0.8f;
 			Color sheenColor = new Color(255, 255, 255, 0) * 0.1f * scale;
 			for (float displacement = 0f; displacement < 1f; displacement += 355f / (678f * (float)Math.PI)) {
 				spriteBatch.Draw(crystalTexture.Value, drawPos - Main.screenPosition + ((float)Math.PI * 2f * displacement).ToRotationVector2() * (6f + centerDisplacement * 2f), crystalFrame, sheenColor, 0f, origin, 1f, SpriteEffects.None, 0f);
 			}
 
-			//Finally, everything below is for the smart cursor, drawing the highlight texture depending on whether or not either:
-			//1) Smart Cursor is off, and no highlight texture is drawn at all (selectionType = 0)
-			//2) Smart Cursor is on, but it is not currently focusing on the Pylon (selectionType = 1)
-			//3) Smart Cursor is on, but it IS currently focusing on the Pylon (selectionType = 2)
+			// Finally, everything below is for the smart cursor, drawing the highlight texture depending on whether or not either:
+			// 1) Smart Cursor is off, and no highlight texture is drawn at all (selectionType = 0)
+			// 2) Smart Cursor is on, but it is not currently focusing on the Pylon (selectionType = 1)
+			// 3) Smart Cursor is on, but it IS currently focusing on the Pylon (selectionType = 2)
 			int selectionType = 0;
 			if (Main.InSmartCursorHighlightArea(pos.X, pos.Y, out bool actuallySelected)) {
 				selectionType = 1;
@@ -293,7 +293,7 @@ namespace Terraria.ModLoader
 				return;
 			}
 
-			//Finally, draw the highlight texture, if applicable.
+			// Finally, draw the highlight texture, if applicable.
 			int colorPotency = (crystalColor.R + crystalColor.G + crystalColor.B) / 3;
 			if (colorPotency > 10) {
 				Color selectionGlowColor = Colors.GetSelectionGlowColor(selectionType == 2, colorPotency);
@@ -312,7 +312,6 @@ namespace Terraria.ModLoader
 		/// <param name="drawColor"> The color to draw the icon as. </param>
 		/// <param name="deselectedScale"> The scale to draw the map icon when it is not selected (not being hovered over). </param>
 		/// <param name="selectedScale"> The scale to draw the map icon when it IS selected (being hovered over). </param>
-		/// <returns></returns>
 		public bool DefaultDrawMapIcon(ref MapOverlayDrawContext context, Asset<Texture2D> mapIcon, Vector2 drawCenter, Color drawColor, float deselectedScale, float selectedScale) {
 			return context.Draw(
 				              mapIcon.Value,
@@ -337,7 +336,7 @@ namespace Terraria.ModLoader
 		/// </param>
 		/// <param name="mouseOverText"> The reference to the string value that actually changes the mouse text value. </param>
 		public void DefaultMapClickHandle(bool mouseIsHovering, TeleportPylonInfo pylonInfo, string hoveringTextKey, ref string mouseOverText) {
-			//We only want these things to happen if the mouse is hovering, thus the check:
+			// We only want these things to happen if the mouse is hovering, thus the check:
 			if (!mouseIsHovering) {
 				return;
 			}
@@ -345,7 +344,7 @@ namespace Terraria.ModLoader
 			Main.cancelWormHole = true;
 			mouseOverText = Language.GetTextValue(hoveringTextKey);
 
-			//If clicking, then teleport!
+			// If clicking, then teleport!
 			if (Main.mouseLeft && Main.mouseLeftRelease) {
 				Main.mouseLeftRelease = false;
 				Main.mapFullscreen = false;


### PR DESCRIPTION
### What are the changes to ExampleMod?

Updated the comments from the recently merged #2564 to properly adhere to tML's comment conventions.

Also cleaned up some un-used `using` statements from previous implementations of said PR, and fixed a couple minor grammatical errors.
