### PR TITLE
Fix RangedPrefix not counting throwing

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -149,7 +149,7 @@ namespace Terraria.ModLoader
 			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.WeaponPrefix();
 
 		internal static bool RangedPrefix(Item item)
-			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.RangedPrefix(); //(item.ranged || item.thrown);
+			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.RangedPrefix();
 
 		internal static bool MagicPrefix(Item item)
 			=> item.ModItem != null && GeneralPrefix(item) && item.ModItem.MagicPrefix();

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -154,7 +154,7 @@ namespace Terraria.ModLoader
 		/// Takes priority over MagicPrefix
 		/// </summary>
 		public virtual bool RangedPrefix()
-			=> Item.ranged;
+			=> Item.ranged || Item.CountsAsClass(DamageClass.Throwing);
 
 		/// <summary>
 		/// Allows you to change whether or not a weapon receives magic prefixes. Return true if the item should receive magic prefixes and false if it should not.


### PR DESCRIPTION
### What is the bug?
Since in 1.4 the throwing damage type was removed, at some point, either before or after tml added its own throwing damage type, it dropped support for thrown item reforges. This PR adds it back.

### How did you fix the bug?
Make `ModItem.RangedPrefix` check for items that count as throwing, restoring 1.3 behavior.

### Are there alternatives to your fix?
No

### Porting notes:
* If you were overriding `ModItem.RangedPrefix` for your items that count as `DamageClass.Throwing` to make them receive ranged prefixes, you can safely remove the override, as its default behavior will now return true for such items.
* If your thrown items are supposed to not receive ranged prefixes (or prefixes at all), override `ModItem.RangedPrefix` and return false.