### PR TITLE
Follow-up Pull Request no. 2 for #2909

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerResourceSetsManager.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerResourceSetsManager.TML.cs
@@ -14,6 +14,9 @@ namespace Terraria.GameContent.UI.ResourceSets
 		private string _activeSetConfigKeyOriginal;  // Used to store the original key value, since PlayerResourceSetsManager is loaded way before mods
 
 		internal void AddModdedDisplaySets() {
+			if (Main.dedServ)
+				return;
+
 			foreach (ModResourceDisplaySet display in ResourceDisplaySetLoader.moddedDisplaySets) {
 				string key = display.ConfigKey;
 				_sets[key] = display;
@@ -23,6 +26,9 @@ namespace Terraria.GameContent.UI.ResourceSets
 
 		// Called by tML after mods have loaded to set the actual display set
 		internal void SetActiveFromOriginalConfigKey() {
+			if (Main.dedServ)
+				return;
+
 			SetActive(_activeSetConfigKeyOriginal);
 			// In case the display set didn't exist, force the original key back to Fancy
 			_activeSetConfigKeyOriginal = _activeSetConfigKey;
@@ -34,6 +40,9 @@ namespace Terraria.GameContent.UI.ResourceSets
 		}
 
 		internal void ResetToVanilla() {
+			if (Main.dedServ)
+				return;
+
 			_activeSetConfigKey = _activeSetConfigKeyOriginal;
 
 			foreach (string key in accessKeys.Skip(vanillaSets.Length))

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -323,10 +323,8 @@ namespace Terraria.ModLoader
 			ResizeArrays();
 			RecipeGroupHelper.FixRecipeGroupLookups();
 
-			if (!Main.dedServ) {
-				Main.ResourceSetsManager.AddModdedDisplaySets();
-				Main.ResourceSetsManager.SetActiveFromOriginalConfigKey();
-			}
+			Main.ResourceSetsManager.AddModdedDisplaySets();
+			Main.ResourceSetsManager.SetActiveFromOriginalConfigKey();
 
 			Interface.loadMods.SetLoadStage("tModLoader.MSSetupContent", ModLoader.Mods.Length);
 			LoadModContent(token, mod => {
@@ -483,11 +481,8 @@ namespace Terraria.ModLoader
 			InfoDisplayLoader.Unload();
 			GoreLoader.Unload();
 			PlantLoader.UnloadPlants();
-
-			if (!Main.dedServ) {
-				ResourceOverlayLoader.Unload();
-				ResourceDisplaySetLoader.Unload();
-			}
+			ResourceOverlayLoader.Unload();
+			ResourceDisplaySetLoader.Unload();
 
 			LoaderManager.Unload();
 

--- a/patches/tModLoader/Terraria/ModLoader/ModResourceDisplaySet.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModResourceDisplaySet.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using ReLogic.Content;
 using System.Text.RegularExpressions;
 using Terraria.DataStructures;
-using Terraria.GameContent;
 using Terraria.GameContent.UI.ResourceSets;
 using Terraria.Localization;
 
@@ -13,6 +11,7 @@ namespace Terraria.ModLoader
 	/// This class serves as a place for you to define your own logic for drawing the player's life and mana resources.<br/>
 	/// For modifying parts of the vanilla display sets, use <see cref="ModResourceOverlay"/>.
 	/// </summary>
+	[Autoload(true, Side = ModSide.Client)]
 	public abstract class ModResourceDisplaySet : ModType, IPlayerResourcesDisplaySet, IConfigKeyHolder
 	{
 		public int Type { get; internal set; }

--- a/patches/tModLoader/Terraria/ModLoader/ModResourceOverlay.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModResourceOverlay.cs
@@ -7,6 +7,7 @@ namespace Terraria.ModLoader
 	/// This class serves as a place for you to customize how the vanilla resource displays (Classic, Fancy and Bars) are drawn.<br/>
 	/// For implementing your own resource displays, use <see cref="ModResourceDisplaySet"/>.
 	/// </summary>
+	[Autoload(true, Side = ModSide.Client)]
 	public abstract class ModResourceOverlay : ModType
 	{
 		public int Type { get; internal set; }


### PR DESCRIPTION
follow-up PR for #2909
- added an `[Autoload(true, Side = ModSide.Client)]` attribute to `ModResourceOverlay` and `ModResourceDisplaySet`
- cleaned up the code responsible for blocking loading/unloading/initializing `ResourceOverlayLoader` and `ResourceDisplaySetLoader` on servers