### PR TITLE
Fixed vines disappearing when teleporting

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -330,7 +330,7 @@
  		}
  
  		private bool IsWindBlocked(int x, int y) {
-@@ -4440,16 +_,20 @@
+@@ -4440,16 +_,21 @@
  			if (solidLayer) {
  				_displayDollTileEntityPositions.Clear();
  				_hatRackTileEntityPositions.Clear();
@@ -338,6 +338,7 @@
 -				_reverseVineRootsPositions.Clear();
 +				return;
  			}
++			//TML: Moved so positions get cleared and added in the same frame
 +			_vineRootsPositions.Clear();
 +			_reverseVineRootsPositions.Clear();
  		}

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -330,8 +330,16 @@
  		}
  
  		private bool IsWindBlocked(int x, int y) {
-@@ -4445,11 +_,14 @@
+@@ -4440,16 +_,20 @@
+ 			if (solidLayer) {
+ 				_displayDollTileEntityPositions.Clear();
+ 				_hatRackTileEntityPositions.Clear();
+-				_vineRootsPositions.Clear();
+-				_reverseVineRootsPositions.Clear();
++				return;
  			}
++			_vineRootsPositions.Clear();
++			_reverseVineRootsPositions.Clear();
  		}
  
 -		private void AddSpecialLegacyPoint(Point p) {


### PR DESCRIPTION
### What is the bug?
Vines and Seaweed disappear for a frame when teleporting in color mode
Easily reproducible by using a rod of discord near vines with lighting mode set to color

More technically:

This issue has to do with `Main.renderNow` being set to true. The positions for where vines are drawn are updated in `Main.RenderTiles2()` and only update when `TileDrawing._vineRootsPositions` does not contain that position. `_vineRootsPositions` is cleared when `solidLayer` is true which occurs when `Main.RenderTiles()` is called. Thus drawing vines relies on the fact that `RenderTiles()` is called before `RenderTiles2()`. However due to how tModLoader changes render order (see #1802) when the game "renders now" after a teleport `RenderTiles2()` is called and `renderCount` is reset to 0 then it gets incremented to 1 (no issue) then it gets incremented to 2 and `RenderTiles2()` is called again and since `RenderTiles()` was not called in-between `_vineRootsPositions` is never cleared so `_specialCount` never gets updated so no vines are drawn until the next call of `RenderTiles2()` where everything is back to normal.

### How did you fix the bug?
I made it so that `_vineRootsPositions` and `_reverseVineRootsPositions` clear when `solidLayer` is false. In other words when `RenderTiles2()` is called so it does not rely on `RenderTiles()` to be called. This is also because the only time they are updated is when `solidLayer` is false so clearing them right before they get updated makes the most sense.

### Are there alternatives to your fix?
Honestly the relationship between `TileDrawing._specialPositions` and `TileDrawing._vineRootsPositions` seems very redundant and it wouldn't be too hard to not use `_vineRootsPositions` all together. It seems like it's there just for convenience.
