### PR TITLE
Add UpdateDamage hook to projectile

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -188,6 +188,15 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify how damage of this projectile is updated. This hook is only called wehen minion, sentry or ContinuouslyUpdateDamage is set.
+		/// </summary>
+		/// <param name="projectile"></param>
+		/// <param name="modifier">Stat modifier that will be applied to damage</param>
+		/// <param name="originalDamage">Damage to which modifier will be applied</param>
+		public virtual void UpdateDamage(Projectile projectile, ref StatModifier modifier, ref int originalDamage) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether a projectile can hit the given NPC. Return true to allow hitting the target, return false to block the projectile from hitting the target, and return null to use the vanilla code for whether the target can be hit. Returns null by default.
 		/// </summary>
 		/// <param name="projectile"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -220,6 +220,14 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to modify how damage of this projectile is updated. This hook is only called wehen minion, sentry or ContinuouslyUpdateDamage is set.
+		/// </summary>
+		/// <param name="modifier">Stat modifier that will be applied to damage</param>
+		/// <param name="originalDamage">Damage to which modifier will be applied</param>
+		public virtual void UpdateDamage(ref StatModifier modifier, ref int originalDamage) {
+		}
+
+		/// <summary>
 		/// Allows you to determine whether this projectile can hit the given NPC. Return true to allow hitting the target, return false to block this projectile from hitting the target, and return null to use the vanilla code for whether the target can be hit. Returns null by default.
 		/// </summary>
 		/// <param name="target">The target.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -414,6 +414,17 @@ namespace Terraria.ModLoader
 			}
 		}
 
+		private delegate void DelegateUpdateDamage(Projectile projectile, ref StatModifier modifier, ref int originalDamage);
+		private static HookList HookUpdateDamage = AddHook<DelegateUpdateDamage>(g => g.UpdateDamage);
+
+		public static void UpdateDamage(Projectile projectile, ref StatModifier modifier, ref int originalDamage) {
+			projectile.ModProjectile?.UpdateDamage(ref modifier, ref originalDamage);
+
+			foreach (GlobalProjectile g in HookUpdateDamage.Enumerate(projectile.globalProjectiles)) {
+				g.UpdateDamage(projectile, ref modifier, ref originalDamage);
+			}
+		}
+
 		private static HookList HookCanHitNPC = AddHook<Func<Projectile, NPC, bool?>>(g => g.CanHitNPC);
 
 		public static bool? CanHitNPC(Projectile projectile, NPC target) {

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -736,7 +736,7 @@
  			if (myRect.Intersects(targetRect))
  				return true;
  
-@@ -11395,9 +_,9 @@
+@@ -11395,9 +_,15 @@
  				if (!noEnchantmentVisuals)
  					UpdateEnchantmentVisuals();
  
@@ -744,7 +744,13 @@
 +				if ((minion || sentry || ContinuouslyUpdateDamage)) {
  					Player player = Main.player[owner];
 -					damage = (int)((float)originalDamage * player.minionDamage + (float)player.minionAddDamage + 5E-06f);
-+					damage = (int)player.GetTotalDamage(DamageType).ApplyTo(originalDamage);
++
++					StatModifier modifier = player.GetTotalDamage(DamageType);
++					int originalDamage = this.originalDamage;
++
++					ProjectileLoader.UpdateDamage(this, ref modifier, ref originalDamage);
++
++					damage = (int)modifier.ApplyTo(originalDamage);
  				}
  
  				if (minion && numUpdates == -1 && type != 625 && type != 628) {


### PR DESCRIPTION
### What is the new feature?

UpdateDamage hook that allows user to modify how damage is updated for projectile.

### Why should this be part of tModLoader?

At the moment, continuous damage update only takes in account originalDamage of projectile and corresponding damage StatModifier of player. With the new hook, user can make projectile damage also depend on other values, which allows for more elaborate projectile design.

### Sample usage for the new feature

For example, hook can be used to make projectile proportionally stronger when player is at low health:

```cs
// In class derived from ModProjectile
public override void UpdateDamage(ref StatModifier modifier, ref int originalDamage)
{
    Player owner = Main.player[Projectile.owner];
    modifier *= owner.statLifeMax / owner.statLife;
}
```