### PR TITLE
#1616 fix by separating collision check hook from melee hit hook

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -113,6 +113,32 @@ namespace Terraria.ModLoader
 			return result;
 		}
 
+		//TODO: Clean up code duplications in methods with same way of combining hooks result
+		public static bool? CanPlayerMeleeAttackCollideWithNPC(Player player, Item item, Rectangle meleeAttackHitbox, NPC target) {
+			bool? result = null;
+
+			bool ModifyResult(bool? nbool) {
+				if (nbool.HasValue) {
+					result = nbool.Value;
+				}
+				return result != false;
+			}
+
+			if (!ModifyResult(PlayerLoader.CanMeleeAttackCollideWithNPC(player, item, meleeAttackHitbox, target))) {
+				return false;
+			}
+
+			if (!ModifyResult(ItemLoader.CanMeleeAttackCollideWithNPC(item, meleeAttackHitbox, player, target))) {
+				return false;
+			}
+
+			if (!ModifyResult(NPCLoader.CanBeCollidedWithPlayerMeleeAttack(target, player, item, meleeAttackHitbox))) {
+				return false;
+			}
+
+			return result;
+		}
+
 		public static void ModifyItemScale(Player player, Item item, ref float scale) {
 			ItemLoader.ModifyItemScale(item, player, ref scale);
 			PlayerLoader.ModifyItemScale(player, item, ref scale);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -451,6 +451,20 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine whether a melee weapon can collide with the given NPC when swung.
+		/// </summary>
+		/// <param name="item">The weapon item the player is holding.</param>
+		/// <param name="meleeAttackHitbox">Hitbox of melee attack.</param>
+		/// <param name="player">The player wielding this item.</param>
+		/// <param name="target">The target npc.</param>
+		/// <returns>
+		/// Return true to allow colliding with target, return false to block the weapon from colliding with target, and return null to use the vanilla code for whether the target can be colliding. Returns null by default.
+		/// </returns>
+		public virtual bool? CanMeleeAttackCollideWithNPC(Item item, Rectangle meleeAttackHitbox, Player player, NPC target) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the damage, knockback, etc., that a melee weapon does to an NPC.
 		/// </summary>
 		public virtual void ModifyHitNPC(Item item, Player player, NPC target, ref int damage, ref float knockBack, ref bool crit) {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -333,6 +333,19 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine whether an NPC can be collided with the player melee weapon when swung.
+		/// </summary>
+		/// <param name="player">The player wielding this item.</param>
+		/// <param name="item">The weapon item the player is holding.</param>
+		/// <param name="meleeAttackHitbox">Hitbox of melee attack.</param>
+		/// <returns>
+		/// Return true to allow colliding with the melee attack, return false to block the weapon from colliding with the NPC, and return null to use the vanilla code for whether the attack can be colliding. Returns null by default.
+		/// </returns>
+		public virtual bool? CanBeCollidedWithPlayerMeleeAttack(NPC npc, Player player, Item item, Rectangle meleeAttackHitbox) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the damage, knockback, etc., that an NPC takes from a melee weapon.
 		/// </summary>
 		/// <param name="npc"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -859,6 +859,38 @@ namespace Terraria.ModLoader
 			return flag;
 		}
 
+		private static HookList HookCanCollideNPC = AddHook<Func<Item, Rectangle, Player, NPC, bool?>>(g => g.CanMeleeAttackCollideWithNPC);
+
+		public static bool? CanMeleeAttackCollideWithNPC(Item item, Rectangle meleeAttackHitbox, Player player, NPC target) {
+			bool? flag = null;
+
+			foreach (var g in HookCanCollideNPC.Enumerate(item.globalItems)) {
+				bool? canCollide = g.CanMeleeAttackCollideWithNPC(item, meleeAttackHitbox, player, target);
+
+				if (canCollide.HasValue) {
+					if (!canCollide.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			if (item.ModItem != null) {
+				bool? canHit = item.ModItem.CanMeleeAttackCollideWithNPC(meleeAttackHitbox, player, target);
+
+				if (canHit.HasValue) {
+					if (!canHit.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
+
 		private delegate void DelegateModifyHitNPC(Item item, Player player, NPC target, ref int damage, ref float knockBack, ref bool crit);
 		private static HookList HookModifyHitNPC = AddHook<DelegateModifyHitNPC>(g => g.ModifyHitNPC);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -534,6 +534,19 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine whether a melee weapon can collide with the given NPC when swung.
+		/// </summary>
+		/// <param name="meleeAttackHitbox">Hitbox of melee attack.</param>
+		/// <param name="player">The player wielding this item.</param>
+		/// <param name="target">The target npc.</param>
+		/// <returns>
+		/// Return true to allow colliding with target, return false to block the weapon from colliding with target, and return null to use the vanilla code for whether the target can be colliding. Returns null by default.
+		/// </returns>
+		public virtual bool? CanMeleeAttackCollideWithNPC(Rectangle meleeAttackHitbox, Player player, NPC target) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the damage, knockback, etc., that this melee weapon does to an NPC.
 		/// </summary>
 		/// <param name="player">The player.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -403,6 +403,19 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine whether an NPC can be collided with the player melee weapon when swung.
+		/// </summary>
+		/// <param name="player">The player wielding this item.</param>
+		/// <param name="item">The weapon item the player is holding.</param>
+		/// <param name="meleeAttackHitbox">Hitbox of melee attack.</param>
+		/// <returns>
+		/// Return true to allow colliding with the melee attack, return false to block the weapon from colliding with the NPC, and return null to use the vanilla code for whether the attack can be colliding. Returns null by default.
+		/// </returns>
+		public virtual bool? CanBeCollidedWithPlayerMeleeAttack(Player player, Item item, Rectangle meleeAttackHitbox) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the damage, knockback, etc., that this NPC takes from a melee weapon.
 		/// </summary>
 		/// <param name="player"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -570,6 +570,19 @@ namespace Terraria.ModLoader
 		}
 
 		/// <summary>
+		/// Allows you to determine whether a player melee attack can collide the given NPC by swinging a melee weapon.
+		/// </summary>
+		/// <param name="item">The weapon item the player is holding.</param>
+		/// <param name="meleeAttackHitbox">Hitbox of melee attack.</param>>
+		/// <param name="target">The target npc.</param>
+		/// <returns>
+		/// Return true to allow colliding the target, return false to block the player weapon from colliding the target, and return null to use the vanilla code for whether the target can be colliding by melee weapon. Returns null by default.
+		/// </returns>
+		public virtual bool? CanMeleeAttackCollideWithNPC(Item item, Rectangle meleeAttackHitbox, NPC target) {
+			return null;
+		}
+
+		/// <summary>
 		/// Allows you to modify the damage, knockback, etc., that this player does to an NPC by swinging a melee weapon.
 		/// </summary>
 		/// <param name="item"></param>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -656,6 +656,38 @@ namespace Terraria.ModLoader
 			return flag;
 		}
 
+		private static HookList HookCanBeCollidedWithPlayerMeleeAttack = AddHook<Func<NPC, Player, Item, Rectangle, bool?>>(g => g.CanBeCollidedWithPlayerMeleeAttack);
+		public static bool? CanBeCollidedWithPlayerMeleeAttack(NPC npc, Player player, Item item, Rectangle meleeAttackHitbox) {
+			bool? flag = null;
+
+			foreach (GlobalNPC g in HookCanBeCollidedWithPlayerMeleeAttack.Enumerate(npc.globalNPCs)) {
+				bool? canCollide = g.CanBeCollidedWithPlayerMeleeAttack(npc, player, item, meleeAttackHitbox);
+
+				if (canCollide.HasValue) {
+					if (!canCollide.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+
+			}
+
+			if (npc.ModNPC != null) {
+				bool? canHit = npc.ModNPC.CanBeCollidedWithPlayerMeleeAttack(player, item, meleeAttackHitbox);
+
+				if (canHit.HasValue) {
+					if (!canHit.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
+
 		private delegate void DelegateModifyHitByItem(NPC npc, Player player, Item item, ref int damage, ref float knockback, ref bool crit);
 		private static HookList HookModifyHitByItem = AddHook<DelegateModifyHitByItem>(g => g.ModifyHitByItem);
 

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -732,6 +732,26 @@ namespace Terraria.ModLoader
 			return flag;
 		}
 
+		private static HookList HookCanCollideNPCWithItem = AddHook<Func<Item, Rectangle, NPC, bool?>>(p => p.CanMeleeAttackCollideWithNPC);
+
+		public static bool? CanMeleeAttackCollideWithNPC(Player player, Item item, Rectangle meleeAttackHitbox, NPC target) {
+			bool? flag = null;
+
+			foreach (var modPlayer in HookCanCollideNPCWithItem.Enumerate(player.modPlayers)) {
+				bool? canHit = modPlayer.CanMeleeAttackCollideWithNPC(item, meleeAttackHitbox, target);
+
+				if (canHit.HasValue) {
+					if (!canHit.Value) {
+						return false;
+					}
+
+					flag = true;
+				}
+			}
+
+			return flag;
+		}
+
 		private delegate void DelegateModifyHitNPC(Item item, NPC target, ref int damage, ref float knockback, ref bool crit);
 		private static HookList HookModifyHitNPC = AddHook<DelegateModifyHitNPC>(p => p.ModifyHitNPC);
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4715,7 +4715,7 @@
  				if (Main.netMode != 0)
  					NetMessage.SendPlayerHurt(i, playerDeathReason, num, direction, flag, pvp: true, -1);
  
-@@ -31142,11 +_,18 @@
+@@ -31142,11 +_,23 @@
  				if (!Main.npc[i].active || Main.npc[i].immune[whoAmI] != 0 || attackCD != 0)
  					continue;
  
@@ -4728,12 +4728,18 @@
  				Main.npc[i].position += Main.npc[i].netOffset;
 -				if (!Main.npc[i].dontTakeDamage && CanNPCBeHitByPlayerOrPlayerProjectile(Main.npc[i])) {
 -					if (!Main.npc[i].friendly || (Main.npc[i].type == 22 && killGuide) || (Main.npc[i].type == 54 && killClothier)) {
+-						Rectangle value = new Rectangle((int)Main.npc[i].position.X, (int)Main.npc[i].position.Y, Main.npc[i].width, Main.npc[i].height);
+-						if (itemRectangle.Intersects(value) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i]))) {
 +				if (modCanHit == true || ((!Main.npc[i].dontTakeDamage && CanNPCBeHitByPlayerOrPlayerProjectile(Main.npc[i])))) {
 +					if (modCanHit == true || ((!Main.npc[i].friendly || (Main.npc[i].type == 22 && killGuide) || (Main.npc[i].type == 54 && killClothier)))) {
- 						Rectangle value = new Rectangle((int)Main.npc[i].position.X, (int)Main.npc[i].position.Y, Main.npc[i].width, Main.npc[i].height);
 +
--						if (itemRectangle.Intersects(value) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i]))) {
-+						if (modCanHit == true || (itemRectangle.Intersects(value) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i])))) {
++						bool? modCanCollide = CombinedHooks.CanPlayerMeleeAttackCollideWithNPC(this, sItem, itemRectangle, Main.npc[i]);
++
++						if (modCanCollide == false) {
++							continue;
++						}
++
++						if (modCanCollide == true || (itemRectangle.Intersects(Main.npc[i].getRect()) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i])))) {
  							int num = originalDamage;
  							bool flag = false;
  							int weaponCrit = GetWeaponCrit(sItem);
@@ -4765,6 +4771,22 @@
  							ApplyNPCOnHitEffects(sItem, itemRectangle, num, knockBack, i, num6, dmgDone);
  							int num7 = Item.NPCtoBanner(Main.npc[i].BannerID());
  							if (num7 >= 0)
+@@ -31227,7 +_,14 @@
+ 				}
+ 				else if (Main.npc[i].type == 63 || Main.npc[i].type == 64 || Main.npc[i].type == 103 || Main.npc[i].type == 242) {
+ 					Rectangle value2 = new Rectangle((int)Main.npc[i].position.X, (int)Main.npc[i].position.Y, Main.npc[i].width, Main.npc[i].height);
+-					if (itemRectangle.Intersects(value2) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i]))) {
++
++					bool? modCanCollide = CombinedHooks.CanPlayerMeleeAttackCollideWithNPC(this, sItem, itemRectangle, Main.npc[i]);
++
++					if (modCanCollide == false) {
++						continue;
++					}
++
++					if (modCanCollide == true || (itemRectangle.Intersects(Main.npc[i].getRect()) && (Main.npc[i].noTileCollide || CanHit(Main.npc[i])))) {
+ 						Hurt(PlayerDeathReason.LegacyDefault(), (int)((double)Main.npc[i].damage * 1.3), -direction);
+ 						Main.npc[i].immune[whoAmI] = itemAnimation;
+ 						attackCD = (int)((double)itemAnimationMax * 0.33);
 @@ -31438,11 +_,13 @@
  		}
  


### PR DESCRIPTION
### What is the new feature?
Hooks that called through `CombinedHooks.CanPlayerHitNPCWithItem` no longer ingores melee hitbox collision if methods returns true (for example already existing `ModPlayer.CanHitNPCWithProj` doesn't ignores the collision).
New methods works simular to `CombinedHooks.CanPlayerHitNPCWithItem` _(same way of combining hooks output, uses vanilla logic if returns null)_, but also have a hitbox of melee attack as additional parameter for custom hitbox check.


### Why should this be part of tModLoader?
It adds much more predictable behavior of metioned hook methods, and more flexibility. (Personally i facing with this same issue when trying to make custom voodoo doll to my mod).

### Are there alternative designs?
direwolf suggested a few in #1616.

### Sample usage for the new feature
Creating a custom voodoo doll:
```cs
public class VoodooDollPlayer : ModPlayer {

    private bool _canKillSomeNPC = false;
    
    public void AllowKillSomeNpc() { // This is called from SomeVoodooDollItem.UpdateEquip
        _canKillSomeNPC = true;
    }
    
    public override bool? CanHitNPC(Item item, NPC target) {
        if (_canKillSomeNPC && target.type == /* some npc id */) {
            return true; // This is no longer ignores collision (previously the player could hit NPCs from any distance)
        }
        
        return null;
    }
    
    // ... 
}
```

Modifying melee hit collision check with new hook:
```cs
public class CannotHitCloseNPCsPlayer : ModPlayer {

    public override bool? CanMeleeAttackCollideWithNPC(Item item, Rectangle meleeAttackHitbox, NPC target) {
        Rectangle playerHitbox = Player.getRect();
        Rectangle tagetNPCHitbox = target.getRect();
        
        if (playerHitbox.Intersects(targetNPCHitbox)) {
           return false; // Player can't damage npc
        }

        return null; // Vanilla collision check
    }
    
    // ...
}
```
### Porting notes
`ModPlayer.CanHitNPC`, `ModItem.CanHitNPC`, `GlobalItem.CanHitNPC`, `ModNPC.CanBeHitByItem` and `GlobalNPC.CanBeHitByItem` now won't ignore the hitbox collision checks when returning `true` in them. 
Collision checking happens after them. To disable collision checking return `true` from corresponding methods: `ModPlayer.CanMeleeAttackCollideWithNPC`, `ModItem.CanMeleeAttackCollideWithNPC`, `GlobalItem.CanMeleeAttackCollideWithNPC`, `ModNPC.CanBeCollidedWithPlayerMeleeAttack`, `GlobalNPC.CanBeCollidedWithPlayerMeleeAttack` _(Also be aware that the collision check also happens if CanHitNPC returns null and the npc can get hit via vanilla behavior)_.