### PR TITLE
[1.4.4] Health bar style options fix

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerResourceSetsManager.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerResourceSetsManager.TML.cs
@@ -6,7 +6,7 @@ namespace Terraria.GameContent.UI.ResourceSets;
 
 partial class PlayerResourceSetsManager
 {
-	private static readonly string[] vanillaSets = new string[] { "New", "HorizontalBars", "Default" };
+	private static readonly string[] vanillaSets = new string[] { "New", "NewWithText", "HorizontalBars", "HorizontalBarsWithText", "HorizontalBarsWithFullText", "Default" };
 
 	private readonly List<string> accessKeys = new(vanillaSets);
 	private int selectedSet = 0;


### PR DESCRIPTION
### What is the bug?
The "Health and Mana Style" option in the interface settings would not cycle to the new options added in 1.4.4
### How did you fix the bug?
Updated `vanillaSets` to contain the new keys
### Are there alternatives to your fix?
No
