### PR TITLE
WIP: Parse text in ModMenu display name before measuring it

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -120,12 +120,7 @@ namespace Terraria.ModLoader
 
 			string text = $"{Language.GetTextValue("tModLoader.ModMenuSwap")}: {currentMenu.DisplayName}{(newMenus == 0 ? "" : ModLoader.notifyNewMainMenuThemes ? $" ({newMenus} New)" : "")}";
 
-			string parsedText = "";
-			foreach (TextSnippet snippet in ChatManager.ParseMessage(text, color)) {
-				parsedText += snippet.Text;
-			}
-
-			Vector2 size = FontAssets.MouseText.Value.MeasureString(parsedText);
+			Vector2 size = ChatManager.GetStringSize(FontAssets.MouseText.Value, ChatManager.ParseMessage(text, color).ToArray(), Vector2.One);
 
 			Rectangle switchTextRect = Main.menuMode == 0 ? new Rectangle((int)(Main.screenWidth / 2 - (size.X / 2)), (int)(Main.screenHeight - 2 - size.Y), (int)size.X, (int)size.Y) : Rectangle.Empty;
 			//Rectangle logoRect = new Rectangle((int)logoDrawPos.X - (logo.Width / 2), (int)logoDrawPos.Y - (logo.Height / 2), logo.Width, logo.Height);

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -120,7 +120,12 @@ namespace Terraria.ModLoader
 
 			string text = $"{Language.GetTextValue("tModLoader.ModMenuSwap")}: {currentMenu.DisplayName}{(newMenus == 0 ? "" : ModLoader.notifyNewMainMenuThemes ? $" ({newMenus} New)" : "")}";
 
-			Vector2 size = FontAssets.MouseText.Value.MeasureString(text);
+			string parsedText = "";
+			foreach (TextSnippet snippet in ChatManager.ParseMessage(text, color)) {
+				parsedText += snippet.Text;
+			}
+
+			Vector2 size = FontAssets.MouseText.Value.MeasureString(parsedText);
 
 			Rectangle switchTextRect = Main.menuMode == 0 ? new Rectangle((int)(Main.screenWidth / 2 - (size.X / 2)), (int)(Main.screenHeight - 2 - size.Y), (int)size.X, (int)size.Y) : Rectangle.Empty;
 			//Rectangle logoRect = new Rectangle((int)logoDrawPos.X - (logo.Width / 2), (int)logoDrawPos.Y - (logo.Height / 2), logo.Width, logo.Height);


### PR DESCRIPTION
### What is the bug?
#3109 - The raw text of the ModMenu's display name is measured, but the raw text might not be exactly what's displayed. For example, color codes are not displayed when the text is drawn, but they are included when measuring the string. This can cause an offset when the text is drawn.

### How did you fix the bug?
I parsed the text with `ChatManager.ParseMessage` before measuring it.

### Are there alternatives to your fix?
There's probably a better way to get the resulting text when parsing the string, or another approach entirely such as removing color codes from the string.

Patch in action (sorry for using your mod's display name @QUIDD60x !)
Before
![4HKuHiY](https://user-images.githubusercontent.com/29156241/204217600-c84a0fe0-5230-410d-83e6-453138db3687.png)
After
![parsedtext](https://user-images.githubusercontent.com/29156241/204217484-e5f2476a-85af-4b30-961d-6158f8aed1de.png)