### PR TITLE
Added WallID.CanBeClearedDuringGeneration

### DIFF
--- a/patches/tModLoader/Terraria/ID/WallID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/WallID.cs.patch
@@ -16,6 +16,14 @@
  			public static bool[] CanBeConvertedToGlowingMushroom = Factory.CreateBoolSet(64, 67, 15, 247);
  			public static bool[] Transparent = Factory.CreateBoolSet(88, 89, 90, 91, 92, 241);
  			public static bool[] Corrupt = Factory.CreateBoolSet(69, 217, 220, 3);
+@@ -25,6 +_,7 @@
+ 			public static bool[] Hallow = Factory.CreateBoolSet(70, 219, 222, 28);
+ 			public static bool[] AllowsWind = Factory.CreateBoolSet(0, 150, 138, 145, 107, 152, 140, 139, 141, 106, 245, 315);
+ 			public static int[] BlendType = Factory.CreateIntSet(-1, 66, 63, 68, 63, 65, 63, 16, 2, 59, 2, 261, 2, 284, 196, 285, 197, 286, 198, 287, 199, 256, 54, 257, 55, 258, 56, 259, 57, 260, 58, 262, 61, 274, 185, 300, 212, 301, 213, 302, 214, 303, 215, 296, 208, 297, 209, 298, 210, 299, 211, 48, 1, 49, 1, 50, 1, 51, 1, 52, 1, 53, 1, 250, 1, 251, 1, 252, 1, 253, 1, 254, 1, 255, 1, 69, 264, 3, 246, 217, 305, 220, 308, 188, 276, 189, 277, 190, 278, 191, 279, 81, 77, 268, 77, 83, 269, 218, 306, 221, 309, 192, 280, 193, 281, 194, 282, 195, 283, 70, 265, 28, 248, 219, 307, 222, 310, 200, 288, 201, 289, 202, 290, 203, 291, 15, 247, 64, 67, 204, 292, 205, 293, 206, 294, 207, 295, 86, 108, 87, 112, 40, 249, 71, 266, 62, 263, 80, 74, 180, 184, 178, 183, 79, 267, 20, 14, 7, 17, 94, 17, 95, 17, 8, 18, 98, 18, 99, 18, 9, 19, 96, 19, 97, 19);
++			public static bool[] CanBeClearedDuringGeneration = Factory.CreateBoolSet(true, 4, 40, 3, 87, 34);
+ 		}
+ 
+ 		public const ushort None = 0;
 @@ -344,5 +_,6 @@
  		public const ushort AmberStoneWallEcho = 314;
  		public const ushort BambooFence = 315;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -14,6 +14,15 @@
  	{
  		public static class SavedOreTiers
  		{
+@@ -157,7 +_,7 @@
+ 						hashSet.Add(item);
+ 						list.Remove(item);
+ 						Tile tile = Main.tile[item.X, item.Y];
+-						if (!SolidTile(item.X, item.Y) && tile.wall != num && tile.wall != 4 && tile.wall != 40 && tile.wall != 3 && tile.wall != 87 && tile.wall != 34) {
++						if (!SolidTile(item.X, item.Y) && tile.wall != num && WallID.CanBeClearedDuringGeneration[tile.wall]) {
+ 							bool flag = num == 63 || num == 62;
+ 							if (flag && tile.wall == 0) {
+ 								list.Remove(item);
 @@ -690,12 +_,18 @@
  		public delegate bool GetTreeFoliageDataMethod(int i, int j, int xoffset, ref int treeFrame, ref int treeStyle, out int floorY, out int topTextureFrameWidth, out int topTextureFrameHeight);
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -23,6 +23,15 @@
  							bool flag = num == 63 || num == 62;
  							if (flag && tile.wall == 0) {
  								list.Remove(item);
+@@ -213,7 +_,7 @@
+ 									list2.Add(item2);
+ 							}
+ 						}
+-						else if (tile.active() && tile.wall != num && tile.wall != 4 && tile.wall != 40 && tile.wall != 3 && tile.wall != 87 && tile.wall != 34) {
++						else if (tile.active() && tile.wall != num && WallID.CanBeClearedDuringGeneration[tile.wall]) {
+ 							tile.wall = num;
+ 						}
+ 					}
 @@ -690,12 +_,18 @@
  		public delegate bool GetTreeFoliageDataMethod(int i, int j, int xoffset, ref int treeFrame, ref int treeStyle, out int floorY, out int topTextureFrameWidth, out int topTextureFrameHeight);
  


### PR DESCRIPTION
### What is the new feature?
Adds WallID.CanBeClearedDuringGeneration to replace the hardcoding of which walls can't be replaced by WorldGen.Spread.Wall2, could probably be more accurately named

### Why should this be part of tModLoader?
Currently any walled caves which happen to extend into areas which will have grass walls have all of their walls (within range) replaced

### Are there alternative designs?
The set could be substantially more or less specific