### PR TITLE
Made ModTileEntity.Name property virtual

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -29,7 +29,7 @@ namespace Terraria.ModLoader
 		/// <summary>
 		/// The internal name of this ModTileEntity.
 		/// </summary>
-		public string Name => GetType().Name;
+		public virtual string Name => GetType().Name;
 
 		public string FullName => $"{Mod.Name}/{Name}";
 


### PR DESCRIPTION
### What is the new feature?
The ``Name`` property of ModTileEntity is now virtual

### Why should this be part of tModLoader?
This allows modders to change the internal name of an instance of ModTileEntity, which is vital for using Mod.AddContent to load tile entities manually, since two loaded tile entities cannot share the same name. It also allows modders to override the name of a tile entity to resolve a naming conflict or if they wish for a different internal name than the name of the type.

### Are there alternative designs?
No practical ones 

### Sample usage for the new feature
```cs
public class MyTileEntity : ModTileEntity {
    public string name;
    // this can now be overridden to change the internal name of a loaded tile entity
    public override string Name => name;

    public MyTileEntity(string name) {
        this.name = name;
    }

    public MyTileEntity(){}
}

pubic class MyModSystem : ModSystem {
    public override void Load() {
        Mod.AddContent(new MyTileEntity("coolEntity1"));
        Mod.AddContent(new MyTileEntity("coolEntity2"));
        Mod.AddContent(new MyTileEntity("splingus"));
        // this results in 3 tile entity types being created, all from the same class. 
        //These can be retrieved later using Mod.Find, the same as all other content loaded this way.
    }
}
```

### ExampleMod updates
N/A
