### PR TITLE
Add ModItem.MeleePrefix, ModItem.WeaponPrefix...

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleWhip.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleWhip.cs
@@ -30,5 +30,10 @@ namespace ExampleMod.Content.Items.Weapons
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
 		}
+		
+		// Makes the whip receive melee prefixes
+		public override bool MeleePrefix() {
+			return true;
+		}
 	}
 }

--- a/ExampleMod/Content/Items/Weapons/ExampleWhipAdvanced.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleWhipAdvanced.cs
@@ -43,5 +43,10 @@ namespace ExampleMod.Content.Items.Weapons
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
 		}
+		
+		// Makes the whip receive melee prefixes
+		public override bool MeleePrefix() {
+			return true;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -143,16 +143,16 @@ namespace Terraria.ModLoader
 			=> item.IsCandidateForReforge && item.damage > 0 && item.ammo == 0 && !item.accessory;
 
 		internal static bool MeleePrefix(Item item)
-			=> item.ModItem != null && GeneralPrefix(item) && item.melee && !item.noUseGraphic;
+			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.MeleePrefix();
 
 		internal static bool WeaponPrefix(Item item)
-			=> item.ModItem != null && GeneralPrefix(item) && item.melee && item.noUseGraphic;
+			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.WeaponPrefix();
 
 		internal static bool RangedPrefix(Item item)
-			=> item.ModItem != null && GeneralPrefix(item) && item.ranged; //(item.ranged || item.thrown);
+			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.RangedPrefix(); //(item.ranged || item.thrown);
 
 		internal static bool MagicPrefix(Item item)
-			=> item.ModItem != null && GeneralPrefix(item) && (item.magic || item.summon);
+			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.MagicPrefix();
 
 		private static HookList HookSetDefaults = AddHook<Action<Item>>(g => g.SetDefaults);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -136,12 +136,14 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to change whether or not a weapon receives melee prefixes. Return true if the item should receive melee prefixes and false if it should not.
+		/// Takes priority over WeaponPrefix, RangedPrefix, and MagicPrefix
 		/// </summary>
 		public virtual bool MeleePrefix()
 			=> Item.melee && !Item.noUseGraphic;
 
 		/// <summary>
 		/// Allows you to change whether or not a weapon only receives generic prefixes. Return true if the item should only receive generic prefixes and false if it should not.
+		/// Takes priority over RangedPrefix and MagicPrefix
 		/// Ignored if MeleePrefix returns true
 		/// </summary>
 		public virtual bool WeaponPrefix()
@@ -149,6 +151,7 @@ namespace Terraria.ModLoader
 
 		/// <summary>
 		/// Allows you to change whether or not a weapon receives ranged prefixes. Return true if the item should receive ranged prefixes and false if it should not.
+		/// Takes priority over MagicPrefix
 		/// </summary>
 		public virtual bool RangedPrefix()
 			=> Item.ranged;

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -135,6 +135,31 @@ namespace Terraria.ModLoader
 		public virtual int ChoosePrefix(UnifiedRandom rand) => -1;
 
 		/// <summary>
+		/// Allows you to change whether or not a weapon receives melee prefixes. Return true if the item should receive melee prefixes and false if it should not.
+		/// </summary>
+		public virtual bool MeleePrefix()
+			=> Item.melee && !Item.noUseGraphic;
+
+		/// <summary>
+		/// Allows you to change whether or not a weapon only receives generic prefixes. Return true if the item should only receive generic prefixes and false if it should not.
+		/// Ignored if MeleePrefix returns true
+		/// </summary>
+		public virtual bool WeaponPrefix()
+			=> Item.melee && Item.noUseGraphic;
+
+		/// <summary>
+		/// Allows you to change whether or not a weapon receives ranged prefixes. Return true if the item should receive ranged prefixes and false if it should not.
+		/// </summary>
+		public virtual bool RangedPrefix()
+			=> Item.ranged;
+
+		/// <summary>
+		/// Allows you to change whether or not a weapon receives magic prefixes. Return true if the item should receive magic prefixes and false if it should not.
+		/// </summary>
+		public virtual bool MagicPrefix()
+			=> Item.magic || Item.summon;
+
+		/// <summary>
 		/// To prevent putting the item in the tinkerer slot, return false when pre is -3.
 		/// To prevent rolling of a prefix on spawn, return false when pre is -1.
 		/// To force rolling of a prefix on spawn, return true when pre is -1.


### PR DESCRIPTION
Adds virtual ModItem.MeleePrefix, ModItem.WeaponPrefix,
ModItem.RangedPrefix, and ModItem.MagicPrefix methods to replace the hardcoded conditions in their respective ItemLoader methods (#2772)

### What is the new feature?
The hardcoded conditions in ItemLoader.MeleePrefix, ItemLoader.WeaponPrefix,
ItemLoader.RangedPrefix, and ItemLoader.MagicPrefix have been moved to virtual methods in ModItem.

### Why should this be part of tModLoader?
Currently the prefixes weapons can get are solely determined by damage type (and Item.noUseGraphic for melee weapons) requiring unintuitive workarounds for weapons that benefit from scale, velocity, or mana cost reduction but aren't the vanilla damage class which normally receives prefixes with such effects

### Are there alternative designs?
The hooks could return null by default and the ItemLoader methods could retain the hardcoded defaults when null is returned;

### Sample usage for the new feature
The following code could be put in a sword to make it receive ranged prefixes instead of melee ones
```cs
public override bool MeleePrefix() {
	return false;
}
public override bool RangedPrefix() {
	return true;
}
```

