### PR TITLE
[1.4.4] Add ItemID.Sets.GeodeDrops

### DIFF
--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Terraria.ID;
 
 partial class ItemID
@@ -58,5 +60,19 @@ partial class ItemID
 			ChlorophytePartisan,
 			NorthPole
 		);
+
+		/// <summary>
+		/// Dictionary for defining what items will drop from a <see cref="ProjectileID.Geode"/> when broken. All items in this dictionary are equally likely to roll, and will drop with a stack size between minStack and maxStack (exclusive).
+		/// <br/>Stack sizes with less than 1 or where minStack is not strictly smaller than maxStack will lead to exceptions being thrown.
+		/// </summary>
+		public static Dictionary<int, (int minStack, int maxStack)> GeodeDrops = new() {
+			{ Sapphire, (3, 7) },
+			{ Ruby, (3, 7) },
+			{ Emerald, (3, 7) },
+			{ Topaz, (3, 7) },
+			{ Amethyst, (3, 7) },
+			{ Diamond, (3, 7) },
+			{ Amber, (3, 7) }
+		};
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -136,6 +136,18 @@ public static class ItemLoader
 		}
 	}
 
+	internal static void ValidateGeodeDropsSet()
+	{
+		foreach (var pair in ItemID.Sets.GeodeDrops) {
+			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.GeodeDrops)}'";
+			if (pair.Value.minStack < 1)
+				throw new Exception($"{exceptionCommon} must have minStack bigger than 0");
+
+			if (pair.Value.maxStack <= pair.Value.minStack)
+				throw new Exception($"{exceptionCommon} must have maxStack bigger than minStack");
+		}
+	}
+
 	internal static void Unload()
 	{
 		items.Clear();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -335,6 +335,7 @@ public static class ModContent
 		SetupRecipes(token);
 		ContentSamples.RebuildItemCreativeSortingIDsAfterRecipesAreSetUp();
 		ItemSorting.SetupWhiteLists();
+		ItemLoader.ValidateGeodeDropsSet();
 
 		MenuLoader.GotoSavedModMenu();
 		BossBarLoader.GotoSavedStyle();

--- a/patches/tModLoader/Terraria/Projectile.TML.cs
+++ b/patches/tModLoader/Terraria/Projectile.TML.cs
@@ -95,14 +95,6 @@ public partial class Projectile : IEntityWithGlobals<GlobalProjectile>
 	public static void DropGeodeLoot(Entity entity)
 	{
 		var dict = ItemID.Sets.GeodeDrops;
-		foreach (var pair in dict) {
-			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.GeodeDrops)}'";
-			if (pair.Value.minStack < 1)
-				throw new Exception($"{exceptionCommon} must have minStack bigger than 0");
-
-			if (pair.Value.maxStack <= pair.Value.minStack)
-				throw new Exception($"{exceptionCommon} must have maxStack bigger than minStack");
-		}
 		var list = dict.Keys.ToList();
 
 		int attempts = 0;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1,5 +1,12 @@
 --- src/TerrariaNetCore/Terraria/Projectile.cs
 +++ src/tModLoader/Terraria/Projectile.cs
+@@ -1,5 +_,6 @@
+ using System;
+ using System.Collections.Generic;
++using System.Linq;
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Audio;
+ using ReLogic.Utilities;
 @@ -20,14 +_,16 @@
  using Terraria.Graphics.Shaders;
  using Terraria.ID;
@@ -1452,7 +1459,7 @@
  				AI_061_FishingBobber_GiveItemToPlayer(Main.player[owner], (int)ai[1]);
  
  			ai[1] = 0f;
-@@ -56584,9 +_,13 @@
+@@ -56584,15 +_,21 @@
  					x2 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					y8 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					NewProjectile(GetProjectileSource_FromThis(), base.Center.X, base.Center.Y, x2, y8, 379, damage, knockBack, owner);
@@ -1466,6 +1473,46 @@
  
  		active = false;
  	}
+ 
+ 	private void DropGeodeGems()
+ 	{
++		// TML: #GeodeDrops
++		/*
+ 		List<int> list = new List<int> {
+ 			181,
+ 			182,
+@@ -56618,6 +_,31 @@
+ 		Main.item[num].noGrabDelay = 0;
+ 		if (Main.netMode == 1)
+ 			NetMessage.SendData(21, -1, -1, null, num, 1f);
++		*/
++		// TML: #GeodeDrops
++
++		var dict = ItemID.Sets.GeodeDrops;
++		foreach (var pair in dict) {
++			if (pair.Value.minStack < 1)
++				throw new Exception($"{Lang.GetItemName(pair.Key)} registered in 'ItemID.Sets.GeodeDrops' must have minStack bigger than 0");
++
++			if (pair.Value.maxStack <= pair.Value.minStack)
++				throw new Exception($"{Lang.GetItemName(pair.Key)} registered in 'ItemID.Sets.GeodeDrops' must have maxStack bigger than minStack");
++		}
++		var list = dict.Keys.ToList();
++
++		int attempts = 0;
++		while (attempts < 2 && list.Count > 0) {
++			attempts++;
++
++			int item = Main.rand.Next(list);
++			list.Remove(item);
++			int stack = Main.rand.Next(dict[item].minStack, dict[item].maxStack);
++			int num = Item.NewItem(new EntitySource_Loot(this), position, base.Size, item, stack);
++			Main.item[num].noGrabDelay = 0;
++			if (Main.netMode == 1)
++				NetMessage.SendData(21, -1, -1, null, num, 1f);
++		}
+ 	}
+ 
+ 	private void TryGettingHitByOtherPlayersExplosives()
 @@ -56692,9 +_,13 @@
  
  	public bool CanExplodeTile(int x, int y)

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1,12 +1,5 @@
 --- src/TerrariaNetCore/Terraria/Projectile.cs
 +++ src/tModLoader/Terraria/Projectile.cs
-@@ -1,5 +_,6 @@
- using System;
- using System.Collections.Generic;
-+using System.Linq;
- using Microsoft.Xna.Framework;
- using Microsoft.Xna.Framework.Audio;
- using ReLogic.Utilities;
 @@ -20,14 +_,16 @@
  using Terraria.Graphics.Shaders;
  using Terraria.ID;
@@ -1459,7 +1452,7 @@
  				AI_061_FishingBobber_GiveItemToPlayer(Main.player[owner], (int)ai[1]);
  
  			ai[1] = 0f;
-@@ -56584,15 +_,21 @@
+@@ -56584,15 +_,23 @@
  					x2 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					y8 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					NewProjectile(GetProjectileSource_FromThis(), base.Center.X, base.Center.Y, x2, y8, 379, damage, knockBack, owner);
@@ -1476,43 +1469,13 @@
  
  	private void DropGeodeGems()
  	{
-+		// TML: #GeodeDrops
-+		/*
++		// TML: Reroute to more flexible TML method
++		DropGeodeLoot(this);
++		return;
++
  		List<int> list = new List<int> {
  			181,
  			182,
-@@ -56618,6 +_,31 @@
- 		Main.item[num].noGrabDelay = 0;
- 		if (Main.netMode == 1)
- 			NetMessage.SendData(21, -1, -1, null, num, 1f);
-+		*/
-+		// TML: #GeodeDrops
-+
-+		var dict = ItemID.Sets.GeodeDrops;
-+		foreach (var pair in dict) {
-+			if (pair.Value.minStack < 1)
-+				throw new Exception($"{Lang.GetItemName(pair.Key)} registered in 'ItemID.Sets.GeodeDrops' must have minStack bigger than 0");
-+
-+			if (pair.Value.maxStack <= pair.Value.minStack)
-+				throw new Exception($"{Lang.GetItemName(pair.Key)} registered in 'ItemID.Sets.GeodeDrops' must have maxStack bigger than minStack");
-+		}
-+		var list = dict.Keys.ToList();
-+
-+		int attempts = 0;
-+		while (attempts < 2 && list.Count > 0) {
-+			attempts++;
-+
-+			int item = Main.rand.Next(list);
-+			list.Remove(item);
-+			int stack = Main.rand.Next(dict[item].minStack, dict[item].maxStack);
-+			int num = Item.NewItem(new EntitySource_Loot(this), position, base.Size, item, stack);
-+			Main.item[num].noGrabDelay = 0;
-+			if (Main.netMode == 1)
-+				NetMessage.SendData(21, -1, -1, null, num, 1f);
-+		}
- 	}
- 
- 	private void TryGettingHitByOtherPlayersExplosives()
 @@ -56692,9 +_,13 @@
  
  	public bool CanExplodeTile(int x, int y)


### PR DESCRIPTION
### What is the new feature?
`ItemID.Sets.GeodeDrops` is a `Dictionary<int, (int minStack, int maxStack)>` which allows modders to add or change the drops of a broken Geode.

### Implementation
I simply rerouted the entire `Projectile.DropGeodeGems` into a public and static `Projectile.DropGeodeLoot` method, because otherwise, even with minimal patches it would cause problems when the dictionary has less than 2 entries. Thus I decided to opt with a while loop instead which is much safer. The drop code is copied from the rerouted vanilla code.

### Why should this be part of tModLoader?
In vanilla, Geode drops 2 different items of equal drop chance with a fixed range stack size. Modifying or adding to this behavior requires IL editing as the list and the stack are not exposed via any TML hooks or suitable methods to detour.
The way `ItemID.Sets.GeodeDrops` is implemented lets the modder add their own loot (usually gems) combined with a custom stack size.
What is _not_ possible is changing how many different items drop from the Geode. It's fixed at 2, and will drop less or nothing if mods change the count of the dictionary to less than 2.

### Are there alternative designs?
* Some way to specify how many _different_ items will drop, not just 2.
* Some way to specify "weight" of each item in the pool (i.e. a mod wants to make Diamond rarer without changing the stack size).
* The exceptions thrown at evaluation of the stack range could be moved to a place where they are checked only once (after loading is finished), but that would make it vulnerable for edits to the dictionary when the game is being played.
* The exceptions could include the existing stack range for verbosity.
* The `(3, 7)` could be a `static readonly` in `Item` so that if vanilla/tml change it in a later update, and mods use it for their own items, they will get the updated stack range.

### Sample usage for the new feature
```cs
ItemID.Sets.GeodeDrops.Remove(ItemID.Sapphire);
ItemID.Sets.GeodeDrops[Type] = (3, 7); //Inside a ModItem class
ItemID.Sets.GeodeDrops[ModContent.ItemType<ExampleGem>()] = (3, 7);
ItemID.Sets.GeodeDrops[ItemID.Sapphire] = (12, 34);
```

### ExampleMod updates
Adding an entire gem for this is out of scope.

