### PR TITLE
Fix: Patreon Items and Developer Items can now be researched

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using Terraria.GameContent.Creative;
 
 namespace Terraria.ModLoader.Default.Developer
 {
@@ -14,6 +15,7 @@ namespace Terraria.ModLoader.Default.Developer
 			string displayName = Name.Replace('_', ' ');
 			displayName = displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 			DisplayName.SetDefault(displayName);
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/JofairdenArmorItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/Jofairden/JofairdenArmorItem.cs
@@ -5,6 +5,8 @@
 		public override string TooltipBrief => "Jofairden's ";
 
 		public sealed override void SetStaticDefaults() {
+			base.SetStaticDefaults();
+
 			DisplayName.SetDefault($"Andromedon {Name.Split('_')[1]}");
 			Tooltip.SetDefault("The power of the Andromedon flows within you");
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using Terraria.GameContent.Creative;
 using Terraria.Localization;
 
 #pragma warning disable IDE0057 // Use range operator
@@ -29,6 +30,8 @@ namespace Terraria.ModLoader.Default.Patreon
 			displayName = displayName.Insert(Name.IndexOf('_'), SetSuffix);
 
 			DisplayName.SetDefault(displayName);
+
+			CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
 		}
 
 		public override void SetDefaults() {


### PR DESCRIPTION
### What is the bug?
Patreon items and developper items could not be researched in journey mode

### How did you fix the bug?
Added `CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;` in DeveloperItem.cs and PatreonItem.cs

### Are there alternatives to your fix?
Not really
