### PR TITLE
Fix double enumeration in `UIList.AddRange`

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIList.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIList.TML.cs
@@ -13,8 +13,8 @@ namespace Terraria.GameContent.UI.Elements
 		}
 
 		public virtual void AddRange(IEnumerable<UIElement> items) {
-			_items.AddRange(items);
 			foreach (var item in items)
+				_items.Add(item);
 				_innerList.Append(item);
 
 			UpdateOrder();

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIList.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIList.TML.cs
@@ -13,9 +13,10 @@ namespace Terraria.GameContent.UI.Elements
 		}
 
 		public virtual void AddRange(IEnumerable<UIElement> items) {
-			foreach (var item in items)
+			foreach (var item in items) {
 				_items.Add(item);
 				_innerList.Append(item);
+			}
 
 			UpdateOrder();
 			_innerList.Recalculate();


### PR DESCRIPTION
### What is the bug?
[Discord message](https://discord.com/channels/103110554649894912/445276626352209920/1007343762118295632)

### How did you fix the bug?
Remove one of the enumerations

### Are there alternatives to your fix?
No
