### PR TITLE
Change some Patreon wings to use WingStats

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/AetherBreaker.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/AetherBreaker.cs
@@ -48,6 +48,12 @@
 	[AutoloadEquip(EquipType.Wings)]
 	internal class AetherBreaker_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
+		}
+		
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -55,10 +61,6 @@
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Coolmike5000.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Coolmike5000.cs
@@ -36,6 +36,12 @@
 	[AutoloadEquip(EquipType.Wings)]
 	internal class Coolmike5000_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
+		}
+		
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -43,10 +49,6 @@
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Sailing_Squid.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Sailing_Squid.cs
@@ -36,6 +36,12 @@
 	[AutoloadEquip(EquipType.Wings)]
 	internal class Sailing_Squid_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
+		}
+		
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -43,10 +49,6 @@
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Zeph.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/Zeph.cs
@@ -36,6 +36,12 @@
 	[AutoloadEquip(EquipType.Wings)]
 	internal class Zeph_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
+		}
+		
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -43,10 +49,6 @@
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/dschosen.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/dschosen.cs
@@ -36,6 +36,12 @@
 	[AutoloadEquip(EquipType.Wings)]
 	internal class dschosen_Wings : PatreonItem
 	{
+		public override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
+			ArmorIDs.Wing.Sets.Stats[Item.wingSlot] = new WingStats(150, 7f);
+		}
+		
 		public override void SetDefaults() {
 			base.SetDefaults();
 
@@ -43,10 +49,6 @@
 			Item.width = 24;
 			Item.height = 8;
 			Item.accessory = true;
-		}
-
-		public override void UpdateAccessory(Player player, bool hideVisual) {
-			player.wingTimeMax = 150;
 		}
 	}
 }


### PR DESCRIPTION
### What is the bug?
Some patreon wings were not adding a `WingStats` instance to the `ArmorIDs.Wing.Sets.Stats` array

### How did you fix the bug?
Added this line to wings that were affected 

### Are there alternatives to your fix?
Maybe, I copied how `dinidini_Wings` added the `ArmorIDs.Wing.Sets.Stats` instance for consistency