### PR TITLE
Add GlobalNPC.Send/ReceiveExtraAI

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCNetSync.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCNetSync.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+
+namespace ExampleMod.Common.GlobalNPCs
+{
+	// Here is a class dedicated to showcasing Send/ReceiveExtraAI()
+	public class ExampleNPCNetSync : GlobalNPC
+	{
+		public override bool InstancePerEntity => true;
+		private bool differentBehavior;
+
+		// This reduces how many NPCs actually have this GlobalNPC
+		public override bool AppliesToEntity(NPC entity, bool lateInstantiation) {
+			return entity.type == NPCID.Sharkron2;
+		}
+
+		// Although this runs on both client and server, only the session that spawned the NPC knows its source
+		// As such, the check demonstrated below will always be false client-side and the code will never run!
+		public override void OnSpawn(NPC npc, IEntitySource source) {
+
+			// When spawned by a Cthulunado during a Blood Moon
+			if (source is EntitySource_Parent parent
+				&& parent.Entity is Projectile projectile
+				&& projectile.type == ProjectileID.Cthulunado
+				&& Main.bloodMoon) {
+				differentBehavior = true;
+			}
+		}
+
+		// Because this GlobalNPC only applies to Sharkrons, this data is not attached to all NPC sync packets
+		public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter) {
+			bitWriter.WriteBit(differentBehavior);
+		}
+
+		// Make sure you always read exactly as much data as you sent!
+		public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader) {
+			differentBehavior = bitReader.ReadBit();
+		}
+
+		public override void AI(NPC npc) {
+			if (differentBehavior) {
+				npc.scale *= 1.0025f;
+				if (npc.scale > 3f) {
+					npc.scale = 3f;
+				}
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
+using System.IO;
 using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.GameContent.Bestiary;
@@ -116,6 +117,29 @@ namespace Terraria.ModLoader
 		/// </summary>
 		/// <param name="npc"></param>
 		public virtual void PostAI(NPC npc) {
+		}
+
+		/// <summary>
+		/// Use this judiciously to avoid straining the network.
+		/// <br/>Checks and methods such as <see cref="AppliesToEntity"/> can reduce how much data must be sent for how many projectiles.
+		/// <br/>Called whenever <see cref="MessageID.SyncNPC"/> is successfully sent, for example on projectile creation, or whenever Projectile.netUpdate is set to true in the update loop for that tick.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
+		/// </summary>
+		/// <param name="npc">The NPC.</param>
+		/// <param name="bitWriter">The compressible bit writer. Booleans written via this are compressed across all mods to improve multiplayer performance.</param>
+		/// <param name="binaryWriter">The writer.</param>
+		public virtual void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter) {
+		}
+
+		/// <summary>
+		/// Use this to receive information that was sent in <see cref="SendExtraAI"/>.
+		/// <br/>Called whenever <see cref="MessageID.SyncNPC"/> is successfully received.
+		/// <br/>Can be called on both server and client, depending on who owns the projectile.
+		/// </summary>
+		/// <param name="npc">The NPC.</param>
+		/// <param name="bitReader">The compressible bit reader.</param>
+		/// <param name="binaryReader">The reader.</param>
+		public virtual void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader) {
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -16,6 +16,7 @@ using Terraria.Localization;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Utilities;
 using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.GlobalNPC>;
+using Terraria.ModLoader.IO;
 
 namespace Terraria.ModLoader
 {
@@ -287,15 +288,29 @@ namespace Terraria.ModLoader
 			}
 		}
 
-		public static byte[] WriteExtraAI(NPC npc) {
-			if (npc.ModNPC == null) {
-				return Array.Empty<byte>();
-			}
+		private static HookList HookWriteExtraAI = AddHook<Action<NPC, BitWriter, BinaryWriter>>(g => g.SendExtraAI);
 
+		public static byte[] WriteExtraAI(NPC npc) {
 			using var stream = new MemoryStream();
 			using var modWriter = new BinaryWriter(stream);
 
-			npc.ModNPC.SendExtraAI(modWriter);
+			npc.ModNPC?.SendExtraAI(modWriter);
+
+			using var bufferedStream = new MemoryStream();
+			using var globalWriter = new BinaryWriter(bufferedStream);
+
+			BitWriter bitWriter = new BitWriter();
+
+			foreach (GlobalNPC g in HookWriteExtraAI.Enumerate(npc.globalNPCs)) {
+				g.SendExtraAI(npc, bitWriter, globalWriter);
+			}
+
+			bitWriter.Flush(modWriter);
+
+			modWriter.Write(bufferedStream.ToArray());
+
+			globalWriter.Flush();
+
 			modWriter.Flush();
 
 			return stream.ToArray();
@@ -305,15 +320,38 @@ namespace Terraria.ModLoader
 			return reader.ReadBytes(reader.Read7BitEncodedInt());
 		}
 
-		public static void ReceiveExtraAI(NPC npc, byte[] extraAI) {
-			if (npc.ModNPC == null) {
-				return;
-			}
+		private static HookList HookReceiveExtraAI = AddHook<Action<NPC, BitReader, BinaryReader>>(g => g.ReceiveExtraAI);
 
+		public static void ReceiveExtraAI(NPC npc, byte[] extraAI) {
 			using var stream = new MemoryStream(extraAI);
 			using var modReader = new BinaryReader(stream);
 
-			npc.ModNPC.ReceiveExtraAI(modReader);
+			npc.ModNPC?.ReceiveExtraAI(modReader);
+
+			BitReader bitReader = new BitReader(modReader);
+
+			try {
+				foreach (GlobalNPC g in HookReceiveExtraAI.Enumerate(npc.globalNPCs)) {
+					g.ReceiveExtraAI(npc, bitReader, modReader);
+				}
+
+				if (bitReader.BitsRead < bitReader.MaxBits) {
+					throw new IOException($"Read underflow {bitReader.MaxBits - bitReader.BitsRead} of {bitReader.MaxBits} compressed bits in ReceiveExtraAI, more info below");
+				}
+
+				if (stream.Position < stream.Length) {
+					throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length} bytes in ReceiveExtraAI, more info below");
+				}
+			}
+			catch (IOException e) {
+				Logging.tML.Error(e.ToString());
+
+				string culprits = $"Above IOException error in NPC {(npc.ModNPC == null ? npc.TypeName : npc.ModNPC.FullName)} may be caused by one of these:";
+				foreach (GlobalNPC g in HookReceiveExtraAI.Enumerate(npc.globalNPCs)) {
+					culprits += $"\n    {g.Name}";
+				}
+				Logging.tML.Error(culprits);
+			}
 		}
 
 		private static HookList HookFindFrame = AddHook<Action<NPC, int>>(g => g.FindFrame);


### PR DESCRIPTION
### What is the new feature?
SendExtraAI and ReceiveExtraAI hooks for GlobalNPC.
Pretty much copy-pasted from #2390 and adapted to NPCs.

### Why should this be part of tModLoader?
Same reasons as in #2390. Also useful for syncing arbitrary data to NPCs without needing to hijack the SyncNPC packet.

### Are there alternative designs?
Same as in #2390.

### ExampleMod updates
Added ExampleNPCNetSync.

