### PR TITLE
Fixed plates in multiplayer

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -664,7 +664,7 @@
 +							item.stack = reader.Read7BitEncodedInt();
 +						}
 +
-+						TEWeaponsRack.TryPlacing(x5, y5, item, item.stack);
++						TEFoodPlatter.TryPlacing(x5, y5, item, item.stack);
  					}
  					break;
  				case 134: {


### PR DESCRIPTION
### What is the bug?
See #2664 

### How did you fix the bug?
Used `TEFoodPlatter.TryPlacing` instead of `TEWeaponRack.TryPlacing`

### Are there alternatives to your fix?
No
