### PR TITLE
Improve .NET Install Version Checking Logic

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -268,7 +268,7 @@ namespace Terraria.ModLoader.UI
 				Logging.tML.Info("\n" + output);
 
 				foreach (var line in output.Split('\n')) {
-					var dotnetVersion = new Version(new Regex("([0-9.]+)[^0-9.].+").Match(line).Groups[1].Value);
+					var dotnetVersion = new Version(new Regex("([0-9.]+).*").Match(line).Groups[1].Value);
 					if (dotnetVersion >= new Version(6, 0)) {
 						dotnetSDKFound = true;
 						break;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -268,7 +268,7 @@ namespace Terraria.ModLoader.UI
 				Logging.tML.Info("\n" + output);
 
 				foreach (var line in output.Split('\n')) {
-					var dotnetVersion = new Version(new Regex("(.+?) ").Match(line).Groups[1].Value);
+					var dotnetVersion = new Version(new Regex("([0-9.]+)[^0-9.].+").Match(line).Groups[1].Value);
 					if (dotnetVersion >= new Version(6, 0)) {
 						dotnetSDKFound = true;
 						break;


### PR DESCRIPTION
This PR fixes #3004 

### What is the bug?
The code responsible for checking a user's .NET installs broke if the version string wasn't exactly `major.minor.build`

### How did you fix the bug?
I changed the regex string in `ModLoader/UI/UIModSources.cs` to have stricter logic for finding the SDK version.

### Are there alternatives to your fix?
n/a