### PR TITLE
[1.4] Add try catch guards when saving data

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Terraria.ID;
 using Terraria.ModLoader.Default;
@@ -50,7 +51,14 @@ namespace Terraria.ModLoader.IO
 
 				var saveData = new TagCompound();
 
-				item.ModItem.SaveData(saveData);
+				try {
+					item.ModItem.SaveData(saveData);
+				}
+				catch (Exception e) {
+					Logging.tML.WarnFormat("ModItem {0} from {1} threw an exception during saving. Please report this to the mod author.",
+						item.ModItem.Name, item.ModItem.Mod.Name);
+					Logging.tML.Warn(e);
+				}
 
 				if (saveData.Count > 0) {
 					tag.Set("data", saveData);
@@ -133,7 +141,15 @@ namespace Terraria.ModLoader.IO
 			foreach (var globalItem in ItemLoader.globalItems) {
 				var globalItemInstance = globalItem.Instance(item);
 
-				globalItemInstance?.SaveData(item, saveData);
+				try {
+					globalItemInstance?.SaveData(item, saveData);
+				}
+				catch (Exception e) {
+					Debug.Assert(globalItemInstance != null);
+					Logging.tML.WarnFormat("GlobalItem {0} from {1} threw an exception during saving. Please report this to the mod author.",
+						globalItemInstance.Name, globalItemInstance.Mod.Name);
+					Logging.tML.Warn(e);
+				}
 
 				if (saveData.Count == 0)
 					continue;
@@ -156,7 +172,7 @@ namespace Terraria.ModLoader.IO
 						globalItem.LoadData(item, tag.GetCompound("data"));
 					}
 					catch (Exception e) {
-						throw new CustomModDataException(globalItem.Mod, $"Error in reading custom player data for {globalItem.FullName}", e);
+						throw new CustomModDataException(globalItem.Mod, $"Error in reading custom global item data for {globalItem.FullName}", e);
 					}
 				}
 				else {

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -54,10 +54,9 @@ namespace Terraria.ModLoader.IO
 				try {
 					item.ModItem.SaveData(saveData);
 				}
-				catch (Exception e) {
+				catch {
 					Logging.tML.WarnFormat("ModItem {0} from {1} threw an exception during saving. Please report this to the mod author.",
 						item.ModItem.Name, item.ModItem.Mod.Name);
-					Logging.tML.Warn(e);
 				}
 
 				if (saveData.Count > 0) {
@@ -144,11 +143,10 @@ namespace Terraria.ModLoader.IO
 				try {
 					globalItemInstance?.SaveData(item, saveData);
 				}
-				catch (Exception e) {
+				catch {
 					Debug.Assert(globalItemInstance != null);
 					Logging.tML.WarnFormat("GlobalItem {0} from {1} threw an exception during saving. Please report this to the mod author.",
 						globalItemInstance.Name, globalItemInstance.Mod.Name);
-					Logging.tML.Warn(e);
 				}
 
 				if (saveData.Count == 0)

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -169,7 +169,14 @@ namespace Terraria.ModLoader.IO
 			var saveData = new TagCompound();
 
 			foreach (var modPlayer in player.modPlayers) {
-				modPlayer.SaveData(saveData);
+				try {
+					modPlayer.SaveData(saveData);
+				}
+				catch (Exception e) {
+					Logging.tML.WarnFormat("ModPlayer {0} from {1} threw an exception during saving. Please report this to the mod author.",
+						modPlayer.Name, modPlayer.Mod.Name);
+					Logging.tML.Warn(e);
+				}
 
 				if (saveData.Count == 0)
 					continue;

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -172,10 +172,9 @@ namespace Terraria.ModLoader.IO
 				try {
 					modPlayer.SaveData(saveData);
 				}
-				catch (Exception e) {
+				catch {
 					Logging.tML.WarnFormat("ModPlayer {0} from {1} threw an exception during saving. Please report this to the mod author.",
 						modPlayer.Name, modPlayer.Mod.Name);
-					Logging.tML.Warn(e);
 				}
 
 				if (saveData.Count == 0)

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
@@ -21,12 +21,11 @@ namespace Terraria.ModLoader.IO
 				try {
 					tileEntity.SaveData(saveData);
 				}
-				catch (Exception e) {
+				catch {
 					Logging.tML.WarnFormat("TileEntity {0} from {1} threw an exception during saving. {2}",
 						modTileEntity?.Name ?? tileEntity.GetType().Name,
 						modTileEntity?.Mod.Name ?? "Terraria",
 						modTileEntity != null ? "Please report this to the mod author." : "");
-					Logging.tML.Warn(e);
 				}
 
 				var tag = new TagCompound {

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_TEs.cs
@@ -18,7 +18,16 @@ namespace Terraria.ModLoader.IO
 				var tileEntity = pair.Value;
 				var modTileEntity = tileEntity as ModTileEntity;
 
-				tileEntity.SaveData(saveData);
+				try {
+					tileEntity.SaveData(saveData);
+				}
+				catch (Exception e) {
+					Logging.tML.WarnFormat("TileEntity {0} from {1} threw an exception during saving. {2}",
+						modTileEntity?.Name ?? tileEntity.GetType().Name,
+						modTileEntity?.Mod.Name ?? "Terraria",
+						modTileEntity != null ? "Please report this to the mod author." : "");
+					Logging.tML.Warn(e);
+				}
 
 				var tag = new TagCompound {
 					["mod"] = modTileEntity?.Mod.Name ?? "Terraria",

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -143,7 +143,14 @@ namespace Terraria.ModLoader.IO
 						continue;
 					}
 
-					globalNPC.SaveData(npc, data);
+					try {
+						globalNPC.SaveData(npc, data);
+					}
+					catch (Exception e) {
+						Logging.tML.WarnFormat("GlobalNPC {0} from {1} threw an exception during saving. Please report this to the mod author.",
+							globalNPC.Name, globalNPC.Mod.Name);
+						Logging.tML.Warn(e);
+					}
 
 					if (data.Count != 0) {
 						globalData.Add(new TagCompound {
@@ -159,7 +166,14 @@ namespace Terraria.ModLoader.IO
 				TagCompound tag;
 
 				if (NPCLoader.IsModNPC(npc)) {
-					npc.ModNPC.SaveData(data);
+					try {
+						npc.ModNPC.SaveData(data);
+					}
+					catch (Exception e) {
+						Logging.tML.WarnFormat("ModNPC {0} from {1} threw an exception during saving. Please report this to the mod author.",
+							npc.ModNPC.Name, npc.ModNPC.Mod.Name);
+						Logging.tML.Warn(e);
+					}
 
 					tag = new TagCompound {
 						["mod"] = npc.ModNPC.Mod.Name,
@@ -279,7 +293,7 @@ namespace Terraria.ModLoader.IO
 							globalNPC2.LoadData(npc, (TagCompound)tagCompound["data"]);
 						}
 						catch (Exception inner) {
-							throw new CustomModDataException(ModLoader.GetMod(modName), $"Error in reading custom player data for {modName}", inner);
+							throw new CustomModDataException(ModLoader.GetMod(modName), $"Error in reading custom global npc data for {modName}", inner);
 						}
 					}
 					else {
@@ -467,7 +481,14 @@ namespace Terraria.ModLoader.IO
 			var saveData = new TagCompound();
 
 			foreach (var system in SystemLoader.Systems) {
-				system.SaveWorldData(saveData);
+				try {
+					system.SaveWorldData(saveData);
+				}
+				catch (Exception e) {
+					Logging.tML.WarnFormat("ModSystem {0} from {1} threw an exception during saving. Please report this to the mod author.",
+						system.Name, system.Mod.Name);
+					Logging.tML.Warn(e);
+				}
 
 				if (saveData.Count == 0)
 					continue;

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -146,10 +146,9 @@ namespace Terraria.ModLoader.IO
 					try {
 						globalNPC.SaveData(npc, data);
 					}
-					catch (Exception e) {
+					catch {
 						Logging.tML.WarnFormat("GlobalNPC {0} from {1} threw an exception during saving. Please report this to the mod author.",
 							globalNPC.Name, globalNPC.Mod.Name);
-						Logging.tML.Warn(e);
 					}
 
 					if (data.Count != 0) {
@@ -169,10 +168,9 @@ namespace Terraria.ModLoader.IO
 					try {
 						npc.ModNPC.SaveData(data);
 					}
-					catch (Exception e) {
+					catch {
 						Logging.tML.WarnFormat("ModNPC {0} from {1} threw an exception during saving. Please report this to the mod author.",
 							npc.ModNPC.Name, npc.ModNPC.Mod.Name);
-						Logging.tML.Warn(e);
 					}
 
 					tag = new TagCompound {
@@ -484,10 +482,9 @@ namespace Terraria.ModLoader.IO
 				try {
 					system.SaveWorldData(saveData);
 				}
-				catch (Exception e) {
+				catch {
 					Logging.tML.WarnFormat("ModSystem {0} from {1} threw an exception during saving. Please report this to the mod author.",
 						system.Name, system.Mod.Name);
-					Logging.tML.Warn(e);
 				}
 
 				if (saveData.Count == 0)


### PR DESCRIPTION
### What is the bug?
There is no handling of exceptions that occur during the saving of mod data.
The result of this is that no data at all is saved, even when most of the data is absolutely fine.
It is also possible for these exceptions to completely crash tML.
#2917 

### How did you fix the bug?
Add try catch and logging

### Are there alternatives to your fix?
#2920 
