### PR TITLE
[1.4.4] Quick stack visual fix

### DIFF
--- a/patches/tModLoader/Terraria/Chest.cs.patch
+++ b/patches/tModLoader/Terraria/Chest.cs.patch
@@ -28,13 +28,16 @@
  		if (t.type == 21 && ((t.frameX >= 72 && t.frameX <= 106) || (t.frameX >= 144 && t.frameX <= 178) || (t.frameX >= 828 && t.frameX <= 1006) || (t.frameX >= 1296 && t.frameX <= 1330) || (t.frameX >= 1368 && t.frameX <= 1402) || (t.frameX >= 1440 && t.frameX <= 1474)))
  			return true;
  
-@@ -257,6 +_,16 @@
+@@ -257,6 +_,19 @@
  				}
  				else if (item.IsTheSameAs(Main.chest[i].item[j])) {
  					flag2 = true;
 +					// flag set above means "item of same type found in chest, able to be put into an empty slot later", which means we have to respect it before TryStackItems
-+					if (!ItemLoader.TryStackItems(Main.chest[i].item[j], item, out _))
++					if (!ItemLoader.TryStackItems(Main.chest[i].item[j], item, out int numTransfered))
 +						continue;
++
++					if(numTransfered > 0)
++						VisualizeChestTransfer(position, vector, item, numTransfered);
 +
 +					if (item.stack <= 0) {
 +						item.SetDefaults();


### PR DESCRIPTION
### What is the bug?
The quick stack visual added in 1.4.4 did not work for most items
### How did you fix the bug?
Called `VisualizeChestTransfer`
### Are there alternatives to your fix?
No

