### PR TITLE
Publicize missing variables from previous Worldgen PR

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.TML.cs
+++ b/patches/tModLoader/Terraria/WorldGen.TML.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using Terraria.ModLoader;
+﻿using Terraria.WorldBuilding;
 
 namespace Terraria
 {
 	public partial class WorldGen
 	{
 		#region WorldGen.GenerateWorld Values
+		public static WorldGenConfiguration configuration;
 		public static int copper;
 		public static int iron;
 		public static int silver;
@@ -50,6 +50,7 @@ namespace Terraria
 		public static int logX;
 		public static int logY;
 		public static int dungeonLocation;
+		public static int i2;
 		#endregion
 
 	}

--- a/patches/tModLoader/Terraria/WorldGen.TML.cs
+++ b/patches/tModLoader/Terraria/WorldGen.TML.cs
@@ -50,7 +50,6 @@ namespace Terraria
 		public static int logX;
 		public static int logY;
 		public static int dungeonLocation;
-		public static int i2;
 		#endregion
 
 	}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -693,15 +693,6 @@
  			AddGenerationPass("Reset", delegate (GenerationProgress progress, GameConfiguration passConfig) {
  				numOceanCaveTreasure = 0;
  				skipDesertTileCheck = false;
-@@ -6232,7 +_,7 @@
- 				}
- 			});
- 
--			int i2;
-+			i2 = 0;
- 			AddGenerationPass("Small Holes", delegate (GenerationProgress progress, GameConfiguration passConfig) {
- 				i2 = 0;
- 				progress.Message = Lang.gen[7].Value;
 @@ -8402,10 +_,11 @@
  							int num557 = 0;
  							while (!flag36 && num557 < 100) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -35,6 +35,15 @@
  		public static int tLeft;
  		public static int tRight;
  		public static int tTop;
+@@ -721,7 +_,7 @@
+ 		public static int oceanBG;
+ 		public static int mushroomBG;
+ 		public static int underworldBG;
+-		private static ushort crackedType = 481;
++		public static ushort crackedType = 481;
+ 		public static int oceanDistance = 250;
+ 		public static int beachDistance = 380;
+ 		public static bool skipDesertTileCheck = false;
 @@ -746,8 +_,8 @@
  		public static int totalX;
  		public static int totalD;
@@ -546,9 +555,12 @@
  			drunkWorldGen = false;
  			drunkWorldGenText = false;
  			switch (seed) {
-@@ -5665,72 +_,89 @@
+@@ -5663,74 +_,91 @@
+ 
+ 			Console.WriteLine("Creating world - Seed: {0} Width: {1}, Height: {2}, Evil: {3}, IsExpert: {4}", seed, Main.maxTilesX, Main.maxTilesY, WorldGenParam_Evil, Main.expertMode);
  			Main.lockMenuBGChange = true;
- 			WorldGenConfiguration configuration = WorldGenConfiguration.FromEmbeddedPath("Terraria.GameContent.WorldBuilding.Configuration.json");
+-			WorldGenConfiguration configuration = WorldGenConfiguration.FromEmbeddedPath("Terraria.GameContent.WorldBuilding.Configuration.json");
++			configuration = WorldGenConfiguration.FromEmbeddedPath("Terraria.GameContent.WorldBuilding.Configuration.json");
  			Hooks.ProcessWorldGenConfig(ref configuration);
 +
 +			Logging.Terraria.InfoFormat("Generating World: {0}", Main.ActiveWorldFileData.Name);
@@ -681,6 +693,15 @@
  			AddGenerationPass("Reset", delegate (GenerationProgress progress, GameConfiguration passConfig) {
  				numOceanCaveTreasure = 0;
  				skipDesertTileCheck = false;
+@@ -6232,7 +_,7 @@
+ 				}
+ 			});
+ 
+-			int i2;
++			i2 = 0;
+ 			AddGenerationPass("Small Holes", delegate (GenerationProgress progress, GameConfiguration passConfig) {
+ 				i2 = 0;
+ 				progress.Message = Lang.gen[7].Value;
 @@ -8402,10 +_,11 @@
  							int num557 = 0;
  							while (!flag36 && num557 < 100) {


### PR DESCRIPTION
### What is the bug?

There were a couple variables missed in the mass publicizing of PR #2729. This PR publicizes them, as well.

### How did you fix the bug?

Made the missing variables public instead of private, or elevated them from their local status to a static variable status.