### PR TITLE
clear static particle lists on unload

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -591,6 +591,10 @@ namespace Terraria.ModLoader
 			}
 
 			TileEntity.Clear(); // drop all possible references to mod TEs
+
+			// clear particles
+			Main.ParticleSystem_World_BehindPlayers.Particles.Clear();
+			Main.ParticleSystem_World_OverPlayers.Particles.Clear();
 		}
 
 		public static Stream OpenRead(string assetName, bool newFileStream = false) {


### PR DESCRIPTION
### What is the bug?
If a mod adds and spawns its own particles, and the particles still exist when the world is exited and the mod is disabled, then the mods reloaded, and _any_ world entered, the game will be prone to crashing, usually due to modded textures not being found.

#### Description of the bug in detail
The two static fields `ParticleSystem_World_BehindPlayers` and `ParticleSystem_World_OverPlayers` in `Main` are responsible for drawing particles (such as rainbow rod impact, stardust guardian attack, etc), and they are also accessible by mods, which can call `Add` to add vanilla or custom particles to be rendered. Usually particles automatically remove themselves from that list, but they don't if the world is exited shortly after spawning them. If a mod which owns those particles is disabled, it will log as "Assembly not fully unloaded", due to the particle still existing in the list of particles _(which is never cleared and persists between worlds by the way, possible vanilla thing to address?)_. If said particles use or access textures which are unloaded/disposed or don't exist, it will crash.

### How did you fix the bug?
Clear both lists in `ModContent.CleanupModReferences`.

### Are there alternatives to your fix?
The fix can be applied in `WorldGen.clearWorld` too, as `ModContent.CleanupModReferences` mostly mirrors code from it in the first place. See my remark above.
