### PR TITLE
Fix engine crash when failed to fetch local mod dependencies

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -138,7 +138,17 @@ namespace Terraria.ModLoader.Core
 				if (!TryReadManifest(GetParentDir(mod.modFile.path), out var manifest))
 					continue;
 
-				WorkshopHelper.QueryHelper.GetDependenciesRecursive(manifest.workshopEntryId, ref dependencies);
+				try {
+					WorkshopHelper.QueryHelper.GetDependenciesRecursive(manifest.workshopEntryId, ref dependencies);
+				}
+				catch (OverflowException e) {
+					Utils.ShowFancyErrorMessage(Language.GetTextValue("tModLoader.WorkshopIrregularDependenciesFailure", mod.DisplayName, e.Message, mod.DisplayName), Interface.loadModsID);
+					Logging.tML.Warn($"Failed to fetch missing dependencies for local mod: {mod.DisplayName}. Irregular dependencies count detected! {e.Message}. Please report this issue to {mod.DisplayName}'s developers!", e);
+				}
+				catch (Exception e) {
+					Utils.ShowFancyErrorMessage(Language.GetTextValue("tModLoader.WorkshopFetchDependenciesFailure", mod.DisplayName), Interface.loadModsID);
+					Logging.tML.Warn($"Failed to fetch missing dependencies for local mod: {mod.DisplayName}. Check your internet connection or download manually from Steam Workshop!!", e);
+				}
 			}
 
 			// Cull out any dependencies that are already installed.

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -342,6 +342,11 @@ namespace Terraria.Social.Steam
 
 					var pDetails = SteamedWraps.FetchItemDetails(_primaryUGCHandle, 0);
 
+					// Some weired mod will have a super big m_unNumChildren and will cause game crash.
+					if (pDetails.m_unNumChildren > 1000) {
+						throw new OverflowException("Numbers of dependencies exceeds 1000. Dependencies from Steam Workshop: " + pDetails.m_unNumChildren);
+					}
+
 					if (queryChildren) {
 						ugcChildren = SteamedWraps.FetchItemDependencies(_primaryUGCHandle, 0, pDetails.m_unNumChildren).Select(x => x.m_PublishedFileId).ToList();
 					}
@@ -417,7 +422,7 @@ namespace Terraria.Social.Steam
 
 						// Backwards compat code for the metadata version change
 						if (metadata["versionsummary"] == null)
-							metadata["versionsummary"] = metadata["version"]; 
+							metadata["versionsummary"] = metadata["version"];
 
 						string[] missingKeys = MetadataKeys.Where(k => metadata.Get(k) == null).ToArray();
 
@@ -457,9 +462,9 @@ namespace Terraria.Social.Steam
 						SteamedWraps.FetchPlayTimeStats(_primaryUGCHandle, i, out var hot, out var downloads);
 
 						// Check against installed mods for updates
-						
+
 						bool updateIsDowngrade = false;
-						
+
 						var installed = InstalledMods.FirstOrDefault(m => m.Name == metadata["name"]);
 						bool update = installed != null && DoesWorkshopItemNeedUpdate(id, installed, cVersion.modV);
 


### PR DESCRIPTION
### What is the bug?
Game crashed when failed to fetch mod dependencies due to bad network connection
### How did you fix the bug?

Surround try catch around this method call and log the issue.
```
WorkshopHelper.QueryHelper.GetDependenciesRecursive(manifest.workshopEntryId, ref dependencies);
```
### Are there alternatives to your fix?
Of course yes! Currently I just log the network issue not showing it to the user. The best way is to open a message box and tell the player about his poor network connection. However I'm not a game developer and I don't know how to draw stuff on screen. So I just catch it and log it.

I have tested my code in both development environment and release environment, both of them are working expectly.