### PR TITLE
[1.4.4] Boss health bar update

### DIFF
--- a/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
+++ b/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
@@ -25,7 +25,7 @@ namespace ExampleMod.Common.GlobalBossBars
 				string text = "GlobalBossBar Showcase";
 				var font = FontAssets.MouseText.Value;
 				Vector2 size = font.MeasureString(text);
-				//Draw centered on the boss bar, offset upwards, otherwise it will overlap with the health text
+				// Draw centered on the boss bar, offset upwards, otherwise it will overlap with the health text
 				spriteBatch.DrawString(font, text, drawParams.BarCenter - size / 2 + new Vector2(0, -30), Color.White);
 			}
 		}

--- a/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
+++ b/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
@@ -25,7 +25,8 @@ namespace ExampleMod.Common.GlobalBossBars
 				string text = "GlobalBossBar Showcase";
 				var font = FontAssets.MouseText.Value;
 				Vector2 size = font.MeasureString(text);
-				spriteBatch.DrawString(font, text, drawParams.BarCenter - size / 2, Color.White);
+				//Draw centered on the boss bar, offset upwards, otherwise it will overlap with the health text
+				spriteBatch.DrawString(font, text, drawParams.BarCenter - size / 2 + new Vector2(0, -30), Color.White);
 			}
 		}
 	}

--- a/ExampleMod/Content/BossBarStyles/ExampleBossBarStyle.cs
+++ b/ExampleMod/Content/BossBarStyles/ExampleBossBarStyle.cs
@@ -2,6 +2,7 @@
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.GameContent.UI.BigProgressBar;
+using Microsoft.Xna.Framework;
 
 namespace ExampleMod.Content.BossBars
 {
@@ -26,6 +27,12 @@ namespace ExampleMod.Content.BossBars
 
 				// Unused method by vanilla, which simply draws a few boxes that represent a boss bar (fixed position, colors, no icon)
 				BigProgressBarHelper.DrawBareBonesBar(spriteBatch, lifePercent);
+
+				if (info.showText && BigProgressBarSystem.ShowText) {
+					// If the bar can currently draw text and the setting for it is enabled, draw the "life/lifeMax" text in the center of the bar (position code taken from DrawBareBonesBar)
+					Rectangle barDimensions = Utils.CenteredRectangle(Main.ScreenSize.ToVector2() * new Vector2(0.5f, 1f) + new Vector2(0f, -50f), new Vector2(400f, 20f));
+					BossBarLoader.DrawHealthText(spriteBatch, barDimensions, 2 * Vector2.UnitY, npc.life, npc.lifeMax);
+				}
 			}
 			else {
 				// If a bar with special behavior is currently selected, draw it instead because we don't have access to its special features

--- a/ExampleMod/Content/BossBarStyles/ExampleBossBarStyle.cs
+++ b/ExampleMod/Content/BossBarStyles/ExampleBossBarStyle.cs
@@ -31,7 +31,7 @@ namespace ExampleMod.Content.BossBars
 				if (info.showText && BigProgressBarSystem.ShowText) {
 					// If the bar can currently draw text and the setting for it is enabled, draw the "life/lifeMax" text in the center of the bar (position code taken from DrawBareBonesBar)
 					Rectangle barDimensions = Utils.CenteredRectangle(Main.ScreenSize.ToVector2() * new Vector2(0.5f, 1f) + new Vector2(0f, -50f), new Vector2(400f, 20f));
-					BossBarLoader.DrawHealthText(spriteBatch, barDimensions, 2 * Vector2.UnitY, npc.life, npc.lifeMax);
+					BigProgressBarHelper.DrawHealthText(spriteBatch, barDimensions, 2 * Vector2.UnitY, npc.life, npc.lifeMax);
 				}
 			}
 			else {

--- a/ExampleMod/Content/BossBars/ExampleBossBar.cs
+++ b/ExampleMod/Content/BossBars/ExampleBossBar.cs
@@ -27,7 +27,7 @@ namespace ExampleMod.Content.BossBars
 			float lifePercent = drawParams.Life / drawParams.LifeMax;
 			float shakeIntensity = Utils.Clamp(1f - lifePercent - 0.2f, 0f, 1f);
 			drawParams.BarCenter.Y -= 20f;
-			drawParams.BarCenter += new Vector2(Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-1f, 1f)) * shakeIntensity * 15f;
+			drawParams.BarCenter += Main.rand.NextVector2Circular(0.5f, 0.5f) * shakeIntensity * 15f;
 
 			drawParams.IconColor = Main.DiscoColor;
 

--- a/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
+++ b/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
@@ -59,7 +59,17 @@ public struct BossBarDrawParams
 	/// </summary>
 	public float IconScale;
 
-	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield = 0f, float shieldMax = 0f, float iconScale = 1f)
+	/// <summary>
+	/// If the current life (or shield) of the boss should be written on the bar.
+	/// </summary>
+	public bool ShowText;
+
+	/// <summary>
+	/// The text offset from the center (<see cref="BarCenter"/>)
+	/// </summary>
+	public Vector2 TextOffset;
+
+	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield = 0f, float shieldMax = 0f, float iconScale = 1f, bool showText = true, Vector2 textOffset = default)
 	{
 		BarTexture = barTexture;
 		BarCenter = barCenter;
@@ -71,9 +81,11 @@ public struct BossBarDrawParams
 		Shield = shield;
 		ShieldMax = shieldMax;
 		IconScale = iconScale;
+		ShowText = showText;
+		TextOffset = textOffset;
 	}
 
-	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale)
+	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
 	{
 		barTexture = BarTexture;
 		barCenter = BarCenter;
@@ -85,5 +97,7 @@ public struct BossBarDrawParams
 		shield = Shield;
 		shieldMax = ShieldMax;
 		iconScale = IconScale;
+		showText = ShowText;
+		textOffset = TextOffset;
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.TML.cs
@@ -1,0 +1,33 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Graphics;
+
+namespace Terraria.GameContent.UI.BigProgressBar;
+
+public partial class BigProgressBarHelper
+{
+	// Copy of the private BigProgressBarHelper.DrawHealthText with an offset parameter
+	/// <summary>
+	/// Draws "<paramref name="current"/>/<paramref name="max"/>" as text centered on <paramref name="area"/>, offset by <paramref name="textOffset"/>.
+	/// </summary>
+	/// <param name="spriteBatch">The spriteBatch that is drawn on</param>
+	/// <param name="area">The Rectangle that the text is centered on</param>
+	/// <param name="textOffset">Offset for the text position</param>
+	/// <param name="current">Number shown left of the "/"</param>
+	/// <param name="max">Number shown right of the "/"</param>
+	public static void DrawHealthText(SpriteBatch spriteBatch, Rectangle area, Vector2 textOffset, float current, float max)
+	{
+		DynamicSpriteFont font = FontAssets.ItemStack.Value;
+		Vector2 center = area.Center.ToVector2() + textOffset;
+		center.Y += 1f;
+		string text = "/";
+		Vector2 textSize = font.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, font, text, center.X, center.Y, Color.White, Color.Black, textSize * 0.5f);
+		text = ((int)current).ToString();
+		textSize = font.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, font, text, center.X - 5f, center.Y, Color.White, Color.Black, textSize * new Vector2(1f, 0.5f));
+		text = ((int)max).ToString();
+		textSize = font.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, font, text, center.X + 5f, center.Y, Color.White, Color.Black, textSize * new Vector2(0f, 0.5f));
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs
 +++ src/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs
-@@ -1,6 +_,8 @@
+@@ -1,10 +_,12 @@
  using Microsoft.Xna.Framework;
  using Microsoft.Xna.Framework.Graphics;
  using ReLogic.Graphics;
@@ -8,6 +8,11 @@
 +using Terraria.ModLoader;
  
  namespace Terraria.GameContent.UI.BigProgressBar;
+ 
+-public class BigProgressBarHelper
++public partial class BigProgressBarHelper
+ {
+ 	private const string _bossBarTexturePath = "Images/UI/UI_BossBar";
  
 @@ -24,6 +_,12 @@
  

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
@@ -36,7 +36,7 @@
 +			Color iconColor = Color.White;
 +			float iconScale = 1f;
 +
-+			BossBarDrawParams drawParams = new BossBarDrawParams(value, barCenter, barIconTexture, barIconFrame, iconColor, lifeAmount, lifeMax, shieldCurrent, shieldMax, iconScale);
++			BossBarDrawParams drawParams = new BossBarDrawParams(value, barCenter, barIconTexture, barIconFrame, iconColor, lifeAmount, lifeMax, shieldCurrent, shieldMax, iconScale, info.showText, Vector2.Zero);
 +
 +			bool skipped = !BossBarLoader.PreDraw(spriteBatch, info, ref drawParams);
 +			if (!skipped)

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarSystem.cs.patch
@@ -46,7 +46,7 @@
  	}
  
  	private void TryFindingNPCToTrack()
-@@ -103,7 +_,12 @@
+@@ -103,14 +_,19 @@
  		bigProgressBarInfo.npcIndexToAimAt = npcIndex;
  		BigProgressBarInfo info = bigProgressBarInfo;
  		IBigProgressBar bigProgressBar = _bossBar;
@@ -59,4 +59,12 @@
 +		else if (_bossBarsByNpcNetId.TryGetValue(nPC.netID, out var value))
  			bigProgressBar = value;
  
++		info.showText = true; // Moved so that mods can set it to false
  		if (!bigProgressBar.ValidateAndCollectNecessaryInfo(ref info))
+ 			return false;
+ 
+ 		_currentBar = bigProgressBar;
+-		info.showText = true;
+ 		_info = info;
+ 		return true;
+ 	}

--- a/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
@@ -1,12 +1,10 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
-using ReLogic.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.DataStructures;
-using Terraria.GameContent;
 using Terraria.GameContent.UI.BigProgressBar;
 using Terraria.Localization;
 using Terraria.ModLoader.Default;
@@ -322,34 +320,9 @@ public static class BossBarLoader
 
 		if (BigProgressBarSystem.ShowText && showText) {
 			if (shield > 0f)
-				DrawHealthText(spriteBatch, barPosition, textOffset, shield, shieldMax);
+				BigProgressBarHelper.DrawHealthText(spriteBatch, barPosition, textOffset, shield, shieldMax);
 			else
-				DrawHealthText(spriteBatch, barPosition, textOffset, life, lifeMax);
+				BigProgressBarHelper.DrawHealthText(spriteBatch, barPosition, textOffset, life, lifeMax);
 		}
-	}
-
-	// Copy of the private BigProgressBarHelper.DrawHealthText with an offset parameter
-	/// <summary>
-	/// Draws "<paramref name="current"/>/<paramref name="max"/>" as text centered on <paramref name="area"/>, offset by <paramref name="textOffset"/>.
-	/// </summary>
-	/// <param name="spriteBatch">The spriteBatch that is drawn on</param>
-	/// <param name="area">The Rectangle that the text is centered on</param>
-	/// <param name="textOffset">Offset for the text position</param>
-	/// <param name="current">Number shown left of the "/"</param>
-	/// <param name="max">Number shown on the right of the "/"</param>
-	public static void DrawHealthText(SpriteBatch spriteBatch, Rectangle area, Vector2 textOffset, float current, float max)
-	{
-		DynamicSpriteFont value = FontAssets.ItemStack.Value;
-		Vector2 vector = area.Center.ToVector2() + textOffset;
-		vector.Y += 1f;
-		string text = "/";
-		Vector2 vector2 = value.MeasureString(text);
-		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X, vector.Y, Color.White, Color.Black, vector2 * 0.5f);
-		text = ((int)current).ToString();
-		vector2 = value.MeasureString(text);
-		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X - 5f, vector.Y, Color.White, Color.Black, vector2 * new Vector2(1f, 0.5f));
-		text = ((int)max).ToString();
-		vector2 = value.MeasureString(text);
-		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X + 5f, vector.Y, Color.White, Color.Black, vector2 * new Vector2(0f, 0.5f));
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
@@ -1,10 +1,12 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
+using ReLogic.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.DataStructures;
+using Terraria.GameContent;
 using Terraria.GameContent.UI.BigProgressBar;
 using Terraria.Localization;
 using Terraria.ModLoader.Default;
@@ -19,7 +21,7 @@ public static class BossBarLoader
 	/// </summary>
 	internal static BigProgressBarInfo? drawingInfo = null;
 
-	//Cache vanilla boss bar texture as it's being accessed via GetTexture again
+	// Cache vanilla boss bar texture as it's being accessed via GetTexture again
 	private static Asset<Texture2D> vanillaBossBarTexture;
 	public static Asset<Texture2D> VanillaBossBarTexture => vanillaBossBarTexture ??= Main.Assets.Request<Texture2D>("Images/UI/UI_BossBar");
 
@@ -48,7 +50,7 @@ public static class BossBarLoader
 		vanillaStyle
 	};
 
-	//Saves repopulating the list again if we just remove all but the by-default styles on unload
+	// Saves repopulating the list again if we just remove all but the by-default styles on unload
 	internal static readonly int defaultStyleCount = bossBarStyles.Count;
 
 	/// <summary>
@@ -187,7 +189,7 @@ public static class BossBarLoader
 	{
 		int index = info.npcIndexToAimAt;
 		if (index < 0 || index > Main.maxNPCs)
-			return false; //Invalid data, abort
+			return false; // Invalid data, abort
 
 		NPC npc = Main.npc[index];
 
@@ -212,7 +214,7 @@ public static class BossBarLoader
 	{
 		int index = info.npcIndexToAimAt;
 		if (index < 0 || index > Main.maxNPCs)
-			return; //Invalid data, abort
+			return; // Invalid data, abort
 
 		NPC npc = Main.npc[index];
 
@@ -239,10 +241,10 @@ public static class BossBarLoader
 	/// <param name="drawParams">The draw parameters for the boss bar</param>
 	public static void DrawFancyBar_TML(SpriteBatch spriteBatch, BossBarDrawParams drawParams)
 	{
-		//DrawFancyBar without shieldPercent gets redirected to DrawFancyBar with shieldPercent as 0f
-		//DrawFancyBar with shieldPercent gets redirected to this
+		// DrawFancyBar without shieldCurrent gets redirected to DrawFancyBar with shieldCurrent as 0f
+		// DrawFancyBar with shieldCurrent gets redirected to this
 
-		(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield, float shieldMax, float iconScale) = drawParams;
+		(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield, float shieldMax, float iconScale, bool showText, Vector2 textOffset) = drawParams;
 
 		Point barSize = new Point(456, 22); //Size of the bar
 		Point topLeftOffset = new Point(32, 24); //Where the top left of the bar starts
@@ -284,38 +286,70 @@ public static class BossBarLoader
 		Vector2 barTopLeft = barPosition.TopLeft();
 		Vector2 topLeft = barTopLeft - topLeftOffset.ToVector2();
 
-		//Background
+		// Background
 		spriteBatch.Draw(barTexture, topLeft, bgFrame, bgColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
 
-		//Bar itself
+		// Bar itself
 		Vector2 stretchScale = new Vector2(scale / barFrame.Width, 1f);
 		Color barColor = Color.White;
 		spriteBatch.Draw(barTexture, barTopLeft, barFrame, barColor, 0f, Vector2.Zero, stretchScale, SpriteEffects.None, 0f);
 
-		//Tip
+		// Tip
 		spriteBatch.Draw(barTexture, barTopLeft + new Vector2(scale - 2, 0f), tipFrame, barColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
 
-		//Bar itself (shield)
+		// Bar itself (shield)
 		if (shield > 0f) {
 			stretchScale = new Vector2(shieldScale / barFrame.Width, 1f);
 			spriteBatch.Draw(barTexture, barTopLeft, barShieldFrame, barColor, 0f, Vector2.Zero, stretchScale, SpriteEffects.None, 0f);
 
-			//Tip
+			// Tip
 			spriteBatch.Draw(barTexture, barTopLeft + new Vector2(shieldScale - 2, 0f), tipShieldFrame, barColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
 		}
 
-		//Frame
+		// Frame
 		Rectangle frameFrame = barTexture.Frame(verticalFrames: frameCount, frameY: 0);
 		spriteBatch.Draw(barTexture, topLeft, frameFrame, Color.White, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
 
-		//Icon
+		// Icon
 		Vector2 iconOffset = new Vector2(4f, 20f);
 		Vector2 iconSize = new Vector2(26f, 28f);
-		//The vanilla method with the shieldPercent parameter, which is used only by the lunar pillars, uses iconSize = iconFrame.Size() instead, which have a size of 26x30,
-		//causing a slight vertical offset that is barely noticeable. Concidering that the non-shieldPercent method is the more general one, let's keep it like this
-		//(changing that using the lunar pillar code will cause many other icons to be offset instead) --direwolf420
+		// The vanilla method with the shieldCurrent parameter, which is used only by the lunar pillars, uses iconSize = iconFrame.Size() instead, which have a size of 26x30,
+		// causing a slight vertical offset that is barely noticeable. Concidering that the non-shieldCurrent method is the more general one, let's keep it like this
+		// (changing that using the lunar pillar code will cause many other icons to be offset instead) --direwolf420
 		Vector2 iconPos = iconOffset + iconSize / 2f;
-		//iconFrame Centered around iconPos
+		// iconFrame Centered around iconPos
 		spriteBatch.Draw(iconTexture, topLeft + iconPos, iconFrame, iconColor, 0f, iconFrame.Size() / 2f, iconScale, SpriteEffects.None, 0f);
+
+		if (BigProgressBarSystem.ShowText && showText) {
+			if (shield > 0f)
+				DrawHealthText(spriteBatch, barPosition, textOffset, shield, shieldMax);
+			else
+				DrawHealthText(spriteBatch, barPosition, textOffset, life, lifeMax);
+		}
+	}
+
+	// Copy of the private BigProgressBarHelper.DrawHealthText with an offset parameter
+	/// <summary>
+	/// Draws "<paramref name="current"/>/<paramref name="max"/>" as text centered on <paramref name="area"/>, offset by <paramref name="textOffset"/>.
+	/// </summary>
+	/// <param name="spriteBatch">The spriteBatch that is drawn on</param>
+	/// <param name="area">The Rectangle that the text is centered on</param>
+	/// <param name="textOffset">Offset for the text position</param>
+	/// <param name="current">Number shown left of the "/"</param>
+	/// <param name="max">Number shown on the right of the "/"</param>
+	public static void DrawHealthText(SpriteBatch spriteBatch, Rectangle area, Vector2 textOffset, float current, float max)
+	{
+		DynamicSpriteFont value = FontAssets.ItemStack.Value;
+		Vector2 vector = area.Center.ToVector2() + textOffset;
+		vector.Y += 1f;
+		string text = "/";
+		Vector2 vector2 = value.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X, vector.Y, Color.White, Color.Black, vector2 * 0.5f);
+		text = ((int)current).ToString();
+		vector2 = value.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X - 5f, vector.Y, Color.White, Color.Black, vector2 * new Vector2(1f, 0.5f));
+		text = ((int)max).ToString();
+		vector2 = value.MeasureString(text);
+		Utils.DrawBorderStringFourWay(spriteBatch, value, text, vector.X + 5f, vector.Y, Color.White, Color.Black, vector2 * new Vector2(0f, 0.5f));
 	}
 }


### PR DESCRIPTION
### What is the new feature?
* Implement `BigProgressBarInfo.showText` functionality
    * Before it was just set to true, and never accessed. Now, it's set to true every update, and mods can reset it. It's combined with `&& BigProgressBarSystem.ShowText` (a config setting) for the code that determines if text can draw.
    * The vanilla callsite of the latter was _not_ changed, only the tml roundabout.
    * Naturally, the API was expanded to accomodate for this functionality, with a bonus offset added (which required `DrawHealthText` to be cloned into separate method). This was done in a breaking fashion, since 1.4.4 is also breaking all mods.
* Updated the tml methods to match vanilla (besides the text, nothing changed)
* Update comments for proper formatting
    * Some comments were not having a space after the `//`
* Fix for ExampleMods GlobalBossBar text overlapping with the health text

### Why should this be part of tModLoader?
1.4.4 added "life/lifeMax" display on health bars, they should be supported by tml and customized by mods.

### Are there alternative designs?
`DrawHealthText` was copied and publicised in `BossBarLoader`. An alternative would be to keep it in the original class it came from. EDIT: This was done.
A more generic `DrawHealthText` can be added that takes in one or multiple strings (i.e. to include the bosses' name), and a color. It would be easy to implement.

### Sample usage for the new feature
The ExampleMod example showcases usage of `info.showText` and `BossBarLoader.DrawHealthText`,
Mods may want to offset, hide, or re-draw the text that displays on the boss. For the latter, more methods may be needed (see the above category).

### Porting Notes
(Not really worth mentioning due to 1.4.4 breaking everything anyway) `BossBarDrawParams` now has `ShowText` and `TextOffset` fields, the only constructor/deconstructor was modified for this, so you need to recompile.