### PR TITLE
[1.4.4] Remix seed fix

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -435,13 +435,14 @@
  		if (everythingWorldGen)
  			Main.starGame = true;
  
-@@ -7904,7 +_,9 @@
+@@ -7904,7 +_,10 @@
  					}
  
  					for (int num861 = num857; num861 < Main.maxTilesY; num861++) {
 +						/*
  						Main.tile[num856, num861] = new Tile();
 +						*/
++						Main.tile[num856, num861].Clear(TileDataType.All);
  						Main.tile[num856, num861].active(active: true);
  						Main.tile[num856, num861].type = 57;
  					}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -435,6 +435,16 @@
  		if (everythingWorldGen)
  			Main.starGame = true;
  
+@@ -7904,7 +_,9 @@
+ 					}
+ 
+ 					for (int num861 = num857; num861 < Main.maxTilesY; num861++) {
++						/*
+ 						Main.tile[num856, num861] = new Tile();
++						*/
+ 						Main.tile[num856, num861].active(active: true);
+ 						Main.tile[num856, num861].type = 57;
+ 					}
 @@ -9368,10 +_,11 @@
  						int num627 = 0;
  						while (!flag37 && num627 < 100) {


### PR DESCRIPTION
### What is the bug?
When generating worlds with `remixWorldGen` (don't dig up and get fixed boi seeds) the generation would fail when generating the underworld. Throwing an exception saying, "Cannot set Tilemap tiles. Only used to init null tiles in Vanilla (which don't exist anymore"
### How did you fix the bug?
Remove the tile assignment
### Are there alternatives to your fix?
No
