### PR TITLE
Fix issue: Stackable Items Use Void Bag Text On Pickup #2976

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4055,7 +4055,7 @@
 +					Recipe.FindRecipes();
 +
 +				if (!settings.NoText)
-+					PopupText.NewText(PopupTextContext.ItemPickupToVoidContainer, newItem, numTransfered, noStack: false, settings.LongText);
++					PopupText.NewText(PopupTextContext.RegularItemPickup, newItem, numTransfered, noStack: false, settings.LongText);
 +
 +				AchievementsHelper.NotifyItemPickup(this, returnItem);
 +				settings.HandlePostAction(inventory[i]);


### PR DESCRIPTION
This issue was introduced by the OnStack PR.  I probably copy/pasted the void bag pick up code since it was almost identical and didn't realize the popup text difference.