### PR TITLE
Fixed chat trying to open in UI menus

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1755,6 +1755,15 @@
  			chatMonitor.Update();
  			upTimer = (float)sw.Elapsed.TotalMilliseconds;
  			if (upTimerMaxDelay > 0f)
+@@ -13445,7 +_,7 @@
+ 
+ 		private static void DoUpdate_Enter_ToggleChat() {
+ 			if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Enter) && !keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.LeftAlt) && !keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.RightAlt) && hasFocus) {
+-				if (chatRelease && !drawingPlayerChat && !editSign && !editChest && !gameMenu && !keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Escape)) {
++				if (chatRelease && !drawingPlayerChat && !editSign && !editChest && !gameMenu && !InGameUI.IsVisible && !ingameOptionsWindow && !keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Escape)) {
+ 					SoundEngine.PlaySound(10);
+ 					OpenPlayerChat();
+ 					chatText = "";
 @@ -13516,7 +_,8 @@
  			if (!inputTextEnter || !chatRelease)
  				return;


### PR DESCRIPTION
### What is the bug?
When you press "Enter" in various UI menus you open the in game chat (even though the chat UI is never drawn). This is a particular problem for the Mod Config menu because if you start typing in an input field, press "Enter", and continue typing it starts populating the chat and not the input field. If you press "Enter" again the chat message is even sent. All the while the chat UI was never drawn, so it can be very confusing to the player
### How did you fix the bug?
I added additional checks to `Main.DoUpdate_Enter_ToggleChat()` to prevent the chat from opening in UI menus
`Main.ingameOptionsWindow` refers to the initial settings menu
`Main.InGameUI` refers to pretty much everything else (Mod Configs, Keybindings, Achievements, etc) 
### Are there alternatives to your fix?
`Main.CurrentInputTextTakerOverride` can also be used to prevent the chat from opening and could be added to the update method of the `UIFocusInuptTextField`/ any other UI element that needs it

`Main.inFancyUI` might be interchangeable with `Main.InGameUI.IsVisible`
