### PR TITLE
Fixed poor implementation of Load() in ModTileEntity.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -172,16 +172,15 @@ namespace Terraria.ModLoader
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
 			Load();
-
-			var legacyLoadMethod = GetType().GetMethod(nameof(Load), BindingFlags.Instance | BindingFlags.Public, new[] { typeof(Mod) });
-
-			if (legacyLoadMethod != null && legacyLoadMethod.DeclaringType != typeof(ModTileEntity)) {
-				legacyLoadMethod.Invoke(this, new[] { Mod });
-			}
+			Load_Obsolete(mod);
 
 			manager.Register(this);
 			ModTypeLookup<ModTileEntity>.Register(this);
 		}
+
+		[Obsolete]
+		private void Load_Obsolete(Mod mod)
+			=> Load(mod);
 
 		[Obsolete("Override the parameterless Load() overload instead.", true)]
 		public virtual void Load(Mod mod) { }

--- a/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTileEntity.cs
@@ -165,15 +165,28 @@ namespace Terraria.ModLoader
 		public sealed override TileEntity GenerateInstance() => ConstructFromBase(this);
 		public sealed override void RegisterTileEntityID(int assignedID) => Type = assignedID;
 
-		public virtual void Load(Mod mod) {
+		void ILoadable.Load(Mod mod) {
 			Mod = mod;
 
 			if (!Mod.loading)
 				throw new Exception("AddTileEntity can only be called from Mod.Load or Mod.Autoload");
 
+			Load();
+
+			var legacyLoadMethod = GetType().GetMethod(nameof(Load), BindingFlags.Instance | BindingFlags.Public, new[] { typeof(Mod) });
+
+			if (legacyLoadMethod != null && legacyLoadMethod.DeclaringType != typeof(ModTileEntity)) {
+				legacyLoadMethod.Invoke(this, new[] { Mod });
+			}
+
 			manager.Register(this);
 			ModTypeLookup<ModTileEntity>.Register(this);
 		}
+
+		[Obsolete("Override the parameterless Load() overload instead.", true)]
+		public virtual void Load(Mod mod) { }
+
+		public virtual void Load() { }
 
 		public virtual bool IsLoadingEnabled(Mod mod) => true;
 


### PR DESCRIPTION
This simple PR fixes the inconsistently present need to call `base.Load(Mod)` when overriding ModTileEntity's Load hook, and removes the `Mod` parameter in that said hook, making it all in line with ModType's Load implementation.

Old overload is kept as Obsolete, while still being called.