### PR TITLE
Fix modded UG backgrounds drawing under ocean

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -96,7 +96,7 @@ namespace Terraria.ModLoader
 	[Autoload(Side = ModSide.Client)]
 	public class UndergroundBackgroundStylesLoader : SceneEffectLoader<ModUndergroundBackgroundStyle>
 	{
-		public const int VanillaUndergroundBackgroundStylesCount = 18;
+		public const int VanillaUndergroundBackgroundStylesCount = 22;
 
 		public UndergroundBackgroundStylesLoader() {
 			Initialize(VanillaUndergroundBackgroundStylesCount);


### PR DESCRIPTION
### What is the bug?

ModUndergroundBackgroundStyles were getting drawn under the ocean.

### How did you fix the bug?

Updated the constant in UndergroundBackgroundStylesLoader so modded BGs wouldn't overwrite vanilla ocean BGs.

### Are there alternatives to your fix?

If anyone knows of an actual vanilla constant to use here, then it'd be great, but I can't find one. The value I used is from `Main.DrawBackground()`.