### PR TITLE
Faster ReLogic.Content.AssetPathHelper.CleanPath

### DIFF
--- a/patches/tModLoader/ReLogic/Content/AssetPathHelper.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/AssetPathHelper.cs.patch
@@ -1,0 +1,55 @@
+--- src/TerrariaNetCore/ReLogic/Content/AssetPathHelper.cs
++++ src/tModLoader/ReLogic/Content/AssetPathHelper.cs
+@@ -1,4 +_,5 @@
+ using System;
++using System.Diagnostics;
+ using System.IO;
+ 
+ namespace ReLogic.Content
+@@ -6,24 +_,24 @@
+ 	public static class AssetPathHelper
+ 	{
+ 		public static string CleanPath(string path) {
+-			path = path.Replace('/', '\\');
+-			path = path.Replace("\\.\\", "\\");
+-			while (path.StartsWith(".\\")) {
++			path = path.Replace("/", "\\", StringComparison.Ordinal);
++			path = path.Replace("\\.\\", "\\", StringComparison.Ordinal);
++			while (path.StartsWith(".\\", StringComparison.Ordinal)) {
+ 				path = path.Substring(".\\".Length);
+ 			}
+ 
+-			while (path.EndsWith("\\.")) {
++			while (path.EndsWith("\\.", StringComparison.Ordinal)) {
+ 				path = ((path.Length <= "\\.".Length) ? "\\" : path.Substring(0, path.Length - "\\.".Length));
+ 			}
+ 
+ 			int num;
+ 			for (num = 1; num < path.Length; num = CollapseParentDirectory(ref path, num, "\\..\\".Length)) {
+-				num = path.IndexOf("\\..\\", num);
++				num = path.IndexOf("\\..\\", num, StringComparison.Ordinal);
+ 				if (num < 0)
+ 					break;
+ 			}
+ 
+-			if (path.EndsWith("\\..")) {
++			if (path.EndsWith("\\..", StringComparison.Ordinal)) {
+ 				int num2 = path.Length - "\\..".Length;
+ 				if (num2 > 0)
+ 					CollapseParentDirectory(ref path, num2, "\\..".Length);
+@@ -33,13 +_,12 @@
+ 				path = string.Empty;
+ 
+ 			if (Path.DirectorySeparatorChar != '\\')
+-				path = path.Replace('\\', Path.DirectorySeparatorChar);
+-
++				path = path.Replace("\\", Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal);
+ 			return path;
+ 		}
+ 
+ 		private static int CollapseParentDirectory(ref string path, int position, int removeLength) {
+-			int num = path.LastIndexOf('\\', position - 1) + 1;
++			int num = path.LastIndexOf("\\", position - 1, StringComparison.Ordinal) + 1;
+ 			path = path.Remove(num, position - num + removeLength);
+ 			return Math.Max(num - 1, 1);
+ 		}


### PR DESCRIPTION
This is an optimization of `ReLogic.Content.AssetPathHelper.CleanPath`
It has been tested that using `StringComparison.Ordinal` as `comparisonType` (default is `StringComparison.CurrentCulture`) will be much faster than default if the enabled language is not English, or the path include characters other than English characters and numbers

Here's a Microsoft document: https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings
> Use comparisons with [StringComparison.Ordinal](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison#system-stringcomparison-ordinal) or [StringComparison.OrdinalIgnoreCase](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison#system-stringcomparison-ordinalignorecase) for better performance.

`CleanPath` is intended to give a legal path to use for loading assets and other things, so using `StringComparison.Ordinal` is probably the best choice for improving performance

## Testing
### Using a non-English language
I called `CleanPath` 100000 times, using different `comparisonType` for string operating
Here is the output of my test

![D59DEE`8U`{`N78{HCZE_K4](https://user-images.githubusercontent.com/35227653/181923070-a3214ddb-95e3-4088-b368-ec2e2f3aab37.png)

Game language: Chinese (`zh-Hans`) (The result have no difference between all 8 non-English languages Terraria supports)
Path: `Content/Items/ExampleSoul`

Apparently, `StringComparison.Ordinal` is the fastest `comparisonType`, almost 100 times faster than the default `StringComparison.CurrentCulture`.

### Using English
If the game uses English as the language. Using `StringComparison.Ordinal` is only 5 times faster for English-only paths
![)}9}Q_YM 4EU3KX $T92OA8](https://user-images.githubusercontent.com/35227653/181925198-7941829d-50ee-47bc-87dc-ae9fd9b71640.png)
However, if the path includes non-English characters (Russian here), it will be 100 times faster as well
![image](https://user-images.githubusercontent.com/35227653/181925384-5f9e6776-dd0d-4e43-896e-2fd5188f52cb.png)
(Of course I know nothing about Russian, I just copied a random text)

## Breakage
It has been tested that by using paths containing specific characters from all 9 languages Terraria supports (like `Content/Items/боеприпасы` and `Content/Items/Käfer`), the path returned with `StringComparison.Ordinal` is the same as the path returned with `StringComparison.CurrentCulture`

So it's certain that using `StringComparison.Ordinal` will not break paths in most languages, and it will improve performance a lot. (Also, why should paths include characters other than English characters and Arabic numerals? Using paths consisting of `a-z`, `A-Z` and `0-9` can avoid many problems)