### PR TITLE
Fixed popup text with custom rarities not disappearing

### DIFF
--- a/patches/tModLoader/Terraria/PopupText.cs.patch
+++ b/patches/tModLoader/Terraria/PopupText.cs.patch
@@ -38,7 +38,7 @@
  			else if (master)
  				color = new Color(255, (byte)(Main.masterColor * 200f), 0, Main.mouseTextColor);
 +
-+			if (rarity > ItemRarityID.Purple)
++			if (rarity > ItemRarityID.Purple && rarity < RarityLoader.RarityCount)
 +				color = RarityLoader.GetRarity(rarity).RarityColor;
  
  			bool flag = false;


### PR DESCRIPTION
### What is the bug?
See #2874 

### How did you fix the bug?
Only updates the color if the rarity is less than the number of rarities in `RarityLoader`
