### PR TITLE
Fix workshop files location for Docker deploy

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Docker/Launch.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Docker/Launch.sh
@@ -12,4 +12,4 @@ ln -s /home/tml/.local/share/Terraria/dotnet/ /home/tml/tModLoader/dotnet
 echo "Launching tModLoader..."
 cd ~/tModLoader
 # Maybe eventually steamcmd will allow for an actual steamserver. For now -nosteam is required.
-exec ./start-tModLoaderServer.sh -config $HOME/.local/share/Terraria/serverconfig.txt -nosteam -steamworkshopfolder $HOME/.local/share/Terraria/wsmods
+exec ./start-tModLoaderServer.sh -config $HOME/.local/share/Terraria/serverconfig.txt -nosteam -steamworkshopfolder $HOME/.local/share/Terraria/wsmods/steamapps/workshop


### PR DESCRIPTION
### What is the bug?
Current Docker deploy does not discover any mods due to mistake in folder structure.

### How did you fix the bug?
I've pointed `Launch.sh` to proper folder.

### Are there alternatives to your fix?
One may edit `Dockerfile` to include `sed` script to fix it for themselves, like I do right now:
```
# Download entrypoint script
RUN curl -O https://raw.githubusercontent.com/tModLoader/tModLoader/1.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Docker/Launch.sh \
 && chmod u+x Launch.sh \
 && sed -i 's/$HOME\/.local\/share\/Terraria\/wsmods/$HOME\/.local\/share\/Terraria\/wsmods\/steamapps\/workshop/' Launch.sh
 ```

