### PR TITLE
Fix #2917 

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -172,7 +172,6 @@ namespace Terraria.ModLoader.IO
 				}
 				catch (Exception e) {
 					var mod = modPlayer.Mod;
-					
 					// Continue to save other mod data without throwing exceptions
 					Utils.LogAndConsoleErrorMessage(new CustomModDataException(mod,
 						"Error in writing custom player data for " + mod.Name, e).ToString());


### PR DESCRIPTION
When PlayerIO/ItemIO throws an exception, only the data of the current mod / current item will be lost.

Test results: show that part of the data before the error is reported can be read and will not crash
![%BF@1$TJ QUEYDE)@A4LEOH](https://user-images.githubusercontent.com/43930552/189544977-99965ced-3c6f-485c-9735-5c6b71b8223d.png)
