### PR TITLE
Made server manage script curl/wget agnostic

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -42,8 +42,7 @@ function update_script {
 }
 
 function get_latest_release {
-	local 
-release_url="https://api.github.com/repos/tModLoader/tModLoader/releases/latest"
+	local release_url="https://api.github.com/repos/tModLoader/tModLoader/releases/latest"
 	local latest_release=$({
 		curl -s "$release_url" 2>/dev/null || wget -q -O- "$release_url";
 	} | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') # Get latest release from github's api

--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -2,7 +2,8 @@
 
 #shellcheck disable=2164
 
-script_version="1.0.0.0"
+script_version="1.0.0.1"
+script_url="https://raw.githubusercontent.com/tModLoader/tModLoader/1.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh"
 
 # Define functions used in script
 
@@ -15,21 +16,13 @@ function popd {
 	command popd > /dev/null || return
 }
 
-# version less than or equal
-verlte() {
-    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-}
-
-# version less than
-verlt() {
-    [ "$1" = "$2" ] && return 1 || verlte $1 $2
-}
-
 # Returns true if an update is needed
 function check_update {
-	latest_script_version=$(curl --silent "https://raw.githubusercontent.com/tModLoader/tModLoader/1.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh" | grep "script_version=" | head -n1 | cut -d '"' -f2)
+	latest_script_version=$({
+		curl -s "$script_url" 2>/dev/null || wget -q -O- "$script_url";
+	} | grep "script_version=" | head -n1 | cut -d '"' -f2)
 
-	if verlt "$script_version" "$latest_script_version"; then
+	if [[ "$script_version" != "`echo -e "$script_version\n$latest_script_version" | sort -rV | head -n1`" ]]; then
 		return 0
 	else
 		return 1
@@ -39,7 +32,7 @@ function check_update {
 function update_script {
 	if check_update; then
 		echo "Updating from version v$script_version to v$latest_script_version"
-		curl --silent -O https://raw.githubusercontent.com/tModLoader/tModLoader/1.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+		curl -s -O "$script_url" 2>/dev/null || wget -q "$script_url"
 		mv manage-tModLoaderServer.sh.1 manage-tModLoaderServer.sh
 	else
 		echo "No new script updates"
@@ -49,21 +42,25 @@ function update_script {
 }
 
 function get_latest_release {
-	local latest_release
-	latest_release=$(curl --silent "https://api.github.com/repos/tModLoader/tModLoader/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') # Get latest release from github's api
+	local 
+release_url="https://api.github.com/repos/tModLoader/tModLoader/releases/latest"
+	local latest_release=$({
+		curl -s "$release_url" 2>/dev/null || wget -q -O- "$release_url";
+	} | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') # Get latest release from github's api
 	echo "$latest_release" # So functions calling this can consume the result since you can't return strings in bash :)
 }
 
 # Takes version number as first parameter
 function down_release {
+	local down_url="https://github.com/tModLoader/tModLoader/releases/download/$1/tModLoader.zip"
 	if [[ -v version ]]; then
 		set -- "$version"
 	fi
 	echo "Downloading version $1"
-	curl --silent -LJO "https://github.com/tModLoader/tModLoader/releases/download/$1/tModLoader.zip"
+	curl -s -LJO "$down_url" 2>/dev/null || wget -q --content-disposition "$down_url"
 }
 
-# Check $username is defined, exit if not
+# Check $username is defined, ask if not
 function check_username {
 	if ! [[ -v username ]]; then
 		read -p "Please enter a Steam username to login with: " username
@@ -75,8 +72,7 @@ function copy_worlds {
 		[ -f "$file" ] || break
 		twld="$(basename "$file" .wld).twld"
 		echo "Copying $file and $twld"
-		mkdir -p ~/.local/share/Terraria/tModLoader/Worlds/
-		cp $file $twld ~/.local/share/Terraria/tModLoader/Worlds/
+		mkdir -p ~/.local/share/Terraria/tModLoader/Worlds/ && cp $file $twld $_  
 	done
 }
 


### PR DESCRIPTION
### What is the bug?
The manage script is designed as an accessory to the docker container.  The container installs curl as a prerequisite for smooth operation.  Those people not using docker, but instead using the script directly will face an error if they're using a Linux distro that's packaged with wget instead of curl (IE: most flavors of Ubuntu, which is what I use).

### How did you fix the bug?
This tweaked manage-tModLoaderServer.sh will silently attempt to use curl first.  In case curl fails, the error is silenced and wget is silently attempted.  Failing wget is not silent, so failing both will produce a wget error and the script will still fail for a system with neither package present.

Unrelated: check_update and copy_worlds functions are condensed for simplicity, and a minor comment update.
Since the functionality is basically unchanged, the version increment is minimal.

### Are there alternatives to your fix?
Attempting to use alternative packages that already exist is the distro is ideal for this purpose.  On the other hand, Docker by design cannot access existing packages on the system, which is why curl is installed automatically.  With that said, a better solution to my method to reduce the chances for the script to fail even further would be to add another failsafe after wget fails to run a function to install curl for the user and try again.  I didn't add that because I'm treating Linux systems with neither installed as an outlier case, and it's more work.