### PR TITLE
[BUG FIX] Restore attack speed scaling on spears

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
@@ -32,7 +32,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.damage = 25;
 			Item.knockBack = 6.5f;
 			Item.noUseGraphic = true; // When true, the item's sprite will not be visible while the item is in use. This is true because the spear projectile is what's shown so we do not want to show the spear sprite as well.
-			Item.DamageType = DamageClass.MeleeNoSpeed;
+			Item.DamageType = DamageClass.Melee;
 			Item.noMelee = true; // Allows the item's animation to do damage. This is important because the spear is actually a projectile instead of an item. This prevents the melee hitbox of this item.
 
 			// Projectile Properties

--- a/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
@@ -13,6 +13,7 @@ namespace ExampleMod.Content.Items.Weapons
 			Tooltip.SetDefault("This is a modded spear");
 
 			ItemID.Sets.SkipsInitialUseSound[Item.type] = true; // This skips use animation-tied sound playback, so that we're able to make it be tied to use time instead in the UseItem() hook.
+			ItemID.Sets.Spears[Item.type] = true; // This allows the game to recognize our new item as a spear.
 			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -46,7 +46,8 @@
 			);
 
 			/// <summary>
-			/// Set for easily defining weapons as spears.
+			/// Set for easily defining weapons as spears.<br/>
+			/// Only used for vanilla spears to make sure they still scale with attack speed (though it's encouraged to set this for your spears as well, for cross-mod support).<br/>
 			/// </summary>
 			public static bool[] Spears = Factory.CreateBoolSet(
 				Spear,

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -51,6 +51,7 @@
 			public static bool[] Spears = Factory.CreateBoolSet(
 				Spear,
 				Trident,
+				Swordfish,
 				ThunderSpear,
 				TheRottedFork,
 				DarkLance,

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -44,6 +44,29 @@
 				GoldenBugNet,
 				FireproofBugNet
 			);
+
+			/// <summary>
+			/// Set for easily defining weapons as spears.
+			/// </summary>
+			public static bool[] Spears = Factory.CreateBoolSet(
+				Spear,
+				Trident,
+				ThunderSpear,
+				TheRottedFork,
+				DarkLance,
+				CobaltNaginata,
+				PalladiumPike,
+				MythrilHalberd,
+				OrichalcumHalberd,
+				AdamantiteGlaive,
+				TitaniumTrident,
+				ObsidianSwordfish,
+				Gungnir,
+				MushroomSpear,
+				MonkStaffT2,
+				ChlorophytePartisan,
+				NorthPole
+			);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -180,7 +180,7 @@ namespace Terraria
 		}
 
 		private void RestoreMeleeSpeedBehaviorOnVanillaItems() {
-			if (type < ItemID.Count && melee && shoot > 0) {
+			if (type < ItemID.Count && melee && shoot > 0 && !ItemID.Sets.Spears[type]) {
 				if (noMelee)
 					DamageType = DamageClass.MeleeNoSpeed;
 				else


### PR DESCRIPTION
this is a bug fix

### What is the bug?
in vanilla, spears scale with attack speed as you'd expect; they attack faster and move faster as a result. in tML, they don't do this due to a blanket fix to melee speed interactions which wasn't properly looked over (this is partially my fault)
(solves #2846)

### How did you fix the bug?
added a set in `ItemID` for spears --- this both allows me to fix the issue by checkin' against it, and also allows people to check if a weapon is a spear for their own reasons

### Are there alternatives to your fix?
not really, unless somebody wants to bring content tags back from the dead

### ExampleMod change + porting notes
**ExampleMod**'s ExampleSpear has been updated to match the new changes and new set, and should be referenced if you're somehow lost on what to do

**porting notes:** these only apply if you've actually made any new spears
- if they currently use `MeleeNoSpeed` as their damage class due to perceived parity with vanilla, make them simply use `Melee` instead
- make sure that their entries in the new `ItemID.Sets.Spears` are set to true, so that mods which make use of this new set can detect yours