### PR TITLE
Allowed 'InstancePerEntity => false' overrides.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -148,6 +148,19 @@ namespace Terraria.ModLoader.Core
 			return providers.Where(p => HasOverride(p.GetType(), method));
 		}
 
+		public static IEnumerable<FieldInfo> GetAllFields(Type type, BindingFlags bindingFlags) {
+			bindingFlags |= BindingFlags.DeclaredOnly;
+			bindingFlags &= ~BindingFlags.FlattenHierarchy;
+
+			while (type != null) {
+				foreach (var field in type.GetFields(bindingFlags)) {
+					yield return field;
+				}
+
+				type = type.BaseType;
+			}
+		}
+
 		public static IEnumerable<T> WhereMethodIsOverridden<T, F>(this IEnumerable<T> providers, Expression<Func<T, F>> expr) where F : Delegate =>
 			WhereMethodIsOverridden(providers, expr.ToMethodInfo());
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalType.cs
@@ -28,8 +28,22 @@ namespace Terraria.ModLoader
 
 			const BindingFlags FieldFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
+			static bool IsFieldUserDefined(FieldInfo field) {
+				var declaringType = field.DeclaringType;
+
+				if (!declaringType.IsSubclassOf(typeof(GlobalType))) {
+					return false;
+				}
+
+				if (declaringType.IsGenericType && declaringType.GetGenericTypeDefinition() == typeof(GlobalType<,>)) {
+					return false;
+				}
+
+				return true;
+			}
+
 			var type = GetType();
-			bool hasInstanceFields = type.GetFields(FieldFlags).Any(f => f.DeclaringType.IsSubclassOf(typeof(GlobalType)));
+			bool hasInstanceFields = LoaderUtils.GetAllFields(type, FieldFlags).Any(IsFieldUserDefined);
 			bool overridesInstancePerEntity = LoaderUtils.HasOverride(type, instancePerEntityGetterMethod);
 
 			if (hasInstanceFields && !overridesInstancePerEntity)


### PR DESCRIPTION
Requiring `InstancePerEntity` to be `true` for all things with instance fields makes it impossible or very uncomfortable to make inheritance-using singletons that don't abuse virtuality.

Fixing the validation check to instead just require an override to be present allows the following memory-preserving code to be written:

```cs
public abstract class ResourcePickupChanges : GlobalItem
{
	public int? ForcedItemType;
	public SoundStyle? PickupSound;

	// The above data is NOT stored per every entity with this global's derivatives.
	public override bool InstancePerEntity => false;

	// Logic that does things with the above data.
	// ...
}

public sealed class HealthPickupChanges : ResourcePickupChanges
{
	public override bool AppliesToEntity(Item item, bool lateInstantiation)
		=> item.type is ItemID.Heart or ItemID.CandyApple or ItemID.CandyCane;

	public override Load()
	{
		ForcedItemType = ItemID.Heart;
		PickupSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Pickups/LifePickup");
	}
}

public sealed class ManaPickupChanges : ResourcePickupChanges
{
	public override bool AppliesToEntity(Item item, bool lateInstantiation)
		=> item.type is ItemID.Star or ItemID.SoulCake or ItemID.SugarPlum;

	public override Load()
	{
		ForcedItemType = ItemID.Star;
		PickupSound = new SoundStyle($"{nameof(TerrariaOverhaul)}/Assets/Sounds/Pickups/ManaPickup");
	}
}
```