### PR TITLE
Fix for #2997

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -124,8 +124,10 @@
 +		public static double dayRate = 1;
 -		public static int desiredWorldTilesUpdateRate = 1;
 +		public static double desiredWorldTilesUpdateRate = 1;
- 		public static int maxScreenW = 1920;
- 		public static int maxScreenH = 1200;
+-		public static int maxScreenW = 1920;
++		public static int maxScreenW = 3840;
+-		public static int maxScreenH = 1200;
++		public static int maxScreenH = 2160;
  		public static int minScreenW = 800;
 -		public static int minScreenH = 600;
 +		public static int minScreenH = 720; // Used to be '600'


### PR DESCRIPTION
This PR fixes the bug leftover from https://github.com/tModLoader/tModLoader/commit/3ac76f550cab8a5b9fd674a36bdda6bf2322a8fa

where the HiDef related variables of maxScreenW & maxScreenH no longer get increased to 4K specifications.

The fix is simply to assume HiDef, like the commit does, and set these to 4K spec.

Fixes #2997