### PR TITLE
Introduce concept of LTS to support #2932

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build tModLoader
 on:
   # This workflow runs when a push to 1.4 branch happens, or when a label is added to a pull request targetting 1.4 branch.
   push:
-    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4]
+    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4, lts_tModLoader]
   pull_request_target:
     types: [labeled]
     branches: [1.4-preview, 1.4-stable, 1.4, 1.4_mergedtesting]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,19 +77,19 @@ jobs:
            custom_tag: ${{ steps.version.outputs.new_version }}
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Check out LTS branch
+      - name: Check out stable branch
         uses: actions/checkout@v2
         with:
           ref: "1.4-stable"
           persist-credentials: false
           fetch-depth: 0
       
-      - name: LTS Version Fetch
-        id: lts
+      - name: stable Version Fetch
+        id: stable
         if: github.event_name == 'push'
         shell: bash
         run: |
-          echo "Fetching the LTS version of tmodloader"
+          echo "Fetching the stable version of tmodloader"
           version=$(git describe --tags --abbrev=0)
           
           regex="^v([0-9]+).([0-9]+).([0-9]+).([0-9]+)?$"
@@ -98,14 +98,14 @@ jobs:
             month="${BASH_REMATCH[2]}"
             feature="${BASH_REMATCH[3]}"
             patch="${BASH_REMATCH[4]}"
-            lts="$year.$month"
+            stable="$year.$month"
           else
             echo "Previous version '$version' is not a valid version"
             exit 1
           fi
           
-          echo "LTS is '$lts'"
-          echo "::set-output name=lts_version::$lts"
+          echo "stable is '$stable'"
+          echo "::set-output name=stable_version::$stable"
       
       - name: Re:Check out base branch
         uses: actions/checkout@v2
@@ -263,7 +263,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           TERRARIA_VERSION: 1436
           TMLVERSION: ${{ steps.version.outputs.new_version }}
-          LTSVERSION: ${{ steps.lts.outputs.lts_version }}
+          STABLEVERSION: ${{ steps.stable.outputs.stable_version }}
                     
       - name: Upload Debug Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build tModLoader
 on:
   # This workflow runs when a push to 1.4 branch happens, or when a label is added to a pull request targetting 1.4 branch.
   push:
-    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4, lts_tModLoader]
+    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4]
   pull_request_target:
     types: [labeled]
     branches: [1.4-preview, 1.4-stable, 1.4, 1.4_mergedtesting]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build tModLoader
 on:
   # This workflow runs when a push to 1.4 branch happens, or when a label is added to a pull request targetting 1.4 branch.
   push:
-    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4]
+    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4, lts_tmodloader]
   pull_request_target:
     types: [labeled]
     branches: [1.4-preview, 1.4-stable, 1.4, 1.4_mergedtesting]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,44 @@ jobs:
         with:
            custom_tag: ${{ steps.version.outputs.new_version }}
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+      
+      - name: Check out LTS branch
+        uses: actions/checkout@v2
+        with:
+          ref: "1.4-stable"
+          persist-credentials: false
+          fetch-depth: 0
+      
+      - name: LTS Version Fetch
+        id: lts
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          echo "Fetching the LTS version of tmodloader"
+          version=$(git describe --tags --abbrev=0)
+          
+          regex="^v([0-9]+).([0-9]+).([0-9]+).([0-9]+)?$"
+          if [[ $version =~ $regex ]] ; then
+            year="${BASH_REMATCH[1]}"
+            month="${BASH_REMATCH[2]}"
+            feature="${BASH_REMATCH[3]}"
+            patch="${BASH_REMATCH[4]}"
+            lts="$year.$month"
+          else
+            echo "Previous version '$version' is not a valid version"
+            exit 1
+          fi
+          
+          echo "LTS is '$lts'"
+          echo "::set-output name=lts_version::$lts"
+      
+      - name: Re:Check out base branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.ref}}
+          persist-credentials: false
+          fetch-depth: 0
+      
       - name: Check out pull request code to separate folder
         uses: actions/checkout@v2
         if: github.event_name == 'pull_request_target'
@@ -226,6 +263,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           TERRARIA_VERSION: 1436
           TMLVERSION: ${{ steps.version.outputs.new_version }}
+          LTSVERSION: ${{ steps.lts.outputs.lts_version }}
                     
       - name: Upload Debug Build Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build tModLoader
 on:
   # This workflow runs when a push to 1.4 branch happens, or when a label is added to a pull request targetting 1.4 branch.
   push:
-    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4, lts_tmodloader]
+    branches: [1.4_mergedtesting, gh_actions_test, 1.4-preview, 1.4-stable, 1.4]
   pull_request_target:
     types: [labeled]
     branches: [1.4-preview, 1.4-stable, 1.4, 1.4_mergedtesting]

--- a/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
@@ -15,7 +15,7 @@ namespace Terraria.ModLoader
 		public static readonly string BuildIdentifier = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
 		public static readonly Version tMLVersion;
-		public static readonly Version ltsVersion;
+		public static readonly Version stableVersion;
 		public static readonly BuildPurpose Purpose;
 		public static readonly string BranchName;
 		public static readonly string CommitSHA;
@@ -40,7 +40,7 @@ namespace Terraria.ModLoader
 			int i = 0;
 
 			tMLVersion = new Version(parts[i++]);
-			ltsVersion = new Version(parts[i++]);
+			stableVersion = new Version(parts[i++]);
 			BranchName = parts[i++];
 			Enum.TryParse(parts[i++], true, out Purpose);
 			CommitSHA = parts[i++];

--- a/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
@@ -15,6 +15,7 @@ namespace Terraria.ModLoader
 		public static readonly string BuildIdentifier = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
 		public static readonly Version tMLVersion;
+		public static readonly Version ltsVersion;
 		public static readonly BuildPurpose Purpose;
 		public static readonly string BranchName;
 		public static readonly string CommitSHA;
@@ -37,23 +38,24 @@ namespace Terraria.ModLoader
 		static BuildInfo() {
 			var parts = BuildIdentifier.Substring(BuildIdentifier.IndexOf('+')+1).Split('|');
 			tMLVersion = new Version(parts[0]);
-			if (parts.Length>=2) {
-				BranchName = parts[1];
+			ltsVersion = new Version(parts[1]);
+			if (parts.Length>=3) {
+				BranchName = parts[2];
 			}
 			else {
 				BranchName = "unknown";
 			}
-			if (parts.Length>=3) {
-				Enum.TryParse(parts[2], true, out Purpose);
-			}
 			if (parts.Length>=4) {
-				CommitSHA = parts[3];
+				Enum.TryParse(parts[3], true, out Purpose);
+			}
+			if (parts.Length>=5) {
+				CommitSHA = parts[4];
 			}
 			else {
 				CommitSHA = "unknown";
 			}
-			if (parts.Length>=5) {
-				BuildDate = DateTime.FromBinary(long.Parse(parts[4])).ToLocalTime();
+			if (parts.Length>=6) {
+				BuildDate = DateTime.FromBinary(long.Parse(parts[5])).ToLocalTime();
 			}
 
 			// Version name for players

--- a/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
@@ -37,26 +37,14 @@ namespace Terraria.ModLoader
 
 		static BuildInfo() {
 			var parts = BuildIdentifier.Substring(BuildIdentifier.IndexOf('+')+1).Split('|');
-			tMLVersion = new Version(parts[0]);
-			ltsVersion = new Version(parts[1]);
-			if (parts.Length>=3) {
-				BranchName = parts[2];
-			}
-			else {
-				BranchName = "unknown";
-			}
-			if (parts.Length>=4) {
-				Enum.TryParse(parts[3], true, out Purpose);
-			}
-			if (parts.Length>=5) {
-				CommitSHA = parts[4];
-			}
-			else {
-				CommitSHA = "unknown";
-			}
-			if (parts.Length>=6) {
-				BuildDate = DateTime.FromBinary(long.Parse(parts[5])).ToLocalTime();
-			}
+			int i = 0;
+
+			tMLVersion = new Version(parts[i++]);
+			ltsVersion = new Version(parts[i++]);
+			BranchName = parts[i++];
+			Enum.TryParse(parts[i++], true, out Purpose);
+			CommitSHA = parts[i++];
+			BuildDate = DateTime.FromBinary(long.Parse(parts[i++])).ToLocalTime();
 
 			// Version name for players
 			versionedName = $"tModLoader v{tMLVersion}";

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -531,7 +531,8 @@ namespace Terraria.ModLoader.Core
 		}
 
 		internal static void CleanupOldPublish(string repo) {
-			RemoveSkippablePreview(repo);
+			if (BuildInfo.IsPreview)
+				RemoveSkippablePreview(repo);
 
 			string[] tmods = Directory.GetFiles(repo, "*.tmod", SearchOption.AllDirectories);
 			if (tmods.Length <= 3)

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -21,7 +21,7 @@
 -    <AssemblyName>$(AssemblyName)Release</AssemblyName>
 +  <PropertyGroup>
 +    <tMLVersion Condition="'$(TmlVersion)' == ''">9999.0</tMLVersion>
-+	<LTSVersion Condition="'$(LTSVersion)' == ''">0.12</LTSVersion>
++	<LTSVersion Condition="'$(LTSVersion)' == ''">0.0</LTSVersion>
 +    <BuildPurpose Condition="'$(BuildPurpose)' == ''">dev</BuildPurpose>
 +    <BranchName Condition="'$(BranchName)' == ''">unknown</BranchName>
 +    <BranchName>$(BranchName.Replace("|","-"))</BranchName>

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -21,13 +21,13 @@
 -    <AssemblyName>$(AssemblyName)Release</AssemblyName>
 +  <PropertyGroup>
 +    <tMLVersion Condition="'$(TmlVersion)' == ''">9999.0</tMLVersion>
-+	<LTSVersion Condition="'$(LTSVersion)' == ''">0.0</LTSVersion>
++	<StableVersion Condition="'$(stableVersion)' == ''">0.0</StableVersion>
 +    <BuildPurpose Condition="'$(BuildPurpose)' == ''">dev</BuildPurpose>
 +    <BranchName Condition="'$(BranchName)' == ''">unknown</BranchName>
 +    <BranchName>$(BranchName.Replace("|","-"))</BranchName>
 +    <CommitSHA Condition="'$(CommitSHA)' == ''">unknown</CommitSHA>
 +    <BuildDate>$([System.DateTime]::UtcNow.ToBinary())</BuildDate>
-+    <SourceRevisionId>$(tMLVersion)|$(LTSVersion)|$(BranchName)|$(BuildPurpose)|$(CommitSHA)|$(BuildDate)</SourceRevisionId>
++    <SourceRevisionId>$(tMLVersion)|$(StableVersion)|$(BranchName)|$(BuildPurpose)|$(CommitSHA)|$(BuildDate)</SourceRevisionId>
    </PropertyGroup>
    <PropertyGroup>
      <OutputName>$(AssemblyName)</OutputName>

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -7,26 +_,27 @@
+@@ -7,26 +_,28 @@
      <Company>Re-Logic</Company>
      <Copyright>Copyright © 2022 Re-Logic</Copyright>
      <RootNamespace>Terraria</RootNamespace>
@@ -21,12 +21,13 @@
 -    <AssemblyName>$(AssemblyName)Release</AssemblyName>
 +  <PropertyGroup>
 +    <tMLVersion Condition="'$(TmlVersion)' == ''">9999.0</tMLVersion>
++	<LTSVersion Condition="'$(LTSVersion)' == ''">0.12</LTSVersion>
 +    <BuildPurpose Condition="'$(BuildPurpose)' == ''">dev</BuildPurpose>
 +    <BranchName Condition="'$(BranchName)' == ''">unknown</BranchName>
 +    <BranchName>$(BranchName.Replace("|","-"))</BranchName>
 +    <CommitSHA Condition="'$(CommitSHA)' == ''">unknown</CommitSHA>
 +    <BuildDate>$([System.DateTime]::UtcNow.ToBinary())</BuildDate>
-+    <SourceRevisionId>$(tMLVersion)|$(BranchName)|$(BuildPurpose)|$(CommitSHA)|$(BuildDate)</SourceRevisionId>
++    <SourceRevisionId>$(tMLVersion)|$(LTSVersion)|$(BranchName)|$(BuildPurpose)|$(CommitSHA)|$(BuildDate)</SourceRevisionId>
    </PropertyGroup>
    <PropertyGroup>
      <OutputName>$(AssemblyName)</OutputName>


### PR DESCRIPTION
This PR adds the long term service metadata to tmodloader builds to allow for extended preview periods.

This is in support of #2932 .

We will still need to disable the relevant portions of MonthlyMerge.yml & PReviewChanges.yml during such periods manually.