### PR TITLE
Fix Multiline Buff Tooltips

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2601,7 +2601,7 @@
  				Y = (int)((float)screenHeight * num4 - zero.Y - 4f);
  
 +			Color color = new Color(Main.mouseTextColor, Main.mouseTextColor, Main.mouseTextColor, 255); // 255 needed for black check in item tags
-+			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, buffString, new Vector2(X, Y + vector.Y), color, 0f, Vector2.Zero, Vector2.One);
++			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, buffString, new Vector2(X, Y + buffNameHeight), color, 0f, Vector2.Zero, Vector2.One);
 +			/*
  			for (int k = 0; k < 5; k++) {
  				int num11 = X;


### PR DESCRIPTION
### What is the bug?
Multiline buff tooltips had an ugly vertical offset.
![Screenshot_924_dotnet](https://user-images.githubusercontent.com/33076411/206356288-4aae853a-c641-477f-aefd-fa489c22a5aa.png)

This issue was originally fixed five years ago: https://github.com/tModLoader/tModLoader/commit/34701d7e1da0483f6ce37ed450aedf8e910d1768
...but was recently undone (likely by accident): https://github.com/tModLoader/tModLoader/commit/faefc4b1fab7e7f68cfd625e172de71f8b38a2ca

### How did you fix the bug?
Offset buff tooltips by the buff name's height, not the tooltip's height.
![Screenshot_923_dotnet](https://user-images.githubusercontent.com/33076411/206356373-88527320-d023-41b5-9838-f204630a02ed.png)

### Are there alternatives to your fix?
No.