### PR TITLE
OnStartDay and OnStartNight hooks

### DIFF
--- a/ExampleMod/Common/Systems/NaturalBossSpawnSystem.cs
+++ b/ExampleMod/Common/Systems/NaturalBossSpawnSystem.cs
@@ -1,0 +1,64 @@
+﻿using ExampleMod.Content.NPCs.MinionBoss;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.Chat;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Systems
+{
+	public class NaturalBossSpawnSystem : ModSystem
+	{
+		public static bool spawnMinionBoss = false;
+
+		// Exiting the world will prevent the Minion Boss from spawing naturally. The same as the Eye of Cthulhu
+		public override void OnWorldLoad() {
+			spawnMinionBoss = false;
+		}
+
+		public override void PostUpdateTime() {
+			if (Main.dayTime) {
+				spawnMinionBoss = false;
+			}
+
+			// The boss will be spawned at 9:10 PM.
+			// How the time value came: 9:10 PM - 7:30 PM = 1:40, Total seconds: 1*60*60 + 40*60 = 6000
+			if (!spawnMinionBoss || Main.time <= 6000) {
+				return;
+			}
+			
+			for (int i = 0; i < Main.maxPlayers; i++) {
+				var player = Main.player[i];
+
+				// Never spawn on players that is dead or under the surface.
+				if (!player.active || player.DeadOrGhost || player.position.Y >= Main.worldSurface * 16.0) {
+					continue;
+				}
+
+				NPC.SpawnOnPlayer(i, ModContent.NPCType<MinionBossBody>());
+				spawnMinionBoss = false;
+				break;
+			}
+		}
+
+		public override void OnStartNight(ref bool stopEvents) {
+			// If events should stop, the sundial is being usedm or minion boss is downed, it should not spawn.
+			// Since the boss spawning code shouldn't run on multiplayer client, we don't have to set the spawnMinionBoss for it.
+			// Each night the Minion Boss has a 10% chance of being spawned.
+			if (Main.fastForwardTime || stopEvents || DownedBossSystem.downedMinionBoss || Main.netMode is NetmodeID.MultiplayerClient || !Main.rand.NextBool(10)) {
+				return;
+			}
+
+			spawnMinionBoss = true;
+			stopEvents = true; // To prevent other events from occuring
+			// Give the player a hint and tell them that the boss will spawn tonight
+			if (Main.netMode == NetmodeID.SinglePlayer) {
+				Main.NewText("The big green eyeball is on its way!", 50, 255, 130);
+			}
+			else {
+				ChatHelper.BroadcastChatMessage(NetworkText.FromLiteral("The big green eyeball is on its way!"), new Color(50, 255, 130));
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5333,7 +5333,16 @@
  						int num8 = 0;
  						for (int j = 0; j < 200; j++) {
  							if (npc[j].active && npc[j].townNPC && npc[j].type != 37 && npc[j].type != 453)
-@@ -50288,7 +_,7 @@
+@@ -50283,12 +_,15 @@
+ 			eclipse = false;
+ 			if (netMode != 1)
+ 				AchievementsHelper.NotifyProgressionEvent(0);
+-
++				
++			time = 0.0;
++			dayTime = false;
++			SystemLoader.OnStartNight(ref stopEvents);
+ 			if (!fastForwardTime && !stopEvents) {
  				if (!NPC.downedBoss1 && netMode != 1) {
  					bool flag = false;
  					for (int i = 0; i < 255; i++) {
@@ -5351,6 +5360,27 @@
  							bloodMoon = true;
  							break;
  						}
+@@ -50376,8 +_,9 @@
+ 				}
+ 			}
+ 
++			// TML: Moved the time set code before events setup for SystemLoader.OnStartNight hook
+-			time = 0.0;
++			//time = 0.0;
+-			dayTime = false;
++			//dayTime = false;
+ 			if (netMode == 2)
+ 				NetMessage.SendData(7);
+ 		}
+@@ -50416,7 +_,7 @@
+ 
+ 			if (drunkWorld && netMode != 1)
+ 				WorldGen.crimson = !WorldGen.crimson;
+-
++			SystemLoader.OnStartDay(ref stopEvents);
+ 			if (netMode == 2)
+ 				NetMessage.SendData(7);
+ 
 @@ -50505,6 +_,11 @@
  		}
  

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -369,5 +369,17 @@ namespace Terraria.ModLoader
 		/// <br/> The <paramref name="tileCounts"/> parameter is a read-only span (treat this as an array) that stores the tile count indexed by tile type.
 		/// </summary>
 		public virtual void TileCountsAvailable(ReadOnlySpan<int> tileCounts) { }
+
+		/// <summary>
+		/// Use this method to do something when day starts. See <see cref="OnStartNight(ref bool)"/> for the night method.
+		/// </summary>
+		/// <param name="stopEvents">Whether special events (invasions, eclipse, etc.) will occur or not. Vanilla prevents events from occuring when the Moon Lord is present or it's a Lantern Night</param>
+		public virtual void OnStartDay(ref bool stopEvents) { }
+
+		/// <summary>
+		/// Use this method to do something when night starts. See <see cref="OnStartDay(ref bool)"/> for the day method.
+		/// </summary>
+		/// <param name="stopEvents">Whether special events (boss spawning, blood moon, etc.) will occur or not. Vanilla prevents events from occuring when the Moon Lord is present or it's a Lantern Night</param>
+		public virtual void OnStartNight(ref bool stopEvents) { }
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -66,6 +66,10 @@ namespace Terraria.ModLoader
 		private delegate bool DelegateHijackGetData(ref byte messageType, ref BinaryReader reader, int playerNumber);
 
 		private delegate void DelegateTileCountsAvailable(ReadOnlySpan<int> tileCounts);
+		
+		private delegate void DelegateOnStartDay(ref bool stopEvents);
+		
+		private delegate void DelegateOnStartNight(ref bool stopEvents);
 
 		//HookLists
 
@@ -164,5 +168,9 @@ namespace Terraria.ModLoader
 		private static HookList HookHijackGetData = AddHook<DelegateHijackGetData>(s => s.HijackGetData);
 
 		private static HookList HookHijackSendData = AddHook<Func<int, int, int, int, NetworkText, int, float, float, float, int, int, int, bool>>(s => s.HijackSendData);
+
+		private static HookList HookOnStartDay = AddHook<DelegateOnStartDay>(s => s.OnStartDay);
+
+		private static HookList HookOnStartNight = AddHook<DelegateOnStartNight>(s => s.OnStartNight);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -449,5 +449,17 @@ namespace Terraria.ModLoader
 
 			return result;
 		}
+
+		internal static void OnStartDay(ref bool stopEvents) {
+			foreach (var system in HookOnStartDay.arr) {
+				system.OnStartDay(ref stopEvents);
+			}
+		}
+
+		internal static void OnStartNight(ref bool stopEvents) {
+			foreach (var system in HookOnStartNight.arr) {
+				system.OnStartNight(ref stopEvents);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### What is the new feature?
Added `OnStartDay` and `OnStartNight` hooks to ModSystem.
### Why should this be part of tModLoader?
Useful if you want to start a invasion or spawn a boss when day/night starts.
### Sample usage for the new feature
Spawn a boss naturally at night like EoC.
### ExampleMod updates
Each night the Minion Boss has a 10% chance of being spawned naturally if it is not downed.

