### PR TITLE
Fix Item.DropItem Sharing ModItems

### DIFF
--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -205,6 +205,8 @@ namespace Terraria
 
 			droppedItem.ModItem = item.ModItem;
 			droppedItem.globalItems = item.globalItems;
+			if (droppedItem.ModItem != null)
+				droppedItem.ModItem.Entity = droppedItem;
 
 			if (Main.netMode == NetmodeID.Server)
 				NetMessage.SendData(21, -1, -1, null, droppedItemId);


### PR DESCRIPTION
### What is the bug?
Items dropped using `Item.DropItem()` would have their `ModItem` linked to two different `Item`s -- the one dropped in the world that the player can interact with and pick up, and the one passed into `DropItem()` that is ultimately lost. This would result in any modifications done to `ModItem.Item` not applying to the player's version of the item. For example, dual-use items that modify an item's fields on use would inexplicably break after being placed and retrieved from Plates or Item Frames.

### How did you fix the bug?
Reassigned `ModItem.Entity` for the newly-dropped `Item`.

### Are there alternatives to your fix?
Not that I'm aware of.