### PR TITLE
UI Fixes

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -170,12 +170,12 @@
 
 		// Mod Info
 		"ModInfoHeader": "Mod Info: ",
-		"ModInfoVisitHomepage": "Visit the Mod's Homepage for even more info",
+		"ModInfoVisitHomepage": "Homepage",
 		"ModInfoExtract": "Extract",
 		"ModInfoNoDescriptionAvailable": "No description available",
 		"ModInfoProblemTryAgain": "There was a problem, try again",
 		"ModInfoDisableModToDelete": "Disable Mod to Delete",
-		"ModInfoVisitSteampage": "Visit the Mod's Steam Workshop page",
+		"ModInfoVisitSteampage": "Steam Workshop page",
 
 		// Mod Packs
 		"ModPacksHeader": "Mod Packs",

--- a/patches/tModLoader/Terraria/ModLoader/UI/UICommon.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UICommon.cs
@@ -15,23 +15,33 @@ namespace Terraria.ModLoader.UI
 	{
 		public static Color DefaultUIBlue = new Color(73, 94, 171);
 		public static Color DefaultUIBlueMouseOver = new Color(63, 82, 151) * 0.7f;
+		public static Color DefaultUIBorder = Color.Black;
+		public static Color DefaultUIBorderMouseOver = Colors.FancyUIFatButtonMouseOver;
 		public static Color MainPanelBackground = new Color(33, 43, 79) * 0.8f;
 
 		public static StyleDimension MaxPanelWidth = new StyleDimension(600, 0);
 
-		public static T WithFadedMouseOver<T>(this T elem, Color overColor = default, Color outColor = default) where T : UIPanel {
+		public static T WithFadedMouseOver<T>(this T elem, Color overColor = default, Color outColor = default, Color overBorderColor = default, Color outBorderColor = default) where T : UIPanel {
 			if (overColor == default)
 				overColor = DefaultUIBlue;
 
 			if (outColor == default)
 				outColor = DefaultUIBlueMouseOver;
 
+			if (overBorderColor == default)
+				overBorderColor = DefaultUIBorderMouseOver;
+
+			if (outBorderColor == default)
+				outBorderColor = DefaultUIBorder;
+
 			elem.OnMouseOver += (evt, _) => {
 				SoundEngine.PlaySound(SoundID.MenuTick);
 				elem.BackgroundColor = overColor;
+				elem.BorderColor = overBorderColor;
 			};
 			elem.OnMouseOut += (evt, _) => {
 				elem.BackgroundColor = outColor;
+				elem.BorderColor = outBorderColor;
 			};
 			return elem;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
@@ -43,7 +43,7 @@ namespace Terraria.ModLoader.UI
 		public override void OnInitialize() {
 			_uIElement = new UIElement {
 				Width = {Percent = 0.8f},
-				MaxWidth = UICommon.MaxPanelWidth,
+				MaxWidth = new StyleDimension(800f, 0f), //UICommon.MaxPanelWidth,
 				Top = {Pixels = 220},
 				Height = {Pixels = -220, Percent = 1f},
 				HAlign = 0.5f
@@ -78,7 +78,7 @@ namespace Terraria.ModLoader.UI
 			_uIElement.Append(_uITextPanel);
 
 			_modHomepageButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoVisitHomepage")) {
-				Width = {Percent = 0.5f},
+				Width = {Percent = 0.49f},
 				Height = {Pixels = 40},
 				HAlign = 1f,
 				VAlign = 1f,
@@ -87,7 +87,7 @@ namespace Terraria.ModLoader.UI
 			_modHomepageButton.OnClick += VisitModHomePage;
 
 			_modSteamButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoVisitSteampage")) {
-				Width = { Percent = 0.5f },
+				Width = { Percent = 0.49f },
 				Height = { Pixels = 40 },
 				HAlign = 0f,
 				VAlign = 1f,


### PR DESCRIPTION
2 things have been fixed / changed:
The mod info UI
Button's changing border colour when hovered over

The mod info UI was previously cramped and difficult to read in, so the panel width has been increased. Additionally, the homepage and workshop page buttons had scaled down text inside of them and were unaligned, so they now have correct spacing and the text inside of them doesn't have to be shrunk down to fit in them.

Modded buttons had previously only changed their background colour when they were moused over, which is different to the vanilla buttons. Now they will have their border changed when they are moused over to better fit them in with the vanilla UI.