### PR TITLE
Switch to CountsAsClass for Feral Glove / SummonMeleeSpeed Interaction

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5059,7 +5059,7 @@
 +			if (CombinedHooks.CanAutoReuseItem(this, sItem) is bool autoReuse)
 +				return autoReuse;
 +
-+			return sItem.autoReuse || autoReuseGlove && (sItem.CountsAsClass(DamageClass.Melee) || sItem.DamageType == DamageClass.SummonMeleeSpeed);
++			return sItem.autoReuse || autoReuseGlove && (sItem.CountsAsClass(DamageClass.Melee) || sItem.CountsAsClass(DamageClass.SummonMeleeSpeed));
  		}
  
  		private void ItemCheck_HandleMount() {


### PR DESCRIPTION
### What is the bug?

Custom DamageClasses that try to inherit the effects of the `SummonMeleeSpeed` DamageClass don't gain its Feral Glove auto-reuse synergy.

### How did you fix the bug?

Switched to using the `Item.CountsAsClass` method in `Player.CanAutoReuseItem`  instead of a direct == check against `DamageClass.SummonMeleeSpeed`.

### Are there alternatives to your fix?

Modders can make their own override to `ModPlayer.CanAutoReuseItem` or `Globaltem.CanAutoReuseItem` for their damage class, but having to do this feels unexpected given the precedent of how `GetEffectInheritance` works for other cases.