### PR TITLE
Delay steam init until needed (eg for mod browser) on dedicated servers

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -100,11 +100,11 @@
 		// Workshop
 		"WorkshopDisclaimer": "By submitting this item, you agree to the tModLoader Terms of Service",
 		"SteamPublishingLimit": "Error: Only Steam tModLoader owners can publish to Workshop in-game.",
-		"NoWorkshopAccess": "Error: Unable to access Steam Workshop",
+		"NoWorkshopAccess": "Error: Unable to access Steam Workshop.\n\nYou must have a valid Steam install on your system in order to use the in-game Mod Browser.\n\nNOTE: GoG users - once Steam is installed, you can use the ingame mod browser to download mods",
 		"ModAlreadyUploaded": "Error: Mod already exists on Workshop!",
 		"ModVersionInfoUnchanged": "Error: Mod Version information must be incremented prior to updating.",
 		"ConsultSteamLogs": "Consult Steam workshop_log.txt (Default Location: {0}) for more information.",
-		"SteamRejectUpdate": "Item is/was already installed: {0}. \nIf attempting to re-install, restart your game first because Steam is weird\nIf restarting your game does not work, apply the following steps:\n1) Open Steam Client\n2)Find the Mod on tModLoader Workshop\n3)Unsubscribe and Resubscribe on the actual Workshop.\nThese steps are required if Steam fails to handle unsubscribing you properly.",
+		"SteamRejectUpdate": "Item is/was already installed: {0}. \nIf attempting to re-install, restart your game first because Steam is weird\nIf restarting your game does not work, apply the following steps:\n1) Open Steam Client\n2) Find the Mod on tModLoader Workshop\n3) Unsubscribe and Resubscribe on the actual Workshop.\nThese steps are required if Steam fails to handle unsubscribing you properly.",
 		"BrowserRejectWarning": "Can't Download. Click For Info",
 		"BeginDownload": "Attempting Download Item: {0}",
 		"EndDownload": "Item Download Completed",

--- a/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
@@ -49,10 +49,16 @@ namespace Terraria.ModLoader.Engine
 		}
 
 		internal static void SetAppId(AppId_t appId) {
+			var steam_appid_path = "steam_appid.txt";
+
 			if (Environment.GetEnvironmentVariable("SteamClientLaunch") != "1") {
-				File.WriteAllText("steam_appid.txt", appId.ToString());
+				File.WriteAllText(steam_appid_path, appId.ToString());
 			}
 			else if (Environment.GetEnvironmentVariable("SteamAppId") != appId.ToString()) {
+				try {
+					File.Delete(steam_appid_path);
+				} catch (IOException) {}
+
 				throw new Exception("Cannot overwrite steam env. SteamAppId=" + Environment.GetEnvironmentVariable("SteamAppId"));
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
@@ -53,12 +53,15 @@ namespace Terraria.ModLoader.Engine
 
 			if (Environment.GetEnvironmentVariable("SteamClientLaunch") != "1") {
 				File.WriteAllText(steam_appid_path, appId.ToString());
+				return;
 			}
-			else if (Environment.GetEnvironmentVariable("SteamAppId") != appId.ToString()) {
-				try {
-					File.Delete(steam_appid_path);
-				} catch (IOException) {}
 
+			try {
+				File.Delete(steam_appid_path);
+			}
+			catch (IOException) { }
+
+			if (Environment.GetEnvironmentVariable("SteamAppId") != appId.ToString()) {
 				throw new Exception("Cannot overwrite steam env. SteamAppId=" + Environment.GetEnvironmentVariable("SteamAppId"));
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -413,16 +413,14 @@ namespace Terraria.ModLoader.UI
 				else {
 					string modname = command;
 					try {
-						if (!WorkshopHelper.QueryHelper.CheckWorkshopConnection()) {
-							Console.WriteLine(Language.GetTextValue("NoWorkshopAccess"));
+						if (!WorkshopHelper.QueryHelper.CheckWorkshopConnection())
 							break;
-						}
 
 						var info = WorkshopHelper.QueryHelper.FindModDownloadItem(modname);
-						if(info == null)
+						if (info == null)
 							Console.WriteLine($"No mod with the name {modname} found on the workshop.");
 						else
-							info.InnerDownloadWithDeps();
+							info.InnerDownloadWithDeps().GetAwaiter().GetResult();
 					}
 					catch (Exception e) {
 						Console.WriteLine(Language.GetTextValue("tModLoader.MBServerDownloadError", modname, e.ToString()));

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Terraria.ModLoader.Core;
 using Terraria.Social.Steam;
@@ -56,11 +57,11 @@ namespace Terraria.ModLoader.UI.ModBrowser
 			ModloaderVersion = modloaderversion;
 		}
 
-		internal void InnerDownloadWithDeps() {
+		internal Task InnerDownloadWithDeps() {
 			var downloads = new HashSet<ModDownloadItem>() { this };
 			downloads.Add(this);
 			GetDependenciesRecursive(this, ref downloads);
-			WorkshopHelper.ModManager.Download(downloads.ToList());
+			return WorkshopHelper.ModManager.Download(downloads.ToList());
 		}
 
 		private IEnumerable<ModDownloadItem> GetDependencies() {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -168,7 +168,7 @@ namespace Terraria.Social.Steam
 			/// <summary>
 			/// Downloads all UIModDownloadItems provided.
 			/// </summary>
-			public static void Download(List<ModDownloadItem> items) {
+			public static Task Download(List<ModDownloadItem> items) {
 				//Set UIWorkshopDownload
 				UIWorkshopDownload uiProgress = null;
 
@@ -192,7 +192,7 @@ namespace Terraria.Social.Steam
 
 				int counter = 0;
 
-				Task.Run(() => TaskDownload(counter, uiProgress, items));
+				return Task.Run(() => TaskDownload(counter, uiProgress, items));
 			}
 
 			internal static void DownloadBatch(string[] workshopIds, UI.UIState returnMenu) {
@@ -245,11 +245,11 @@ namespace Terraria.Social.Steam
 						foreach (var localMod in enabledItems) {
 							localMod.Enabled = true;
 						}
-					ModLoader.ModLoader.Reload();
-			}
+						ModLoader.ModLoader.Reload();
+					}
 				}
 				else
-					Task.Run(() => TaskDownload(counter, uiProgress, items, ids));
+					TaskDownload(counter, uiProgress, items, ids);
 			}
 
 			private EResult downloadResult;


### PR DESCRIPTION
### What is the new feature?
When launching a server without steam, avoid loading the native `steam_api64` library until it is actually needed (eg, when requesting a mod from the mod browser).

Also includes a bunch of code cleanups and refactors I came across.

### Why should this be part of tModLoader?

Makes dedicated servers more reliable.

The steam native libraries can't be loaded on every platform due to dependency resolution conflicts. In the example below, steam needs a version of glibc which isn't installed. 
```
Unable to load shared library '/home/tml/tModLoader/Libraries/Native/Linux/libsteam_api64.so' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: Error relocating /home/tml/tModLoader/Libraries/Native/Linux/libsteam_api64.so: __vsnprintf_chk: symbol not found (see server.log for full trace)
Server crash: 8/4/2022 3:24:05 AM
System.DllNotFoundException: Unable to load shared library '/home/tml/tModLoader/Libraries/Native/Linux/libsteam_api64.so' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: Error relocating /home/tml/tModLoader/Libraries/Native/Linux/libsteam_api64.so: __vsnprintf_chk: symbol not found
   at System.Runtime.InteropServices.NativeLibrary.LoadFromPath(String libraryName, Boolean throwOnError)
   at System.Runtime.InteropServices.NativeLibrary.Load(String libraryPath)
   at MonoLaunch.ResolveNativeLibrary(Assembly assembly, String name) in tModLoader\Terraria\MonoLaunch.cs:line 96
   at System.Runtime.Loader.AssemblyLoadContext.GetResolvedUnmanagedDll(Assembly assembly, String unmanagedDllName)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDllUsingEvent(String unmanagedDllName, Assembly assembly, IntPtr gchManagedAssemblyLoadContext)
   at Steamworks.NativeMethods.SteamInternal_GameServer_Init(UInt32 unIP, UInt16 usPort, UInt16 usGamePort, UInt16 usQueryPort, EServerMode eServerMode, UTF8StringHandle pchVersionString)
   at Steamworks.GameServer.Init(UInt32 unIP, UInt16 usGamePort, UInt16 usQueryPort, EServerMode eServerMode, String pchVersionString)
   at Terraria.Social.Steam.WorkshopHelper.ModManager.Initialize() in tModLoader\Terraria\Social\Steam\WorkshopHelper.TML.cs:line 111
   at Terraria.Social.SocialAPI.Initialize(Nullable`1 mode) in tModLoader\Terraria\Social\SocialAPI.cs:line 64
   at Terraria.Program.LaunchGame_(Boolean isServer) in tModLoader\Terraria\Program.cs:line 230
```

### Are there alternative designs?

Could init the game server on entering the server mod browser menu, rather than on downloading an item, but it's a couple seconds on what's already a 15 second process anyway.

