### PR TITLE
update steamcmd setup to use full paths

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Setup_tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Setup_tModLoaderServer.sh
@@ -1,8 +1,8 @@
-steamcmd +force_install_dir ../tmod +login anonymous +app_update 1281930 +quit
+steamcmd +force_install_dir $(pwd)../tmod +login anonymous +app_update 1281930 +quit
 
 input="install.txt"
 if [ -f "$input" ] ; then
-	str="+force_install_dir ../tmod +login anonymous"
+	str="+force_install_dir $(pwd)../tmod +login anonymous"
 	while read -r line
 	do
 		str="$str +workshop_download_item 1281930 $line"


### PR DESCRIPTION
### What is the bug?
For setting up a dedicated server, the `steamcmd` utility incorrectly uses paths relative to its usual install directory rather than the `Setup_tModLoaderServer.sh` script's path. Mods get installed into `/home/user/.steam/` rather than, e.g. `/home/user/.local/share/Steam/tmod`.

### How did you fix the bug?
Using ´pwd´ gets a full path to the working directory. Going up one level and then to the tmod directory ensures the mods are installed to the right directory.

### Are there alternatives to your fix?
- Uploading the mods manually
- Manually patching the script
- Using `-modpath /home/user/.steam/tmod` when launching the server