### PR TITLE
Fix temporary items not saving modded data

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -33,6 +33,10 @@ namespace Terraria.ModLoader.IO
 		}
 
 		internal static TagCompound SaveData(Player player) {
+			player._temporaryItemSlots[0] = Main.mouseItem;
+			player._temporaryItemSlots[1] = Main.CreativeMenu.GetItemByIndex(0);
+			player._temporaryItemSlots[2] = Main.guideItem;
+			player._temporaryItemSlots[3] = Main.reforgeItem;
 			return new TagCompound {
 				["armor"] = SaveInventory(player.armor),
 				["dye"] = SaveInventory(player.dye),
@@ -43,6 +47,7 @@ namespace Terraria.ModLoader.IO
 				["bank2"] = SaveInventory(player.bank2.item),
 				["bank3"] = SaveInventory(player.bank3.item),
 				["bank4"] = SaveInventory(player.bank4.item),
+				["temporaryItemSlots"] = SaveInventory(player._temporaryItemSlots),
 				["hairDye"] = SaveHairDye(player.hairDye),
 				["research"] = SaveResearch(player),
 				["modData"] = SaveModData(player),
@@ -64,6 +69,7 @@ namespace Terraria.ModLoader.IO
 			LoadInventory(player.bank2.item, tag.GetList<TagCompound>("bank2"));
 			LoadInventory(player.bank3.item, tag.GetList<TagCompound>("bank3"));
 			LoadInventory(player.bank4.item, tag.GetList<TagCompound>("bank4"));
+			LoadInventory(player._temporaryItemSlots, tag.GetList<TagCompound>("temporaryItemSlots"));
 			LoadHairDye(player, tag.GetString("hairDye"));
 			LoadResearch(player, tag.GetList<TagCompound>("research"));
 			LoadModData(player, tag.GetList<TagCompound>("modData"));

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -261,6 +261,15 @@
  		public float luck;
  		public float luckMinimumCap = -0.7f;
  		public float luckMaximumCap = 1f;
+@@ -1417,7 +_,7 @@
+ 		private const int SaveSlotIndex_GuideItem = 2;
+ 		private const int SaveSlotIndex_TinkererItem = 3;
+ 		private const int SaveSlotIndexCount = 4;
+-		private Item[] _temporaryItemSlots = new Item[4];
++		internal Item[] _temporaryItemSlots = new Item[4];
+ 
+ 		public Vector2 BlehOldPositionFixer => -Vector2.UnitY;
+ 
 @@ -2084,6 +_,7 @@
  		public void SetTalkNPC(int npcIndex, bool fromNet = false) {
  			talkNPC = npcIndex;
@@ -6049,68 +6058,6 @@
  		}
  
  		private void SaveTemporaryItemSlotContents(BinaryWriter writer) {
-@@ -38241,40 +_,49 @@
- 			bb[3] = !Main.reforgeItem.IsAir;
- 			ItemSerializationContext context = ItemSerializationContext.SavingAndLoading;
- 			writer.Write(bb);
-+			// TML: Changed Item.Serialize to ItemIO.Send to serialize and save modded data
- 			if (bb[0])
-+				ItemIO.Send(Main.mouseItem, writer, writeStack: true);
--				Main.mouseItem.Serialize(writer, context);
-+				// Main.mouseItem.Serialize(writer, context);
- 
- 			if (bb[1])
-+				ItemIO.Send(itemByIndex, writer, writeStack: true);
--				itemByIndex.Serialize(writer, context);
-+				// itemByIndex.Serialize(writer, context);
- 
- 			if (bb[2])
-+				ItemIO.Send(Main.guideItem, writer, writeStack: true);
--				Main.guideItem.Serialize(writer, context);
-+				// Main.guideItem.Serialize(writer, context);
- 
- 			if (bb[3])
-+				ItemIO.Send(Main.reforgeItem, writer, writeStack: true);
--				Main.reforgeItem.Serialize(writer, context);
-+				// Main.reforgeItem.Serialize(writer, context);
- 		}
- 
- 		private void LoadTemporaryItemSlotContents(BinaryReader reader) {
- 			BitsByte bitsByte = reader.ReadByte();
- 			ItemSerializationContext context = ItemSerializationContext.SavingAndLoading;
- 			if (bitsByte[0]) {
-+				_temporaryItemSlots[0] = ItemIO.Receive(reader, readStack: true);
--				_temporaryItemSlots[0] = new Item();
-+				// _temporaryItemSlots[0] = new Item();
--				_temporaryItemSlots[0].DeserializeFrom(reader, context);
-+				// _temporaryItemSlots[0].DeserializeFrom(reader, context);
- 			}
- 
- 			if (bitsByte[1]) {
-+				_temporaryItemSlots[1] = ItemIO.Receive(reader, readStack: true);
--				_temporaryItemSlots[1] = new Item();
-+				// _temporaryItemSlots[1] = new Item();
--				_temporaryItemSlots[1].DeserializeFrom(reader, context);
-+				// _temporaryItemSlots[1].DeserializeFrom(reader, context);
- 			}
- 
- 			if (bitsByte[2]) {
-+				_temporaryItemSlots[2] = ItemIO.Receive(reader, readStack: true);
--				_temporaryItemSlots[2] = new Item();
-+				// _temporaryItemSlots[2] = new Item();
--				_temporaryItemSlots[2].DeserializeFrom(reader, context);
-+				// _temporaryItemSlots[2].DeserializeFrom(reader, context);
- 			}
- 
- 			if (bitsByte[3]) {
-+				_temporaryItemSlots[3] = ItemIO.Receive(reader, readStack: true);
--				_temporaryItemSlots[3] = new Item();
-+				// _temporaryItemSlots[3] = new Item();
--				_temporaryItemSlots[3].DeserializeFrom(reader, context);
-+				// _temporaryItemSlots[3].DeserializeFrom(reader, context);
- 			}
- 		}
- 
 @@ -38334,6 +_,8 @@
  
  			Player player = new Player();

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6049,6 +6049,68 @@
  		}
  
  		private void SaveTemporaryItemSlotContents(BinaryWriter writer) {
+@@ -38241,40 +_,49 @@
+ 			bb[3] = !Main.reforgeItem.IsAir;
+ 			ItemSerializationContext context = ItemSerializationContext.SavingAndLoading;
+ 			writer.Write(bb);
++			// TML: Changed Item.Serialize to ItemIO.Send to serialize and save modded data
+ 			if (bb[0])
++				ItemIO.Send(Main.mouseItem, writer, writeStack: true);
+-				Main.mouseItem.Serialize(writer, context);
++				// Main.mouseItem.Serialize(writer, context);
+ 
+ 			if (bb[1])
++				ItemIO.Send(itemByIndex, writer, writeStack: true);
+-				itemByIndex.Serialize(writer, context);
++				// itemByIndex.Serialize(writer, context);
+ 
+ 			if (bb[2])
++				ItemIO.Send(Main.guideItem, writer, writeStack: true);
+-				Main.guideItem.Serialize(writer, context);
++				// Main.guideItem.Serialize(writer, context);
+ 
+ 			if (bb[3])
++				ItemIO.Send(Main.reforgeItem, writer, writeStack: true);
+-				Main.reforgeItem.Serialize(writer, context);
++				// Main.reforgeItem.Serialize(writer, context);
+ 		}
+ 
+ 		private void LoadTemporaryItemSlotContents(BinaryReader reader) {
+ 			BitsByte bitsByte = reader.ReadByte();
+ 			ItemSerializationContext context = ItemSerializationContext.SavingAndLoading;
+ 			if (bitsByte[0]) {
++				_temporaryItemSlots[0] = ItemIO.Receive(reader, readStack: true);
+-				_temporaryItemSlots[0] = new Item();
++				// _temporaryItemSlots[0] = new Item();
+-				_temporaryItemSlots[0].DeserializeFrom(reader, context);
++				// _temporaryItemSlots[0].DeserializeFrom(reader, context);
+ 			}
+ 
+ 			if (bitsByte[1]) {
++				_temporaryItemSlots[1] = ItemIO.Receive(reader, readStack: true);
+-				_temporaryItemSlots[1] = new Item();
++				// _temporaryItemSlots[1] = new Item();
+-				_temporaryItemSlots[1].DeserializeFrom(reader, context);
++				// _temporaryItemSlots[1].DeserializeFrom(reader, context);
+ 			}
+ 
+ 			if (bitsByte[2]) {
++				_temporaryItemSlots[2] = ItemIO.Receive(reader, readStack: true);
+-				_temporaryItemSlots[2] = new Item();
++				// _temporaryItemSlots[2] = new Item();
+-				_temporaryItemSlots[2].DeserializeFrom(reader, context);
++				// _temporaryItemSlots[2].DeserializeFrom(reader, context);
+ 			}
+ 
+ 			if (bitsByte[3]) {
++				_temporaryItemSlots[3] = ItemIO.Receive(reader, readStack: true);
+-				_temporaryItemSlots[3] = new Item();
++				// _temporaryItemSlots[3] = new Item();
+-				_temporaryItemSlots[3].DeserializeFrom(reader, context);
++				// _temporaryItemSlots[3].DeserializeFrom(reader, context);
+ 			}
+ 		}
+ 
 @@ -38334,6 +_,8 @@
  
  			Player player = new Player();


### PR DESCRIPTION
### What is the bug?
Temporary items (mouseItem, research slot item, guide item and reforge item) don't have modded data saved.
That means if you leave a weapon in the reforge slot and then rejoin the world, which is doable in the game, all of its modded data will be lost.
### How did you fix the bug?
Vanilla saves and loads temporary item data (`netID`,`stack` and `prefix`) in `Player.SaveTemporaryItemSlotContents` via `Item.Serialize` and `Item.DeserializeFrom`, which don't include modded data.
The fix saves `player_temporaryItemSlots` in `PlayerIO.SaveData` just as what other player data do in tML:
```CSharp
["temporaryItemSlots"] = SaveInventory(player._temporaryItemSlots)
```
Before saving, temporary items must be assigned to `player._temporaryItemSlots` as well since in vanilla it only gets values when loading data:
```CSharp
player._temporaryItemSlots[0] = Main.mouseItem;
player._temporaryItemSlots[1] = Main.CreativeMenu.GetItemByIndex(0);
player._temporaryItemSlots[2] = Main.guideItem;
player._temporaryItemSlots[3] = Main.reforgeItem;
```
And finally, loads the data in `PlayerIO.Load`:
```CSharp
LoadInventory(player._temporaryItemSlots, tag.GetList<TagCompound>("temporaryItemSlots"))
```