### PR TITLE
Item.NewItem overloads that takes Item, fix small moditem<->item issuees from TEs and dying.

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEFoodPlatter.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEFoodPlatter.cs.patch
@@ -26,14 +26,12 @@
  			writer.Write((short)item.stack);
  		}
  
-@@ -93,20 +_,26 @@
+@@ -93,20 +_,23 @@
  
  		public void DropItem() {
  			if (Main.netMode != 1)
-+				/*
- 				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 16, 16, item.netID, 1, noBroadcast: false, item.prefix);
-+				*/
-+				Item.DropItem(new EntitySource_TileBreak(Position.X, Position.Y), item, new Rectangle(Position.X * 16, Position.Y * 16, 16, 16));
+-				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 16, 16, item.netID, 1, noBroadcast: false, item.prefix);
++				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 16, 16, item, noBroadcast: false);
  
  			item = new Item();
  		}
@@ -50,7 +48,7 @@
  				Main.item[num2].stack = stack;
  				NetMessage.SendData(21, -1, -1, null, num2);
 +				*/
-+				Item.DropItem(new EntitySource_TileBreak(x, y), item, new Rectangle(x * 16, y * 16, 16, 16));
++				Item.NewItem(new EntitySource_TileBreak(x, y), new Rectangle(x * 16, y * 16, 16, 16), item);
  				return;
  			}
  

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEItemFrame.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEItemFrame.cs.patch
@@ -26,14 +26,12 @@
  			writer.Write((short)item.stack);
  		}
  
-@@ -92,20 +_,26 @@
+@@ -92,20 +_,23 @@
  
  		public void DropItem() {
  			if (Main.netMode != 1)
-+				/*
- 				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item.netID, 1, noBroadcast: false, item.prefix);
-+				*/
-+				Item.DropItem(new EntitySource_TileBreak(Position.X, Position.Y), item, new Rectangle(Position.X * 16, Position.Y * 16, 16, 16));
+-				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item.netID, 1, noBroadcast: false, item.prefix);
++				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item, noBroadcast: false);
  
  			item = new Item();
  		}
@@ -50,7 +48,7 @@
  				Main.item[num2].stack = stack;
  				NetMessage.SendData(21, -1, -1, null, num2);
 +				*/
-+				Item.DropItem(new EntitySource_TileBreak(x, y), item, new Rectangle(x * 16, y * 16, 16, 16));
++				Item.NewItem(new EntitySource_TileBreak(x, y), new Rectangle(x * 16, y * 16, 16, 16), item);
  				return;
  			}
  

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEWeaponsRack.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEWeaponsRack.cs.patch
@@ -26,14 +26,12 @@
  			writer.Write((short)item.stack);
  		}
  
-@@ -137,20 +_,26 @@
+@@ -137,20 +_,23 @@
  
  		public void DropItem() {
  			if (Main.netMode != 1)
-+				/*
- 				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item.netID, 1, noBroadcast: false, item.prefix);
-+				*/
-+				Item.DropItem(new EntitySource_TileBreak(Position.X, Position.Y), item, new Rectangle(Position.X * 16, Position.Y * 16, 16, 16));
+-				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item.netID, 1, noBroadcast: false, item.prefix);
++				Item.NewItem(new EntitySource_TileBreak(Position.X, Position.Y), Position.X * 16, Position.Y * 16, 32, 32, item, noBroadcast: false);
  
  			item = new Item();
  		}
@@ -50,7 +48,7 @@
  				Main.item[num2].stack = stack;
  				NetMessage.SendData(21, -1, -1, null, num2);
 +				*/
-+				Item.DropItem(new EntitySource_TileBreak(x, y), item, new Rectangle(x * 16, y * 16, 16, 16));
++				Item.NewItem(new EntitySource_TileBreak(x, y), new Rectangle(x * 16, y * 16, 16, 16), item);
  				return;
  			}
  

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -188,10 +188,7 @@ namespace Terraria
 			if (NPCLoader.blockLoot.Contains(Type))
 				return Main.maxItems;
 
-			if (Type > 0 && cachedItemSpawnsByType[Type] != -1) {
-				cachedItemSpawnsByType[Type] += item.stack;
-				return 400;
-			}
+			// cachedItemSpawnsByType feature deliberately omitted from this NewItem
 
 			Main.item[400] = new Item();
 			int num = 400;

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -1,13 +1,10 @@
 using Microsoft.Xna.Framework;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
-using Terraria.Utilities;
 
 namespace Terraria
 {

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using Terraria.DataStructures;
@@ -177,28 +178,7 @@ namespace Terraria
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// </summary>
 		public static int NewItem(IEntitySource source, int X, int Y, int Width, int Height, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false) {
-			int Type = item.type;
-
-			if (WorldGen.gen)
-				return 0;
-
-			if (Main.rand == null)
-				Main.rand = new UnifiedRandom();
-
-			if (NPCLoader.blockLoot.Contains(Type))
-				return Main.maxItems;
-
-			// cachedItemSpawnsByType feature deliberately omitted from this NewItem
-
-			Main.item[400] = new Item();
-			int num = 400;
-			if (Main.netMode != 1)
-				num = PickAnItemSlotToSpawnItemOn(reverseLookup, num);
-
-			Main.timeItemSlotCannotBeReusedFor[num] = 0;
-			Main.item[num] = item.Clone();
-
-			return Item.NewItem_Inner(num, source, X, Y, Width, Height, Main.item[num], noBroadcast, noGrabDelay);
+			return Item.NewItem_Inner(source, X, Y, Width, Height, item, item.type, item.stack, noBroadcast, item.prefix, noGrabDelay, reverseLookup);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -160,6 +160,7 @@ namespace Terraria
 		/// <inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>
 		/// <br/><br/>This particular overload uses a Rectangle instead of X, Y, Width, and Height to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Rectangle rectangle, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false)
 			=> NewItem(source, rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
@@ -167,6 +168,7 @@ namespace Terraria
 		/// <inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>
 		/// <br/><br/>This particular overload uses a Vector2 instead of X, Y, Width, and Height to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Vector2 position, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false)
 			=> NewItem(source, (int)position.X, (int)position.Y, 0, 0, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
 
@@ -174,6 +176,7 @@ namespace Terraria
 		/// <inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, int X, int Y, int Width, int Height, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false) {
 			return Item.NewItem_Inner(source, X, Y, Width, Height, item, item.type, item.stack, noBroadcast, item.prefix, noGrabDelay, reverseLookup);
 		}
@@ -183,6 +186,7 @@ namespace Terraria
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// <br/><br/>This particular overload uses a Vector2 instead of X and Y to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Vector2 pos, Vector2 randomBox, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false) => NewItem(source, (int)pos.X, (int)pos.Y, (int)randomBox.X, (int)randomBox.Y, item, noBroadcast, noGrabDelay, reverseLookup);
 
 		/// <summary>
@@ -190,6 +194,7 @@ namespace Terraria
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// <br/><br/>This particular overload uses a Vector2 instead of X and Y to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Vector2 pos, int Width, int Height, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false) => NewItem(source, (int)pos.X, (int)pos.Y, Width, Height, item, noBroadcast, noGrabDelay, reverseLookup);
 
 		/// <summary>
@@ -197,6 +202,7 @@ namespace Terraria
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// <br/><br/>This particular overload uses a Vector2 instead of X, Y, Width, and Height to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Vector2 position, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false)
 			=> NewItem(source, (int)position.X, (int)position.Y, 0, 0, item, noBroadcast, noGrabDelay, reverseLookup);
 
@@ -205,6 +211,7 @@ namespace Terraria
 		/// <br/><br/>This particular overload uses an Item instead of just the item type. All modded data will be preserved.
 		/// <br/><br/>This particular overload uses a Rectangle instead of X, Y, Width, and Height to determine the actual spawn position.
 		/// </summary>
+		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
 		public static int NewItem(IEntitySource source, Rectangle rectangle, Item item, bool noBroadcast = false, bool noGrabDelay = false, bool reverseLookup = false)
 			=> NewItem(source, rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height, item, noBroadcast, noGrabDelay, reverseLookup);
 

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -956,7 +956,7 @@
  					if (item.stack <= 0) {
  						item.SetDefaults();
  						item.active = false;
-@@ -46280,13 +_,47 @@
+@@ -46280,20 +_,61 @@
  				case 4070:
  					return TextureAssets.Item[type].Frame(1, 4);
  				default:
@@ -1003,9 +1003,13 @@
 +		/// <param name="reverseLookup"></param>
 +		/// <returns></returns>
  		public static int NewItem(IEntitySource source, int X, int Y, int Width, int Height, int Type, int Stack = 1, bool noBroadcast = false, int pfix = 0, bool noGrabDelay = false, bool reverseLookup = false) {
++			return Item.NewItem_Inner(source, X, Y, Width, Height, null, Type, Stack, noBroadcast, pfix, noGrabDelay, reverseLookup);
++		}
++
++		private static int NewItem_Inner(IEntitySource source, int X, int Y, int Width, int Height, Item itemToClone, int Type, int Stack = 1, bool noBroadcast = false, int pfix = 0, bool noGrabDelay = false, bool reverseLookup = false) {
  			if (WorldGen.gen)
  				return 0;
-@@ -46294,6 +_,9 @@
+ 
  			if (Main.rand == null)
  				Main.rand = new UnifiedRandom();
  
@@ -1015,17 +1019,33 @@
  			if (Main.tenthAnniversaryWorld) {
  				if (Type == 58) {
  					Type = Main.rand.NextFromList(new short[3] {
-@@ -46344,6 +_,13 @@
- 			item.SetDefaults(Type);
- 			item.Prefix(pfix);
- 			item.stack = Stack;
-+
-+			return Item.NewItem_Inner(num, source, X, Y, Width, Height, item, noBroadcast, noGrabDelay);
-+		}
-+		
-+		private static int NewItem_Inner(int num, IEntitySource source, int X, int Y, int Width, int Height, Item item, bool noBroadcast = false, bool noGrabDelay = false) {
-+			int Type = item.type;
-+
+@@ -46328,7 +_,7 @@
+ 					Type = 1868;
+ 			}
+ 
+-			if (Type > 0 && cachedItemSpawnsByType[Type] != -1) {
++			if (itemToClone != null && Type > 0 && cachedItemSpawnsByType[Type] != -1) {
+ 				cachedItemSpawnsByType[Type] += Stack;
+ 				return 400;
+ 			}
+@@ -46339,11 +_,16 @@
+ 				num = PickAnItemSlotToSpawnItemOn(reverseLookup, num);
+ 
+ 			Main.timeItemSlotCannotBeReusedFor[num] = 0;
+-			Main.item[num] = new Item();
++			Main.item[num] = itemToClone?.Clone() ?? new Item();
+ 			Item item = Main.item[num];
++			if (itemToClone == null) {
+-			item.SetDefaults(Type);
++				item.SetDefaults(Type);
+-			item.Prefix(pfix);
++				item.Prefix(pfix);
+-			item.stack = Stack;
++				item.stack = Stack;
++			}
++			else {
++				Type = itemToClone.type; // just to be safe if IL edits change type swaps and velocity tweaks.
++			}
  			item.position.X = X + Width / 2 - item.width / 2;
  			item.position.Y = Y + Height / 2 - item.height / 2;
  			item.wet = Collision.WetCollision(item.position, item.width, item.height);

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1015,6 +1015,20 @@
  			if (Main.tenthAnniversaryWorld) {
  				if (Type == 58) {
  					Type = Main.rand.NextFromList(new short[3] {
+@@ -46344,6 +_,13 @@
+ 			item.SetDefaults(Type);
+ 			item.Prefix(pfix);
+ 			item.stack = Stack;
++
++			return Item.NewItem_Inner(num, source, X, Y, Width, Height, item, noBroadcast, noGrabDelay);
++		}
++		
++		private static int NewItem_Inner(int num, IEntitySource source, int X, int Y, int Width, int Height, Item item, bool noBroadcast = false, bool noGrabDelay = false) {
++			int Type = item.type;
++
+ 			item.position.X = X + Width / 2 - item.width / 2;
+ 			item.position.Y = Y + Height / 2 - item.height / 2;
+ 			item.wet = Collision.WetCollision(item.position, item.width, item.height);
 @@ -46363,6 +_,8 @@
  			if (ItemSlot.Options.HighlightNewItems && item.type >= 0 && !ItemID.Sets.NeverAppearsAsNewInInventory[item.type])
  				item.newAndShiny = true;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -956,7 +956,7 @@
  					if (item.stack <= 0) {
  						item.SetDefaults();
  						item.active = false;
-@@ -46280,20 +_,61 @@
+@@ -46280,20 +_,63 @@
  				case 4070:
  					return TextureAssets.Item[type].Frame(1, 4);
  				default:
@@ -976,12 +976,14 @@
 +		/// <inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>
 +		/// <br/><br/>This particular overload uses two Vector2 to determine the actual spawn position.
 +		/// </summary>
++		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
  		public static int NewItem(IEntitySource source, Vector2 pos, Vector2 randomBox, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false) => NewItem(source, (int)pos.X, (int)pos.Y, (int)randomBox.X, (int)randomBox.Y, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
-+		
++
 +		/// <summary>
 +		/// <inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>
 +		/// <br/><br/>This particular overload uses a Vector2 instead of X and Y to determine the actual spawn position.
 +		/// </summary>
++		/// <returns><inheritdoc cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/></returns>
  		public static int NewItem(IEntitySource source, Vector2 pos, int Width, int Height, int Type, int Stack = 1, bool noBroadcast = false, int prefixGiven = 0, bool noGrabDelay = false, bool reverseLookup = false) => NewItem(source, (int)pos.X, (int)pos.Y, Width, Height, Type, Stack, noBroadcast, prefixGiven, noGrabDelay, reverseLookup);
  
 +		/// <summary>
@@ -1001,7 +1003,7 @@
 +		/// <param name="pfix"></param>
 +		/// <param name="noGrabDelay"></param>
 +		/// <param name="reverseLookup"></param>
-+		/// <returns></returns>
++		/// <returns>The index of the item within <see cref="Main.item"/></returns>
  		public static int NewItem(IEntitySource source, int X, int Y, int Width, int Height, int Type, int Stack = 1, bool noBroadcast = false, int pfix = 0, bool noGrabDelay = false, bool reverseLookup = false) {
 +			return Item.NewItem_Inner(source, X, Y, Width, Height, null, Type, Stack, noBroadcast, pfix, noGrabDelay, reverseLookup);
 +		}
@@ -1028,24 +1030,20 @@
  				cachedItemSpawnsByType[Type] += Stack;
  				return 400;
  			}
-@@ -46339,11 +_,16 @@
- 				num = PickAnItemSlotToSpawnItemOn(reverseLookup, num);
- 
+@@ -46341,9 +_,16 @@
  			Main.timeItemSlotCannotBeReusedFor[num] = 0;
--			Main.item[num] = new Item();
-+			Main.item[num] = itemToClone?.Clone() ?? new Item();
+ 			Main.item[num] = new Item();
  			Item item = Main.item[num];
-+			if (itemToClone == null) {
--			item.SetDefaults(Type);
-+				item.SetDefaults(Type);
--			item.Prefix(pfix);
-+				item.Prefix(pfix);
--			item.stack = Stack;
-+				item.stack = Stack;
-+			}
-+			else {
++			if (itemToClone != null) {
++				Main.item[num] = itemToClone.Clone();
++				item = Main.item[num];
 +				Type = itemToClone.type; // just to be safe if IL edits change type swaps and velocity tweaks.
++				goto skipItemCreation;
 +			}
+ 			item.SetDefaults(Type);
+ 			item.Prefix(pfix);
+ 			item.stack = Stack;
++			skipItemCreation:
  			item.position.X = X + Width / 2 - item.width / 2;
  			item.position.Y = Y + Height / 2 - item.height / 2;
  			item.wet = Collision.WetCollision(item.position, item.width, item.height);

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -118,11 +118,13 @@ namespace Terraria
 		}
 
 		/// <summary>
-		/// Will spawn an item like QuickSpawnItem, but clones it (handy when you need to retain item infos)
+		/// Will spawn an item like <see cref="Player.QuickSpawnItem(IEntitySource, int, int)"/>, but clones it (handy when you need to retain item infos)
 		/// </summary>
 		/// <param name="source">The spawn context</param>
 		/// <param name="item">The item you want to be cloned</param>
 		/// <param name="stack">The stack to give the item. Note that this will override maxStack if it's higher.</param>
+		// TODO: 1.4.4, delete this and move code to Player.QuickSpawnItem(IEntitySource source, Item item, int stack).
+		[Obsolete("Use Player.QuickSpawnItem(IEntitySource source, Item item, int stack) instead.")]
 		public int QuickSpawnClonedItem(IEntitySource source, Item item, int stack = 1) {
 			int index = Item.NewItem(source, getRect(), item, false, false, false);
 			Main.item[index].stack = stack;
@@ -134,19 +136,22 @@ namespace Terraria
 			return index;
 		}
 
-		/// <inheritdoc cref="QuickSpawnItem(IEntitySource, int, int)"/>
-		public int QuickSpawnItem(IEntitySource source, Item item, int stack = 1)
-			=> QuickSpawnItem(source, item.type, stack);
-
 		/// <inheritdoc cref="QuickSpawnClonedItem"/>
+		public int QuickSpawnItem(IEntitySource source, Item item, int stack = 1)
+			=> QuickSpawnClonedItem(source, item, stack);
+
+		/// <summary><inheritdoc cref="QuickSpawnClonedItem"/></summary>
+		/// <returns>Returns the Item instance</returns>
 		public Item QuickSpawnClonedItemDirect(IEntitySource source, Item item, int stack = 1)
 			=> Main.item[QuickSpawnClonedItem(source, item, stack)];
 
-		/// <inheritdoc cref="QuickSpawnClonedItem"/>
+		/// <summary><inheritdoc cref="QuickSpawnClonedItem"/></summary>
+		/// <returns>Returns the Item instance</returns>
 		public Item QuickSpawnItemDirect(IEntitySource source, Item item, int stack = 1)
-			=> Main.item[QuickSpawnItem(source, item.type, stack)];
+			=> Main.item[QuickSpawnClonedItem(source, item, stack)];
 
-		/// <inheritdoc cref="QuickSpawnClonedItem"/>
+		/// <summary><inheritdoc cref="QuickSpawnItem(IEntitySource, int, int)"/></summary>
+		/// <returns>Returns the Item instance</returns>
 		public Item QuickSpawnItemDirect(IEntitySource source, int type, int stack = 1)
 			=> Main.item[QuickSpawnItem(source, type, stack)];
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -124,11 +124,8 @@ namespace Terraria
 		/// <param name="item">The item you want to be cloned</param>
 		/// <param name="stack">The stack to give the item. Note that this will override maxStack if it's higher.</param>
 		public int QuickSpawnClonedItem(IEntitySource source, Item item, int stack = 1) {
-			int index = Item.NewItem(source, getRect(), item.type, stack, false, -1, false, false);
-			Item clone = Main.item[index] = item.Clone();
-			clone.whoAmI = index;
-			clone.position = position;
-			clone.stack = stack;
+			int index = Item.NewItem(source, getRect(), item, false, false, false);
+			Main.item[index].stack = stack;
 
 			// Sync the item for mp
 			if (Main.netMode == NetmodeID.MultiplayerClient)
@@ -464,18 +461,13 @@ namespace Terraria
 		/// </summary>
 		public void DropItem(IEntitySource source, Vector2 position, ref Item item) {
 			if (item.stack > 0) {
-				int itemDropId = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item.type);
+				int itemDropId = Item.NewItem(source, (int)position.X, (int)position.Y, width, height, item);
 				var itemDrop = Main.item[itemDropId];
 
-				itemDrop.netDefaults(item.netID);
-				itemDrop.Prefix(item.prefix);
-				itemDrop.stack = item.stack;
 				itemDrop.velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
 				itemDrop.velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
 				itemDrop.noGrabDelay = 100;
 				itemDrop.newAndShiny = false;
-				itemDrop.ModItem = item.ModItem;
-				itemDrop.globalItems = item.globalItems;
 
 				if (Main.netMode == 1)
 					NetMessage.SendData(21, -1, -1, null, itemDropId);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5740,7 +5740,7 @@
  
  			if (tileTarget.type == 147 || tileTarget.type == 0 || tileTarget.type == 40 || tileTarget.type == 53 || tileTarget.type == 57 || tileTarget.type == 59 || tileTarget.type == 123 || tileTarget.type == 224 || tileTarget.type == 397)
  				num += pickPower;
-@@ -37704,24 +_,54 @@
+@@ -37704,37 +_,60 @@
  
  		public void DropItems() {
  			IEntitySource itemSource_Death = GetItemSource_Death();
@@ -5769,24 +5769,22 @@
  						flag = false;
  
  					if (flag) {
+-						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i].type);
+-						Main.item[num].netDefaults(inventory[i].netID);
+-						Main.item[num].Prefix(inventory[i].prefix);
+-						Main.item[num].stack = inventory[i].stack;
 +						int stack = item.stack;
 +						if (startCounts.ContainsKey(item.netID)) {
 +							stack -= startCounts[item.netID];
 +							startCounts[item.netID] = 0;
 +						}
 +
- 						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i].type);
- 						Main.item[num].netDefaults(inventory[i].netID);
- 						Main.item[num].Prefix(inventory[i].prefix);
--						Main.item[num].stack = inventory[i].stack;
++						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i]);
 +						Main.item[num].stack = stack; // inventory[i].stack
  						Main.item[num].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num].noGrabDelay = 100;
  						Main.item[num].newAndShiny = false;
-+
-+						Main.item[num].ModItem = item.ModItem;
-+						Main.item[num].globalItems = item.globalItems;
 +
  						if (Main.netMode == 1)
  							NetMessage.SendData(21, -1, -1, null, num);
@@ -5797,44 +5795,57 @@
  				}
  
  				inventory[i].TurnToAir();
-@@ -37735,6 +_,10 @@
+ 				if (i < armor.Length) {
+ 					if (armor[i].stack > 0) {
+-						int num2 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, armor[i].type);
++						int num2 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, armor[i]);
+-						Main.item[num2].netDefaults(armor[i].netID);
+-						Main.item[num2].Prefix(armor[i].prefix);
+-						Main.item[num2].stack = armor[i].stack;
+ 						Main.item[num2].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num2].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num2].noGrabDelay = 100;
  						Main.item[num2].newAndShiny = false;
 +
-+						Main.item[num2].ModItem = armor[i].ModItem;
-+						Main.item[num2].globalItems = armor[i].globalItems;
-+
  						if (Main.netMode == 1)
  							NetMessage.SendData(21, -1, -1, null, num2);
  					}
-@@ -37752,6 +_,8 @@
+@@ -37744,10 +_,7 @@
+ 
+ 				if (i < dye.Length) {
+ 					if (dye[i].stack > 0) {
+-						int num3 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, dye[i].type);
++						int num3 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, dye[i]);
+-						Main.item[num3].netDefaults(dye[i].netID);
+-						Main.item[num3].Prefix(dye[i].prefix);
+-						Main.item[num3].stack = dye[i].stack;
+ 						Main.item[num3].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num3].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num3].noGrabDelay = 100;
- 						Main.item[num3].newAndShiny = false;
-+						Main.item[num3].ModItem = dye[i].ModItem;
-+						Main.item[num3].globalItems = dye[i].globalItems;
- 						if (Main.netMode == 1)
- 							NetMessage.SendData(21, -1, -1, null, num3);
- 					}
-@@ -37769,6 +_,8 @@
+@@ -37761,10 +_,7 @@
+ 
+ 				if (i < miscEquips.Length) {
+ 					if (miscEquips[i].stack > 0) {
+-						int num4 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscEquips[i].type);
++						int num4 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscEquips[i]);
+-						Main.item[num4].netDefaults(miscEquips[i].netID);
+-						Main.item[num4].Prefix(miscEquips[i].prefix);
+-						Main.item[num4].stack = miscEquips[i].stack;
+ 						Main.item[num4].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num4].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num4].noGrabDelay = 100;
- 						Main.item[num4].newAndShiny = false;
-+						Main.item[num4].ModItem = miscEquips[i].ModItem;
-+						Main.item[num4].globalItems = miscEquips[i].globalItems;
- 						if (Main.netMode == 1)
- 							NetMessage.SendData(21, -1, -1, null, num4);
- 					}
-@@ -37788,6 +_,8 @@
+@@ -37780,10 +_,7 @@
+ 					continue;
+ 
+ 				if (miscDyes[i].stack > 0) {
+-					int num5 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscDyes[i].type);
++					int num5 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscDyes[i]);
+-					Main.item[num5].netDefaults(miscDyes[i].netID);
+-					Main.item[num5].Prefix(miscDyes[i].prefix);
+-					Main.item[num5].stack = miscDyes[i].stack;
+ 					Main.item[num5].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  					Main.item[num5].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  					Main.item[num5].noGrabDelay = 100;
- 					Main.item[num5].newAndShiny = false;
-+					Main.item[num5].ModItem = miscDyes[i].ModItem;
-+					Main.item[num5].globalItems = miscDyes[i].globalItems;
- 					if (Main.netMode == 1)
- 						NetMessage.SendData(21, -1, -1, null, num5);
- 				}
 @@ -37795,12 +_,26 @@
  				miscDyes[i].TurnToAir();
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -873,7 +873,7 @@
 +		// Return value added by TML.
 +		/// <summary>
 +		/// Spawns an item into the world at this players position. This is a simpler alternative to <see cref="Item.NewItem(IEntitySource, int, int, int, int, int, int, bool, int, bool, bool)"/>. This method can be called from multiplayer client code without necessitating manually syncing the item.
-+		/// <br/> Use <see cref="QuickSpawnClonedItem(IEntitySource, Item, int)"/> if a specific instance of an Item needs to be spawned into the world to preserve modded data.
++		/// <br/> Use <see cref="QuickSpawnItem(IEntitySource, Item, int)"/> if a specific instance of an Item needs to be spawned into the world to preserve modded data.
 +		/// </summary>
 +		/// <param name="source"></param>
 +		/// <param name="item"></param>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5740,7 +5740,7 @@
  
  			if (tileTarget.type == 147 || tileTarget.type == 0 || tileTarget.type == 40 || tileTarget.type == 53 || tileTarget.type == 57 || tileTarget.type == 59 || tileTarget.type == 123 || tileTarget.type == 224 || tileTarget.type == 397)
  				num += pickPower;
-@@ -37704,37 +_,60 @@
+@@ -37704,37 +_,69 @@
  
  		public void DropItems() {
  			IEntitySource itemSource_Death = GetItemSource_Death();
@@ -5769,17 +5769,19 @@
  						flag = false;
  
  					if (flag) {
--						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i].type);
--						Main.item[num].netDefaults(inventory[i].netID);
--						Main.item[num].Prefix(inventory[i].prefix);
--						Main.item[num].stack = inventory[i].stack;
 +						int stack = item.stack;
 +						if (startCounts.ContainsKey(item.netID)) {
 +							stack -= startCounts[item.netID];
 +							startCounts[item.netID] = 0;
 +						}
 +
+-						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i].type);
 +						int num = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, inventory[i]);
++						/*
+ 						Main.item[num].netDefaults(inventory[i].netID);
+ 						Main.item[num].Prefix(inventory[i].prefix);
+-						Main.item[num].stack = inventory[i].stack;
++						*/
 +						Main.item[num].stack = stack; // inventory[i].stack
  						Main.item[num].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
@@ -5799,9 +5801,11 @@
  					if (armor[i].stack > 0) {
 -						int num2 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, armor[i].type);
 +						int num2 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, armor[i]);
--						Main.item[num2].netDefaults(armor[i].netID);
--						Main.item[num2].Prefix(armor[i].prefix);
--						Main.item[num2].stack = armor[i].stack;
++						/*
+ 						Main.item[num2].netDefaults(armor[i].netID);
+ 						Main.item[num2].Prefix(armor[i].prefix);
+ 						Main.item[num2].stack = armor[i].stack;
++						*/
  						Main.item[num2].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num2].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num2].noGrabDelay = 100;
@@ -5810,39 +5814,45 @@
  						if (Main.netMode == 1)
  							NetMessage.SendData(21, -1, -1, null, num2);
  					}
-@@ -37744,10 +_,7 @@
+@@ -37744,10 +_,12 @@
  
  				if (i < dye.Length) {
  					if (dye[i].stack > 0) {
 -						int num3 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, dye[i].type);
 +						int num3 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, dye[i]);
--						Main.item[num3].netDefaults(dye[i].netID);
--						Main.item[num3].Prefix(dye[i].prefix);
--						Main.item[num3].stack = dye[i].stack;
++						/*
+ 						Main.item[num3].netDefaults(dye[i].netID);
+ 						Main.item[num3].Prefix(dye[i].prefix);
+ 						Main.item[num3].stack = dye[i].stack;
++						*/
  						Main.item[num3].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num3].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num3].noGrabDelay = 100;
-@@ -37761,10 +_,7 @@
+@@ -37761,10 +_,12 @@
  
  				if (i < miscEquips.Length) {
  					if (miscEquips[i].stack > 0) {
 -						int num4 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscEquips[i].type);
 +						int num4 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscEquips[i]);
--						Main.item[num4].netDefaults(miscEquips[i].netID);
--						Main.item[num4].Prefix(miscEquips[i].prefix);
--						Main.item[num4].stack = miscEquips[i].stack;
++						/*
+ 						Main.item[num4].netDefaults(miscEquips[i].netID);
+ 						Main.item[num4].Prefix(miscEquips[i].prefix);
+ 						Main.item[num4].stack = miscEquips[i].stack;
++						*/
  						Main.item[num4].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  						Main.item[num4].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  						Main.item[num4].noGrabDelay = 100;
-@@ -37780,10 +_,7 @@
+@@ -37780,10 +_,12 @@
  					continue;
  
  				if (miscDyes[i].stack > 0) {
 -					int num5 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscDyes[i].type);
 +					int num5 = Item.NewItem(itemSource_Death, (int)position.X, (int)position.Y, width, height, miscDyes[i]);
--					Main.item[num5].netDefaults(miscDyes[i].netID);
--					Main.item[num5].Prefix(miscDyes[i].prefix);
--					Main.item[num5].stack = miscDyes[i].stack;
++					/*
+ 					Main.item[num5].netDefaults(miscDyes[i].netID);
+ 					Main.item[num5].Prefix(miscDyes[i].prefix);
+ 					Main.item[num5].stack = miscDyes[i].stack;
++					*/
  					Main.item[num5].velocity.Y = (float)Main.rand.Next(-20, 1) * 0.2f;
  					Main.item[num5].velocity.X = (float)Main.rand.Next(-20, 21) * 0.2f;
  					Main.item[num5].noGrabDelay = 100;

--- a/tModPorter/tModPorter.Tests/AutomaticTest.cs
+++ b/tModPorter/tModPorter.Tests/AutomaticTest.cs
@@ -120,7 +120,7 @@ public class AutomaticTest {
 
 		using MSBuildWorkspace workspace = MSBuildWorkspace.Create();
 		workspace.WorkspaceFailed += (o, e) => {
-			if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+			if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure && !e.Diagnostic.ToString().Contains("This mismatch may cause runtime failures"))
 				throw new Exception(e.Diagnostic.ToString());
 
 			Console.Error.WriteLine(e.Diagnostic.ToString());

--- a/tModPorter/tModPorter.Tests/TestData/IEntitySourceTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/IEntitySourceTest.Expected.cs
@@ -20,7 +20,7 @@ public class IEntitySourceTest
 		Player player = new Player();
 		player.QuickSpawnItem(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, 1, 2);
 		player.QuickSpawnItem(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, new Item(), 2);
-		player.QuickSpawnClonedItem(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, new Item(), 2);
+		player.QuickSpawnItem(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, new Item(), 2);
 
 		Projectile.NewProjectile(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, new Vector2(), new Vector2(), 3, 4, 5, 6, 7, 8); // vec2 both
 		Projectile.NewProjectile(/* tModPorter Suggestion: player/npc/projectile.GetSource_... */, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10); // full coords

--- a/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.Expected.cs
@@ -1,5 +1,5 @@
 using Microsoft.Xna.Framework;
-using Microsoft.XNA.Framework.Graphics;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using Terraria;
@@ -60,5 +60,10 @@ public class ModPlayerTest : ModPlayer
 		int questFishLocal = attempt.questFish;
 		ref int caughtTypeLocal = ref itemDrop;
 		// ref int junkLocal = ref junk; // Can't really be transformed, unless you check for fisher.rolledItemDrop = Main.rand.Next(2337, 2340);
+	}
+
+	public void UseQuickSpawnItem() {
+		Item item = new Item(22);
+		Player.QuickSpawnItem(null, item);
 	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
@@ -61,8 +61,8 @@ public class ModPlayerTest : ModPlayer
 		// ref int junkLocal = ref junk; // Can't really be transformed, unless you check for fisher.rolledItemDrop = Main.rand.Next(2337, 2340);
 	}
 
-	public void UseQuickSpawnItem()	{
+	public void UseQuickSpawnItem() {
 		Item item = new Item(22);
 		Player.QuickSpawnClonedItem(null, item);
-	} 
+	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.XNA.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using Terraria;
@@ -60,4 +60,9 @@ public class ModPlayerTest : ModPlayer
 		ref int caughtTypeLocal = ref caughtType;
 		// ref int junkLocal = ref junk; // Can't really be transformed, unless you check for fisher.rolledItemDrop = Main.rand.Next(2337, 2340);
 	}
+
+	public void UseQuickSpawnItem()	{
+		Item item = new Item(22);
+		Player.QuickSpawnClonedItem(null, item);
+	} 
 }

--- a/tModPorter/tModPorter.Tests/tModPorter.Tests.csproj
+++ b/tModPorter/tModPorter.Tests/tModPorter.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="CodeChicken.DiffPatch" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.2.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -103,6 +103,7 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.ModType",		from: "Autoload",			to: "IsLoadingEnabled").FollowBy(AddCommentToOverride("Suggestion: If you return false for the purposes of manual loading, use the [Autoload(false)] attribute on your class instead"));
 		RenameMethod("Terraria.ModLoader.ModTree",		from: "GrowthFXGore",		to: "TreeLeaf");
 		RenameMethod("Terraria.ModLoader.ModPalmTree",	from: "GrowthFXGore",		to: "TreeLeaf");
+		RenameMethod("Terraria.Player",					from: "QuickSpawnClonedItem",to: "QuickSpawnItem");
 
 		ChangeHookSignature("Terraria.ModLoader.ModItem",			"HoldStyle");
 		ChangeHookSignature("Terraria.ModLoader.GlobalItem",		"HoldStyle");

--- a/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/InvokeRewriter.cs
@@ -29,7 +29,7 @@ public partial class InvokeRewriter : BaseRewriter
 			return newNode;
 
 		IOperation op = model.GetOperation(node);
-		if (op is not IInvalidOperation && (op is not IInvocationOperation invocation|| !invocation.TargetMethod.IsObsolete()))
+		if (!IsInvalidOrObsolete(op))
 			return node;
 
 		return node.Expression switch {

--- a/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
@@ -11,7 +11,7 @@ namespace tModPorter.Rewriters;
 
 public class MemberUseRewriter : BaseRewriter {
 
-	public delegate SyntaxNode RewriteMemberUse(MemberUseRewriter rw, IInvalidOperation op, IdentifierNameSyntax memberName);
+	public delegate SyntaxNode RewriteMemberUse(MemberUseRewriter rw, IOperation op, IdentifierNameSyntax memberName);
 
 	private static List<(string type, string name, RewriteMemberUse handler)> handlers = new();
 


### PR DESCRIPTION
Currently, we have to juggle `Item.NewItem`, item cloning, and manually sending network syncing packets to spawn an item in the world while preserving modded data.  

Player.QuickSpawnClonedItem did it almost right, but TileEntities dropping their items and mediumcode players dropping items when dying had bad logic.

The bad logic was this:
```
				itemDrop.ModItem = item.ModItem;
				itemDrop.globalItems = item.globalItems;
```

This code neglects to set ModItem.Item/Entity to the actual item, resulting in the 2 way binding of Item and ModItem to be wrong.

Player.QuickSpawnClonedItem used the approach of using Item.Clone and then tweaking Item.position, but this approach actually lost many of the changes set in Item.NewItem, such as Item.velocity

Using the Clone approach, we would have to make sure to assign all fields modified intentionally by Item.NewItem:
```
int droppedItemId = NewItem(source, rectangle, item.netID, 1, noBroadcast: true, prefixGiven: item.prefix);
var droppedItem = Main.item[droppedItemId];

Item clone = item.Clone();
clone.whoAmI = droppedItemId;
clone.position = droppedItem.position;
clone.wet = droppedItem.wet;
clone.velocity = droppedItem.velocity;
clone.active = droppedItem.active;
clone.timeSinceItemSpawned = droppedItem.timeSinceItemSpawned;
clone.newAndShiny = droppedItem.newAndShiny;
clone.playerIndexTheItemIsReservedFor = droppedItem.playerIndexTheItemIsReservedFor;
Main.item[droppedItemId] = clone;

if (Main.netMode == 1)
	NetMessage.SendData(21, -1, -1, null, itemDropId);
```

Another issue with this is ItemLoader.OnSpawn in Item.NewItem acts on an Item instance that is discarded.

Setting `newItem.ModItem = original.ModItem;` seems like a mistake waiting to happen. 

#2977 bandaid fixes the original issue by setting `droppedItem.ModItem.Entity = droppedItem;`, but this approach won't fix the bigger issues.


Adding Item.NewItem overloads that accept an Item instance will simplify tmod and modder code. The code for Item.NewItem is split between the code creating the item instance and the code applying NewItem changes to that item instance. This allows the Item to be constructed from itemType/stack/prefix or from a clone of the passed in item. 