### PR TITLE
Fix typo

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -362,7 +362,7 @@ namespace Terraria.ModLoader.Core
 
 			reader.ReadString(); //tModLoader version
 			if (!reader.ReadBytes(20).SequenceEqual(Hash))
-				throw new Exception($"File has been modifed, hash. {path}");
+				throw new Exception($"File has been modified, hash. {path}");
 
 			// could also check name and version but hash should suffice
 		}


### PR DESCRIPTION
### What is the bug?
There is a typo in the exception message for failing the tmod file reopen hash check

### How did you fix the bug?
Fix typo

### Are there alternatives to your fix?
No
