### PR TITLE
Mod loading starts during splash screen.

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -337,7 +337,7 @@
  		public static int selectedPlayer = 0;
  		public static int selectedWorld;
 -		public static int menuMode;
-+		public static int menuMode = Interface.loadModsID;
++		public static int menuMode = Interface.welcomeID;
  		public static int menuSkip;
  		private static bool _needsLanguageSelect = true;
 -		private static Item tooltipPrefixComparisonItem = new Item();
@@ -470,7 +470,7 @@
  			}
  		}
  
-+		/* Disabled, tML only supports HiDef		
++		/* Disabled, tML only supports HiDef
  		public static void SetGraphicsProfile(GraphicsProfile profile, bool forceSet) {
  			if (_currentGraphicsProfile != profile || forceSet) {
  				_selectedGraphicsProfile = profile;
@@ -4570,6 +4570,38 @@
  		}
  
  		private static void PostDrawMenu(Microsoft.Xna.Framework.Point screenSizeCache, Microsoft.Xna.Framework.Point screenSizeCacheAfterScaling) {
+@@ -39984,8 +_,12 @@
+ 				num = 0;
+ 			}
+ 
+-			if (Assets.PendingAssets == 0 && _musicLoaded && _artLoaded && Program.LoadedEverything)
++			if (Assets.PendingAssets == 0 && _musicLoaded && _artLoaded && Program.LoadedEverything && !_isAsyncLoadComplete) {
+ 				_isAsyncLoadComplete = true;
++				Initialize_AlmostEverything();
++				PostContentLoadInitialize();
++                Main.MenuUI.SetState(ModLoader.UI.Interface.loadMods);
++			}
+ 
+ 			spriteBatch.Begin();
+ 			splashCounter++;
+@@ -40005,8 +_,6 @@
+ 					b = (byte)((float)(75 - (splashCounter - 125)) / 75f * 255f);
+ 				}
+ 				else {
+-					Initialize_AlmostEverything();
+-					PostContentLoadInitialize();
+ 					showSplash = false;
+ 					fadeCounter = 75;
+ 					splashTimer.Stop();
+@@ -40034,8 +_,6 @@
+ 						num = 1;
+ 					}
+ 					else {
+-						Initialize_AlmostEverything();
+-						PostContentLoadInitialize();
+ 						showSplash = false;
+ 						fadeCounter = 120;
+ 						splashTimer.Stop();
 @@ -40268,9 +_,16 @@
  			float value3 = (float)((double)(screenPosition.Y - (float)(screenHeight / 2) + 200f) - rockLayer * 16.0) / 300f;
  			value3 = MathHelper.Clamp(value3, 0f, 1f);

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -65,7 +65,7 @@ namespace Terraria.ModLoader
 		internal static bool skipLoad;
 		internal static Action OnSuccessfulLoad;
 
-		private static bool isLoading;
+		internal static bool isLoading { get; private set; }
 
 		public static Mod[] Mods { get; private set; } = new Mod[0];
 
@@ -128,7 +128,7 @@ namespace Terraria.ModLoader
 					OnSuccessfulLoad();
 				}
 				else {
-					Main.menuMode = 0;
+					Main.menuMode = Interface.welcomeID;
 				}
 			}
 			catch when (token.IsCancellationRequested) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -45,6 +45,7 @@ namespace Terraria.ModLoader.UI
 		internal const int modConfigID = 10024;
 		internal const int createModID = 10025;
 		internal const int exitID = 10026;
+		internal const int welcomeID = 10027;
 		internal static UIMods modsMenu = new UIMods();
 		internal static UILoadMods loadMods = new UILoadMods();
 		internal static UIModSources modSources = new UIModSources();
@@ -105,13 +106,13 @@ namespace Terraria.ModLoader.UI
 		//add to end of if else chain of Main.menuMode in Terraria.Main.DrawMenu
 		//Interface.ModLoaderMenus(this, this.selectedMenu, array9, array7, array4, ref num2, ref num4, ref num5, ref flag5);
 		internal static void ModLoaderMenus(Main main, int selectedMenu, string[] buttonNames, float[] buttonScales, int[] buttonVerticalSpacing, ref int offY, ref int spacing, ref int numButtons, ref bool backButtonDown) {
-			if (Main.menuMode == loadModsID) {
+			if (Main.menuMode == welcomeID) {
 				if (ModLoader.ShowFirstLaunchWelcomeMessage) {
 					ModLoader.ShowFirstLaunchWelcomeMessage = false;
 					infoMessage.Show(Language.GetTextValue("tModLoader.FirstLaunchWelcomeMessage"), Main.menuMode);
 				}
 
-				if (SteamedWraps.FamilyShared && !ModLoader.WarnedFamilyShare) {
+				else if (SteamedWraps.FamilyShared && !ModLoader.WarnedFamilyShare) {
 					ModLoader.WarnedFamilyShare = true;
 					infoMessage.Show(Language.GetTextValue("tModLoader.SteamFamilyShareWarning"), Main.menuMode);
 				}
@@ -181,6 +182,16 @@ namespace Terraria.ModLoader.UI
 
                     if (!string.IsNullOrWhiteSpace(message))
 	                    infoMessage.Show(message, Main.menuMode, altButtonText: continueButton, altButtonAction: downloadAction, okButtonText: cancelButton);
+				}
+
+				if (Main.menuMode != infoMessageID) {
+					if (ModLoader.isLoading) {
+						Main.menuMode = loadModsID;
+						loadMods.continueCurrentLoad = true;
+					}
+					else {
+						Main.menuMode = 0;
+					}
 				}
 			}
 			if (Main.menuMode == modsMenuID) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -10,12 +10,20 @@ namespace Terraria.ModLoader.UI
 	{
 		public int modCount;
 
+		internal bool continueCurrentLoad;
+
 		private string stageText;
 
 		private CancellationTokenSource _cts;
 
 		public override void OnActivate() {
 			base.OnActivate();
+
+			if (continueCurrentLoad) {
+				continueCurrentLoad = false;
+				return;
+			}
+
 			_cts = new CancellationTokenSource();
 			OnCancel += () => {
 				SetLoadStage("Loading Cancelled");


### PR DESCRIPTION
### What is the new feature?

Mod loading starts during the splash screen.

### Why should this be part of tModLoader?

Initially while mucking around, I implemented skipping the splash screen as soon as vanilla was done loading however I thought this made more sense. This feature makes it quicker for everyone to get to the main menu and get in game as the splash screen has dead time where it is doing nothing and is much better spent getting a head start on loading.

Please let me know if you think this would be better implemented in a different way or could use changes, I am more than happy to implement any feedback.