### PR TITLE
Fix JIT Attributes Checking Happening in the Wrong Order

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -347,7 +347,8 @@ namespace Terraria.ModLoader.Core
 							.Where(m => !m.IsSpecialName) // exclude property accessors, collect them below after checking ShouldJIT on the PropertyInfo
 							.Concat<MethodBase>(type.GetConstructors(ALL))
 							.Concat(type.GetProperties(ALL).Where(filter.ShouldJIT).SelectMany(p => p.GetAccessors()))
-							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && m.DeclaringType == type && filter.ShouldJIT(m))
+							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && m.DeclaringType == type)
+							.Where(filter.ShouldJIT)
 					)
 					.ToArray();
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -347,8 +347,7 @@ namespace Terraria.ModLoader.Core
 							.Where(m => !m.IsSpecialName) // exclude property accessors, collect them below after checking ShouldJIT on the PropertyInfo
 							.Concat<MethodBase>(type.GetConstructors(ALL))
 							.Concat(type.GetProperties(ALL).Where(filter.ShouldJIT).SelectMany(p => p.GetAccessors()))
-							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && m.GetMethodBody() != null && m.DeclaringType == type)
-							.Where(filter.ShouldJIT)
+							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && filter.ShouldJIT(m) && m.GetMethodBody() != null && m.DeclaringType == type)
 					)
 					.ToArray();
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -347,7 +347,7 @@ namespace Terraria.ModLoader.Core
 							.Where(m => !m.IsSpecialName) // exclude property accessors, collect them below after checking ShouldJIT on the PropertyInfo
 							.Concat<MethodBase>(type.GetConstructors(ALL))
 							.Concat(type.GetProperties(ALL).Where(filter.ShouldJIT).SelectMany(p => p.GetAccessors()))
-							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && filter.ShouldJIT(m) && m.GetMethodBody() != null && m.DeclaringType == type)
+							.Where(m => !m.IsAbstract && !m.ContainsGenericParameters && m.DeclaringType == type && filter.ShouldJIT(m))
 					)
 					.ToArray();
 
@@ -379,7 +379,8 @@ namespace Terraria.ModLoader.Core
 		}
 
 		private static void ForceJITOnMethod(MethodBase method) {
-			RuntimeHelpers.PrepareMethod(method.MethodHandle);
+			if (method.GetMethodBody() != null)
+				RuntimeHelpers.PrepareMethod(method.MethodHandle);
 
 			// Here we check for overrides that override methods that no longer exist.
 			// tModLoader contributors should consult https://github.com/tModLoader/tModLoader/wiki/tModLoader-Style-Guide#be-aware-of-breaking-changes to properly handle breaking changes, especially once 1.4 is stable.


### PR DESCRIPTION
### What is the bug?
Using any JIT attributes on a method (e.g. `JITWhenModsEnabled`) didn't properly prevent the method from being effectively blocked from being JIT compiled.

Furthermore, the resulting error didn't indicate which class and method were the cause, which made it difficult to find what code broke.

Quoted verbatim from the collaborators channel in the Discord server, the following is likely what happens:
> 1) the mod i'm coding has calamity as a weak reference
> 2) a method that uses calamity types has `[JITWhenModsEnabled("CalamityMod")]`, which should prevent it from throwing errors when calamity isn't enabled
> 3) the mod JITting step during mod loading calls `MethodBase.GetMethodBody()` for the methods that it deems as valid for JIT targets
> 4) `MethodBase.GetMethodBody()` constructs the method body from the method's instructions
> 5) the method's instructions contain references to types in Calamity
> 6) types don't exist, error is thrown

As an example, here's some code that was used to restrict access of types from Calamity:
```cs
[MethodImpl(MethodImplOptions.NoInlining)]
[JITWhenModsEnabled("CalamityMod")]
private static void PlanteraLoot_Calamity(ILoot loot) {
    if (loot.Get().FindRecursive(PlanteraLoot_Calamity_IsRuleValid) is DropHelper.AllOptionsAtOnceWithPityDropRule pity) {
        Array.Resize(ref pity.stacks, pity.stacks.Length + 1);
        pity.stacks[^1] = ModContent.ItemType<RevolverUpgradePlantera>();
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
[JITWhenModsEnabled("CalamityMod")]
private static bool PlanteraLoot_Calamity_IsRuleValid(IItemDropRule r) => r is DropHelper.AllOptionsAtOnceWithPityDropRule;
```

Yet the code still caused an error to be thrown during mod loading:
![image](https://user-images.githubusercontent.com/30454621/197641040-be1d55f3-f133-4671-845d-2f99879ca2c3.png)

### How did you fix the bug?

I fixed the bug by forcing the JIT attribute checks to happen before the method's body is loaded.

### Are there alternatives to your fix?
n/a

### More information
The relevant Discord discussion can be found [here](https://discord.com/channels/103110554649894912/445276626352209920/1034227871343968336).