### PR TITLE
[1.4.4] Obsidian Armor Set Bonus Whip Speed Fix

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1911,10 +1911,12 @@
  			dashType = 5;
  		}
  
-@@ -12581,11 +_,16 @@
+@@ -12580,12 +_,17 @@
+ 			setBonus = Language.GetTextValue("ArmorSetBonus.ObsidianOutlaw");
  			minionDamage += 0.15f;
  			whipRangeMultiplier += 0.3f;
- 			float num17 = 1.15f;
+-			float num17 = 1.15f;
++			float num17 = 0.15f;
 +			/*
  			float num18 = 1f / num17;
  			whipUseTimeMultiplier *= num18;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1911,17 +1911,15 @@
  			dashType = 5;
  		}
  
-@@ -12580,12 +_,17 @@
- 			setBonus = Language.GetTextValue("ArmorSetBonus.ObsidianOutlaw");
+@@ -12581,11 +_,16 @@
  			minionDamage += 0.15f;
  			whipRangeMultiplier += 0.3f;
--			float num17 = 1.15f;
-+			float num17 = 0.15f;
+ 			float num17 = 1.15f;
 +			/*
  			float num18 = 1f / num17;
  			whipUseTimeMultiplier *= num18;
 +			*/
-+			summonerWeaponSpeedBonus += num17; //TML: Obsidian armor changed to additive.
++			summonerWeaponSpeedBonus += num17 - 1; //TML: Obsidian armor changed to additive.
  		}
  
  		ApplyArmorSoundAndDustChanges();


### PR DESCRIPTION
### What is the bug?
The Obsidian Armor set bonus is giving an incorrect amount of whip speed. I suspect it's an oversite from 1.4.4 patches. tML changed the bonus from multiplicative to additive but didn't change the value that is being applied. So, instead of `*= 1.15f` like in vanilla, it gives `+= 1.15f` which is +115% increased speed.

### How did you fix the bug?
Changed the variable that has the speed increase (`num17` in this case) from 1.15f to 0.15f

### Are there alternatives to your fix?
Instead of editing `num17` itself, `summonerWeaponSpeedBonus += num17` could be changed to `summonerWeaponSpeedBonus += num17 - 1`. This is a little uglier, but it does reduce the patch size.

Let me know if a comment should be added saying tML changed the value like `//TML: Changed from 1.15f to 0.15f`