### PR TITLE
Include Dotnet 64 win maybe??? Might decrease remaining reports of not opening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,8 +190,12 @@ jobs:
             exit $err
           )
           
+          mkdir -p artifacts/dotnet
+          mv steam_build/LaunchUtils/dotnet-runtime-6.0.0-win-x64.zip artifacts/dotnet/dotnet-runtime-6.0.0-win-x64.zip
+          
           mkdir -p artifacts/Release
           cp -r steam_build/. artifacts/Release
+          
           echo ::endgroup::
           
           echo Cleaning up output directory in-between builds...
@@ -234,6 +238,13 @@ jobs:
           name: Release Build
           path: |
             ./artifacts/Release/
+            
+      - name: Upload Dotnet Win64 Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Dotnet Win64 include
+          path: |
+            ./artifacts/dotnet/
            
       - name: Upload temporary encrypted src artifact
         if: github.event_name == 'push' && (github.ref == 'refs/heads/1.4-stable' || github.ref == 'refs/heads/1.4-preview')
@@ -447,6 +458,12 @@ jobs:
           name: Release Build
           path: artifacts/Build
           
+      - name: Download dotnet artifact from build job
+        uses: actions/download-artifact@v2
+        with: 
+          name: Dotnet Win64 include
+          path: artifacts/dotnet
+          
       - name: View build artifact files
         run: |
           echo pwd is: ${PWD}
@@ -480,6 +497,7 @@ jobs:
       - name: Attempt run_app_build_http 
         shell: bash
         run: |
+          cp artifacts/dotnet/dotnet-runtime-6.0.0-win-x64.zip  artifacts/Build/LaunchUtils/dotnet-runtime-6.0.0-win-x64.zip   
           mkdir artifacts/shared
           echo pwd is: ${PWD}
           echo "Listing manifests directory"

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/InstallNetFramework.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/InstallNetFramework.sh
@@ -40,9 +40,9 @@ if [[ ! -f "$install_dir/dotnet.exe" && "$_uname" == *"_NT"* && "$(uname -m)" ==
 	echo "Update Required. Checking for Windows pre-deployed x64 dotnet files"
 	# Allow for zip to be already delivered by steam win on system and placed in the root directory with this name convention:
 	dotnet_portable_archive_name="dotnet-runtime-$dotnet_version-win-x64.zip"
-	dotnet_portable_archive="$root_dir/$dotnet_portable_archive_name"
+	dotnet_portable_archive="$dotnet_portable_archive_name"
 	
-	# @TODO: This does nothing currently. Needs more thought. Seems wasteful of disk space
+	# @TODO: Needs more thought. Seems wasteful of disk space. Seems required as installers on windows are just not 100% in all setups
 	if [ -f "$dotnet_portable_archive" ]; then
 		echo "Found \"$dotnet_portable_archive_name\""
 		echo "Extracting..."


### PR DESCRIPTION
This PR adds an included win64 6.0.0 dotnet zip that can be extracted without having to download it from the internet.

This should reduce teh number of issues with game not launching on Steam Windows, but the actual impact remains to be seen as to how much.

The github zips will have the dotnet separated, while steam will include it upfront.