### PR TITLE
Fix vertical biome detection not matching vanilla

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -125,8 +125,7 @@
 -		public static int desiredWorldTilesUpdateRate = 1;
 +		public static double desiredWorldTilesUpdateRate = 1;
  		public static int maxScreenW = 1920;
--		public static int maxScreenH = 1200;
-+		public static int maxScreenH = 1080;
+ 		public static int maxScreenH = 1200;
  		public static int minScreenW = 800;
 -		public static int minScreenH = 600;
 +		public static int minScreenH = 720; // Used to be '600'


### PR DESCRIPTION
### What is the bug?
As a followup to the latest hotfixes regarding screen size and "biome bleed", a minor biome detection issue is still present: Biomes aren't properly detected vertically, compared to vanilla.

### How did you fix the bug?
restore `Main.maxScreenH` to pre-hotfixes value (1200)

### Are there alternatives to your fix?
No, as the proper fix was implemented before, and this just restores the values as they were before hotfixes began
