### PR TITLE
1.4.4 Making WorldGen.heartCount public

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -78,6 +78,15 @@
  	private static WorldGenerator _generator;
  	public static int SmallConsecutivesFound = 0;
  	public static int SmallConsecutivesEliminated = 0;
+@@ -916,7 +_,7 @@
+ 	public const bool BUBBLES_SOLID_STATE_FOR_HOUSING = true;
+ 	public static int grassSpread;
+ 	private static Point[] heartPos = new Point[100];
+-	private static int heartCount;
++	public static int heartCount; // Made public
+ 	private const int strip_w = 200;
+ 	private const int strip_h = 50;
+ 	private static readonly Vertical64BitStrips bitStrip = new Vertical64BitStrips(202);
 @@ -1284,7 +_,7 @@
  			}
  		}


### PR DESCRIPTION
heartCount is a field found in WorldGen that tracks where hearts are placed along with heartPos
Both were made private in 1.4.4 but as heartCount is initialized in the Reset pass that some modders may not want to happen, heartCount needs to be set to 0 by a different pass owned by a mod and making it public avoids the reflection

The fact that heartPos could also be made public would also make sense if a mod wanted to set the positions without changing much of the logic behind their creation