### PR TITLE
[1.4.4] Interface layer drawing fix

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3994,7 +3994,7 @@
  	public static void TryRemovingBuff(int i, int b)
  	{
  		bool flag = false;
-@@ -36393,10 +_,20 @@
+@@ -36393,10 +_,21 @@
  			SetupDrawInterfaceLayers();
  
  		PlayerInput.SetZoom_UI();
@@ -4010,7 +4010,8 @@
 +		SystemLoader.ModifyInterfaceLayers(interfaceLayers);
 +		
 +		foreach (var layer in interfaceLayers) {
-+			layer.Draw();
++			if(!layer.Draw())
++				break;
 +		}
  
  		PlayerInput.SetZoom_World();


### PR DESCRIPTION
### What is the bug?
Interface layers are being drawn when they are not supposed to
This causes many bugs like the hotbar covering up the capture buttons, and bestiary entries not being drawn
### How did you fix the bug?
Break iteration when `layer.Draw` is false to match old enumerator iteration
### Are there alternatives to your fix?
No
