### PR TITLE
Fix Chest.cs.patch for 1.4.4.2

### DIFF
--- a/patches/tModLoader/Terraria/Chest.cs.patch
+++ b/patches/tModLoader/Terraria/Chest.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Chest.cs
 +++ src/tModLoader/Terraria/Chest.cs
-@@ -8,6 +_,7 @@
+@@ -9,6 +_,7 @@
  using Terraria.GameContent.Events;
  using Terraria.ID;
  using Terraria.ObjectData;
@@ -8,7 +8,7 @@
  
  namespace Terraria
  {
-@@ -193,12 +_,15 @@
+@@ -201,12 +_,15 @@
  			return list;
  		}
  
@@ -26,10 +26,11 @@
  			if (t.type == 21 && ((t.frameX >= 72 && t.frameX <= 106) || (t.frameX >= 144 && t.frameX <= 178) || (t.frameX >= 828 && t.frameX <= 1006) || (t.frameX >= 1296 && t.frameX <= 1330) || (t.frameX >= 1368 && t.frameX <= 1402) || (t.frameX >= 1440 && t.frameX <= 1474)))
  				return true;
  
-@@ -229,6 +_,16 @@
- 							continue;
+@@ -248,7 +_,17 @@
+ 						continue;
  
- 						flag = true;
+ 					if (item.IsTheSameAs(Main.chest[i].item[j])) {
+ 						flag2 = true;
 +						// flag set above means "item of same type found in chest, able to be put into an empty slot later", which means we have to respect it before TryStackItems
 +						if (!ItemLoader.TryStackItems(Main.chest[i].item[j], item, out _))
 +							continue;
@@ -43,15 +44,15 @@
  						int num = Main.chest[i].item[j].maxStack - Main.chest[i].item[j].stack;
  						if (num > 0) {
  							if (num > item.stack)
-@@ -241,6 +_,7 @@
+@@ -265,6 +_,7 @@
  								return item;
  							}
  						}
 +						*/
  					}
  					else {
- 						flag2 = true;
-@@ -273,6 +_,17 @@
+ 						flag3 = true;
+@@ -309,6 +_,17 @@
  			Tile tileSafely = Framing.GetTileSafely(X, Y);
  			int type2 = tileSafely.type;
  			int num2 = tileSafely.frameX / 36;
@@ -69,7 +70,7 @@
  			switch (type2) {
  				case 21:
  					switch (num2) {
-@@ -318,6 +_,7 @@
+@@ -354,6 +_,7 @@
  					}
  					return false;
  			}
@@ -77,7 +78,7 @@
  
  			SoundEngine.PlaySound(22, X * 16, Y * 16);
  			for (int i = X; i <= X + 1; i++) {
-@@ -325,7 +_,7 @@
+@@ -361,7 +_,7 @@
  					Tile tileSafely2 = Framing.GetTileSafely(i, j);
  					if (tileSafely2.type == type2) {
  						tileSafely2.frameX -= num;
@@ -86,7 +87,7 @@
  						for (int k = 0; k < 4; k++) {
  							Dust.NewDust(new Vector2(i * 16, j * 16), 16, 16, type);
  						}
-@@ -412,15 +_,21 @@
+@@ -509,15 +_,21 @@
  			}
  			else {
  				switch (type) {
@@ -111,7 +112,7 @@
  				}
  			}
  
-@@ -505,14 +_,15 @@
+@@ -602,14 +_,15 @@
  			}
  		}
  
@@ -130,7 +131,7 @@
  					if (item[num2] == null || item[num2].type == 0)
  						break;
  
-@@ -520,7 +_,7 @@
+@@ -617,7 +_,7 @@
  					continue;
  				}
  
@@ -139,28 +140,24 @@
  			}
  
  			item[num2] = newItem.Clone();
-@@ -529,6 +_,7 @@
+@@ -626,6 +_,7 @@
  			item[num2].stack -= num;
  			_ = item[num2].value;
  			_ = 0;
 +			return num2;
  		}
  
- 		public static void SetupTravelShop() {
-@@ -902,9 +_,12 @@
- 							Main.travelShop[num2++] = 3636;
- 							Main.travelShop[num2++] = 3641;
- 							break;
+ 		public static void SetupTravelShop_AddToShop(int it, ref int added, ref int count) {
+@@ -702,6 +_,8 @@
+ 						Main.travelShop[count++] = 3636;
+ 						Main.travelShop[count++] = 3641;
+ 						break;
 +						//patch file: num2
- 					}
  				}
  			}
-+
-+			NPCLoader.SetupTravelShop(Main.travelShop, ref num2);
++				NPCLoader.SetupTravelShop(Main.travelShop, ref num2);
  		}
- 
- 		public void SetupShop(int type) {
-@@ -2015,12 +_,12 @@
+@@ -2282,12 +_,12 @@
  						num++;
  						array[num].SetDefaults(1979);
  						num++;
@@ -175,7 +172,7 @@
  							array[num].SetDefaults(1978);
  							num++;
  						}
-@@ -2611,6 +_,7 @@
+@@ -2953,6 +_,7 @@
  					array[num++].SetDefaults(4921);
  			}
  


### PR DESCRIPTION
### What is the bug?
Terraria 1.4.4.2 broke Chest.cs.patch.

### How did you fix the bug?
I compared decompiled code of Terraria 1.3.6 to 1.4.4.2 and used that to update this patch file.

Patches now apply correctly for Chest.cs

```
src/TerrariaNetCore/Terraria/Chest.cs,	exact: 14,	offset: 0,	fuzzy: 0,	failed: 17
EXACT: @@ -9,6 +9,7 @@
EXACT: @@ -201,12 +202,15 @@
EXACT: @@ -248,7 +252,17 @@
EXACT: @@ -265,6 +279,7 @@
EXACT: @@ -309,6 +324,17 @@
EXACT: @@ -354,6 +380,7 @@
EXACT: @@ -361,7 +388,7 @@
EXACT: @@ -509,15 +536,21 @@
EXACT: @@ -602,14 +635,15 @@
EXACT: @@ -617,7 +651,7 @@
EXACT: @@ -626,6 +660,7 @@
EXACT: @@ -702,6 +737,8 @@
EXACT: @@ -2282,12 +2319,12 @@
EXACT: @@ -2953,6 +2990,7 @@
``` 

### Are there alternatives to your fix?
Nope