### PR TITLE
Fix #2935 (Display error and don't overwrite vanilla data when modded player save fails)

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -162,6 +162,7 @@
 		"LoadErrorResourceNotFoundPathHint": "Expected resource not found:\n    {0}\nClosest guess: (Is there a spelling or folder placement error?)\n    {1}",
 		"RuntimeErrorSilentlyCaughtException": "Silently Caught Exception: ",
 		"RuntimeErrorSeeLogsForFullTrace": "(see {0} for full trace)",
+		"PlayerSaveFail": "An error occurred while saving the player",
 		"OpenLogs": "Open Logs",
 		"OpenWebHelp": "Open Web Help",
 		"SkipToMainMenu": "Skip Loading Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -163,6 +163,7 @@
 		"LoadErrorResourceNotFoundPathHint": "未找到预期的资源:\n    {0}\n很可能:(是否拼写或文件夹放置错误?)\n    {1}",
 		"RuntimeErrorSilentlyCaughtException": "静默捕获异常: ",
 		"RuntimeErrorSeeLogsForFullTrace": "(请参阅 {0} 以获取完整调用堆栈)",
+		"PlayerSaveFail": "保存人物时发生错误",
 		"OpenLogs": "打开日志",
 		"OpenWebHelp": "打开网页帮助",
 		"SkipToMainMenu": "跳过加载模组",

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -21,7 +21,7 @@ namespace Terraria.ModLoader.IO
 
 		//make Terraria.Player.ENCRYPTION_KEY internal
 		//add to end of Terraria.Player.SavePlayer
-		public static void Save(TagCompound tag, string path, bool isCloudSave) {
+		internal static void Save(TagCompound tag, string path, bool isCloudSave) {
 			path = Path.ChangeExtension(path, ".tplr");
 			if (FileUtilities.Exists(path, isCloudSave))
 				FileUtilities.Copy(path, path + ".bak", isCloudSave);
@@ -33,7 +33,7 @@ namespace Terraria.ModLoader.IO
 			}
 		}
 
-		public static TagCompound SaveData(Player player) {
+		internal static TagCompound SaveData(Player player) {
 			return new TagCompound {
 				["armor"] = SaveInventory(player.armor),
 				["dye"] = SaveInventory(player.dye),
@@ -55,7 +55,7 @@ namespace Terraria.ModLoader.IO
 		}
 
 		//add near end of Terraria.Player.LoadPlayer before accessory check
-		public static void Load(Player player,TagCompound tag) {
+		internal static void Load(Player player, TagCompound tag) {
 			LoadInventory(player.armor, tag.GetList<TagCompound>("armor"));
 			LoadInventory(player.dye, tag.GetList<TagCompound>("dye"));
 			LoadInventory(player.inventory, tag.GetList<TagCompound>("inventory"));
@@ -74,7 +74,7 @@ namespace Terraria.ModLoader.IO
 			LoadUsedModPack(player, tag.GetString("usedModPack"));
 		}
 
-		public static bool TryLoadData(string path, bool isCloudSave, out TagCompound tag) {
+		internal static bool TryLoadData(string path, bool isCloudSave, out TagCompound tag) {
 			path = Path.ChangeExtension(path, ".tplr");
 			tag = new TagCompound();
 

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
 using Terraria.ModLoader.Default;

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -21,12 +21,20 @@ namespace Terraria.ModLoader.IO
 
 		//make Terraria.Player.ENCRYPTION_KEY internal
 		//add to end of Terraria.Player.SavePlayer
-		internal static void Save(Player player, string path, bool isCloudSave) {
+		public static void Save(TagCompound tag, string path, bool isCloudSave) {
 			path = Path.ChangeExtension(path, ".tplr");
 			if (FileUtilities.Exists(path, isCloudSave))
 				FileUtilities.Copy(path, path + ".bak", isCloudSave);
 
-			var tag = new TagCompound {
+			using (Stream stream = isCloudSave ? (Stream)new MemoryStream() : (Stream)new FileStream(path, FileMode.Create)) {
+				TagIO.ToStream(tag, stream);
+				if (isCloudSave && SocialAPI.Cloud != null)
+					SocialAPI.Cloud.Write(path, ((MemoryStream)stream).ToArray());
+			}
+		}
+
+		public static TagCompound SaveData(Player player) {
+			return new TagCompound {
 				["armor"] = SaveInventory(player.armor),
 				["dye"] = SaveInventory(player.dye),
 				["inventory"] = SaveInventory(player.inventory),
@@ -44,28 +52,10 @@ namespace Terraria.ModLoader.IO
 				["usedMods"] = SaveUsedMods(player),
 				["usedModPack"] = SaveUsedModPack(player)
 			};
-
-			using (Stream stream = isCloudSave ? (Stream)new MemoryStream() : (Stream)new FileStream(path, FileMode.Create)) {
-				TagIO.ToStream(tag, stream);
-				if (isCloudSave && SocialAPI.Cloud != null)
-					SocialAPI.Cloud.Write(path, ((MemoryStream)stream).ToArray());
-			}
 		}
+
 		//add near end of Terraria.Player.LoadPlayer before accessory check
-		internal static void Load(Player player, string path, bool isCloudSave) {
-			path = Path.ChangeExtension(path, ".tplr");
-
-			if (!FileUtilities.Exists(path, isCloudSave))
-				return;
-
-			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
-
-			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				//LoadLegacy(player, buf);
-				return;
-			}
-
-			var tag = TagIO.FromStream(new MemoryStream(buf));
+		public static void Load(Player player,TagCompound tag) {
 			LoadInventory(player.armor, tag.GetList<TagCompound>("armor"));
 			LoadInventory(player.dye, tag.GetList<TagCompound>("dye"));
 			LoadInventory(player.inventory, tag.GetList<TagCompound>("inventory"));
@@ -82,6 +72,24 @@ namespace Terraria.ModLoader.IO
 			LoadInfoDisplays(player, tag.GetList<string>("infoDisplays"));
 			LoadUsedMods(player, tag.GetList<string>("usedMods"));
 			LoadUsedModPack(player, tag.GetString("usedModPack"));
+		}
+
+		public static bool TryLoadData(string path, bool isCloudSave, out TagCompound tag) {
+			path = Path.ChangeExtension(path, ".tplr");
+			tag = new TagCompound();
+
+			if (!FileUtilities.Exists(path, isCloudSave))
+				return false;
+
+			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
+
+			if (buf[0] != 0x1F || buf[1] != 0x8B) {
+				//LoadLegacy(player, buf);
+				return false;
+			}
+
+			tag = TagIO.FromStream(new MemoryStream(buf));
+			return true;
 		}
 
 		public static List<TagCompound> SaveInventory(Item[] inv) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5682,34 +5682,30 @@
  				return false;
  
  			for (int i = x - 1; i <= x + 1; i++) {
-@@ -38052,7 +_,18 @@
+@@ -38052,7 +_,12 @@
  				}
  			}
  			catch (Exception exception) {
 -				FancyErrorPrinter.ShowFileSavingFailError(exception, playerFile.Path);
 +				FancyErrorPrinter.ShowFileSavingFailError(exception, playerFile.Path); // IO Exception
 +
-+				if(true && !Main.gameMenu) {
-+					if(Main.netMode==NetmodeID.SinglePlayer)
-+						WorldFile.SaveWorld();
-+					if(Main.netMode!=NetmodeID.Server) {
-+						WorldGen.JustQuit(); // Main.menuMode = 10
-+						Main.menuMode = MenuID.Title;
-+					}
-+				}
++				if (!Main.gameMenu)
++					WorldGen.SaveAndQuit();
 +
 +				Utils.ShowFancyErrorMessage($"{Language.GetTextValue("tModLoader.PlayerSaveFail")}\n\n{exception}", Main.menuMode);
  				throw;
  			}
  		}
-@@ -38067,20 +_,25 @@
+@@ -38067,20 +_,30 @@
  			if (string.IsNullOrEmpty(path))
  				return;
  
--			if (FileUtilities.Exists(path, isCloudSave))
--				FileUtilities.Copy(path, path + ".bak", isCloudSave);
--
-+			byte[] binary; // Priority data generation
++			/* tML - Delay vanilla saving until modded data is serialized (in case of exceptions)
+ 			if (FileUtilities.Exists(path, isCloudSave))
+ 				FileUtilities.Copy(path, path + ".bak", isCloudSave);
++			*/
+ 
++			byte[] bytes;
  			RijndaelManaged rijndaelManaged = new RijndaelManaged();
 -			using (Stream stream = isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create))) {
 +			using (Stream stream = (Stream)new MemoryStream(2000)) {
@@ -5825,26 +5821,31 @@
  							binaryWriter.Write(player.hideInfo[num7]);
  						}
  
-@@ -38225,11 +_,21 @@
+@@ -38225,11 +_,28 @@
  						binaryWriter.Flush();
  						cryptoStream.FlushFinalBlock();
  						stream.Flush();
--						if (isCloudSave && SocialAPI.Cloud != null)
--							SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
-+						binary = ((MemoryStream)stream).ToArray();
++
++						/* tML - Delay vanilla saving until modded data is serialized (in case of exceptions)
+ 						if (isCloudSave && SocialAPI.Cloud != null)
+ 							SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
++						*/
++						bytes = ((MemoryStream)stream).ToArray();
 +
 +						PlayerLoader.PostSavePlayer(player); // For native data only
  					}
  				}
  			}
 +
-+			var tag = PlayerIO.SaveData(player); // Priority data generation
++			// tML - Delay vanilla saving until modded data is serialized (in case of exceptions)
++			var tag = PlayerIO.SaveData(player);
 +
 +			BackupIO.Player.ArchivePlayer(path, isCloudSave);
 +			if (FileUtilities.Exists(path, isCloudSave))
 +				FileUtilities.Copy(path, path + ".bak", isCloudSave);
 +
-+			FileUtilities.WriteAllBytes(path, binary, isCloudSave);
++			FileUtilities.WriteAllBytes(path, bytes, isCloudSave);
++
 +			PlayerIO.Save(tag, path, isCloudSave);
  		}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5891,7 +5891,7 @@
  		}
  
 -		private static void LoadPlayer_LastMinuteFixes(Player newPlayer) {
-+		public static void LoadPlayer_LastMinuteFixes(Player newPlayer, PlayerFileData playerFileData) {
++		private static void LoadPlayer_LastMinuteFixes(Player newPlayer, PlayerFileData playerFileData) {
  			newPlayer.skinVariant = (int)MathHelper.Clamp(newPlayer.skinVariant, 0f, 11f);
 +			if(PlayerIO.TryLoadData(playerFileData.Path, playerFileData.IsCloudSave, out var tag))
 +				PlayerIO.Load(newPlayer, tag);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5682,16 +5682,37 @@
  				return false;
  
  			for (int i = x - 1; i <= x + 1; i++) {
-@@ -38067,6 +_,7 @@
+@@ -38052,7 +_,18 @@
+ 				}
+ 			}
+ 			catch (Exception exception) {
+-				FancyErrorPrinter.ShowFileSavingFailError(exception, playerFile.Path);
++				FancyErrorPrinter.ShowFileSavingFailError(exception, playerFile.Path); // IO Exception
++
++				if(true && !Main.gameMenu) {
++					if(Main.netMode==NetmodeID.SinglePlayer)
++						WorldFile.SaveWorld();
++					if(Main.netMode!=NetmodeID.Server) {
++						WorldGen.JustQuit(); // Main.menuMode = 10
++						Main.menuMode = MenuID.Title;
++					}
++				}
++
++				Utils.ShowFancyErrorMessage($"{Language.GetTextValue("tModLoader.PlayerSaveFail")}\n\n{exception}", Main.menuMode);
+ 				throw;
+ 			}
+ 		}
+@@ -38067,20 +_,25 @@
  			if (string.IsNullOrEmpty(path))
  				return;
  
-+			BackupIO.Player.ArchivePlayer(path, isCloudSave);
- 			if (FileUtilities.Exists(path, isCloudSave))
- 				FileUtilities.Copy(path, path + ".bak", isCloudSave);
- 
-@@ -38074,13 +_,20 @@
- 			using (Stream stream = isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create))) {
+-			if (FileUtilities.Exists(path, isCloudSave))
+-				FileUtilities.Copy(path, path + ".bak", isCloudSave);
+-
++			byte[] binary; // Priority data generation
+ 			RijndaelManaged rijndaelManaged = new RijndaelManaged();
+-			using (Stream stream = isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create))) {
++			using (Stream stream = (Stream)new MemoryStream(2000)) {
  				using (CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write)) {
  					using (BinaryWriter binaryWriter = new BinaryWriter(cryptoStream)) {
 +						PlayerLoader.PreSavePlayer(player);
@@ -5804,17 +5825,27 @@
  							binaryWriter.Write(player.hideInfo[num7]);
  						}
  
-@@ -38227,9 +_,13 @@
+@@ -38225,11 +_,21 @@
+ 						binaryWriter.Flush();
+ 						cryptoStream.FlushFinalBlock();
  						stream.Flush();
- 						if (isCloudSave && SocialAPI.Cloud != null)
- 							SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
+-						if (isCloudSave && SocialAPI.Cloud != null)
+-							SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
++						binary = ((MemoryStream)stream).ToArray();
 +
-+						PlayerLoader.PostSavePlayer(player);
++						PlayerLoader.PostSavePlayer(player); // For native data only
  					}
  				}
  			}
 +
-+			PlayerIO.Save(player, path, isCloudSave);
++			var tag = PlayerIO.SaveData(player); // Priority data generation
++
++			BackupIO.Player.ArchivePlayer(path, isCloudSave);
++			if (FileUtilities.Exists(path, isCloudSave))
++				FileUtilities.Copy(path, path + ".bak", isCloudSave);
++
++			FileUtilities.WriteAllBytes(path, binary, isCloudSave);
++			PlayerIO.Save(tag, path, isCloudSave);
  		}
  
  		private void SaveTemporaryItemSlotContents(BinaryWriter writer) {
@@ -5855,14 +5886,15 @@
  			catch {
  			}
  
-@@ -38803,9 +_,12 @@
+@@ -38803,9 +_,13 @@
  			}
  		}
  
 -		private static void LoadPlayer_LastMinuteFixes(Player newPlayer) {
 +		public static void LoadPlayer_LastMinuteFixes(Player newPlayer, PlayerFileData playerFileData) {
  			newPlayer.skinVariant = (int)MathHelper.Clamp(newPlayer.skinVariant, 0f, 11f);
-+			PlayerIO.Load(newPlayer, playerFileData.Path, playerFileData.IsCloudSave);
++			if(PlayerIO.TryLoadData(playerFileData.Path, playerFileData.IsCloudSave, out var tag))
++				PlayerIO.Load(newPlayer, tag);
  			for (int i = 3; i < 10; i++) {
 +				LoadPlayer_LastMinuteFixes(newPlayer.armor[i], newPlayer);
 +				/*


### PR DESCRIPTION
### What is the new feature?

When saving error occurs, do not save and kick out

### Why should this be part of tModLoader?

Protect players' data

### Are there alternative designs?

no
