### PR TITLE
fix in dedicated server setup script

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Setup_tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Setup_tModLoaderServer.sh
@@ -1,8 +1,8 @@
-steamcmd +force_install_dir $(pwd)../tmod +login anonymous +app_update 1281930 +quit
+steamcmd +force_install_dir $(pwd)/../tmod +login anonymous +app_update 1281930 +quit
 
 input="install.txt"
 if [ -f "$input" ] ; then
-	str="+force_install_dir $(pwd)../tmod +login anonymous"
+	str="+force_install_dir $(pwd)/../tmod +login anonymous"
 	while read -r line
 	do
 		str="$str +workshop_download_item 1281930 $line"


### PR DESCRIPTION
### What is the bug?
Missing slashes after the `$(pwd)` command result in the path being expanded incorrectly, ex. `/home/user/.local/share/Steam/steamcmd../tmod` rather than `/home/user/.local/share/Steam/steamcmd/../tmod`. This was introduced in my pull request #2735, thanks for the tip, @guillheu!
### How did you fix the bug?
Added the missing slashes where they should be

### Are there alternatives to your fix?
Editing the script manually
