### PR TITLE
ExpandAttribute

### DIFF
--- a/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
+++ b/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
@@ -62,6 +62,11 @@ namespace ExampleMod.Common.Configs.ModConfigShowcases
 		public List<Pair> ListOfPair2 = new List<Pair>();
 		public Pair pairExample2 = new Pair();
 
+		// In this example, the list defaults to collapse.
+		[Expand(false)]
+		public List<string> expand = new List<string>() { "1", "2", "3", "4", "5" };
+
+		[Expand(false)]
 		public SimpleData simpleDataExample; // you can also initialize in the constructor, see initialization in public ModConfigShowcaseMisc() below.
 
 		// This annotation allows the UI to null out this class. You need to make sure to initialize fields without the NullAllowed annotation in constructor or initializer or you might have issues. Of course, if you allow nulls, you'll need to make sure the rest of your mod will handle them correctly. Try to avoid null unless you have a good reason to use them, as null objects will only complicate the rest of your code.

--- a/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
+++ b/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
@@ -64,7 +64,11 @@ namespace ExampleMod.Common.Configs.ModConfigShowcases
 
 		// In this example, the list defaults to collapse.
 		[Expand(false)]
-		public List<string> expand = new List<string>() { "1", "2", "3", "4", "5" };
+		public List<string> collapsedList = new List<string>() { "1", "2", "3", "4", "5" };
+
+		// This example collapses the list elements as well as the list itself.
+		[Expand(false, false)]
+		public List<Pair> collapsedListOfCollapsedObjects = new List<Pair>() { new Pair() { enabled = true, boost = 3 }, new Pair { enabled = true, boost = 6 } };
 
 		[Expand(false)]
 		public SimpleData simpleDataExample; // you can also initialize in the constructor, see initialization in public ModConfigShowcaseMisc() below.

--- a/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
@@ -381,6 +381,23 @@ namespace Terraria.ModLoader.Config
 
 	}
 
+	/// <summary>
+	/// Affects whether this data will be expanded by default. The default value is true.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class)]
+	public class ExpandAttribute : Attribute
+	{
+		public bool Expand { get; }
+		// TODO: Need? CollectionElement cannot nest itself. Can only be nested with ObjectElement.
+		// public bool? ExpandListElements  { get; }
+
+		// public ExpandAttribute(bool? expand = null, bool? expandListElements = null ) {
+		public ExpandAttribute(bool expand = true) {
+			Expand = expand;
+			// ExpandListElements = expandListElements;
+		}
+	}
+
 	// Unimplemented ideas below:
 	/*
 
@@ -396,7 +413,7 @@ namespace Terraria.ModLoader.Config
 	public class StringRepresentationAttribute : Attribute
 	{
 		public Func<string> StringRepresentation { get; set; }
-	
+
 		public StringRepresentationAttribute(Type delegateType, string delegateName) {
 			StringRepresentation = (Func<string>)Delegate.CreateDelegate(delegateType, delegateType.GetMethod(delegateName));
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
@@ -382,19 +382,23 @@ namespace Terraria.ModLoader.Config
 	}
 
 	/// <summary>
-	/// Affects whether this data will be expanded by default. The default value is true.
+	/// Affects whether this data will be expanded by default. The default value currently is true. Use the constructor with 2 parameters to control if list elements should be collapsed or expanded.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class)]
 	public class ExpandAttribute : Attribute
 	{
 		public bool Expand { get; }
-		// TODO: Need? CollectionElement cannot nest itself. Can only be nested with ObjectElement.
-		// public bool? ExpandListElements  { get; }
+		public bool? ExpandListElements  { get; }
 
-		// public ExpandAttribute(bool? expand = null, bool? expandListElements = null ) {
+		// bool? not allowed in attribute ctor, so 2 ctors
 		public ExpandAttribute(bool expand = true) {
 			Expand = expand;
-			// ExpandListElements = expandListElements;
+			ExpandListElements = null;
+		}
+
+		public ExpandAttribute(bool expand = true, bool expandListElements = true) {
+			Expand = expand;
+			ExpandListElements = expandListElements;
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/CollectionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/CollectionElement.cs
@@ -32,6 +32,10 @@ namespace Terraria.ModLoader.Config.UI
 		public override void OnBind() {
 			base.OnBind();
 
+			var expandAttribute = ConfigManager.GetCustomAttribute<ExpandAttribute>(MemberInfo, Item, List);
+			if (expandAttribute != null)
+				expanded = expandAttribute.Expand;
+
 			Data = MemberInfo.GetValue(Item);
 			DefaultListValueAttribute = ConfigManager.GetCustomAttribute<DefaultListValueAttribute>(MemberInfo, null, null);
 
@@ -46,7 +50,7 @@ namespace Terraria.ModLoader.Config.UI
 			//panel.BackgroundColor = Microsoft.Xna.Framework.Color.Transparent;
 			//panel.BorderColor =  Microsoft.Xna.Framework.Color.Transparent;
 
-			if (Data != null)
+			if (Data != null && expanded)
 				Append(DataListElement);
 
 			DataListElement.OverflowHidden = true;
@@ -115,7 +119,7 @@ namespace Terraria.ModLoader.Config.UI
 				};
 			}
 
-			expandButton = new UIModConfigHoverImage(CollapsedTexture, "Expand");
+			expandButton = new UIModConfigHoverImage(expanded ? CollapsedTexture : ExpandedTexture, expanded ? "Collapse" : "Expand");
 			expandButton.Top.Set(4, 0f); // 10, -25: 4, -52
 			expandButton.Left.Set(-79, 1f);
 			expandButton.OnClick += (a, b) => {

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/CollectionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/CollectionElement.cs
@@ -119,7 +119,7 @@ namespace Terraria.ModLoader.Config.UI
 				};
 			}
 
-			expandButton = new UIModConfigHoverImage(expanded ? CollapsedTexture : ExpandedTexture, expanded ? "Collapse" : "Expand");
+			expandButton = new UIModConfigHoverImage(expanded ? ExpandedTexture : CollapsedTexture, expanded ? "Collapse" : "Expand");
 			expandButton.Top.Set(4, 0f); // 10, -25: 4, -52
 			expandButton.Left.Set(-79, 1f);
 			expandButton.OnClick += (a, b) => {

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
@@ -108,9 +108,22 @@ namespace Terraria.ModLoader.Config.UI
 			//data = _GetValue();// memberInfo.GetValue(this.item);
 			//drawLabel = false;
 
-			var expandAttribute = ConfigManager.GetCustomAttribute<ExpandAttribute>(MemberInfo, Item, List);
-			if (expandAttribute != null)
-				expanded = expandAttribute.Expand;
+			if (List == null) {
+				// Member > Class
+				var expandAttribute = ConfigManager.GetCustomAttribute<ExpandAttribute>(MemberInfo, Item, List);
+				if (expandAttribute != null)
+					expanded = expandAttribute.Expand;
+			}
+			else {
+				// ListMember's ExpandListElements > Class
+				var listType = MemberInfo.Type.GetGenericArguments()[0];
+				var expandAttribute = (ExpandAttribute)Attribute.GetCustomAttribute(listType, typeof(ExpandAttribute), true);
+				if (expandAttribute != null)
+					expanded = expandAttribute.Expand;
+				expandAttribute = (ExpandAttribute)Attribute.GetCustomAttribute(MemberInfo.MemberInfo, typeof(ExpandAttribute), true);
+				if (expandAttribute != null && expandAttribute.ExpandListElements.HasValue)
+					expanded = expandAttribute.ExpandListElements.Value;
+			}
 
 			dataList = new NestedUIList();
 			dataList.Width.Set(-14, 1f);

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
@@ -108,13 +108,18 @@ namespace Terraria.ModLoader.Config.UI
 			//data = _GetValue();// memberInfo.GetValue(this.item);
 			//drawLabel = false;
 
+			var expandAttribute = ConfigManager.GetCustomAttribute<ExpandAttribute>(MemberInfo, Item, List);
+			if (expandAttribute != null)
+				expanded = expandAttribute.Expand;
+
 			dataList = new NestedUIList();
 			dataList.Width.Set(-14, 1f);
 			dataList.Left.Set(14, 0f);
 			dataList.Height.Set(-30, 1f);
 			dataList.Top.Set(30, 0);
 			dataList.ListPadding = 5f;
-			Append(dataList);
+			if(expanded)
+				Append(dataList);
 
 			//string name = memberInfo.Name;
 			//if (labelAttribute != null) {
@@ -150,7 +155,7 @@ namespace Terraria.ModLoader.Config.UI
 				Interface.modConfig.SetPendingChanges();
 			};
 
-			expandButton = new UIModConfigHoverImage(ExpandedTexture, "Expand");
+			expandButton = new UIModConfigHoverImage(expanded ? CollapsedTexture : ExpandedTexture, expanded ? "Collapse" : "Expand");
 			expandButton.Top.Set(4, 0f); // 10, -25: 4, -52
 			expandButton.Left.Set(-52, 1f);
 			expandButton.OnClick += (a, b) => {

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/ObjectElement.cs
@@ -168,7 +168,7 @@ namespace Terraria.ModLoader.Config.UI
 				Interface.modConfig.SetPendingChanges();
 			};
 
-			expandButton = new UIModConfigHoverImage(expanded ? CollapsedTexture : ExpandedTexture, expanded ? "Collapse" : "Expand");
+			expandButton = new UIModConfigHoverImage(expanded ? ExpandedTexture : CollapsedTexture, expanded ? "Collapse" : "Expand");
 			expandButton.Top.Set(4, 0f); // 10, -25: 4, -52
 			expandButton.Left.Set(-52, 1f);
 			expandButton.OnClick += (a, b) => {


### PR DESCRIPTION
### What is the new feature?

Modders can now choose the default expand of the list/class.

### Why should this be part of tModLoader?

It can be well managed when there are many config items.

### Are there alternative designs?

no

### Sample usage for the new feature

[Expand(true/false)]
public List<string> arg;

[Expand(true/false)]
public Dictionary<int, string> arg;

[Expand(true/false)]
public HashSet<string> arg;

[Expand(true/false)]
public class SubConfig{}

### ExampleMod updates

Added an example in ModConfigShowcaseMisc
