### PR TITLE
Clarify where client.log can be found

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,11 +75,12 @@ body:
     label: Log File
     description: |
       Please attach the `client.log` file here. You'll find the log files in the logs folder. Look for the `client.log` file.
+      In 1.3 it can be found in the following folders:
       Windows Logs: `C:\Documents\My Games\Terraria\ModLoader\Logs`
       Linux Logs: `~/.local/share/Terraria/ModLoader/Logs/` or `$XDG_DATA_HOME/Terraria/ModLoader/Logs/`
       Mac Logs: `~/Library/Application support/Terraria/ModLoader/Logs/`
       
-      If you are on the 1.4-stable or 1.4-preview, the folder will be a folder called `tModLoader-Logs` in the install directory.
+      On the 1.4 versions it can be found in the "tModLoader-Logs" folder in your tModLoader install directory
       
       Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,12 +75,13 @@ body:
     label: Log File
     description: |
       Please attach the `client.log` file here. You'll find the log files in the logs folder. Look for the `client.log` file.
+      On the 1.4 versions it can be found in the "tModLoader-Logs" folder in your tModLoader install directory (to find your install directory on Steam right click on tModloader, then Manage and "Browse local files" 
+      
       In 1.3 it can be found in the following folders:
       Windows Logs: `C:\Documents\My Games\Terraria\ModLoader\Logs`
       Linux Logs: `~/.local/share/Terraria/ModLoader/Logs/` or `$XDG_DATA_HOME/Terraria/ModLoader/Logs/`
       Mac Logs: `~/Library/Application support/Terraria/ModLoader/Logs/`
       
-      On the 1.4 versions it can be found in the "tModLoader-Logs" folder in your tModLoader install directory
       
       Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -75,7 +75,7 @@ body:
     label: Log File
     description: |
       Please attach the `client.log` file here. You'll find the log files in the logs folder. Look for the `client.log` file.
-      On the 1.4 versions it can be found in the "tModLoader-Logs" folder in your tModLoader install directory (to find your install directory on Steam right click on tModloader, then Manage and "Browse local files" 
+      On the 1.4 versions it can be found in the "tModLoader-Logs" folder in your tModLoader install directory (to find your install directory on Steam right click on tModloader, then Manage and "Browse local files") 
       
       In 1.3 it can be found in the following folders:
       Windows Logs: `C:\Documents\My Games\Terraria\ModLoader\Logs`


### PR DESCRIPTION
I fixed the bug report template so it clarifies better where the client.log file can be found (1.4 is the default branch and therefore should be mentioned equally, if not more to 1.3)
