### PR TITLE
[1.4.4] Fix PrefixID.Sets not being resized

### DIFF
--- a/patches/tModLoader/Terraria/ID/PrefixID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/PrefixID.cs.patch
@@ -1,11 +1,20 @@
 --- src/TerrariaNetCore/Terraria/ID/PrefixID.cs
 +++ src/tModLoader/Terraria/ID/PrefixID.cs
-@@ -1,3 +_,5 @@
+@@ -1,10 +_,13 @@
 +using ReLogic.Reflection;
++using Terraria.ModLoader;
 +
  namespace Terraria.ID;
  
  public class PrefixID
+ {
+ 	public static class Sets
+ 	{
+-		public static SetFactory Factory = new SetFactory(Count);
++		public static SetFactory Factory = new SetFactory(PrefixLoader.PrefixCount);
+ 		public static bool[] ReducedNaturalChance = Factory.CreateBoolSet(7, 8, 9, 10, 11, 22, 23, 24, 29, 30, 31, 39, 40, 56, 41, 47, 48, 49);
+ 	}
+ 
 @@ -93,4 +_,7 @@
  	public const int Mythical = 83;
  	public const int Legendary2 = 84;

--- a/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.ID;
+using Terraria.ModLoader.Core;
 using Terraria.Utilities;
 
 namespace Terraria.ModLoader;
@@ -51,7 +52,13 @@ public static class PrefixLoader
 		=> categoryPrefixes[category];
 
 	internal static void ResizeArrays()
-		=> Array.Resize(ref Lang.prefix, PrefixCount);
+	{
+		//Sets
+		LoaderUtils.ResetStaticMembers(typeof(PrefixID), true);
+
+		//Etc
+		Array.Resize(ref Lang.prefix, PrefixCount);
+	}
 
 	internal static void Unload()
 	{


### PR DESCRIPTION
### What is the bug?
When items get rolled for prefixes using Item.Prefix(-1), and any mod adds suitable prefixes for this item, the game can crash due to an IOOB on a set in PrefixID.Sets.

### How did you fix the bug?
Sets for prefixes are new in 1.4.4, so they are now properly handled like every other content type that has sets.

### Are there alternatives to your fix?
No
