### PR TITLE
Added ModNPC.NoTownNPCHappiness Property to Allow Town NPCs to Not Be Affected by Happiness.

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
@@ -185,6 +185,7 @@ namespace ExampleMod.Content.NPCs
 			NPC.knockBackResist = 0.5f;
 			AnimationType = NPCID.Guide;
 			TownNPCStayingHomeless = true;
+			NoTownNPCHappiness = true;
 			CreateNewShop();
 		}
 

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -40,6 +40,15 @@
  			_database = new PersonalityDatabase();
  			new PersonalityDatabasePopulator().Populate(_database);
  		}
+@@ -86,7 +_,7 @@
+ 				if (npc.type == 656 || npc.type == 637 || npc.type == 638)
+ 					return;
+ 
+-				if (IsNotReallyTownNPC(npc)) {
++				if (IsNotReallyTownNPC(npc) || npc.ModNPC?.NoTownNPCHappiness == true) {
+ 					_currentPriceAdjustment = 1f;
+ 					return;
+ 				}
 @@ -129,7 +_,7 @@
  					_currentPriceAdjustment *= 0.95f;
  				}

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -74,6 +74,9 @@ namespace Terraria.ModLoader
 		/// <summary> Setting this to true will make the NPC not appear in the housing menu nor make it find an house. </summary>
 		public bool TownNPCStayingHomeless { get; set; }
 
+		/// <summary> Setting this to true will make the Town NPC not affected by Happiness. Their price modifier will be 1f (neutral). </summary>
+		public bool NoTownNPCHappiness { get; set; } = false;
+
 		protected override NPC CreateTemplateEntity() => new() { ModNPC = this };
 
 		protected sealed override void Register() {


### PR DESCRIPTION
### What is the new feature?

Added a new `ModNPC` property, `NoTownNPCHappiness`, that allows the modder to make their Town NPC not affect by Happiness.

### Why should this be part of tModLoader?

Even if you do not set any Town NPC affection in your Town NPC, the Town NPC will still be affected by solitude/crowding, being homeless, and being in the Corruption/Crimson/Dungeon.

One way to remove Happiness for your Town NPC is to add it to the `ActsLikeTownNPC[]` set. However, that comes with other side effects like the Town NPC not having a map icon and despawning when far away.

You can hide the Happiness button if you manually set `Main.LocalPlayer.currentShoppingSettings.HappinessReport = ""` in `GetChat()`, but that only stops the button from being drawn. Price calculations are still done.

With this property, you can easily make it so your Town NPC does not have the Happiness button and their prices are always neutral.

### Are there alternative designs?

An alternative design would be to use `NPCID.Sets`, but I chose a `ModNPC` property instead so the field could be changed during the game (instead of just mod load time). For example, a mod wants their Town NPC to not be affected by Happiness after meeting a certain requirement such as defeating a boss. They can change `NPC.ModNPC.NoTownNPCHappiness` to true in something like `PreAI()`.

Another alternative design would be to make it an `NPC` field instead of `ModNPC`.

### Sample usage for the new feature

Updated Example Traveling Merchant to use this new property. Previously, all of their prices were at maximum because they were homeless. They also had a Happiness button unlike the vanilla Traveling Merchant which does not.

### ExampleMod updates
Updated Example Traveling Merchant. The Example Bone Merchant is already not affected by Happiness because it uses the `ActsLikeTownNPC[]` set.
