### PR TITLE
[1.4] Fix modded generation passes not being removed

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -572,6 +572,8 @@ namespace Terraria.ModLoader
 			if (ItemSlot.singleSlotArray[0] != null) {
 				ItemSlot.singleSlotArray[0] = new Item();
 			}
+
+			WorldGen.ClearGenerationPasses(); // Clean up modded generation passes
 		}
 
 		public static Stream OpenRead(string assetName, bool newFileStream = false) {

--- a/patches/tModLoader/Terraria/WorldGen.TML.cs
+++ b/patches/tModLoader/Terraria/WorldGen.TML.cs
@@ -52,5 +52,6 @@ namespace Terraria
 		public static int dungeonLocation;
 		#endregion
 
+		internal static void ClearGenerationPasses() => _generator?._passes.Clear();
 	}
 }


### PR DESCRIPTION
### What is the bug?
#2410 

### How did you fix the bug?
Clear the list of generation passes

### Are there alternatives to your fix?
Run `WorldGen.ClearGenerationPasses()` inside `SystemLoader.Unload`
