### PR TITLE
Improve mod version selection when multiple versions are present

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -613,7 +613,7 @@
 +
 +			DateTime now = DateTime.UtcNow;
 +			// If you are a modder, and the current date is during the preview freeze, and the last notification wasn't this major.minor, then show the notification.
-+			if (BuildInfo.IsStable && ModCompile.DeveloperMode && now.Day >= 21 && ModLoader.ModLoader.LastPreviewFreezeNotificationSeen != new System.Version(BuildInfo.tMLVersion.Major, BuildInfo.tMLVersion.Minor)) {
++			if (BuildInfo.IsStable && ModCompile.DeveloperMode && now.Day >= 21 && ModLoader.ModLoader.LastPreviewFreezeNotificationSeen != BuildInfo.tMLVersion.MajorMinor()) {
 +				ModLoader.ModLoader.PreviewFreezeNotification = true;
 +			}
 +			if (currentValue != Main.curRelease || ModLoader.ModLoader.LastLaunchedTModLoaderVersion != BuildInfo.tMLVersion || (BuildInfo.Purpose == BuildInfo.BuildPurpose.Dev && ModLoader.ModLoader.LastLaunchedTModLoaderAlphaSha != BuildInfo.CommitSHA)) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
@@ -6,12 +6,14 @@ namespace Terraria.ModLoader.Core
 {
 	internal class LocalMod
 	{
+		public readonly ModLocation location;
 		public readonly TmodFile modFile;
 		public readonly BuildProperties properties;
 		public DateTime lastModified;
 
 		public string Name => modFile.Name;
 		public string DisplayName => string.IsNullOrEmpty(properties.displayName) ? Name : properties.displayName;
+		public Version Version => properties.version;
 		public Version tModLoaderVersion => properties.buildVersion;
 
 		public bool Enabled {
@@ -21,12 +23,13 @@ namespace Terraria.ModLoader.Core
 
 		public override string ToString() => Name;
 
-		public LocalMod(TmodFile modFile, BuildProperties properties) {
+		public LocalMod(ModLocation location, TmodFile modFile, BuildProperties properties) {
+			this.location = location;
 			this.modFile = modFile;
 			this.properties = properties;
 		}
 
-		public LocalMod(TmodFile modFile) : this(modFile, BuildProperties.ReadModFile(modFile)) {
+		public LocalMod(ModLocation location, TmodFile modFile) : this(location, modFile, BuildProperties.ReadModFile(modFile)) {
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -45,7 +45,7 @@ namespace Terraria.ModLoader.Core
 		{
 			public string path;
 
-			public BuildingMod(TmodFile modFile, BuildProperties properties, string path) : base(modFile, properties)
+			public BuildingMod(TmodFile modFile, BuildProperties properties, string path) : base(ModLocation.Dev, modFile, properties)
 			{
 				this.path = path;
 			}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModLocation.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModLocation.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Terraria.ModLoader.Core
+{
+	public enum ModLocation { Dev, Workshop, ActiveModpack }
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -111,7 +111,7 @@ namespace Terraria.ModLoader
 			if (!Unload())
 				return;
 
-			var availableMods = ModOrganizer.FindMods(logDuplicates: true);
+			var availableMods = ModOrganizer.FindMods();
 			try {
 				var modsToLoad = ModOrganizer.SelectAndSortMods(availableMods, token);
 				var modInstances = AssemblyManager.InstantiateMods(modsToLoad, token);
@@ -152,7 +152,7 @@ namespace Terraria.ModLoader
 				if (responsibleMods.Count == 1) {
 					var mod = availableMods.FirstOrDefault(m => m.Name == responsibleMods[0]); //use First rather than Single, incase of "Two mods with the same name" error message from ModOrganizer (#639)
 					if (mod != null)
-						msg += $" v{mod.properties.version}";
+						msg += $" v{mod.Version}";
 					if (mod != null && mod.tModLoaderVersion != BuildInfo.tMLVersion)
 						msg += "\n" + Language.GetTextValue("tModLoader.LoadErrorVersionMessage", mod.tModLoaderVersion, versionedName);
 					if (e is Exceptions.JITException)

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -145,7 +145,7 @@ namespace Terraria.ModLoader.UI
 				}
 				else if (ModLoader.PreviewFreezeNotification) {
 					ModLoader.PreviewFreezeNotification = false;
-					ModLoader.LastPreviewFreezeNotificationSeen = new Version(BuildInfo.tMLVersion.Major, BuildInfo.tMLVersion.Minor);
+					ModLoader.LastPreviewFreezeNotificationSeen = BuildInfo.tMLVersion.MajorMinor();
 					infoMessage.Show(Language.GetTextValue("tModLoader.MonthlyFreezeNotification"), Main.menuMode, null, Language.GetTextValue("tModLoader.ModsMoreInfo"),
 						() => {
 							SoundEngine.PlaySound(SoundID.MenuOpen);
@@ -352,7 +352,7 @@ namespace Terraria.ModLoader.UI
 			while (!exit) {
 				Console.WriteLine("Terraria Server " + Main.versionNumber2 + " - " + ModLoader.versionedName);
 				Console.WriteLine();
-				var mods = ModOrganizer.FindMods(logDuplicates: true);
+				var mods = ModOrganizer.FindMods();
 				for (int k = 0; k < mods.Length; k++) {
 					Console.Write((k + 1) + "\t\t" + mods[k].DisplayName);
 					Console.WriteLine(" (" + (mods[k].Enabled ? "enabled" : "disabled") + ")");

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
@@ -348,7 +348,7 @@ namespace Terraria.ModLoader.UI
 
 		private static void EnableList(UIMouseEvent evt, UIElement listeningElement) {
 			UIModPackItem modListItem = (UIModPackItem)listeningElement.Parent;
-			foreach (var mod in ModOrganizer.FindMods()) {
+			foreach (var mod in ModOrganizer.FoundMods) {
 				mod.Enabled = modListItem._mods.Contains(mod.Name);
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
@@ -230,9 +230,8 @@ namespace Terraria.ModLoader.UI
 				*/
 
 				// Export Publish ID information from Steam Workshop mods for easy re-downloading/downloading
-				if (ModOrganizer.TryReadManifest(ModOrganizer.GetParentDir(mod.File.path), out var info)) {
+				if (ModOrganizer.TryReadManifest(mod.File, out var info, out _))
 					workshopIds.Add(info.workshopEntryId.ToString());
-				}
 
 				// Copy the frozen mod to the Mod Pack if its different/new
 				if (mod.File.path != Path.Combine(modsPath, mod.Name + ".tmod"))

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -316,7 +316,7 @@ namespace Terraria.ModLoader.UI
 				var modPath = Path.Combine(ModLoader.ModPath, modName + ".tmod");
 				var modFile = new TmodFile(modPath);
 				using (modFile.Open()) // savehere, -tmlsavedirectory, normal (test linux too)
-					localMod = new LocalMod(modFile);
+					localMod = new LocalMod(ModLocation.Dev, modFile);
 
 				string icon = Path.Combine(ModCompile.ModSourcePath, modName, "icon_workshop.png");
 				if (!File.Exists(icon))
@@ -336,20 +336,16 @@ namespace Terraria.ModLoader.UI
 		}
 
 		private static void PublishModInner(LocalMod mod, string iconPath) {
-			var modFile = mod.modFile;
 			var bp = mod.properties;
 
-			if (bp.buildVersion != modFile.TModLoaderVersion)
-				throw new WebException(Language.GetTextValue("OutdatedModCantPublishError.BetaModCantPublishError"));
-
-			var changeLogFile = Path.Combine(ModCompile.ModSourcePath, modFile.Name, "changelog.txt");
+			var changeLogFile = Path.Combine(ModCompile.ModSourcePath, mod.Name, "changelog.txt");
 			string changeLog;
 			if (File.Exists(changeLogFile))
 				changeLog = File.ReadAllText(changeLogFile);
 			else
 				changeLog = "";
 
-			var workshopDescFile = Path.Combine(ModCompile.ModSourcePath, modFile.Name, "description_workshop.txt");
+			var workshopDescFile = Path.Combine(ModCompile.ModSourcePath, mod.Name, "description_workshop.txt");
 			string workshopDesc;
 			if (File.Exists(workshopDescFile))
 				workshopDesc = File.ReadAllText(workshopDescFile);
@@ -360,14 +356,14 @@ namespace Terraria.ModLoader.UI
 			{
 				{ "displayname", bp.displayName },
 				{ "displaynameclean", string.Join("", ChatManager.ParseMessage(bp.displayName, Color.White).Where(x => x.GetType() == typeof(TextSnippet)).Select(x => x.Text)) },
-				{ "name", modFile.Name },
-				{ "version", $"v{bp.version}" },
+				{ "name", mod.Name },
+				{ "version", $"v{mod.Version}" },
 				{ "author", bp.author },
 				{ "homepage", bp.homepage },
 				{ "description", workshopDesc },
 				{ "iconpath", iconPath },
-				{ "sourcesfolder", Path.Combine(ModCompile.ModSourcePath, modFile.Name) },
-				{ "modloaderversion", $"tModLoader v{modFile.TModLoaderVersion}" },
+				{ "sourcesfolder", Path.Combine(ModCompile.ModSourcePath, mod.Name) },
+				{ "modloaderversion", $"tModLoader v{mod.tModLoaderVersion}" },
 				{ "modreferences", string.Join(", ", bp.modReferences.Select(x => x.mod)) },
 				{ "modside", bp.side.ToFriendlyString() },
 				{ "changelog" , changeLog }
@@ -380,7 +376,7 @@ namespace Terraria.ModLoader.UI
 				throw new WebException($"You need to specify a version in build.txt");
 
 			if (!Main.dedServ) {
-				Main.MenuUI.SetState(new WorkshopPublishInfoStateForMods(Interface.modSources, modFile, values));
+				Main.MenuUI.SetState(new WorkshopPublishInfoStateForMods(Interface.modSources, mod.modFile, values));
 			}
 			else {
 				SocialAPI.LoadSteam();
@@ -391,7 +387,7 @@ namespace Terraria.ModLoader.UI
 					PreviewImagePath = iconPath
 				};
 				WorkshopHelper.ModManager.SteamUser = true;
-				SocialAPI.Workshop.PublishMod(modFile, values, publishSetttings);
+				SocialAPI.Workshop.PublishMod(mod.modFile, values, publishSetttings);
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -221,7 +221,7 @@ namespace Terraria.ModLoader.UI
 		internal void Populate() {
 			Task.Run(() => {
 				var modSources = ModCompile.FindModSources();
-				var modFiles = ModOrganizer.FindDevFolderMods();
+				var modFiles = ModOrganizer.FindAllMods().Where(m => m.location == ModLocation.Dev);
 				foreach (string sourcePath in modSources) {
 					var builtMod = modFiles.SingleOrDefault(m => m.Name == Path.GetFileName(sourcePath));
 					_items.Add(new UIModSourceItem(sourcePath, builtMod));

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -258,7 +258,7 @@ namespace Terraria.ModLoader.UI
 			}
 
 			// If auto reloading required mods is enabled, check if any mods need reloading and reload as required
-			if (ModLoader.autoReloadRequiredModsLeavingModsScreen && items.Count(i => i.NeedsReload) > 0) {
+			if (ModLoader.autoReloadRequiredModsLeavingModsScreen && items.Any(i => i.NeedsReload)) {
 				Main.menuMode = Interface.reloadModsID;
 				return;
 			}
@@ -396,7 +396,7 @@ namespace Terraria.ModLoader.UI
 
 		internal void Populate() {
 			Task.Run(() => {
-				var mods = ModOrganizer.FindMods(logDuplicates: true);
+				var mods = ModOrganizer.FindMods();
 				foreach (var mod in mods) {
 					UIModItem modItem = new UIModItem(mod);
 					modItem.Activate();

--- a/test/SortingTests.cs
+++ b/test/SortingTests.cs
@@ -21,7 +21,7 @@ namespace Terraria.ModLoader
 			ModSide side = ModSide.Both, string version = null,
 			IEnumerable<string> refs = null, IEnumerable<string> weakRefs = null,
 			IEnumerable<string> sortAfter = null, IEnumerable<string> sortBefore = null) {
-			return new LocalMod(new TmodFile(null, name), new BuildProperties {
+			return new LocalMod(default, new TmodFile(null, name), new BuildProperties {
 				side = side,
 				version = new Version(version ?? "1.0.0.0"),
 				modReferences = refs?.Select(BuildProperties.ModReference.Parse).ToArray() ?? new BuildProperties.ModReference[0],


### PR DESCRIPTION
### What is the new feature?
Changes to the priority of `.tmod` selection in `ModOrganizer` when multiple versions of the same mod exist, as well as more detailed logging about the selection process.

Old search order:
- Active mod pack
- Local `Mods` folder (which may have been synced from a server)
- Steam workshop folder
  - tML versions in order of newest to oldest

New search order:
- Active mod pack
- Highest _mod_ (not tML) version
- Steam workshop folder
- Local `Mods` folder

Additionally, mods with the `!playableOnPreview` flag will be excluded (unless they're in the local mods folder)

Other refactors and cleanups included.

### Why should this be part of tModLoader?

Fixes the following issues:
- An older version of a mod in the local mods folder (potentially synced from the server) is loaded instead of a newer version in the steam workshop folder, hiding updates and confusing users.
- If a preview version of a mod is published, but the mod author decides to put the new features on stable instead, they cannot delete or supercede the preview version. Higher mod versions on stable are ignored on preview (and when the month rolls over). #2897

### Are there alternative designs?
Server mods could be synced to a different directory (a decent idea for the future). 
Modders may not want the 'not playable on preview' feature to be dodged by copying the preview version from steam workshop into your local dev folder.

