### PR TITLE
Add new secret seed conditions for ItemDropRules

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/Conditions.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/Conditions.TML.cs
@@ -20,5 +20,41 @@
 			public bool CanShowItemDropInUI() => true;
 			public string GetConditionDescription() => null;
 		}
+		public class DrunkWorldIsUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => Main.drunkWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
+		public class ForTheWorthyIsUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => Main.getGoodWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
+		public class NotTheBeesIsUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => Main.notTheBeesWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
+		public class DrunkWorldIsNotUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => !Main.drunkWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
+		public class ForTheWorthyIsNotUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => !Main.getGoodWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
+		public class NotTheBeesIsNotUp : IItemDropRuleCondition, IProvideItemConditionDescription
+		{
+			public bool CanDrop(DropAttemptInfo info) => !Main.notTheBeesWorld;
+			public bool CanShowItemDropInUI() => true;
+			public string GetConditionDescription() => null;
+		}
 	}
 }


### PR DESCRIPTION
Condition descriptions are null but I want them to have values just like in the actual conditions.cs file, where GetTextValue gets the entry being in string "Bestiary_ItemDropConditions.Is10thAnniverary" for example. If possible, change the patch file to add the new seeds the way the conditions file has them. Also see #2972 for the issue.

### What is the new feature?
I noticed that there is no drop conditions for any other seed, like the "For The Worthy" seed world and Drunk World.
So why don't we add drop conditions for the other seeds?
See Issue #2972 
### Why should this be part of tModLoader?
See Issue #2972 
### Are there alternative designs?
Alternatively, you can just use an if statement and check if the player is in a seed world, and then add your drop rule there like you normally would.
See Issue #2972 
### Sample usage for the new feature
```cs
public class ForTheWorthyIsUp : IItemDropRuleCondition, IProvideItemConditionDescription
        {
            public bool CanDrop(DropAttemptInfo info)
            {
                return Main.getGoodWorld;
            }

            public bool CanShowItemDropInUI()
            {
                return Main.getGoodWorld;
            }

            public string GetConditionDescription()
            {
                return Language.GetTextValue("Bestiary_ItemDropConditions.IsForTheWorthy");
            }
        }
```
There is no actual Localization description for GetTextValue on IsForTheWorthy, and I am unable to provide that for tModLoader (if anyone knows how, please help provide it for me).
### ExampleMod updates
_N/A_
