### PR TITLE
Various ExampleMod fixes

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleAdvancedFlail.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleAdvancedFlail.cs
@@ -32,7 +32,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.UseSound = SoundID.Item1; // The sound that this item makes when used
 			Item.rare = ItemRarityID.Green; // The color of the name of your item
 			Item.value = Item.sellPrice(gold: 1, silver: 50); // Sells for 1 gold 50 silver
-			Item.DamageType = DamageClass.Melee; // Deals melee damage
+			Item.DamageType = DamageClass.MeleeNoSpeed; // Deals melee damage
 			Item.channel = true;
 			Item.noMelee = true; // This makes sure the item does not deal damage from the swinging animation
 		}

--- a/ExampleMod/Content/Items/Weapons/ExampleFlail.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleFlail.cs
@@ -37,7 +37,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.UseSound = SoundID.Item1; // The sound that this item makes when used
 			Item.rare = ItemRarityID.Orange; // The color of the name of your item
 			Item.value = Item.sellPrice(gold: 2, silver: 50); // Sells for 2 gold 50 silver
-			Item.DamageType = DamageClass.Melee; // Deals melee damage
+			Item.DamageType = DamageClass.MeleeNoSpeed; // Deals melee damage
 			Item.channel = true;
 			Item.noMelee = true; // This makes sure the item does not deal damage from the swinging animation
 		}

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetBuff.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetBuff.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using Terraria;
-using Terraria.DataStructures;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Pets.ExamplePet
@@ -8,9 +7,6 @@ namespace ExampleMod.Content.Pets.ExamplePet
 	public class ExamplePetBuff : ModBuff
 	{
 		public override void SetStaticDefaults() {
-			DisplayName.SetDefault("Paper Airplane");
-			Description.SetDefault(@"""Let this pet be an example to you!""");
-
 			Main.buffNoTimeDisplay[Type] = true;
 			Main.vanityPet[Type] = true;
 		}

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
@@ -10,9 +10,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 	public class ExamplePetItem : ModItem
 	{
 		public override void SetStaticDefaults() {
-			DisplayName.SetDefault("Paper Airplane");
-			Tooltip.SetDefault("Summons a Paper Airplane to follow aimlessly behind you");
-
+			// Names and descriptions of all ExamplePetX classes are defined using .hjson files in the Localization folder
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -7,8 +7,6 @@ namespace ExampleMod.Content.Pets.ExamplePet
 	public class ExamplePetProjectile : ModProjectile
 	{
 		public override void SetStaticDefaults() {
-			DisplayName.SetDefault("Paper Airplane");
-
 			Main.projFrames[Projectile.type] = 4;
 			Main.projPet[Projectile.type] = true;
 		}

--- a/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
@@ -63,12 +63,11 @@ namespace ExampleMod.Content.Projectiles
 				drawColor.A = 127;
 				drawColor *= 0.5f;
 				int launchTimer = (int)Projectile.ai[1];
-				if (launchTimer > 5)
+				if (launchTimer > 5) {
 					launchTimer = 5;
+				}
 
-				SpriteEffects spriteEffects = SpriteEffects.None;
-				if (Projectile.spriteDirection == -1)
-					spriteEffects = SpriteEffects.FlipHorizontally;
+				SpriteEffects spriteEffects = Projectile.spriteDirection == 1 ? SpriteEffects.None : SpriteEffects.FlipHorizontally;
 
 				for (float transparancy = 1f; transparancy >= 0f; transparancy -= 0.125f) {
 					float opacity = 1f - transparancy;

--- a/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleBed.cs
@@ -13,6 +13,8 @@ namespace ExampleMod.Content.Tiles.Furniture
 {
 	public class ExampleBed : ModTile
 	{
+		public const int NextStyleHeight = 38; //Calculated by adding all CoordinateHeights + CoordinatePaddingFix.Y applied to all of them + 2
+
 		public override void SetStaticDefaults() {
 			// Properties
 			Main.tileFrameImportant[Type] = true;
@@ -71,7 +73,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			int spawnX = (i - (tile.TileFrameX / 18)) + (tile.TileFrameX >= 72 ? 5 : 2);
 			int spawnY = j + 2;
 
-			if (tile.TileFrameY % 38 != 0) {
+			if (tile.TileFrameY % NextStyleHeight != 0) {
 				spawnY--;
 			}
 

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -54,7 +54,7 @@ Mods: {
 			# Note that the translation files for other languages don't need to define ItemTooltip.OctopusBanner, they would only need to define NPCName.Octopus, as seen in zh-Hans.hjson file. 
 			OctopusBanner: "{$CommonItemTooltip.BannerBonus}{$Mods.ExampleMod.NPCName.Octopus}"
 			SarcophagusBanner: "{$CommonItemTooltip.BannerBonus}{$Mods.ExampleMod.NPCName.Sarcophagus}"
-			ExamplePet:
+			ExamplePetItem:
 				'''
 				Summons a {$Mods.ExampleMod.Common.PaperAirplane} to follow aimlessly behind you
 				Second Line!
@@ -85,22 +85,22 @@ Mods: {
 		}
 		
 		ItemName: {
-			ExamplePet: "{$Mods.ExampleMod.Common.PaperAirplane}"
+			ExamplePetItem: "{$Mods.ExampleMod.Common.PaperAirplane}"
 			ExampleSpecificAmmoGun: '''Example Rifle'''
 			ExamplePylonItem: "Example Pylon"
 			ExamplePylonItemAdvanced: "Unstable Pylon"
 		}
 		
 		ProjectileName: {
-			ExamplePet: "{$Mods.ExampleMod.Common.PaperAirplane}"
+			ExamplePetProjectile: "{$Mods.ExampleMod.Common.PaperAirplane}"
 		}
 		
 		BuffName: {
-			ExamplePet: "{$Mods.ExampleMod.Common.PaperAirplane}"
+			ExamplePetBuff: "{$Mods.ExampleMod.Common.PaperAirplane}"
 		}
 		
 		BuffDescription: {
-			ExamplePet: '''"Let this pet be an example to you!"'''
+			ExamplePetBuff: '''"Let this pet be an example to you!"'''
 		}
 		
 		RecipeConditions: {


### PR DESCRIPTION
### What are the changes to ExampleMod?
* Flails:
   * `MeleeNoSpeed` applied to mirror base game behavior
   * fix wrong melee speed calc to mirror base game behavior
   * general cleanup/formatting

* Fixed the old 1.3 localizations of ExamplePet by updating the content names, and removing the existing names/descriptions

* Fixed typos in ExampleBed

### Do these changes need additional documentation?
Added a comment for the lack of name/descriptions in the `ExamplePetX` classes

