### PR TITLE
More Grab Bag Loot Fixes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace Terraria.GameContent.ItemDropRules
+{
+	/// <summary>
+	/// Re-runs all drop rules if none succeded.
+	/// </summary>
+	public class AlwaysAtleastOneSuccessDropRule : IItemDropRule
+	{
+		public IItemDropRule[] rules;
+
+		public List<IItemDropRuleChainAttempt> ChainedRules {
+			get;
+			private set;
+		}
+
+		public AlwaysAtleastOneSuccessDropRule(params IItemDropRule[] rules) {
+			this.rules = rules;
+			ChainedRules = new List<IItemDropRuleChainAttempt>();
+		}
+
+		public bool CanDrop(DropAttemptInfo info) => true;
+
+		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) => new() { State = ItemDropAttemptResultState.DidNotRunCode };
+
+		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info, ItemDropRuleResolveAction resolveAction) {
+			ItemDropAttemptResult result = default;
+
+			bool fail = true;
+			bool wasAtleastOneSoCanStop = false;
+			while (fail) {
+				for (int i = 0; i < rules.Length; i++) {
+					IItemDropRule rule = rules[i];
+					result = resolveAction(rule, info);
+					if (result.State == ItemDropAttemptResultState.Success) {
+						wasAtleastOneSoCanStop = true;
+					}
+				}
+				if (wasAtleastOneSoCanStop)
+					fail = false;
+			}
+
+			result.State = ItemDropAttemptResultState.FailedRandomRoll;
+			return result;
+		}
+
+		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
+			for (int i = rules.Length - 1; i >= 1; i--) {
+				rules[i - 1].OnFailedRoll(rules[i]);
+			}
+
+			float baseChance = ratesInfo.parentDroprateChance;
+			rules[0].ReportDroprates(drops, ratesInfo.With(baseChance));
+
+			Chains.ReportDroprates(ChainedRules, 1f, drops, ratesInfo);
+
+			for (int i = 0; i < rules.Length - 1; i++) {
+				rules[i].ChainedRules.RemoveAt(rules[i].ChainedRules.Count - 1);
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Terraria.GameContent.ItemDropRules
 {
@@ -7,6 +9,19 @@ namespace Terraria.GameContent.ItemDropRules
 	/// </summary>
 	public class AlwaysAtleastOneSuccessDropRule : IItemDropRule, INestedItemDropRule
 	{
+		private class PersonalDropRateReportingRule : IItemDropRuleChainAttempt
+		{
+			private readonly Action<float> report;
+
+			public PersonalDropRateReportingRule(Action<float> report) {
+				this.report = report;
+			}
+
+			public IItemDropRule RuleToChain => throw new NotImplementedException();
+			public bool CanChainIntoRule(ItemDropAttemptResult parentResult) => throw new NotImplementedException();
+			public void ReportDroprates(float personalDropRate, List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) => report(personalDropRate);
+		}
+
 		public IItemDropRule[] rules;
 
 		public List<IItemDropRuleChainAttempt> ChainedRules {
@@ -39,10 +54,41 @@ namespace Terraria.GameContent.ItemDropRules
 		}
 
 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
+			float reroll = 1f;
 			foreach (var rule in rules) {
-				rule.ReportDroprates(drops, ratesInfo);
+				reroll *= 1f - GetPersonalDropRate(rule);
 			}
+
+			float scale = reroll == 1f ? 1f : 1f / (1f - reroll);
+			foreach (var rule in rules) {
+				rule.ReportDroprates(drops, ratesInfo.With(scale));
+			}
+
+			/*for (int i = rules.Length - 1; i >= 1; i--) {
+				rules[i].ReportDroprates(drops, ratesInfo);
+			}
+
+			float reroll = rules.Select(r => 1 - GetPersonalDropRate(r)).Aggregate((a, b) => a * b);
+
+			float scale = 1 / (1 - reroll);
+			float[] overall = new float[drops.Count];
+			foreach (DropRateInfo drop in drops) {
+				rules[j].ReportDroprates(drops, new(drop.dropRate * scale));
+			}*/
+
 			Chains.ReportDroprates(ChainedRules, 1f, drops, ratesInfo);
+		}
+
+		public static float GetPersonalDropRate(IItemDropRule rule) {
+			var chained = rule.ChainedRules.ToArray();
+			rule.ChainedRules.Clear();
+
+			float dropRate = 0;
+			rule.ChainedRules.Add(new PersonalDropRateReportingRule(f => dropRate = f));
+			rule.ReportDroprates(new(), new(1f));
+			rule.ChainedRules.Clear();
+			rule.ChainedRules.AddRange(chained);
+			return dropRate;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
@@ -45,18 +45,10 @@ namespace Terraria.GameContent.ItemDropRules
 		}
 
 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
-			for (int i = rules.Length - 1; i >= 1; i--) {
-				rules[i - 1].OnFailedRoll(rules[i]);
-			}
-
 			float baseChance = ratesInfo.parentDroprateChance;
 			rules[0].ReportDroprates(drops, ratesInfo.With(baseChance));
 
 			Chains.ReportDroprates(ChainedRules, 1f, drops, ratesInfo);
-
-			for (int i = 0; i < rules.Length - 1; i++) {
-				rules[i].ChainedRules.RemoveAt(rules[i].ChainedRules.Count - 1);
-			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
@@ -26,24 +26,16 @@ namespace Terraria.GameContent.ItemDropRules
 		}
 
 		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info, ItemDropRuleResolveAction resolveAction) {
-			ItemDropAttemptResult result = default;
-
-			bool fail = true;
-			bool wasAtleastOneSoCanStop = false;
-			while (fail) {
-				for (int i = 0; i < rules.Length; i++) {
-					IItemDropRule rule = rules[i];
-					result = resolveAction(rule, info);
-					if (result.State == ItemDropAttemptResultState.Success) {
-						wasAtleastOneSoCanStop = true;
-					}
+			while (true) {
+				bool anyDropped = false;
+				foreach (var rule in rules) {
+					if (resolveAction(rule, info).State == ItemDropAttemptResultState.Success)
+						anyDropped = true;
 				}
-				if (wasAtleastOneSoCanStop)
-					fail = false;
-			}
 
-			result.State = ItemDropAttemptResultState.FailedRandomRoll;
-			return result;
+				if (anyDropped)
+					return new() { State = ItemDropAttemptResultState.Success };
+			}
 		}
 
 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/AlwaysAtleastOneSuccessDropRule.cs
@@ -5,7 +5,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// <summary>
 	/// Re-runs all drop rules if none succeded.
 	/// </summary>
-	public class AlwaysAtleastOneSuccessDropRule : IItemDropRule
+	public class AlwaysAtleastOneSuccessDropRule : IItemDropRule, INestedItemDropRule
 	{
 		public IItemDropRule[] rules;
 
@@ -21,7 +21,9 @@ namespace Terraria.GameContent.ItemDropRules
 
 		public bool CanDrop(DropAttemptInfo info) => true;
 
-		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) => new() { State = ItemDropAttemptResultState.DidNotRunCode };
+		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
+			return new() { State = ItemDropAttemptResultState.DidNotRunCode };
+		}
 
 		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info, ItemDropRuleResolveAction resolveAction) {
 			ItemDropAttemptResult result = default;
@@ -45,9 +47,9 @@ namespace Terraria.GameContent.ItemDropRules
 		}
 
 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
-			float baseChance = ratesInfo.parentDroprateChance;
-			rules[0].ReportDroprates(drops, ratesInfo.With(baseChance));
-
+			foreach (var rule in rules) {
+				rule.ReportDroprates(drops, ratesInfo);
+			}
 			Chains.ReportDroprates(ChainedRules, 1f, drops, ratesInfo);
 		}
 	}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonCode.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonCode.cs.patch
@@ -23,7 +23,7 @@
  				int x = (int)npc.position.X + npc.width / 2;
  				int y = (int)npc.position.Y + npc.height / 2;
  				if (scattered) {
-@@ -15,12 +_,35 @@
+@@ -15,12 +_,40 @@
  				}
  
  				int itemIndex = Item.NewItem(npc.GetItemSource_Loot(), x, y, 0, 0, itemId, stack, noBroadcast: false, -1);
@@ -51,7 +51,12 @@
 +		}
 +
 +		public static int DropItem(Vector2 position, IEntitySource entitySource, int itemId, int stack) {
-+			return Item.NewItem(entitySource, position, itemId, stack, noBroadcast: false, -1);
++			int number = Item.NewItem(entitySource, position, itemId, stack, noBroadcast: false, -1);
++
++			if (entitySource is EntitySource_ItemOpen && Main.netMode == 1)
++				NetMessage.SendData(21, -1, -1, null, number, 1f);
++
++			return number;
 +		}
 +
  		public static void DropItemLocalPerClientAndSetNPCMoneyTo0(NPC npc, int itemId, int stack, bool interactionRequired = true) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonCode.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonCode.cs.patch
@@ -53,7 +53,7 @@
 +		public static int DropItem(Vector2 position, IEntitySource entitySource, int itemId, int stack) {
 +			int number = Item.NewItem(entitySource, position, itemId, stack, noBroadcast: false, -1);
 +
-+			if (entitySource is EntitySource_ItemOpen && Main.netMode == 1)
++			if (Main.netMode == 1)
 +				NetMessage.SendData(21, -1, -1, null, number, 1f);
 +
 +			return number;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -626,7 +626,7 @@ namespace Terraria.GameContent.ItemDropRules
 			RegisterToMultipleItems(bc_scarab, ItemID.OasisCrate, ItemID.OasisCrateHard);
 			RegisterToMultipleItems(bc_bomb, ItemID.OasisCrate, ItemID.OasisCrateHard);
 			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_lava), ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea), ItemID.OasisCrate, ItemID.OasisCrateHard);
+			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea), ItemID.OceanCrate, ItemID.OceanCrateHard);
 
 			RegisterToMultipleItems(bc_pot, ItemID.LavaCrate, ItemID.LavaCrateHard);
 			RegisterToMultipleItems(bc_obsi, ItemID.LavaCrate, ItemID.LavaCrateHard);
@@ -651,8 +651,8 @@ namespace Terraria.GameContent.ItemDropRules
 			RegisterToMultipleItems(bc_fish, ItemID.FrozenCrate, ItemID.FrozenCrateHard);
 			RegisterToMultipleItems(bc_ornate, ItemID.LavaCrate, ItemID.LavaCrateHard);
 			RegisterToMultipleItems(bc_cake, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_pile, ItemID.OasisCrate, ItemID.OasisCrateHard);
-			RegisterToMultipleItems(bc_sand, ItemID.OasisCrate, ItemID.OasisCrateHard);
+			RegisterToMultipleItems(bc_pile, ItemID.OceanCrate, ItemID.OceanCrateHard);
+			RegisterToMultipleItems(bc_sand, ItemID.OceanCrate, ItemID.OceanCrateHard);
 			#endregion
 		}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -229,109 +229,104 @@ namespace Terraria.GameContent.ItemDropRules
 
 		private void RegisterCrateDrops()
 		{
-			// im so good at local var names ngl
 			#region Wooden Crate and Pearlwood Crate
-			IItemDropRule[] seqDrop1 = new IItemDropRule[]
+			IItemDropRule[] themed = new IItemDropRule[]
 			{
 				ItemDropRule.NotScalingWithLuck(ItemID.SailfishBoots, 40),
 				ItemDropRule.NotScalingWithLuck(ItemID.TsunamiInABottle, 40),
 				ItemDropRule.NotScalingWithLuck(ItemID.Extractinator, 50)
 			};
-			IItemDropRule[] seqDrop2 = new IItemDropRule[]
+			IItemDropRule[] hardmodeThemed = new IItemDropRule[]
 			{
 				ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.Sundial, 200),
 				ItemDropRule.NotScalingWithLuck(ItemID.SailfishBoots, 40),
 				ItemDropRule.NotScalingWithLuck(ItemID.TsunamiInABottle, 40),
 				ItemDropRule.NotScalingWithLuck(ItemID.Anchor, 25)
 			};
-			IItemDropRule[] seqDrop3 = new IItemDropRule[]
+			IItemDropRule[] coin = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 1, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverCoin, 1, 20, 91)
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 1, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverCoin, 1, 20, 90)
 			};
-			IItemDropRule[] oneDrop1 = new IItemDropRule[]
+			IItemDropRule[] oresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 6, 24)
+				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 6, 23),
+				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 6, 23),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 6, 23),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 6, 23)
 			};
-			IItemDropRule[] oneDrop2 = new IItemDropRule[]
-			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 6, 24),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 6, 24)
+			IItemDropRule[] hardmodeOresTier1 = new IItemDropRule[] {
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 6, 23),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 6, 23)
 			};
-			IItemDropRule[] oneDrop3 = new IItemDropRule[]
+			IItemDropRule[] barsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 2, 8)
+				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 2, 7),
+				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 2, 7),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 2, 7),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 2, 7)
 			};
-			IItemDropRule[] oneDrop4 = new IItemDropRule[]
-			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 2, 8),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 2, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 2, 6)
+			IItemDropRule[] hardmodeBarsTier1 = new IItemDropRule[] {
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 2, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 2, 5)
 			};
-			IItemDropRule[] oneDrop5 = new IItemDropRule[]
+			IItemDropRule[] potions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.SwiftnessPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronskinPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.NightOwlPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.ShinePotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.GillsPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 1, 4),
-				ItemDropRule.NotScalingWithLuck(2329, 1, 1, 4) // dangersense
+				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.SwiftnessPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronskinPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.NightOwlPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.ShinePotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.GillsPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 1, 3),
+				ItemDropRule.NotScalingWithLuck(2329, 1, 1, 3) // dangersense
 			};
-			IItemDropRule[] oneDrop6 = new IItemDropRule[]
+			IItemDropRule[] extraPotions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.LesserHealingPotion, 1, 5, 16),
-				ItemDropRule.NotScalingWithLuck(ItemID.LesserManaPotion, 1, 5, 16)
+				ItemDropRule.NotScalingWithLuck(ItemID.LesserHealingPotion, 1, 5, 15),
+				ItemDropRule.NotScalingWithLuck(ItemID.LesserManaPotion, 1, 5, 15)
 			};
-			IItemDropRule[] seqDrop4 = new IItemDropRule[]
+			IItemDropRule[] extraBait = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 3, 1, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.ApprenticeBait, 1, 1, 5)
+				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 3, 1, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.ApprenticeBait, 1, 1, 4)
 			};
 
+			List<IItemDropRule> oresList = new List<IItemDropRule>();
+			List<IItemDropRule> barsList = new List<IItemDropRule>();
+			oresList.AddRange(oresTier1);
+			oresList.AddRange(hardmodeOresTier1);
+			barsList.AddRange(barsTier1);
+			barsList.AddRange(hardmodeBarsTier1);
 			IItemDropRule[] woodenCrateDrop = new IItemDropRule[]
 			{
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
 				ItemDropRule.OneFromOptionsNotScalingWithLuck(45, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.Umbrella, 3068, ItemID.Radar),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(7, seqDrop3),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop1), new OneFromRulesRule(8, oneDrop3)),
-				new OneFromRulesRule(7, oneDrop5),
-				new OneFromRulesRule(3, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(3, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(7, coin),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oresTier1), new OneFromRulesRule(8, barsTier1)),
+				new OneFromRulesRule(7, potions),
 			};
 			IItemDropRule[] pearlwoodCrateDrop = new IItemDropRule[]
 			{
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
 				ItemDropRule.OneFromOptionsNotScalingWithLuck(45, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.Umbrella, 3068, ItemID.Radar),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(7, seqDrop3),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop2), new OneFromRulesRule(8, oneDrop4)),
-				new OneFromRulesRule(7, oneDrop5),
-				new OneFromRulesRule(3, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(3, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(7, coin),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oresList.ToArray()), new OneFromRulesRule(8, barsList.ToArray())),
+				new OneFromRulesRule(7, potions),
 			};
 
 			RegisterToItem(ItemID.WoodenCrate, ItemDropRule.AlwaysAtleastOneSuccess(woodenCrateDrop));
 			RegisterToItem(ItemID.WoodenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(pearlwoodCrateDrop));
+			RegisterToMultipleItems(new OneFromRulesRule(3, extraPotions), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
+			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(3, extraBait), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
+			oresList.Clear();
+			barsList.Clear();
 			#endregion
 
 			#region Iron Crate and Mythril Crate
-			seqDrop1 = new IItemDropRule[]
+			themed = new IItemDropRule[]
 			{
 				ItemDropRule.NotScalingWithLuck(ItemID.GingerBeard, 25),
 				ItemDropRule.NotScalingWithLuck(ItemID.TartarSauce, 20),
@@ -339,7 +334,7 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.SailfishBoots, 20),
 				ItemDropRule.NotScalingWithLuck(ItemID.TsunamiInABottle, 20)
 			};
-			seqDrop2 = new IItemDropRule[]
+			hardmodeThemed = new IItemDropRule[]
 			{
 				ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.Sundial, 60),
 				ItemDropRule.NotScalingWithLuck(ItemID.GingerBeard, 25),
@@ -348,178 +343,166 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.SailfishBoots, 20),
 				ItemDropRule.NotScalingWithLuck(ItemID.TsunamiInABottle, 20)
 			};
-			oneDrop1 = new IItemDropRule[]
+			oresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 18, 30)
+				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 18, 29)
 			};
-			oneDrop2 = new IItemDropRule[]
+			hardmodeOresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 18, 30),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 18, 30)
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 18, 29),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 18, 29)
 			};
-			oneDrop3 = new IItemDropRule[]
+			barsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 6, 10)
+				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 6, 9)
 			};
-			oneDrop4 = new IItemDropRule[]
+			hardmodeBarsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 6, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 5, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 5, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 5, 10)
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 6, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 5, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 5, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 5, 9)
 			};
-			oneDrop5 = new IItemDropRule[]
+			potions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.CalmingPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.FlipperPotion, 1, 2, 5)
+				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.CalmingPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.FlipperPotion, 1, 2, 4)
 			};
-			oneDrop6 = new IItemDropRule[]
+			extraPotions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 16),
-				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 16)
+				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 15),
+				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 15)
 			};
-			seqDrop4 = new IItemDropRule[]
+			extraBait = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 3, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 5)
+				ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 3, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 4)
 			};
 
+			oresList.AddRange(oresTier1);
+			oresList.AddRange(hardmodeOresTier1);
+			barsList.AddRange(barsTier1);
+			barsList.AddRange(hardmodeBarsTier1);
 			IItemDropRule[] ironCrate = new IItemDropRule[]
 			{
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 11),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop1), new OneFromRulesRule(4, oneDrop3)),
-				new OneFromRulesRule(4, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 10),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oresTier1), new OneFromRulesRule(4, barsTier1)),
+				new OneFromRulesRule(4, potions),
 			};
 			IItemDropRule[] mythrilCrate = new IItemDropRule[]
 			{
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 11),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop2), new OneFromRulesRule(4, oneDrop4)),
-				new OneFromRulesRule(4, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 10),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oresList.ToArray()), new OneFromRulesRule(4, barsList.ToArray())),
+				new OneFromRulesRule(4, potions),
 			};
 
 			RegisterToItem(ItemID.IronCrate, ItemDropRule.AlwaysAtleastOneSuccess(ironCrate));
 			RegisterToItem(ItemID.IronCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(mythrilCrate));
+			RegisterToMultipleItems(new OneFromRulesRule(2, extraPotions), ItemID.IronCrate, ItemID.IronCrateHard);
+			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(2, extraBait), ItemID.IronCrate, ItemID.IronCrateHard);
+			oresList.Clear();
+			barsList.Clear();
 			#endregion
 
 			#region Gold Crate and Titanium Crate
-			seqDrop1 = new IItemDropRule[]
+			themed = new IItemDropRule[]
 			{
 				ItemDropRule.NotScalingWithLuck(ItemID.LifeCrystal, 15),
 				ItemDropRule.NotScalingWithLuck(ItemID.HardySaddle, 10),
 			};
-			seqDrop2 = new IItemDropRule[]
+			hardmodeThemed = new IItemDropRule[]
 			{
 				ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.Sundial, 20),
 				ItemDropRule.NotScalingWithLuck(ItemID.LifeCrystal, 15),
 				ItemDropRule.NotScalingWithLuck(ItemID.HardySaddle, 10),
 			};
-			oneDrop1 = new IItemDropRule[]
+			oresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 45)
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 44)
 			};
-			oneDrop2 = new IItemDropRule[]
+			hardmodeOresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteOre, 1, 30, 45),
-				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumOre, 1, 30, 45)
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteOre, 1, 30, 44),
+				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumOre, 1, 30, 44)
 			};
-			oneDrop3 = new IItemDropRule[]
+			barsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 15)
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 14),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 14),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 14),
+				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 14)
 			};
-			oneDrop4 = new IItemDropRule[]
+			hardmodeBarsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 15),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 5, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 5, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteBar, 1, 5, 10),
-				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumBar, 1, 5, 10)
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 5, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 5, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteBar, 1, 5, 9),
+				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumBar, 1, 5, 9)
 			};
-			oneDrop5 = new IItemDropRule[]
+			potions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 6),
-				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 6)
+				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 5),
+				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 5)
 			};
-			oneDrop6 = new IItemDropRule[]
+			extraPotions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 21)
+				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 20)
 			};
 
+			oresList.AddRange(oresTier1);
+			oresList.AddRange(hardmodeOresTier1);
+			barsList.AddRange(barsTier1);
+			barsList.AddRange(hardmodeBarsTier1);
 			IItemDropRule[] goldCrate = new IItemDropRule[] {
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 21),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				new CommonDrop(ItemID.MasterBait, 3, 3, 8, 2),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 20),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 				ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 50),
 			};
 			IItemDropRule[] titaniumCrate = new IItemDropRule[] {
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 21),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				new CommonDrop(ItemID.MasterBait, 3, 3, 8, 2),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 20),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 				ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 50),
 			};
 
 			RegisterToItem(ItemID.GoldenCrate, ItemDropRule.AlwaysAtleastOneSuccess(goldCrate));
 			RegisterToItem(ItemID.GoldenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(titaniumCrate));
+			RegisterToMultipleItems(new OneFromRulesRule(2, extraPotions), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
+			RegisterToMultipleItems(new CommonDrop(ItemID.MasterBait, 3, 3, 7, 2), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
+			oresList.Clear();
+			barsList.Clear();
 			#endregion
 
 			#region Biome Crates
@@ -529,38 +512,38 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.FlowerBoots, 20),
 				ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.AnkletoftheWind, ItemID.Boomstick, ItemID.FeralClaws, ItemID.StaffofRegrowth, ItemID.FiberglassFishingPole),
 			};
-			IItemDropRule bc_bamboo = ItemDropRule.NotScalingWithLuck(ItemID.BambooBlock, 3, 20, 51);
+			IItemDropRule bc_bamboo = ItemDropRule.NotScalingWithLuck(ItemID.BambooBlock, 3, 20, 50);
 			IItemDropRule bc_seaweed = ItemDropRule.NotScalingWithLuck(ItemID.Seaweed, 20);
 
 			IItemDropRule bc_sky = ItemDropRule.OneFromOptionsNotScalingWithLuck(1, 4978, ItemID.Starfury, ItemID.ShinyRedBalloon);
 
-			IItemDropRule bc_son = ItemDropRule.NotScalingWithLuck(ItemID.SoulofNight, 2, 2, 6);
+			IItemDropRule bc_son = ItemDropRule.NotScalingWithLuck(ItemID.SoulofNight, 2, 2, 5);
 			IItemDropRule bc_corrupt = ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.BallOHurt, ItemID.BandofStarpower, ItemID.Musket, ItemID.ShadowOrb, ItemID.Vilethorn);
 			IItemDropRule bc_crimson = ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.TheUndertaker, ItemID.TheRottedFork, ItemID.CrimsonRod, ItemID.PanicNecklace, ItemID.CrimsonHeart);
-			IItemDropRule bc_cursed = ItemDropRule.NotScalingWithLuck(ItemID.CursedFlame, 2, 2, 6);
-			IItemDropRule bc_ichor = ItemDropRule.NotScalingWithLuck(ItemID.Ichor, 2, 2, 6);
+			IItemDropRule bc_cursed = ItemDropRule.NotScalingWithLuck(ItemID.CursedFlame, 2, 2, 5);
+			IItemDropRule bc_ichor = ItemDropRule.NotScalingWithLuck(ItemID.Ichor, 2, 2, 5);
 
-			IItemDropRule bc_sol = ItemDropRule.NotScalingWithLuck(ItemID.SoulofLight, 2, 2, 6);
-			IItemDropRule bc_shard = ItemDropRule.NotScalingWithLuck(ItemID.CrystalShard, 2, 4, 11);
+			IItemDropRule bc_sol = ItemDropRule.NotScalingWithLuck(ItemID.SoulofLight, 2, 2, 5);
+			IItemDropRule bc_shard = ItemDropRule.NotScalingWithLuck(ItemID.CrystalShard, 2, 4, 10);
 
 			IItemDropRule bc_lockbox = ItemDropRule.Common(ItemID.LockBox);
-			IItemDropRule bc_book = ItemDropRule.NotScalingWithLuck(ItemID.Book, 2, 5, 16);
+			IItemDropRule bc_book = ItemDropRule.NotScalingWithLuck(ItemID.Book, 2, 5, 15);
 
 			IItemDropRule bc_ice = ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.IceBoomerang, ItemID.IceBlade, ItemID.IceSkates, ItemID.SnowballCannon, ItemID.BlizzardinaBottle, ItemID.FlurryBoots);
 			IItemDropRule bc_fish = ItemDropRule.NotScalingWithLuck(ItemID.Fish, 20);
 
 			IItemDropRule bc_scarab = ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.AncientChisel, ItemID.ScarabFishingRod, ItemID.SandBoots, ItemID.ThunderSpear, ItemID.ThunderStaff, ItemID.CatBast, ItemID.MysticCoilSnake, ItemID.MagicConch);
-			IItemDropRule bc_bomb = ItemDropRule.NotScalingWithLuck(ItemID.ScarabBomb, 4, 4, 7);
-			IItemDropRule bc_fossil = ItemDropRule.NotScalingWithLuck(3380, 4, 10, 17); // sturdy fossil
+			IItemDropRule bc_bomb = ItemDropRule.NotScalingWithLuck(ItemID.ScarabBomb, 4, 4, 6);
+			IItemDropRule bc_fossil = ItemDropRule.NotScalingWithLuck(3380, 4, 10, 16); // sturdy fossil
 
 			IItemDropRule[] bc_lava = new IItemDropRule[]
 			{
 				ItemDropRule.NotScalingWithLuck(ItemID.LavaCharm, 20),
 				ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.FlameWakerBoots, ItemID.SuperheatedBlood, ItemID.LavaFishbowl, 4881, ItemID.VolcanoSmall),
 			};
-			IItemDropRule bc_pot = ItemDropRule.NotScalingWithLuck(4858, 4, 2, 3); // Main.rand.Next(2, 3) should always result 2?? CHECK
+			IItemDropRule bc_pot = ItemDropRule.NotScalingWithLuck(4858, 4, 2, 2);
 			IItemDropRule bc_obsi = ItemDropRule.Common(ItemID.ObsidianLockbox);
-			IItemDropRule bc_wet = ItemDropRule.NotScalingWithLuck(ItemID.WetBomb, 3, 7, 11);
+			IItemDropRule bc_wet = ItemDropRule.NotScalingWithLuck(ItemID.WetBomb, 3, 7, 10);
 			IItemDropRule bc_plant = ItemDropRule.OneFromOptionsNotScalingWithLuck(2, ItemID.PottedLavaPlantPalm, ItemID.PottedLavaPlantBush, ItemID.PottedLavaPlantBramble, ItemID.PottedLavaPlantBulb, ItemID.PottedLavaPlantTendrils);
 			IItemDropRule bc_ornate = ItemDropRule.NotScalingWithLuck(ItemID.OrnateShadowKey, 20);
 			IItemDropRule bc_cake = ItemDropRule.NotScalingWithLuck(ItemID.HellCake, 20);
@@ -571,95 +554,84 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.WaterWalkingBoots, 10),
 				ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.BreathingReed, ItemID.FloatingTube, ItemID.Trident, ItemID.Flipper),
 			};
-			IItemDropRule bc_pile = ItemDropRule.NotScalingWithLuck(ItemID.ShellPileBlock, 3, 20, 51);
+			IItemDropRule bc_pile = ItemDropRule.NotScalingWithLuck(ItemID.ShellPileBlock, 3, 20, 50);
 			IItemDropRule bc_sand = ItemDropRule.NotScalingWithLuck(ItemID.SandcastleBucket, 10);
 			#endregion
 
 			#region Pseudo-global
 			IItemDropRule bc_goldCoin = ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 13);
 
-			oneDrop1 = new IItemDropRule[]
+			oresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 50)
+				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 49)
 			};
-			oneDrop2 = new IItemDropRule[]
+			hardmodeOresTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.CopperOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.TinOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.IronOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteOre, 1, 30, 50),
-				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumOre, 1, 30, 50)
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteOre, 1, 30, 49),
+				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumOre, 1, 30, 49)
 			};
-			oneDrop3 = new IItemDropRule[]
+			barsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 21)
+				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 10, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 10, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 20)
 			};
-			oneDrop4 = new IItemDropRule[]
+			hardmodeBarsTier1 = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.IronBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.LeadBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.SilverBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.TungstenBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.GoldBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.PlatinumBar, 1, 10, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 8, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 8, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 8, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 8, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteBar, 1, 8, 21),
-				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumBar, 1, 8, 21)
+				ItemDropRule.NotScalingWithLuck(ItemID.CobaltBar, 1, 8, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.PalladiumBar, 1, 8, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.MythrilBar, 1, 8, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.OrichalcumBar, 1, 8, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.AdamantiteBar, 1, 8, 20),
+				ItemDropRule.NotScalingWithLuck(ItemID.TitaniumBar, 1, 8, 20)
 			};
-			oneDrop5 = new IItemDropRule[]
+			potions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 5),
-				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 5)
+				ItemDropRule.NotScalingWithLuck(ItemID.ObsidianSkinPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.SpelunkerPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.HunterPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.GravitationPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.MiningPotion, 1, 2, 4),
+				ItemDropRule.NotScalingWithLuck(ItemID.HeartreachPotion, 1, 2, 4)
 			};
-			oneDrop6 = new IItemDropRule[]
+			extraPotions = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 18),
-				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 18)
+				ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 5, 17),
+				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 17)
 			};
-			seqDrop4 = new IItemDropRule[]
+			extraBait = new IItemDropRule[]
 			{
-				ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 3, 2, 7),
-				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 7)
+				ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 3, 2, 6),
+				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 6)
 			};
 			#endregion
+
+			oresList.AddRange(oresTier1);
+			oresList.AddRange(hardmodeOresTier1);
+			barsList.AddRange(barsTier1);
+			barsList.AddRange(hardmodeBarsTier1);
 
 			IItemDropRule[] jungle = new IItemDropRule[]
 			{
 				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 
 				bc_bamboo,
 				bc_seaweed,
@@ -669,10 +641,8 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_bamboo,
 				bc_seaweed,
@@ -682,38 +652,30 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_sky,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] azure = new IItemDropRule[]
 			{
 				bc_sky,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] corrupt = new IItemDropRule[] {
 				bc_corrupt,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] defiled = new IItemDropRule[] {
 				bc_corrupt,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_son,
 				bc_cursed,
@@ -722,36 +684,28 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_crimson,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] hematic = new IItemDropRule[] {
 				bc_crimson,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_son,
 				bc_ichor,
 			};
 			IItemDropRule[] hallowed = new IItemDropRule[] {
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] divine = new IItemDropRule[] {
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_sol,
 				bc_shard,
@@ -761,29 +715,23 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_book,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] stockade = new IItemDropRule[] {
 				bc_lockbox,
 				bc_book,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] frozen = new IItemDropRule[] {
 				bc_ice,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 
 				bc_fish,
 			};
@@ -791,10 +739,8 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_ice,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_fish,
 			};
@@ -804,10 +750,8 @@ namespace Terraria.GameContent.ItemDropRules
 
 				bc_goldCoin,
 				bc_fossil,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] mirage = new IItemDropRule[] {
 				bc_scarab,
@@ -815,10 +759,8 @@ namespace Terraria.GameContent.ItemDropRules
 
 				bc_goldCoin,
 				bc_fossil,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 			};
 			IItemDropRule[] obsidian = new IItemDropRule[] {
 				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_lava),
@@ -829,10 +771,8 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_plant,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+				new OneFromRulesRule(3, potions),
 
 				bc_ornate,
 				bc_cake,
@@ -846,10 +786,8 @@ namespace Terraria.GameContent.ItemDropRules
 				bc_plant,
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_ornate,
 				bc_cake,
@@ -858,10 +796,8 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea),
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, hardmodeOresTier1), new OneFromRulesRule(3, 2, hardmodeBarsTier1)),
+				new OneFromRulesRule(3, potions),
 
 				bc_pile,
 				bc_sand,
@@ -870,10 +806,8 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea),
 
 				bc_goldCoin,
-				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
-				new OneFromRulesRule(3, oneDrop5),
-				new OneFromRulesRule(2, oneDrop6),
-				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+				new OneFromRulesRule(3, potions),
 
 				bc_pile,
 				bc_sand,
@@ -899,6 +833,22 @@ namespace Terraria.GameContent.ItemDropRules
 			RegisterToItem(ItemID.LavaCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(hellstone));
 			RegisterToItem(ItemID.OceanCrate, ItemDropRule.AlwaysAtleastOneSuccess(ocean));
 			RegisterToItem(ItemID.OceanCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(seaside));
+
+			int[] allCrates = new int[]
+			{
+				ItemID.JungleFishingCrate, ItemID.JungleFishingCrateHard,
+				ItemID.FloatingIslandFishingCrate, ItemID.FloatingIslandFishingCrateHard,
+				ItemID.CorruptFishingCrate, ItemID.CorruptFishingCrateHard,
+				ItemID.CrimsonFishingCrate, ItemID.CrimsonFishingCrateHard,
+				ItemID.HallowedFishingCrate, ItemID.HallowedFishingCrateHard,
+				ItemID.DungeonFishingCrate, ItemID.DungeonFishingCrateHard,
+				ItemID.FrozenCrate, ItemID.FrozenCrateHard,
+				ItemID.OasisCrate, ItemID.OasisCrateHard,
+				ItemID.LavaCrate, ItemID.LavaCrateHard,
+				ItemID.OceanCrate, ItemID.OceanCrateHard,
+			};
+			RegisterToMultipleItems(new OneFromRulesRule(2, extraPotions), allCrates);
+			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(2, extraBait), allCrates);
 			#endregion
 		}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -305,15 +305,29 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.ApprenticeBait, 1, 1, 5)
 			};
 
-			RegisterToItem(ItemID.WoodenCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1));
-			RegisterToItem(ItemID.WoodenCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2));
-			RegisterToMultipleItems(ItemDropRule.OneFromOptionsNotScalingWithLuck(45, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.Umbrella, 3068, ItemID.Radar), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(7, seqDrop3), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
-			RegisterToItem(ItemID.WoodenCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop1), new OneFromRulesRule(8, oneDrop3)));
-			RegisterToItem(ItemID.WoodenCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop2), new OneFromRulesRule(8, oneDrop4)));
-			RegisterToMultipleItems(new OneFromRulesRule(7, oneDrop5), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
-			RegisterToMultipleItems(new OneFromRulesRule(3, oneDrop6), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(3, seqDrop4), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
+			IItemDropRule[] woodenCrateDrop = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
+				ItemDropRule.OneFromOptionsNotScalingWithLuck(45, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.Umbrella, 3068, ItemID.Radar),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(7, seqDrop3),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop1), new OneFromRulesRule(8, oneDrop3)),
+				new OneFromRulesRule(7, oneDrop5),
+				new OneFromRulesRule(3, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(3, seqDrop4),
+			};
+			IItemDropRule[] pearlwoodCrateDrop = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
+				ItemDropRule.OneFromOptionsNotScalingWithLuck(45, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.Umbrella, 3068, ItemID.Radar),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(7, seqDrop3),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oneDrop2), new OneFromRulesRule(8, oneDrop4)),
+				new OneFromRulesRule(7, oneDrop5),
+				new OneFromRulesRule(3, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(3, seqDrop4),
+			};
+
+			RegisterToItem(ItemID.WoodenCrate, ItemDropRule.AlwaysAtleastOneSuccess(woodenCrateDrop));
+			RegisterToItem(ItemID.WoodenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(pearlwoodCrateDrop));
 			#endregion
 
 			#region Iron Crate and Mythril Crate
@@ -400,14 +414,27 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 5)
 			};
 
-			RegisterToItem(ItemID.IronCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1));
-			RegisterToItem(ItemID.IronCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2));
-			RegisterToMultipleItems(ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 11), ItemID.IronCrate, ItemID.IronCrateHard);
-			RegisterToItem(ItemID.IronCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop1), new OneFromRulesRule(4, oneDrop3)));
-			RegisterToItem(ItemID.IronCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop2), new OneFromRulesRule(4, oneDrop4)));
-			RegisterToMultipleItems(new OneFromRulesRule(4, oneDrop5), ItemID.IronCrate, ItemID.IronCrateHard);
-			RegisterToMultipleItems(new OneFromRulesRule(2, oneDrop6), ItemID.IronCrate, ItemID.IronCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4), ItemID.IronCrate, ItemID.IronCrateHard);
+			IItemDropRule[] ironCrate = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 11),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop1), new OneFromRulesRule(4, oneDrop3)),
+				new OneFromRulesRule(4, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] mythrilCrate = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 11),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oneDrop2), new OneFromRulesRule(4, oneDrop4)),
+				new OneFromRulesRule(4, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+
+			RegisterToItem(ItemID.IronCrate, ItemDropRule.AlwaysAtleastOneSuccess(ironCrate));
+			RegisterToItem(ItemID.IronCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(mythrilCrate));
 			#endregion
 
 			#region Gold Crate and Titanium Crate
@@ -472,22 +499,30 @@ namespace Terraria.GameContent.ItemDropRules
 				ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 21)
 			};
 
-			RegisterToItem(ItemID.GoldenCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1));
-			RegisterToItem(ItemID.GoldenCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2));
-			RegisterToMultipleItems(ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 21), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
-			RegisterToItem(ItemID.GoldenCrate, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)));
-			RegisterToItem(ItemID.GoldenCrateHard, ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)));
-			RegisterToMultipleItems(new OneFromRulesRule(3, oneDrop5), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
-			RegisterToMultipleItems(new OneFromRulesRule(2, oneDrop6), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
-			RegisterToMultipleItems(new CommonDrop(ItemID.MasterBait, 3, 3, 8, 2), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
-			RegisterToMultipleItems(ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 50), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
+			IItemDropRule[] goldCrate = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop1),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 21),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				new CommonDrop(ItemID.MasterBait, 3, 3, 8, 2),
+				ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 50),
+			};
+			IItemDropRule[] titaniumCrate = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, seqDrop2),
+				ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 21),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				new CommonDrop(ItemID.MasterBait, 3, 3, 8, 2),
+				ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 50),
+			};
+
+			RegisterToItem(ItemID.GoldenCrate, ItemDropRule.AlwaysAtleastOneSuccess(goldCrate));
+			RegisterToItem(ItemID.GoldenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(titaniumCrate));
 			#endregion
 
 			#region Biome Crates
-			int[] phmCrate = new int[] { ItemID.JungleFishingCrate, ItemID.FloatingIslandFishingCrate, ItemID.CorruptFishingCrate, ItemID.CrimsonFishingCrate, ItemID.HallowedFishingCrate, ItemID.DungeonFishingCrate, ItemID.FrozenCrate, ItemID.OasisCrate, ItemID.LavaCrate, ItemID.OceanCrate };
-			int[] hmCrate = new int[] { ItemID.JungleFishingCrateHard, ItemID.FloatingIslandFishingCrateHard, ItemID.CorruptFishingCrateHard, ItemID.CrimsonFishingCrateHard, ItemID.HallowedFishingCrateHard, ItemID.DungeonFishingCrateHard, ItemID.FrozenCrateHard, ItemID.OasisCrateHard, ItemID.LavaCrateHard, ItemID.OceanCrateHard };
-			int[] allCrates = new int[] { ItemID.JungleFishingCrate, ItemID.JungleFishingCrateHard, ItemID.FloatingIslandFishingCrate, ItemID.FloatingIslandFishingCrateHard, ItemID.CorruptFishingCrate, ItemID.CorruptFishingCrateHard, ItemID.CrimsonFishingCrate, ItemID.CrimsonFishingCrateHard, ItemID.HallowedFishingCrate, ItemID.HallowedFishingCrateHard, ItemID.DungeonFishingCrate, ItemID.DungeonFishingCrateHard, ItemID.FrozenCrate, ItemID.FrozenCrateHard, ItemID.OasisCrate, ItemID.OasisCrateHard, ItemID.LavaCrate, ItemID.LavaCrateHard, ItemID.OceanCrate, ItemID.OceanCrateHard };
-
 			#region Biome related
 			IItemDropRule[] bc_jungle = new IItemDropRule[]
 			{
@@ -616,43 +651,254 @@ namespace Terraria.GameContent.ItemDropRules
 			};
 			#endregion
 
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle), ItemID.JungleFishingCrate, ItemID.JungleFishingCrateHard);
-			RegisterToMultipleItems(bc_sky, ItemID.FloatingIslandFishingCrate, ItemID.FloatingIslandFishingCrateHard);
-			RegisterToMultipleItems(bc_corrupt, ItemID.CorruptFishingCrate, ItemID.CorruptFishingCrateHard);
-			RegisterToMultipleItems(bc_crimson, ItemID.CrimsonFishingCrate, ItemID.CrimsonFishingCrateHard);
-			RegisterToMultipleItems(bc_lockbox, ItemID.DungeonFishingCrate, ItemID.DungeonFishingCrateHard);
-			RegisterToMultipleItems(bc_book, ItemID.DungeonFishingCrate, ItemID.DungeonFishingCrateHard);
-			RegisterToMultipleItems(bc_ice, ItemID.FrozenCrate, ItemID.FrozenCrateHard);
-			RegisterToMultipleItems(bc_scarab, ItemID.OasisCrate, ItemID.OasisCrateHard);
-			RegisterToMultipleItems(bc_bomb, ItemID.OasisCrate, ItemID.OasisCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_lava), ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea), ItemID.OceanCrate, ItemID.OceanCrateHard);
+			IItemDropRule[] jungle = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
-			RegisterToMultipleItems(bc_pot, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_obsi, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_wet, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_plant, ItemID.LavaCrate, ItemID.LavaCrateHard);
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
 
-			RegisterToMultipleItems(bc_goldCoin, allCrates);
-			RegisterToMultipleItems(bc_fossil, ItemID.OasisCrate, ItemID.OasisCrateHard);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)), phmCrate);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)), hmCrate);
-			RegisterToMultipleItems(new OneFromRulesRule(3, oneDrop5), allCrates);
-			RegisterToMultipleItems(new OneFromRulesRule(2, oneDrop6), allCrates);
-			RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4), allCrates);
+				bc_bamboo,
+				bc_seaweed,
+			};
+			IItemDropRule[] bramble = new IItemDropRule[]
+			{
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
-			RegisterToMultipleItems(bc_bamboo, ItemID.JungleFishingCrate, ItemID.JungleFishingCrateHard);
-			RegisterToMultipleItems(bc_seaweed, ItemID.JungleFishingCrate, ItemID.JungleFishingCrateHard);
-			RegisterToMultipleItems(bc_son, ItemID.CorruptFishingCrateHard, ItemID.CrimsonFishingCrateHard);
-			RegisterToItem(ItemID.CorruptFishingCrateHard, bc_cursed);
-			RegisterToItem(ItemID.CrimsonFishingCrateHard, bc_ichor);
-			RegisterToItem(ItemID.HallowedFishingCrateHard, bc_sol);
-			RegisterToItem(ItemID.HallowedFishingCrateHard, bc_shard);
-			RegisterToMultipleItems(bc_fish, ItemID.FrozenCrate, ItemID.FrozenCrateHard);
-			RegisterToMultipleItems(bc_ornate, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_cake, ItemID.LavaCrate, ItemID.LavaCrateHard);
-			RegisterToMultipleItems(bc_pile, ItemID.OceanCrate, ItemID.OceanCrateHard);
-			RegisterToMultipleItems(bc_sand, ItemID.OceanCrate, ItemID.OceanCrateHard);
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_bamboo,
+				bc_seaweed,
+			};
+			IItemDropRule[] sky = new IItemDropRule[]
+			{
+				bc_sky,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] azure = new IItemDropRule[]
+			{
+				bc_sky,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] corrupt = new IItemDropRule[] {
+				bc_corrupt,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] defiled = new IItemDropRule[] {
+				bc_corrupt,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_son,
+				bc_cursed,
+			};
+			IItemDropRule[] crimson = new IItemDropRule[] {
+				bc_crimson,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] hematic = new IItemDropRule[] {
+				bc_crimson,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_son,
+				bc_ichor,
+			};
+			IItemDropRule[] hallowed = new IItemDropRule[] {
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] divine = new IItemDropRule[] {
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_sol,
+				bc_shard,
+			};
+			IItemDropRule[] dungeon = new IItemDropRule[] {
+				bc_lockbox,
+				bc_book,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] stockade = new IItemDropRule[] {
+				bc_lockbox,
+				bc_book,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] frozen = new IItemDropRule[] {
+				bc_ice,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_fish,
+			};
+			IItemDropRule[] boreal = new IItemDropRule[] {
+				bc_ice,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_fish,
+			};
+			IItemDropRule[] oasis = new IItemDropRule[] {
+				bc_scarab,
+				bc_bomb,
+
+				bc_goldCoin,
+				bc_fossil,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] mirage = new IItemDropRule[] {
+				bc_scarab,
+				bc_bomb,
+
+				bc_goldCoin,
+				bc_fossil,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+			};
+			IItemDropRule[] obsidian = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_lava),
+
+				bc_pot,
+				bc_obsi,
+				bc_wet,
+				bc_plant,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop1), new OneFromRulesRule(3, 2, oneDrop3)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_ornate,
+				bc_cake,
+			};
+			IItemDropRule[] hellstone = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_lava),
+
+				bc_pot,
+				bc_obsi,
+				bc_wet,
+				bc_plant,
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_ornate,
+				bc_cake,
+			};
+			IItemDropRule[] ocean = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea),
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_pile,
+				bc_sand,
+			};
+			IItemDropRule[] seaside = new IItemDropRule[] {
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_sea),
+
+				bc_goldCoin,
+				ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oneDrop2), new OneFromRulesRule(3, 2, oneDrop4)),
+				new OneFromRulesRule(3, oneDrop5),
+				new OneFromRulesRule(2, oneDrop6),
+				ItemDropRule.SequentialRulesNotScalingWithLuck(2, seqDrop4),
+
+				bc_pile,
+				bc_sand,
+			};
+
+			RegisterToItem(ItemID.JungleFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(jungle));
+			RegisterToItem(ItemID.JungleFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(bramble));
+			RegisterToItem(ItemID.FloatingIslandFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(sky));
+			RegisterToItem(ItemID.FloatingIslandFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(azure));
+			RegisterToItem(ItemID.CorruptFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(corrupt));
+			RegisterToItem(ItemID.CorruptFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(defiled));
+			RegisterToItem(ItemID.CrimsonFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(crimson));
+			RegisterToItem(ItemID.CrimsonFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(hematic));
+			RegisterToItem(ItemID.HallowedFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(hallowed));
+			RegisterToItem(ItemID.HallowedFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(divine));
+			RegisterToItem(ItemID.DungeonFishingCrate, ItemDropRule.AlwaysAtleastOneSuccess(dungeon));
+			RegisterToItem(ItemID.DungeonFishingCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(stockade));
+			RegisterToItem(ItemID.FrozenCrate, ItemDropRule.AlwaysAtleastOneSuccess(frozen));
+			RegisterToItem(ItemID.FrozenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(boreal));
+			RegisterToItem(ItemID.OasisCrate, ItemDropRule.AlwaysAtleastOneSuccess(oasis));
+			RegisterToItem(ItemID.OasisCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(mirage));
+			RegisterToItem(ItemID.LavaCrate, ItemDropRule.AlwaysAtleastOneSuccess(obsidian));
+			RegisterToItem(ItemID.LavaCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(hellstone));
+			RegisterToItem(ItemID.OceanCrate, ItemDropRule.AlwaysAtleastOneSuccess(ocean));
+			RegisterToItem(ItemID.OceanCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(seaside));
 			#endregion
 		}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
@@ -15,5 +15,6 @@
 			// TODO, support dynamic NPC value, expert/master scaling etc. Not sure the best way to display/handle it.
 			return Coins((long)npc.value, withRandomBonus: true);
 		}
+		public static IItemDropRule AlwaysAtleastOneSuccess(params IItemDropRule[] rules) => new AlwaysAtleastOneSuccessDropRule(rules);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1276,6 +1276,10 @@ namespace Terraria.ModLoader
 				g.RightClick(item, player);
 			}
 
+			if (ItemID.Sets.BossBag[item.type] && (!ItemID.Sets.PreHardmodeLikeBossBag[item.type] || Main.tenthAnniversaryWorld)) {
+				player.TryGettingDevArmor(player.GetItemSource_OpenItem(item.type));
+			}
+
 			if (ConsumeItem(item, player) && --item.stack == 0)
 				item.SetDefaults();
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1307,7 +1307,7 @@ namespace Terraria.ModLoader
 		public static void ModifyItemLoot(Item item, ItemLoot itemLoot) {
 			item.ModItem?.ModifyItemLoot(itemLoot);
 
-			foreach (var g in HookModifyItemLoot.Enumerate(globalItems)) {
+			foreach (var g in HookModifyItemLoot.Enumerate(item.globalItems)) {
 				g.ModifyItemLoot(item, itemLoot);
 			}
 		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -847,7 +847,7 @@
  			IEntitySource itemSource_OpenItem = GetItemSource_OpenItem(itemType);
  			if (Main.rand.Next(15) == 0 && Main.hardMode) {
  				int number = Item.NewItem(itemSource_OpenItem, (int)position.X, (int)position.Y, width, height, 602);
-@@ -4009,21 +_,41 @@
+@@ -4009,21 +_,42 @@
  					}
  				default: {
  						int number21 = Item.NewItem(itemSource_OpenItem, (int)position.X, (int)position.Y, width, height, 591, Main.rand.Next(20, 50));
@@ -877,14 +877,15 @@
 +				return;
 +
 +			DropFromItem(type);
-+			ItemLoader.OpenBossBag_Obsolete(type, this);
 +
++			ItemLoader.OpenBossBag_Obsolete(type, this);
 +			ItemLoader.OpenVanillaBag_Obsolete("bossBag", this, type);
-+			NPCLoader.blockLoot.Clear();
 +
 +			if ((!ItemID.Sets.PreHardmodeLikeBossBag[type] || Main.tenthAnniversaryWorld)) {
 +				TryGettingDevArmor(GetItemSource_OpenItem(type));
 +			}
++
++			NPCLoader.blockLoot.Clear();
 +
 +			/*
  			IEntitySource itemSource_OpenItem = GetItemSource_OpenItem(type);

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -334,14 +334,16 @@
  					PickupItemIntoMouse(inv, context, slot, player);
  					SoundEngine.PlaySound(12);
  					RefreshStackSplitCooldown();
-@@ -1052,10 +_,12 @@
+@@ -1052,10 +_,13 @@
  			switch (context) {
  				case 0:
  					result = true;
 -					if (Main.mouseRight && ((inv[slot].type >= 3318 && inv[slot].type <= 3332) || inv[slot].type == 3860 || inv[slot].type == 3862 || inv[slot].type == 3861 || inv[slot].type == 4782 || inv[slot].type == 4957 || inv[slot].type == 5111)) {
+-						if (Main.mouseRightRelease) {
 +					if (Main.mouseRight && ((inv[slot].type >= 3318 && inv[slot].type <= 3332) || inv[slot].type == 3860 || inv[slot].type == 3862 || inv[slot].type == 3861 || inv[slot].type == 4782 || inv[slot].type == 4957 || inv[slot].type == 5111 || ItemLoader.IsModBossBag_Obsolete(inv[slot]))) {
- 						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
  							player.OpenBossBag(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
 -							inv[slot].stack--;
 +								inv[slot].stack--;
@@ -349,14 +351,16 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1065,10 +_,12 @@
+@@ -1065,10 +_,13 @@
  							Recipe.FindRecipes();
  						}
  					}
 -					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < 5125 && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
+-						if (Main.mouseRightRelease) {
 +					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < ItemID.Count && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
- 						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
  							player.OpenFishingCrate(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
 -							inv[slot].stack--;
 +								inv[slot].stack--;
@@ -364,10 +368,14 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1081,7 +_,10 @@
+@@ -1079,9 +_,13 @@
+ 						}
+ 					}
  					else if (Main.mouseRight && inv[slot].type == 3093) {
- 						if (Main.mouseRightRelease) {
+-						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
  							player.OpenHerbBag(3093);
++							ItemLoader.RightClick(inv[slot], player);
 +
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
 -							inv[slot].stack--;
@@ -376,40 +384,106 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1145,7 +_,9 @@
+@@ -1092,8 +_,9 @@
+ 						}
+ 					}
+ 					else if (Main.mouseRight && inv[slot].type == 4345) {
+-						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 							player.OpenCanofWorms(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
+ 							inv[slot].stack--;
+ 							if (inv[slot].stack == 0)
+ 								inv[slot].SetDefaults();
+@@ -1105,8 +_,9 @@
+ 						}
+ 					}
+ 					else if (Main.mouseRight && inv[slot].type == 4410) {
+-						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 							player.OpenOyster(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
+ 							inv[slot].stack--;
+ 							if (inv[slot].stack == 0)
+ 								inv[slot].SetDefaults();
+@@ -1118,8 +_,9 @@
+ 						}
+ 					}
+ 					else if (Main.mouseRight && inv[slot].type == 5059) {
+-						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 							player.OpenCapricornLegs(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
+ 							inv[slot].stack--;
+ 							if (inv[slot].stack == 0)
+ 								inv[slot].SetDefaults();
+@@ -1131,8 +_,9 @@
+ 						}
+ 					}
+ 					else if (Main.mouseRight && inv[slot].type == 5060) {
+-						if (Main.mouseRightRelease) {
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 							player.OpenCapricornTail(inv[slot].type);
++							ItemLoader.RightClick(inv[slot], player);
+ 							inv[slot].stack--;
+ 							if (inv[slot].stack == 0)
+ 								inv[slot].SetDefaults();
+@@ -1144,8 +_,10 @@
+ 						}
  					}
  					else if (Main.mouseRight && inv[slot].type == 1774) {
- 						if (Main.mouseRightRelease) {
-+							if (ItemLoader.ConsumeItem(inv[slot], player))
+-						if (Main.mouseRightRelease) {
 -							inv[slot].stack--;
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
++							if (ItemLoader.ConsumeItem(inv[slot], player))
 +								inv[slot].stack--;
 +
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1158,7 +_,9 @@
+@@ -1153,12 +_,15 @@
+ 							Main.stackSplit = 30;
+ 							Main.mouseRightRelease = false;
+ 							player.OpenGoodieBag(1774);
++							ItemLoader.RightClick(inv[slot], player);
+ 							Recipe.FindRecipes();
+ 						}
  					}
  					else if (Main.mouseRight && inv[slot].type == 3085) {
- 						if (Main.mouseRightRelease && player.ConsumeItem(327)) {
-+							if (ItemLoader.ConsumeItem(inv[slot], player))
+-						if (Main.mouseRightRelease && player.ConsumeItem(327)) {
 -							inv[slot].stack--;
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease && player.ConsumeItem(327)) {
++							if (ItemLoader.ConsumeItem(inv[slot], player))
 +								inv[slot].stack--;
 +
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1171,7 +_,9 @@
+@@ -1166,12 +_,15 @@
+ 							Main.stackSplit = 30;
+ 							Main.mouseRightRelease = false;
+ 							player.OpenLockBox(3085);
++							ItemLoader.RightClick(inv[slot], player);
+ 							Recipe.FindRecipes();
+ 						}
  					}
  					else if (Main.mouseRight && inv[slot].type == 4879) {
- 						if (Main.mouseRightRelease && player.HasItem(329)) {
-+							if (ItemLoader.ConsumeItem(inv[slot], player))
+-						if (Main.mouseRightRelease && player.HasItem(329)) {
 -							inv[slot].stack--;
++						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease && player.HasItem(329)) {
++							if (ItemLoader.ConsumeItem(inv[slot], player))
 +								inv[slot].stack--;
 +
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1184,7 +_,9 @@
+@@ -1179,12 +_,15 @@
+ 							Main.stackSplit = 30;
+ 							Main.mouseRightRelease = false;
+ 							player.OpenShadowLockbox(4879);
++							ItemLoader.RightClick(inv[slot], player);
+ 							Recipe.FindRecipes();
+ 						}
  					}
  					else if (Main.mouseRight && inv[slot].type == 1869) {
  						if (Main.mouseRightRelease) {
@@ -420,6 +494,14 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
+@@ -1192,6 +_,7 @@
+ 							Main.stackSplit = 30;
+ 							Main.mouseRightRelease = false;
+ 							player.OpenPresent(1869);
++							ItemLoader.RightClick(inv[slot], player);
+ 							Recipe.FindRecipes();
+ 						}
+ 					}
 @@ -1214,11 +_,15 @@
  
  						Recipe.FindRecipes();

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -339,9 +339,8 @@
  				case 0:
  					result = true;
 -					if (Main.mouseRight && ((inv[slot].type >= 3318 && inv[slot].type <= 3332) || inv[slot].type == 3860 || inv[slot].type == 3862 || inv[slot].type == 3861 || inv[slot].type == 4782 || inv[slot].type == 4957 || inv[slot].type == 5111)) {
--						if (Main.mouseRightRelease) {
 +					if (Main.mouseRight && ((inv[slot].type >= 3318 && inv[slot].type <= 3332) || inv[slot].type == 3860 || inv[slot].type == 3862 || inv[slot].type == 3861 || inv[slot].type == 4782 || inv[slot].type == 4957 || inv[slot].type == 5111 || ItemLoader.IsModBossBag_Obsolete(inv[slot]))) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenBossBag(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
@@ -356,9 +355,8 @@
  						}
  					}
 -					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < 5125 && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
--						if (Main.mouseRightRelease) {
 +					else if (Main.mouseRight && inv[slot].type > 0 && inv[slot].type < ItemID.Count && ItemID.Sets.IsFishingCrate[inv[slot].type]) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenFishingCrate(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
@@ -368,12 +366,9 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1079,9 +_,13 @@
- 						}
- 					}
+@@ -1081,7 +_,11 @@
  					else if (Main.mouseRight && inv[slot].type == 3093) {
--						if (Main.mouseRightRelease) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenHerbBag(3093);
 +							ItemLoader.RightClick(inv[slot], player);
 +
@@ -384,58 +379,44 @@
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
  
-@@ -1092,8 +_,9 @@
- 						}
- 					}
+@@ -1094,6 +_,7 @@
  					else if (Main.mouseRight && inv[slot].type == 4345) {
--						if (Main.mouseRightRelease) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenCanofWorms(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
  							inv[slot].stack--;
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
-@@ -1105,8 +_,9 @@
- 						}
- 					}
+@@ -1107,6 +_,7 @@
  					else if (Main.mouseRight && inv[slot].type == 4410) {
--						if (Main.mouseRightRelease) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenOyster(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
  							inv[slot].stack--;
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
-@@ -1118,8 +_,9 @@
- 						}
- 					}
+@@ -1120,6 +_,7 @@
  					else if (Main.mouseRight && inv[slot].type == 5059) {
--						if (Main.mouseRightRelease) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenCapricornLegs(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
  							inv[slot].stack--;
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
-@@ -1131,8 +_,9 @@
- 						}
- 					}
+@@ -1133,6 +_,7 @@
  					else if (Main.mouseRight && inv[slot].type == 5060) {
--						if (Main.mouseRightRelease) {
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
  							player.OpenCapricornTail(inv[slot].type);
 +							ItemLoader.RightClick(inv[slot], player);
  							inv[slot].stack--;
  							if (inv[slot].stack == 0)
  								inv[slot].SetDefaults();
-@@ -1144,8 +_,10 @@
- 						}
+@@ -1145,7 +_,9 @@
  					}
  					else if (Main.mouseRight && inv[slot].type == 1774) {
--						if (Main.mouseRightRelease) {
--							inv[slot].stack--;
-+						if (ItemLoader.CanRightClick(inv[slot]) && Main.mouseRightRelease) {
+ 						if (Main.mouseRightRelease) {
 +							if (ItemLoader.ConsumeItem(inv[slot], player))
+-							inv[slot].stack--;
 +								inv[slot].stack--;
 +
  							if (inv[slot].stack == 0)


### PR DESCRIPTION
Fixed ocean/seaside loot being dropped from the wrong crates.
now `ModifyItemLoot` respects `AppliesToEntity`
moved `NPCLoader.blockLoot.Clear()` after dev armor
added new drop rule called `AlwaysAtleastOneSuccessDropRule`, which will ensure that always atleast one rule will be successful.
fixed items not being dropped in mp from bags
GlobalItem.Right now can affect crates and other stuff