### PR TITLE
[1.4.4] Infinite shooting fix

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3509,6 +3509,15 @@
  		return num2;
  	}
  
+@@ -29131,6 +_,8 @@
+ 		_funkytownAchievementCheckCooldown = 100;
+ 		bool flag = false;
+ 		if (context == PlayerSpawnContext.SpawningIntoWorld) {
++			itemAnimationMax = -1; // Added by TML. Issue #3138
++
+ 			if (Main.netMode == 0 && unlockedBiomeTorches) {
+ 				NPC nPC = new NPC();
+ 				nPC.SetDefaults(664);
 @@ -29189,6 +_,10 @@
  			}
  
@@ -3520,14 +3529,6 @@
  			dead = false;
  			immuneTime = 0;
  		}
-@@ -29204,6 +_,7 @@
- 			Spawn_SetPositionAtWorldSpawn();
- 		}
- 
-+		itemAnimationMax = -1; // Added by TML. Issue #3138
- 		wet = false;
- 		wetCount = 0;
- 		lavaWet = false;
 @@ -29547,6 +_,13 @@
  				}
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -353,7 +353,7 @@
 +	/// <summary>
 +	/// Returns true if the item animation is in its first frame.
 +	/// </summary>
-+	public bool ItemAnimationJustStarted => itemAnimation == itemAnimationMax/* - 1*/; //#2351
++	public bool ItemAnimationJustStarted => itemAnimation == itemAnimationMax && itemAnimation > 0/* - 1*/; //#2351 & #3139
  
  	public float NormalizedLuck {
  		get {
@@ -3509,15 +3509,6 @@
  		return num2;
  	}
  
-@@ -29131,6 +_,8 @@
- 		_funkytownAchievementCheckCooldown = 100;
- 		bool flag = false;
- 		if (context == PlayerSpawnContext.SpawningIntoWorld) {
-+			itemAnimationMax = -1; // Added by TML. Issue #3138
-+
- 			if (Main.netMode == 0 && unlockedBiomeTorches) {
- 				NPC nPC = new NPC();
- 				nPC.SetDefaults(664);
 @@ -29189,6 +_,10 @@
  			}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3520,6 +3520,14 @@
  			dead = false;
  			immuneTime = 0;
  		}
+@@ -29204,6 +_,7 @@
+ 			Spawn_SetPositionAtWorldSpawn();
+ 		}
+ 
++		itemAnimationMax = -1; // Added by TML. Issue #3138
+ 		wet = false;
+ 		wetCount = 0;
+ 		lavaWet = false;
 @@ -29547,6 +_,13 @@
  				}
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -353,7 +353,7 @@
 +	/// <summary>
 +	/// Returns true if the item animation is in its first frame.
 +	/// </summary>
-+	public bool ItemAnimationJustStarted => itemAnimation == itemAnimationMax && itemAnimation > 0/* - 1*/; //#2351 & #3139
++	public bool ItemAnimationJustStarted => itemAnimation == itemAnimationMax/* - 1*/ && itemAnimation > 0; //#2351 & #3139
  
  	public float NormalizedLuck {
  		get {


### PR DESCRIPTION
### What is the bug?
Issue #3138 
### How did you fix the bug?
Simply added `itemAnimationMax = -1` to `Player.Spawn()`
### Are there alternatives to your fix?
I don't know the exact changes tModLoader makes to item usage. Maybe the contributor(s) of the change will have a better solution