### PR TITLE
Fractions, new interfaces for drop rules, and ItemDropRule overloads

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCLoot.cs
@@ -20,7 +20,7 @@ namespace ExampleMod.Common.GlobalNPCs
 		public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot) {
 			if (!NPCID.Sets.CountsAsCritter[npc.type]) { // If npc is not a critter
 				// Make it drop ExampleItem.
-				npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleItem>(), 1));
+				npcLoot.Add(ItemDropRule.Common<ExampleItem>(1));
 
 				// ItemDropRule.Common is what you would use in most cases, it simply drops the item with a fractional chance specified.
 				// The chanceDenominator int is used for the denominator part of the fractional chance of dropping this item.
@@ -31,7 +31,7 @@ namespace ExampleMod.Common.GlobalNPCs
 				// ItemDropRule.Common(...) does not let you specify the numerator, so you can use new CommonDrop(...) instead.
 				// (1 by default if using ItemDropRule.Common)
 				// For example, if you had a chanceDenominator as 7 and a chanceNumerator as 2, then the chance the item would drop is 2/7 or about 28%.
-				presentDropRule.OnSuccess(new CommonDrop(ModContent.ItemType<ExampleResearchPresent>(), chanceDenominator: 7, chanceNumerator: 2));
+				presentDropRule.OnSuccess(ItemDropRule.Common<ExampleResearchPresent>(new Fraction(2, 7)));
 				npcLoot.Add(presentDropRule);
 			}
 
@@ -113,7 +113,7 @@ namespace ExampleMod.Common.GlobalNPCs
 		// Any drop rules in ModifyGlobalLoot should only run once. Everything else should go in ModifyNPCLoot.
 		public override void ModifyGlobalLoot(GlobalLoot globalLoot) {
 			// If the ExampleSoulCondition is true, drop ExampleSoul 20% of the time. See Common/ItemDropRules/DropConditions/ExampleSoulCondition.cs for how it's determined
-			globalLoot.Add(ItemDropRule.ByCondition(new ExampleSoulCondition(), ModContent.ItemType<ExampleSoul>(), 5, 1, 1));
+			globalLoot.Add(ItemDropRule.ByCondition<ExampleSoul>(new ExampleSoulCondition(), 5, 1, 1));
 		}
 	}
 }

--- a/ExampleMod/Content/Items/Consumables/ExampleFishingCrate.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleFishingCrate.cs
@@ -73,7 +73,7 @@ namespace ExampleMod.Content.Items.Consumables
 				ItemDropRule.Common(ItemID.TungstenBar, 1, 10, 21),
 				ItemDropRule.Common(ItemID.GoldBar, 1, 10, 21),
 				ItemDropRule.Common(ItemID.PlatinumBar, 1, 10, 21),
-				ItemDropRule.Common(ModContent.ItemType<Placeable.ExampleBar>(), 1, 10, 21),
+				ItemDropRule.Common<Placeable.ExampleBar>(1, 10, 21),
 			};
 			itemLoot.Add(new OneFromRulesRule(4, oreBars));
 
@@ -85,7 +85,7 @@ namespace ExampleMod.Content.Items.Consumables
 				ItemDropRule.Common(ItemID.GravitationPotion, 1, 2, 5),
 				ItemDropRule.Common(ItemID.MiningPotion, 1, 2, 5),
 				ItemDropRule.Common(ItemID.HeartreachPotion, 1, 2, 5),
-				ItemDropRule.Common(ModContent.ItemType<Consumables.ExampleBuffPotion>(), 1, 2, 5),
+				ItemDropRule.Common<Consumables.ExampleBuffPotion>(1, 2, 5),
 			};
 			itemLoot.Add(new OneFromRulesRule(4, explorationPotions));
 

--- a/ExampleMod/Content/Items/Consumables/MinionBossBag.cs
+++ b/ExampleMod/Content/Items/Consumables/MinionBossBag.cs
@@ -40,9 +40,9 @@ namespace ExampleMod.Content.Items.Consumables
 		public override void ModifyItemLoot(ItemLoot itemLoot) {
 			// We have to replicate the expert drops from MinionBossBody here
 
-			itemLoot.Add(ItemDropRule.NotScalingWithLuck(ModContent.ItemType<MinionBossMask>(), 7));
-			itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleItem>(), 1, 12, 16));
-			itemLoot.Add(ItemDropRule.CoinsBasedOnNPCValue(ModContent.NPCType<MinionBossBody>()));
+			itemLoot.Add(ItemDropRule.NotScalingWithLuck<MinionBossMask>(7));
+			itemLoot.Add(ItemDropRule.Common<ExampleItem>(1, 12, 16));
+			itemLoot.Add(ItemDropRule.CoinsBasedOnNPCValue<MinionBossBody>());
 		}
 
 		// Below is code for the visuals

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -294,7 +294,7 @@ namespace ExampleMod.Content.NPCs
 		// }
 
 		public override void ModifyNPCLoot(NPCLoot npcLoot) {
-			npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleCostume>()));
+			npcLoot.Add(ItemDropRule.Common<ExampleCostume>());
 		}
 
 		// Make this Town NPC teleport to the King and/or Queen statue when triggered.

--- a/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
@@ -270,7 +270,7 @@ namespace ExampleMod.Content.NPCs
 		}
 
 		public override void ModifyNPCLoot(NPCLoot npcLoot) {
-			npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<ExampleCostume>()));
+			npcLoot.Add(ItemDropRule.Common<ExampleCostume>());
 		}
 
 		public override void TownNPCAttackStrength(ref int damage, ref float knockback) {

--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
@@ -172,23 +172,23 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 			// Do NOT misuse the ModifyNPCLoot and OnKill hooks: the former is only used for registering drops, the latter for everything else
 
 			// Add the treasure bag using ItemDropRule.BossBag (automatically checks for expert mode)
-			npcLoot.Add(ItemDropRule.BossBag(ModContent.ItemType<MinionBossBag>()));
+			npcLoot.Add(ItemDropRule.BossBag<MinionBossBag>());
 
 			// Trophies are spawned with 1/10 chance
-			npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Placeable.Furniture.MinionBossTrophy>(), 10));
+			npcLoot.Add(ItemDropRule.Common<Items.Placeable.Furniture.MinionBossTrophy>(10));
 
 			// ItemDropRule.MasterModeCommonDrop for the relic
-			npcLoot.Add(ItemDropRule.MasterModeCommonDrop(ModContent.ItemType<Items.Placeable.Furniture.MinionBossRelic>()));
+			npcLoot.Add(ItemDropRule.MasterModeCommonDrop<Items.Placeable.Furniture.MinionBossRelic>());
 
 			// ItemDropRule.MasterModeDropOnAllPlayers for the pet
-			npcLoot.Add(ItemDropRule.MasterModeDropOnAllPlayers(ModContent.ItemType<MinionBossPetItem>(), 4));
+			npcLoot.Add(ItemDropRule.MasterModeDropOnAllPlayers<MinionBossPetItem>(4));
 
 			// All our drops here are based on "not expert", meaning we use .OnSuccess() to add them into the rule, which then gets added
 			LeadingConditionRule notExpertRule = new LeadingConditionRule(new Conditions.NotExpert());
 
 			// Notice we use notExpertRule.OnSuccess instead of npcLoot.Add so it only applies in normal mode
 			// Boss masks are spawned with 1/7 chance
-			notExpertRule.OnSuccess(ItemDropRule.Common(ModContent.ItemType<MinionBossMask>(), 7));
+			notExpertRule.OnSuccess(ItemDropRule.Common<MinionBossMask>(7));
 
 			// This part is not required for a boss and is just showcasing some advanced stuff you can do with drop rules to control how items spawn
 			// We make 12-15 ExampleItems spawn randomly in all directions, like the lunar pillar fragments. Hereby we need the DropOneByOne rule,

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CoinsRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CoinsRule.cs
@@ -27,7 +27,8 @@ namespace Terraria.GameContent.ItemDropRules
 			}
 
 			long money = (long)(value * scale);
-			foreach ((int itemId, int count) in ToCoins(money)) {
+			var coins = ToCoins(money);
+			foreach ((int itemId, int count) in coins) {
 				CommonCode.DropItem(info, itemId, count);
 			}
 
@@ -35,6 +36,7 @@ namespace Terraria.GameContent.ItemDropRules
 		}
 
 		public static IEnumerable<(int itemId, int count)> ToCoins(long money) {
+			List<(int itemId, int count)> list = new();
 			int copper = (int)(money % 100);
 			money /= 100;
 			int silver = (int)(money % 100);
@@ -43,16 +45,18 @@ namespace Terraria.GameContent.ItemDropRules
 			money /= 100;
 			int plat = (int)money;
 
-			if (copper > 0) yield return (ItemID.CopperCoin, copper);
-			if (silver > 0) yield return (ItemID.SilverCoin, silver);
-			if (gold > 0) yield return (ItemID.GoldCoin, gold);
-			if (plat > 0) yield return (ItemID.PlatinumCoin, plat);
+			if (copper > 0) list.Add((ItemID.CopperCoin, copper));
+			if (silver > 0) list.Add((ItemID.SilverCoin, silver));
+			if (gold > 0) list.Add((ItemID.GoldCoin, gold));
+			if (plat > 0) list.Add((ItemID.PlatinumCoin, plat));
+			return list;
 		}
 
 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
 			// TODO: is there a sensible way to report variance here? probably not
 
-			foreach ((int itemId, int count) in ToCoins(value)) {
+			var coins = ToCoins(value);
+			foreach ((int itemId, int count) in coins) {
 				drops.Add(new DropRateInfo(itemId, count, count, ratesInfo.parentDroprateChance, ratesInfo.conditions));
 			}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs.patch
@@ -1,11 +1,33 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/CommonDrop.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/CommonDrop.cs
-@@ -1,3 +_,4 @@
+@@ -1,8 +_,10 @@
 +using System;
  using System.Collections.Generic;
++using Terraria.ModLoader;
  
  namespace Terraria.GameContent.ItemDropRules
-@@ -16,6 +_,10 @@
+ {
+-	public class CommonDrop : IItemDropRule
++	public class CommonDrop : IItemDropRule, IItemDropRuleWithNumerator
+ 	{
+ 		public int itemId;
+ 		public int chanceDenominator;
+@@ -10,12 +_,25 @@
+ 		public int amountDroppedMaximum;
+ 		public int chanceNumerator;
+ 
++		public int Numerator {
++			get => chanceNumerator;
++			set => chanceNumerator = value;
++		}
++		public int Denominator {
++			get => chanceDenominator;
++			set => chanceDenominator = value;
++		}
++
+ 		public List<IItemDropRuleChainAttempt> ChainedRules {
+ 			get;
+ 			private set;
  		}
  
  		public CommonDrop(int itemId, int chanceDenominator, int amountDroppedMinimum = 1, int amountDroppedMaximum = 1, int chanceNumerator = 1) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropNotScalingWithLuck.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropNotScalingWithLuck.cs.patch
@@ -1,6 +1,16 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/CommonDropNotScalingWithLuck.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropNotScalingWithLuck.cs
-@@ -9,7 +_,7 @@
+@@ -2,14 +_,15 @@
+ {
+ 	public class CommonDropNotScalingWithLuck : CommonDrop
+ 	{
++		// chanceNumerator parameter added by TML.
+-		public CommonDropNotScalingWithLuck(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum)
++		public CommonDropNotScalingWithLuck(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum, int chanceNumerator = 1)
+-			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum) {
++			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum, chanceNumerator) {
+ 		}
+ 
  		public override ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			ItemDropAttemptResult result;
  			if (info.rng.Next(chanceDenominator) < chanceNumerator) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropWithRerolls.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropWithRerolls.cs.patch
@@ -1,5 +1,17 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/CommonDropWithRerolls.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/CommonDropWithRerolls.cs
+@@ -6,8 +_,9 @@
+ 	{
+ 		public int timesToRoll;
+ 
++		// chanceNumerator parameter added by TML.
+-		public CommonDropWithRerolls(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum, int rerolls)
++		public CommonDropWithRerolls(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum, int rerolls, int chanceNumerator = 1)
+-			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum) {
++			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum, chanceNumerator) {
+ 			timesToRoll = rerolls + 1;
+ 		}
+ 
 @@ -19,7 +_,7 @@
  
  			ItemDropAttemptResult result;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs.patch
@@ -1,11 +1,17 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/DropOneByOne.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/DropOneByOne.cs
-@@ -1,3 +_,4 @@
+@@ -1,8 +_,9 @@
 +using System;
  using System.Collections.Generic;
  
  namespace Terraria.GameContent.ItemDropRules
-@@ -19,7 +_,11 @@
+ {
+-	public class DropOneByOne : IItemDropRule
++	public class DropOneByOne : IItemDropRule, IItemDropRuleWithNumerator
+ 	{
+ 		public struct Parameters
+ 		{
+@@ -19,7 +_,18 @@
  		}
  
  		public int itemId;
@@ -14,6 +20,13 @@
 +		public Parameters parameters {
 +			get;
 +			private init;
++		}
++
++		public int Numerator {
++			get => parameters.ChanceNumerator;
++		}
++		public int Denominator {
++			get => parameters.ChanceDenominator;
 +		}
  
  		public List<IItemDropRuleChainAttempt> ChainedRules {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropPerPlayerOnThePlayer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/DropPerPlayerOnThePlayer.cs.patch
@@ -1,0 +1,14 @@
+--- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/DropPerPlayerOnThePlayer.cs
++++ src/tModLoader/Terraria/GameContent/ItemDropRules/DropPerPlayerOnThePlayer.cs
+@@ -4,8 +_,9 @@
+ 	{
+ 		public IItemDropRuleCondition condition;
+ 
++		// chanceNumerator parameter added by TML.
+-		public DropPerPlayerOnThePlayer(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum, IItemDropRuleCondition optionalCondition)
++		public DropPerPlayerOnThePlayer(int itemId, int chanceDenominator, int amountDroppedMinimum, int amountDroppedMaximum, IItemDropRuleCondition optionalCondition, int chanceNumerator = 1)
+-			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum) {
++			: base(itemId, chanceDenominator, amountDroppedMinimum, amountDroppedMaximum, chanceNumerator) {
+ 			condition = optionalCondition;
+ 		}
+ 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsDropRule.cs
@@ -8,7 +8,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// <summary>
 	/// Runs multiple rules if successes.
 	/// </summary>
-	public class FewFromOptionsDropRule : IItemDropRule
+	public class FewFromOptionsDropRule : IItemDropRule, IItemDropRuleWithNumerator
 	{
 		public int[] dropIds;
 		public int chanceDenominator;
@@ -18,6 +18,15 @@ namespace Terraria.GameContent.ItemDropRules
 		public List<IItemDropRuleChainAttempt> ChainedRules {
 			get;
 			private set;
+		}
+
+		public int Numerator {
+			get => chanceNumerator;
+			set => chanceNumerator = value;
+		}
+		public int Denominator {
+			get => chanceDenominator;
+			set => chanceDenominator = value;
 		}
 
 		public FewFromOptionsDropRule(int amount, int chanceDenominator, int chanceNumerator, params int[] options) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsNotScaledWithLuckDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsNotScaledWithLuckDropRule.cs
@@ -9,7 +9,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// Runs multiple rules if successes.
 	/// Does not use player luck.
 	/// </summary>
-	public class FewFromOptionsNotScaledWithLuckDropRule : IItemDropRule
+	public class FewFromOptionsNotScaledWithLuckDropRule : IItemDropRule, IItemDropRuleWithNumerator
 	{
 		public int amount;
 		public int[] dropIds;
@@ -19,6 +19,15 @@ namespace Terraria.GameContent.ItemDropRules
 		public List<IItemDropRuleChainAttempt> ChainedRules {
 			get;
 			private set;
+		}
+
+		public int Numerator {
+			get => chanceNumerator;
+			set => chanceNumerator = value;
+		}
+		public int Denominator {
+			get => chanceDenominator;
+			set => chanceDenominator = value;
 		}
 
 		public FewFromOptionsNotScaledWithLuckDropRule(int amount, int chanceDenominator, int chanceNumerator, params int[] options) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromRulesRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromRulesRule.cs
@@ -8,7 +8,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// <summary>
 	/// Runs multiple drop rules if successes.
 	/// </summary>
-	public class FewFromRulesRule : IItemDropRule, INestedItemDropRule
+	public class FewFromRulesRule : IItemDropRule, INestedItemDropRule, IItemDropRuleWithDenominator
 	{
 		public int amount;
 		public IItemDropRule[] options;
@@ -17,6 +17,11 @@ namespace Terraria.GameContent.ItemDropRules
 		public List<IItemDropRuleChainAttempt> ChainedRules {
 			get;
 			private set;
+		}
+
+		public int Denominator {
+			get => chanceDenominator;
+			set => chanceDenominator = value;
 		}
 
 		public FewFromRulesRule(int amount, int chanceNumerator, params IItemDropRule[] options) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/IItemDropRuleWithX.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/IItemDropRuleWithX.cs
@@ -1,0 +1,24 @@
+﻿namespace Terraria.GameContent.ItemDropRules
+{
+	// added by tml
+	public interface IItemDropRuleWithChance {
+		float Chance {
+			get {
+				float chance = 1.0f;
+				if (this is IItemDropRuleWithNumerator ruleWithNumerator) {
+					chance = ruleWithNumerator.Numerator / (float)ruleWithNumerator.Denominator;
+				}
+				else if (this is IItemDropRuleWithDenominator ruleWithDenominator) {
+					chance /= ruleWithDenominator.Denominator;
+				}
+				return chance;
+			}
+		}
+	}
+	public interface IItemDropRuleWithDenominator : IItemDropRuleWithChance {
+		int Denominator { get; }
+	}
+	public interface IItemDropRuleWithNumerator : IItemDropRuleWithDenominator {
+		int Numerator { get; }
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
@@ -1,4 +1,8 @@
-﻿namespace Terraria.GameContent.ItemDropRules
+﻿using System;
+using System.Threading.Channels;
+using Terraria.ModLoader;
+
+namespace Terraria.GameContent.ItemDropRules
 {
 	partial class ItemDropRule
 	{
@@ -16,5 +20,41 @@
 			return Coins((long)npc.value, withRandomBonus: true);
 		}
 		public static IItemDropRule AlwaysAtleastOneSuccess(params IItemDropRule[] rules) => new AlwaysAtleastOneSuccessDropRule(rules);
+
+		// overloads
+		public static IItemDropRule Common(int itemId, Fraction fraction, int minimumDropped = 1, int maximumDropped = 1) => Common(itemId, fraction.Denominator, minimumDropped, maximumDropped, fraction.Numerator);
+		public static IItemDropRule Common<T>(int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) where T : ModItem => Common(ModContent.ItemType<T>(), chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+		public static IItemDropRule Common<T>(Fraction fraction, int minimumDropped = 1, int maximumDropped = 1) where T : ModItem => Common(ModContent.ItemType<T>(), fraction.Denominator, minimumDropped, maximumDropped, fraction.Numerator);
+		public static IItemDropRule BossBag<T>() where T : ModItem => BossBag(ModContent.ItemType<T>());
+		public static IItemDropRule BossBagByCondition<T>(IItemDropRuleCondition condition) where T : ModItem => BossBagByCondition(condition, ModContent.ItemType<T>());
+		public static IItemDropRule ExpertGetsRerolls(int itemId, Fraction chance, int expertRerolls) => ExpertGetsRerolls(itemId, chance.Denominator, expertRerolls, chance.Numerator);
+		public static IItemDropRule ExpertGetsRerolls<T>(int chanceDenominator, int expertRerolls, int chanceNumerator = 1) where T : ModItem => ExpertGetsRerolls(ModContent.ItemType<T>(), chanceDenominator, expertRerolls, chanceNumerator);
+		public static IItemDropRule ExpertGetsRerolls<T>(Fraction chance, int expertRerolls) where T : ModItem => ExpertGetsRerolls(ModContent.ItemType<T>(), chance.Denominator, expertRerolls, chance.Numerator);
+		public static IItemDropRule MasterModeCommonDrop<T>() where T : ModItem => MasterModeCommonDrop(ModContent.ItemType<T>());
+		public static IItemDropRule MasterModeDropOnAllPlayers(int itemId, Fraction chance) => MasterModeDropOnAllPlayers(itemId, chance.Denominator, chance.Numerator);
+		public static IItemDropRule MasterModeDropOnAllPlayers<T>(int chanceDenominator = 1, int chanceNumerator = 1) where T : ModItem => MasterModeDropOnAllPlayers(ModContent.ItemType<T>(), chanceDenominator, chanceNumerator);
+		public static IItemDropRule MasterModeDropOnAllPlayers<T>(Fraction chance) where T : ModItem => MasterModeDropOnAllPlayers(ModContent.ItemType<T>(), chance.Denominator, chance.Numerator);
+		public static IItemDropRule WithRerolls(int itemId, int rerolls, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) => WithRerolls(itemId, rerolls, chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule WithRerolls<T>(int rerolls, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) where T : ModItem => WithRerolls(ModContent.ItemType<T>(), rerolls, chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+		public static IItemDropRule WithRerolls<T>(int rerolls, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) where T : ModItem => WithRerolls(ModContent.ItemType<T>(), rerolls, chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule ByCondition(IItemDropRuleCondition condition, int itemId, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) => ByCondition(condition, itemId, chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule ByCondition<T>(IItemDropRuleCondition condition, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) where T : ModItem => ByCondition(condition, ModContent.ItemType<T>(), chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+		public static IItemDropRule ByCondition<T>(IItemDropRuleCondition condition, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) where T : ModItem => ByCondition(condition, ModContent.ItemType<T>(), chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule NotScalingWithLuck(int itemId, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) => NotScalingWithLuck(itemId, chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule NotScalingWithLuck<T>(int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) where T : ModItem => NotScalingWithLuck(ModContent.ItemType<T>(), chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+		public static IItemDropRule NotScalingWithLuck<T>(Fraction chance, int minimumDropped = 1, int maximumDropped = 1) where T : ModItem => NotScalingWithLuck(ModContent.ItemType<T>(), chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule OneFromOptionsNotScalingWithLuckWithX(Fraction chance, params int[] options) => OneFromOptionsNotScalingWithLuckWithX(chance.Denominator, chance.Numerator, options);
+		public static IItemDropRule OneFromOptionsWithNumerator(Fraction chance, params int[] options) => OneFromOptionsWithNumerator(chance.Denominator, chance.Numerator, options);
+		public static IItemDropRule NormalvsExpert<T>(int chanceDenominatorInNormal, int chanceDenominatorInExpert) where T : ModItem => NormalvsExpert(ModContent.ItemType<T>(), chanceDenominatorInNormal, chanceDenominatorInExpert);
+		public static IItemDropRule NormalvsExpert(int itemId, int chanceDenominatorInNormal, int chanceNumeratorInNormal, int chanceDenominatorInExpert, int chanceNumeratorInExpert) => new DropBasedOnExpertMode(Common(itemId, chanceDenominatorInNormal, 1, 1, chanceNumeratorInNormal), Common(itemId, chanceDenominatorInExpert, 1, 1, chanceNumeratorInExpert));
+		public static IItemDropRule NormalvsExpert(int itemId, Fraction chanceInNormal, Fraction chanceInExpert) => NormalvsExpert(itemId, chanceInNormal.Denominator, chanceInNormal.Numerator, chanceInExpert.Denominator, chanceInExpert.Numerator);
+		public static IItemDropRule NormalvsExpert<T>(int chanceDenominatorInNormal, int chanceNumeratorInNormal, int chanceDenominatorInExpert, int chanceNumeratorInExpert) where T : ModItem => NormalvsExpert(ModContent.ItemType<T>(), chanceDenominatorInNormal, chanceNumeratorInNormal, chanceDenominatorInExpert, chanceNumeratorInExpert);
+		public static IItemDropRule NormalvsExpert<T>(Fraction chanceInNormal, Fraction chanceInExpert) where T : ModItem => NormalvsExpert(ModContent.ItemType<T>(), chanceInNormal, chanceInExpert);
+		public static IItemDropRule Food(int itemId, Fraction chance, int minimumDropped = 1, int maximumDropped = 1) => Food(itemId, chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule Food<T>(int chanceDenominator, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) where T : ModItem => Food(ModContent.ItemType<T>(), chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+		public static IItemDropRule Food<T>(Fraction chance, int minimumDropped = 1, int maximumDropped = 1) where T : ModItem => Food(ModContent.ItemType<T>(), chance.Denominator, minimumDropped, maximumDropped, chance.Numerator);
+		public static IItemDropRule StatusImmunityItem(int itemId, Fraction chance) => StatusImmunityItem(itemId, chance.Denominator, chance.Numerator);
+		public static IItemDropRule StatusImmunityItem<T>(int dropsOutOfX, int chanceNumerator = 1) where T : ModItem => ExpertGetsRerolls(ModContent.ItemType<T>(), dropsOutOfX, chanceNumerator);
+		public static IItemDropRule StatusImmunityItem<T>(Fraction chance) where T : ModItem => ExpertGetsRerolls(ModContent.ItemType<T>(), chance.Denominator, chance.Numerator);
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
@@ -19,6 +19,7 @@ namespace Terraria.GameContent.ItemDropRules
 			// TODO, support dynamic NPC value, expert/master scaling etc. Not sure the best way to display/handle it.
 			return Coins((long)npc.value, withRandomBonus: true);
 		}
+		public static IItemDropRule CoinsBasedOnNPCValue<T>() where T : ModNPC => CoinsBasedOnNPCValue(ModContent.NPCType<T>());
 		public static IItemDropRule AlwaysAtleastOneSuccess(params IItemDropRule[] rules) => new AlwaysAtleastOneSuccessDropRule(rules);
 
 		// overloads

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.cs.patch
@@ -1,10 +1,42 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/ItemDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.cs
-@@ -1,6 +_,6 @@
+@@ -1,16 +_,21 @@
  namespace Terraria.GameContent.ItemDropRules
  {
 -	public class ItemDropRule
 +	public partial class ItemDropRule
  	{
- 		public static IItemDropRule Common(int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1) => new CommonDrop(itemId, chanceDenominator, minimumDropped, maximumDropped);
++		// chanceNumerator parameter added by TML.
+-		public static IItemDropRule Common(int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1) => new CommonDrop(itemId, chanceDenominator, minimumDropped, maximumDropped);
++		public static IItemDropRule Common(int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) => new CommonDrop(itemId, chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
  		public static IItemDropRule BossBag(int itemId) => new DropBasedOnExpertMode(DropNothing(), new DropLocalPerClientAndResetsNPCMoneyTo0(itemId, 1, 1, 1, null));
+ 		public static IItemDropRule BossBagByCondition(IItemDropRuleCondition condition, int itemId) => new DropBasedOnExpertMode(DropNothing(), new DropLocalPerClientAndResetsNPCMoneyTo0(itemId, 1, 1, 1, condition));
+-		public static IItemDropRule ExpertGetsRerolls(int itemId, int chanceDenominator, int expertRerolls) => new DropBasedOnExpertMode(WithRerolls(itemId, 0, chanceDenominator), WithRerolls(itemId, expertRerolls, chanceDenominator));
++		// chanceNumerator parameter added by TML.
++		public static IItemDropRule ExpertGetsRerolls(int itemId, int chanceDenominator, int expertRerolls, int chanceNumerator = 1) => new DropBasedOnExpertMode(WithRerolls(itemId, 0, chanceDenominator, 1, 1, chanceNumerator), WithRerolls(itemId, expertRerolls, chanceDenominator, 1, 1, chanceNumerator));
+ 		public static IItemDropRule MasterModeCommonDrop(int itemId) => ByCondition(new Conditions.IsMasterMode(), itemId);
+-		public static IItemDropRule MasterModeDropOnAllPlayers(int itemId, int chanceDenominator = 1) => new DropBasedOnMasterMode(DropNothing(), new DropPerPlayerOnThePlayer(itemId, chanceDenominator, 1, 1, new Conditions.IsMasterMode()));
+-		public static IItemDropRule WithRerolls(int itemId, int rerolls, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1) => new CommonDropWithRerolls(itemId, chanceDenominator, minimumDropped, maximumDropped, rerolls);
++		// chanceNumerator parameter added by TML.
++		public static IItemDropRule MasterModeDropOnAllPlayers(int itemId, int chanceDenominator = 1, int chanceNumerator = 1) => new DropBasedOnMasterMode(DropNothing(), new DropPerPlayerOnThePlayer(itemId, chanceDenominator, 1, 1, new Conditions.IsMasterMode(), chanceNumerator));
++		// chanceNumerator parameter added by TML.
++		public static IItemDropRule WithRerolls(int itemId, int rerolls, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) => new CommonDropWithRerolls(itemId, chanceDenominator, minimumDropped, maximumDropped, rerolls, chanceNumerator);
+ 		public static IItemDropRule ByCondition(IItemDropRuleCondition condition, int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) => new ItemDropWithConditionRule(itemId, chanceDenominator, minimumDropped, maximumDropped, condition, chanceNumerator);
++		// chanceNumerator parameter added by TML.
+-		public static IItemDropRule NotScalingWithLuck(int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1) => new CommonDropNotScalingWithLuck(itemId, chanceDenominator, minimumDropped, maximumDropped);
++		public static IItemDropRule NotScalingWithLuck(int itemId, int chanceDenominator = 1, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) => new CommonDropNotScalingWithLuck(itemId, chanceDenominator, minimumDropped, maximumDropped, chanceNumerator);
+ 		public static IItemDropRule OneFromOptionsNotScalingWithLuck(int chanceDenominator, params int[] options) => new OneFromOptionsNotScaledWithLuckDropRule(chanceDenominator, 1, options);
+ 		public static IItemDropRule OneFromOptionsNotScalingWithLuckWithX(int chanceDenominator, int chanceNumerator, params int[] options) => new OneFromOptionsNotScaledWithLuckDropRule(chanceDenominator, chanceNumerator, options);
+ 		public static IItemDropRule OneFromOptions(int chanceDenominator, params int[] options) => new OneFromOptionsDropRule(chanceDenominator, 1, options);
+@@ -20,7 +_,9 @@
+ 		public static IItemDropRule NormalvsExpertNotScalingWithLuck(int itemId, int chanceDenominatorInNormal, int chanceDenominatorInExpert) => new DropBasedOnExpertMode(NotScalingWithLuck(itemId, chanceDenominatorInNormal), NotScalingWithLuck(itemId, chanceDenominatorInExpert));
+ 		public static IItemDropRule NormalvsExpertOneFromOptionsNotScalingWithLuck(int chanceDenominatorInNormal, int chanceDenominatorInExpert, params int[] options) => new DropBasedOnExpertMode(OneFromOptionsNotScalingWithLuck(chanceDenominatorInNormal, options), OneFromOptionsNotScalingWithLuck(chanceDenominatorInExpert, options));
+ 		public static IItemDropRule NormalvsExpertOneFromOptions(int chanceDenominatorInNormal, int chanceDenominatorInExpert, params int[] options) => new DropBasedOnExpertMode(OneFromOptions(chanceDenominatorInNormal, options), OneFromOptions(chanceDenominatorInExpert, options));
+-		public static IItemDropRule Food(int itemId, int chanceDenominator, int minimumDropped = 1, int maximumDropped = 1) => new ItemDropWithConditionRule(itemId, chanceDenominator, minimumDropped, maximumDropped, new Conditions.NotFromStatue());
+-		public static IItemDropRule StatusImmunityItem(int itemId, int dropsOutOfX) => ExpertGetsRerolls(itemId, dropsOutOfX, 1);
++		// chanceNumerator parameter added by TML.
++		public static IItemDropRule Food(int itemId, int chanceDenominator, int minimumDropped = 1, int maximumDropped = 1, int chanceNumerator = 1) => new ItemDropWithConditionRule(itemId, chanceDenominator, minimumDropped, maximumDropped, new Conditions.NotFromStatue(), chanceNumerator);
++		// chanceNumerator parameter added by TML.
++		public static IItemDropRule StatusImmunityItem(int itemId, int dropsOutOfX, int chanceNumerator = 1) => ExpertGetsRerolls(itemId, dropsOutOfX, chanceNumerator);
+ 	}
+ }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs.patch
@@ -28,10 +28,11 @@
  		public MechBossSpawnersDropRule() {
  			ChainedRules = new List<IItemDropRuleChainAttempt>();
  		}
-@@ -24,22 +_,22 @@
+@@ -24,22 +_,25 @@
  
  		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			ItemDropAttemptResult result;
++			//if (!NPC.downedMechBoss1 && info.player.RollLuck(2500) == 0) {
 -			if (!NPC.downedMechBoss1 && info.player.RollLuck(2500) == 0) {
 +			if (!NPC.downedMechBoss1 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 556, 1);
@@ -42,6 +43,7 @@
  			}
  
 -			if (!NPC.downedMechBoss2 && info.player.RollLuck(2500) == 0) {
++			//if (!NPC.downedMechBoss2 && info.player.RollLuck(2500) == 0) {
 +			if (!NPC.downedMechBoss2 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 544, 1);
 +				CommonCode.DropItem(info, 544, 1);
@@ -51,17 +53,19 @@
  			}
  
 -			if (!NPC.downedMechBoss3 && info.player.RollLuck(2500) == 0) {
++			//if (!NPC.downedMechBoss3 && info.player.RollLuck(2500) == 0) {
 +			if (!NPC.downedMechBoss3 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 557, 1);
 +				CommonCode.DropItem(info, 557, 1);
  				result = default(ItemDropAttemptResult);
  				result.State = ItemDropAttemptResultState.Success;
  				return result;
-@@ -52,7 +_,7 @@
+@@ -52,7 +_,8 @@
  
  		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
  			ratesInfo.AddCondition(dummyCondition);
 -			float num = 0.0004f;
++			//float num = 0.0004f;
 +			float num = (float)chanceNumerator / (float)chanceDenominator;
  			float dropRate = num * ratesInfo.parentDroprateChance;
  			drops.Add(new DropRateInfo(556, 1, 1, dropRate, ratesInfo.conditions));

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs.patch
@@ -1,9 +1,39 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/MechBossSpawnersDropRule.cs
-@@ -25,21 +_,21 @@
+@@ -2,15 +_,26 @@
+ 
+ namespace Terraria.GameContent.ItemDropRules
+ {
+-	public class MechBossSpawnersDropRule : IItemDropRule
++	public class MechBossSpawnersDropRule : IItemDropRule, IItemDropRuleWithNumerator
+ 	{
+ 		public Conditions.MechanicalBossesDummyCondition dummyCondition = new Conditions.MechanicalBossesDummyCondition();
++		private int chanceNumerator = 1; // added by tml
++		private int chanceDenominator = 2500; // added by tml
+ 
+ 		public List<IItemDropRuleChainAttempt> ChainedRules {
+ 			get;
+ 			private set;
+ 		}
+ 
++		public int Numerator {
++			get => chanceNumerator;
++			set => chanceNumerator = value;
++		}
++		public int Denominator {
++			get => chanceDenominator;
++			set => chanceDenominator = value;
++		}
++
+ 		public MechBossSpawnersDropRule() {
+ 			ChainedRules = new List<IItemDropRuleChainAttempt>();
+ 		}
+@@ -24,22 +_,22 @@
+ 
  		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			ItemDropAttemptResult result;
- 			if (!NPC.downedMechBoss1 && info.player.RollLuck(2500) == 0) {
+-			if (!NPC.downedMechBoss1 && info.player.RollLuck(2500) == 0) {
++			if (!NPC.downedMechBoss1 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 556, 1);
 +				CommonCode.DropItem(info, 556, 1);
  				result = default(ItemDropAttemptResult);
@@ -11,7 +41,8 @@
  				return result;
  			}
  
- 			if (!NPC.downedMechBoss2 && info.player.RollLuck(2500) == 0) {
+-			if (!NPC.downedMechBoss2 && info.player.RollLuck(2500) == 0) {
++			if (!NPC.downedMechBoss2 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 544, 1);
 +				CommonCode.DropItem(info, 544, 1);
  				result = default(ItemDropAttemptResult);
@@ -19,9 +50,19 @@
  				return result;
  			}
  
- 			if (!NPC.downedMechBoss3 && info.player.RollLuck(2500) == 0) {
+-			if (!NPC.downedMechBoss3 && info.player.RollLuck(2500) == 0) {
++			if (!NPC.downedMechBoss3 && info.player.RollLuck(chanceDenominator) < chanceNumerator) {
 -				CommonCode.DropItemFromNPC(info.npc, 557, 1);
 +				CommonCode.DropItem(info, 557, 1);
  				result = default(ItemDropAttemptResult);
  				result.State = ItemDropAttemptResultState.Success;
  				return result;
+@@ -52,7 +_,7 @@
+ 
+ 		public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
+ 			ratesInfo.AddCondition(dummyCondition);
+-			float num = 0.0004f;
++			float num = (float)chanceNumerator / (float)chanceDenominator;
+ 			float dropRate = num * ratesInfo.parentDroprateChance;
+ 			drops.Add(new DropRateInfo(556, 1, 1, dropRate, ratesInfo.conditions));
+ 			drops.Add(new DropRateInfo(544, 1, 1, dropRate, ratesInfo.conditions));

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsDropRule.cs.patch
@@ -1,5 +1,30 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/OneFromOptionsDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsDropRule.cs
+@@ -2,7 +_,7 @@
+ 
+ namespace Terraria.GameContent.ItemDropRules
+ {
+-	public class OneFromOptionsDropRule : IItemDropRule
++	public class OneFromOptionsDropRule : IItemDropRule, IItemDropRuleWithNumerator
+ 	{
+ 		public int[] dropIds;
+ 		public int chanceDenominator;
+@@ -13,6 +_,15 @@
+ 			private set;
+ 		}
+ 
++		public int Numerator {
++			get => chanceNumerator;
++			set => chanceNumerator = value;
++		}
++		public int Denominator {
++			get => chanceDenominator;
++			set => chanceDenominator = value;
++		}
++
+ 		public OneFromOptionsDropRule(int chanceDenominator, int chanceNumerator, params int[] options) {
+ 			this.chanceDenominator = chanceDenominator;
+ 			this.chanceNumerator = chanceNumerator;
 @@ -25,7 +_,7 @@
  		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			ItemDropAttemptResult result;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsNotScaledWithLuckDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsNotScaledWithLuckDropRule.cs.patch
@@ -1,5 +1,30 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/OneFromOptionsNotScaledWithLuckDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/OneFromOptionsNotScaledWithLuckDropRule.cs
+@@ -2,7 +_,7 @@
+ 
+ namespace Terraria.GameContent.ItemDropRules
+ {
+-	public class OneFromOptionsNotScaledWithLuckDropRule : IItemDropRule
++	public class OneFromOptionsNotScaledWithLuckDropRule : IItemDropRule, IItemDropRuleWithNumerator
+ 	{
+ 		public int[] dropIds;
+ 		public int chanceDenominator;
+@@ -13,6 +_,15 @@
+ 			private set;
+ 		}
+ 
++		public int Numerator {
++			get => chanceNumerator;
++			set => chanceNumerator = value;
++		}
++		public int Denominator {
++			get => chanceDenominator;
++			set => chanceDenominator = value;
++		}
++
+ 		public OneFromOptionsNotScaledWithLuckDropRule(int chanceDenominator, int chanceNumerator, params int[] options) {
+ 			this.chanceDenominator = chanceDenominator;
+ 			dropIds = options;
 @@ -25,7 +_,7 @@
  		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			ItemDropAttemptResult result;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
@@ -1,6 +1,11 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs
-@@ -6,14 +_,18 @@
+@@ -2,18 +_,31 @@
+ 
+ namespace Terraria.GameContent.ItemDropRules
+ {
+-	public class OneFromRulesRule : IItemDropRule, INestedItemDropRule
++	public class OneFromRulesRule : IItemDropRule, INestedItemDropRule, IItemDropRuleWithNumerator
  	{
  		public IItemDropRule[] options;
  		public int chanceDenominator;
@@ -13,6 +18,15 @@
  
 -		public OneFromRulesRule(int chanceNumerator, params IItemDropRule[] options) {
 -			chanceDenominator = chanceNumerator;
++		public int Numerator {
++			get => chanceNumerator;
++			set => chanceNumerator = value;
++		}
++		public int Denominator {
++			get => chanceDenominator;
++			set => chanceDenominator = value;
++		}
++
 +		public OneFromRulesRule(int chanceDenominator, params IItemDropRule[] options) : this(chanceDenominator, 1, options) { }
 +
 +		public OneFromRulesRule(int chanceDenominator, int chanceNumerator, params IItemDropRule[] options) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SequentialRulesNotScalingWithLuckRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SequentialRulesNotScalingWithLuckRule.cs
@@ -8,7 +8,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// Runs the provided rules in order, stopping after a rule succeeds.<br/>
 	/// Does not use player luck.<br/>
 	/// </summary>
-	public class SequentialRulesNotScalingWithLuckRule : IItemDropRule, INestedItemDropRule
+	public class SequentialRulesNotScalingWithLuckRule : IItemDropRule, INestedItemDropRule, IItemDropRuleWithDenominator
 	{
 		public IItemDropRule[] rules;
 		public int chanceDenominator;
@@ -16,6 +16,11 @@ namespace Terraria.GameContent.ItemDropRules
 		public List<IItemDropRuleChainAttempt> ChainedRules {
 			get;
 			private set;
+		}
+
+		public int Denominator {
+			get => chanceDenominator;
+			set => chanceDenominator = value;
 		}
 
 		public SequentialRulesNotScalingWithLuckRule(int chanceDenominator, params IItemDropRule[] rules) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SequentialRulesRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SequentialRulesRule.cs
@@ -7,7 +7,7 @@ namespace Terraria.GameContent.ItemDropRules
 	/// <summary>
 	/// Runs the provided rules in order, stopping after a rule succeeds.<br/>
 	/// </summary>
-	public class SequentialRulesRule : IItemDropRule, INestedItemDropRule
+	public class SequentialRulesRule : IItemDropRule, INestedItemDropRule, IItemDropRuleWithDenominator
 	{
 		public IItemDropRule[] rules;
 		public int chanceDenominator;
@@ -15,6 +15,11 @@ namespace Terraria.GameContent.ItemDropRules
 		public List<IItemDropRuleChainAttempt> ChainedRules {
 			get;
 			private set;
+		}
+
+		public int Denominator {
+			get => chanceDenominator;
+			set => chanceDenominator = value;
 		}
 
 		public SequentialRulesRule(int chanceDenominator, params IItemDropRule[] rules) {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -1,5 +1,20 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs
+@@ -1,4 +_,5 @@
+ using System.Collections.Generic;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.GameContent.ItemDropRules
+ {
+@@ -15,7 +_,7 @@
+ 
+ 		public bool CanDrop(DropAttemptInfo info) {
+ 			if (info.npc.type == 1 && info.npc.ai[1] > 0f)
+-				return info.npc.ai[1] < 5125f;
++				return info.npc.ai[1] < ItemLoader.ItemCount;
+ 
+ 			return false;
+ 		}
 @@ -23,7 +_,7 @@
  		public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
  			int itemId = (int)info.npc.ai[1];

--- a/patches/tModLoader/Terraria/ModLoader/Fraction.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Fraction.cs
@@ -1,0 +1,363 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+
+namespace Terraria.ModLoader {
+	/// <summary>
+	/// Represents a part of a whole or, more generally, any number of equal parts.
+	/// </summary>
+	[DebuggerDisplay("{Numerator}/{Denominator}")]
+	public struct Fraction
+		: IEquatable<float>, IEquatable<double>, IEquatable<decimal>, IEquatable<Fraction>,
+		IComparable, IComparable<float>, IComparable<double>, IComparable<decimal>, IComparable<Fraction> {
+		#region Private Variables
+		// Should there be SingleFraction that will have numerator and denominator that are float? (maybe IFraction interface as well)
+		private int numerator;
+		private int denominator;
+		#endregion
+
+		#region Public Properties
+		/// <summary>
+		/// The lower part.
+		/// </summary>
+		public int Numerator {
+			get {
+				return numerator;
+			}
+			set {
+				numerator = value;
+			}
+		}
+
+		/// <summary>
+		/// The bottom part. Cannot be zero.
+		/// </summary>
+		public int Denominator {
+			get {
+				return denominator;
+			}
+			set {
+				if (value == 0) {
+					throw new DivideByZeroException();
+				}
+				denominator = value;
+			}
+		}
+		#endregion
+
+		#region Public Static Read-onlys
+		/// <summary>
+		/// Represents 0/1, or 0%.
+		/// </summary>
+		public static readonly Fraction Zero = new(0, 1);
+		/// <summary>
+		/// Represents 1/1, or 100%.
+		/// </summary>
+		public static readonly Fraction One = new(1, 1);
+		/// <summary>
+		/// Represents 1/2, or 50%.
+		/// </summary>
+		public static readonly Fraction OneHalf = new(1, 2);
+		/// <summary>
+		/// Represents 1/3, or 33%.
+		/// </summary>
+		public static readonly Fraction OneThird = new(1, 3);
+		/// <summary>
+		/// Represents 2/3, or 66%.
+		/// </summary>
+		public static readonly Fraction TwoThirds = new(2, 3);
+		/// <summary>
+		/// Represents 1/4, or 25%.
+		/// </summary>
+		public static readonly Fraction OneQuarter = new(1, 4);
+		/// <summary>
+		/// <inheritdoc cref="OneHalf"/>
+		/// </summary>
+		public static readonly Fraction TwoQuarters = OneHalf;
+		/// <summary>
+		/// Represents 3/4, or 75%.
+		/// </summary>
+		public static readonly Fraction ThreeQuarters = new(3, 4);
+		/// <summary>
+		/// Represents 1/5, or 20%.
+		/// </summary>
+		public static readonly Fraction OneFifth = new(1, 5);
+		/// <summary>
+		/// Represents 2/5, or 40%.
+		/// </summary>
+		public static readonly Fraction TwoFifths = new(2, 5);
+		/// <summary>
+		/// Represents 3/5, or 60%.
+		/// </summary>
+		public static readonly Fraction ThreeFifths = new(3, 5);
+		/// <summary>
+		/// Represents 4/5, or 80%.
+		/// </summary>
+		public static readonly Fraction FourFifths = new(4, 5);
+		#endregion
+
+		#region Public Constructors
+		public Fraction(float chance) : this(Convert.ToDecimal(chance)) {
+		}
+
+		public Fraction(double chance) : this(Convert.ToDecimal(chance)) {
+		}
+
+		public Fraction(decimal chance) {
+			if (chance == decimal.Zero) {
+				numerator = Zero.denominator;
+				denominator = Zero.numerator;
+				return;
+			}
+
+			int tries = 0;
+			do {
+				chance *= 10.0m;
+				tries++;
+			}
+			while (tries < 15 && chance != (int)chance);
+			int num = (int)chance;
+			int den = (int)Math.Pow(10, tries);
+
+			numerator = num;
+			denominator = den;
+
+			Normalize();
+		}
+
+		public Fraction(int numerator, int denominator) {
+			this.numerator = numerator;
+			this.denominator = denominator;
+		}
+		#endregion
+
+		#region Normalizing
+		/// <summary>
+		/// Simplifies fraction. For example, from 5/100 to 1/20.
+		/// </summary>
+		/// <exception cref="ArithmeticException">Thrown if numerator and denominator are greater than <code>int.MaxValue / 2</code> or if numerator and denominator are lesser than <code>-int.MaxValue / 2</code>.</exception>
+		public void Normalize() {
+			bool numeratorIsNegative = numerator < 0;
+			bool denominatorIsNegative = denominator < 0;
+			if (numeratorIsNegative) {
+				numerator *= -1;
+			}
+			if (denominatorIsNegative) {
+				denominator *= -1;
+			}
+
+			if (numerator > int.MaxValue / 2 && denominator > int.MaxValue / 2) {
+				throw new ArithmeticException($"Numerator or denominator are greater than {int.MaxValue / 2} or lesser than {-int.MaxValue / 2}.");
+			}
+
+			numerator += denominator;
+			Reduce(GCD(numerator, denominator));
+			Reduce(Math.Sign(denominator));
+			numerator %= denominator;
+
+			if (numeratorIsNegative) {
+				numerator *= -1;
+			}
+			if (denominatorIsNegative) {
+				denominator *= -1;
+			}
+		}
+
+		private void Reduce(int x) {
+			numerator /= x;
+			denominator /= x;
+		}
+
+		private static int GCD(int a, int b) {
+			while (b != 0) {
+				int t = b;
+				b = a % b;
+				a = t;
+			}
+			return a;
+		}
+		#endregion
+
+		#region Percentages
+		[Pure]
+		public float ToPercentageSingle() {
+			return numerator / (float)denominator;
+		}
+
+		[Pure]
+		public double ToPercentageDouble() {
+			return numerator / (double)denominator;
+		}
+
+		[Pure]
+		public decimal ToPercentageDecimal() {
+			return numerator / (decimal)denominator;
+		}
+		#endregion
+
+		#region Object methods
+		public override string ToString() {
+#if !NETSTANDARD2_0 && !NETFRAMEWORK
+			Span<char> span = stackalloc char[1 + (2 * 20)];
+			int pos = 0;
+
+			bool formatted = numerator.TryFormat(span[pos..], out int charsWritten);
+			Debug.Assert(formatted);
+			pos += charsWritten;
+
+			span[pos++] = '/';
+			
+			formatted = denominator.TryFormat(span[pos..], out charsWritten);
+			Debug.Assert(formatted);
+			pos += charsWritten;
+
+			return new string(span[..pos]);
+#else
+			return $"{numerator}/{denominator}";
+#endif
+		}
+
+		public override int GetHashCode() {
+			return HashCode.Combine(numerator, denominator);
+		}
+		#endregion
+
+		#region Equatable
+		public override bool Equals([NotNullWhen(true)] object? obj) {
+			return obj switch {
+				Fraction other => Equals(other),
+				float single => Equals(single),
+				double dou => Equals(dou),
+				decimal deci => Equals(deci),
+				_ => false
+			};
+		}
+
+		public bool Equals(Fraction other) {
+			return other.numerator == numerator && other.denominator == denominator;
+		}
+
+		public bool Equals(float single) {
+			return ToPercentageSingle() == single;
+		}
+
+		public bool Equals(double dou) {
+			return ToPercentageDouble() == dou;
+		}
+
+		public bool Equals(decimal deci) {
+			return ToPercentageDecimal() == deci;
+		}
+		#endregion
+
+		#region Comparable
+		public int CompareTo(object? obj) {
+			return obj switch {
+				Fraction other => CompareTo(other),
+				float single => CompareTo(single),
+				double dou => CompareTo(dou),
+				decimal deci => CompareTo(deci),
+				_ => 0
+			};
+		}
+
+		public int CompareTo(Fraction other) {
+			if (this < other) return -1;
+			if (this > other) return 1;
+			return 0;
+		}
+
+		public int CompareTo(float other) {
+			return ToPercentageSingle().CompareTo(other);
+		}
+
+		public int CompareTo(double other) {
+			return ToPercentageSingle().CompareTo(other);
+		}
+
+		public int CompareTo(decimal other) {
+			return ToPercentageSingle().CompareTo(other);
+		}
+		#endregion
+
+		#region Conversion operators
+		public static implicit operator float(Fraction self) => self.ToPercentageSingle();
+		public static implicit operator double(Fraction self) => self.ToPercentageDouble();
+		public static implicit operator decimal(Fraction self) => self.ToPercentageDecimal();
+		public static explicit operator Fraction(float chance) => new(chance);
+		public static explicit operator Fraction(double chance) => new(chance);
+		public static explicit operator Fraction(decimal chance) => new(chance);
+		#endregion
+
+		#region Arithmetic operators
+		public static Fraction operator +(Fraction single) => single;
+		public static Fraction operator +(Fraction left, Fraction right) => new(left.numerator * right.denominator + right.numerator * left.denominator, left.denominator * right.denominator);
+		public static Fraction operator +(Fraction left, float right) => new(left.ToPercentageSingle() + right);
+		public static Fraction operator +(Fraction left, double right) => new(left.ToPercentageDouble() + right);
+		public static Fraction operator +(Fraction left, decimal right) => new(left.ToPercentageDecimal() + right);
+		public static Fraction operator -(Fraction single) => new(-single.numerator, single.denominator);
+		public static Fraction operator -(Fraction left, Fraction right) => left + (-right);
+		public static Fraction operator -(Fraction left, float right) => new(left.ToPercentageSingle() - right);
+		public static Fraction operator -(Fraction left, double right) => new(left.ToPercentageDouble() - right);
+		public static Fraction operator -(Fraction left, decimal right) => new(left.ToPercentageDecimal() - right);
+		public static Fraction operator *(Fraction left, Fraction right) => new(left.numerator * right.numerator, left.denominator * right.denominator);
+		public static Fraction operator *(Fraction left, float right) => new(left.ToPercentageSingle() * right);
+		public static Fraction operator *(Fraction left, double right) => new(left.ToPercentageDouble() * right);
+		public static Fraction operator *(Fraction left, decimal right) => new(left.ToPercentageDecimal() * right);
+		public static Fraction operator /(Fraction left, Fraction right) {
+			if (right.numerator == 0) {
+				throw new DivideByZeroException();
+			}
+			return new(left.numerator * right.denominator, left.denominator * right.numerator);
+		}
+		public static Fraction operator /(Fraction left, float right) => new(left.ToPercentageSingle() / right);
+		public static Fraction operator /(Fraction left, double right) => new(left.ToPercentageDouble() / right);
+		public static Fraction operator /(Fraction left, decimal right) => new(left.ToPercentageDecimal() / right);
+		public static Fraction operator %(Fraction left, Fraction right) => new(left.numerator % right.numerator, left.denominator % right.denominator);
+		public static Fraction operator %(Fraction left, float right) => new(left.ToPercentageSingle() % right);
+		public static Fraction operator %(Fraction left, double right) => new(left.ToPercentageDouble() % right);
+		public static Fraction operator %(Fraction left, decimal right) => new(left.ToPercentageDecimal() % right);
+		#endregion
+
+		#region Comparison operators
+		public static bool operator >(Fraction left, Fraction right) => left.denominator > right.denominator && left.numerator > right.denominator;
+		public static bool operator >(Fraction left, float right) => left.ToPercentageSingle() > right;
+		public static bool operator >(Fraction left, double right) => left.ToPercentageDouble() > right;
+		public static bool operator >(Fraction left, decimal right) => left.ToPercentageDecimal() > right;
+		public static bool operator >=(Fraction left, Fraction right) => left.denominator >= right.denominator && left.numerator >= right.denominator;
+		public static bool operator >=(Fraction left, float right) => left.ToPercentageSingle() >= right;
+		public static bool operator >=(Fraction left, double right) => left.ToPercentageDouble() >= right;
+		public static bool operator >=(Fraction left, decimal right) => left.ToPercentageDecimal() >= right;
+		public static bool operator <(Fraction left, Fraction right) => !(left > right);
+		public static bool operator <(Fraction left, float right) => !(left > right);
+		public static bool operator <(Fraction left, double right) => !(left > right);
+		public static bool operator <(Fraction left, decimal right) => !(left > right);
+		public static bool operator <=(Fraction left, Fraction right) => !(left >= right);
+		public static bool operator <=(Fraction left, float right) => !(left >= right);
+		public static bool operator <=(Fraction left, double right) => !(left >= right);
+		public static bool operator <=(Fraction left, decimal right) => !(left >= right);
+		#endregion
+
+		#region Bitwise operators
+		public static Fraction operator ~(Fraction single) => new(single.denominator, single.numerator);
+		//public static Fraction operator <<(Fraction left, Fraction other) => new(left.numerator << (int)other.numerator, left.numerator << (int)other.denominator);
+		//public static Fraction operator >>(Fraction left, Fraction other) => new(left.numerator >> (int)other.numerator, left.numerator >> (int)other.denominator);
+		//public static Fraction operator >>>(Fraction left, Fraction other) => new(left.numerator >>> (int)other.numerator, left.numerator >>> (int)other.denominator);
+		public static Fraction operator &(Fraction left, Fraction other) => new(left.numerator & other.numerator, left.denominator & other.denominator);
+		public static Fraction operator ^(Fraction left, Fraction other) => new(left.numerator ^ other.numerator, left.denominator ^ other.denominator);
+		public static Fraction operator |(Fraction left, Fraction other) => new(left.numerator | other.numerator, left.denominator | other.denominator);
+		#endregion
+
+		#region Equality operators
+		public static bool operator ==(Fraction left, Fraction right) => left.Equals(right);
+		public static bool operator ==(Fraction left, float right) => left.Equals(right);
+		public static bool operator ==(Fraction left, double right) => left.Equals(right);
+		public static bool operator ==(Fraction left, decimal right) => left.Equals(right);
+		public static bool operator !=(Fraction left, Fraction right) => !(left == right);
+		public static bool operator !=(Fraction left, float right) => !(left == right);
+		public static bool operator !=(Fraction left, double right) => !(left == right);
+		public static bool operator !=(Fraction left, decimal right) => !(left == right);
+		#endregion
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Fraction.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Fraction.cs
@@ -199,7 +199,7 @@ namespace Terraria.ModLoader {
 		#region Object methods
 		public override string ToString() {
 #if !NETSTANDARD2_0 && !NETFRAMEWORK
-			Span<char> span = stackalloc char[1 + (2 * 20)];
+			Span<char> span = stackalloc char[1 + (2 * 11)];
 			int pos = 0;
 
 			bool formatted = numerator.TryFormat(span[pos..], out int charsWritten);

--- a/patches/tModLoader/Terraria/Utilities/UnifiedRandom.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/UnifiedRandom.cs.patch
@@ -1,5 +1,15 @@
 --- src/TerrariaNetCore/Terraria/Utilities/UnifiedRandom.cs
 +++ src/tModLoader/Terraria/Utilities/UnifiedRandom.cs
+@@ -44,7 +_,8 @@
+ 			Seed = 1;
+ 		}
+ 
++		// TML: Made public.
+-		protected virtual double Sample() => (double)InternalSample() * 4.656612875245797E-10;
++		public virtual double Sample() => (double)InternalSample() * 4.656612875245797E-10;
+ 
+ 		private int InternalSample() {
+ 			int num = inext;
 @@ -78,6 +_,13 @@
  			return ((double)num + 2147483646.0) / 4294967293.0;
  		}


### PR DESCRIPTION
### What is the new feature?
Adds `Fraction` struct, `IItemDropRuleWithChance`, `IItemDropRuleWithDenominator`, `IItemDropRuleWithNumerator` interfaces and quite a few overloads to `ItemDropRule` methods, as well as few technical changes.

EDIT: Should there be a set for slime drops in this PR, or separate PR?

### Why should this be part of tModLoader?
It horribly annoys me that you have to type each time `ModContent.ItemType<T>()` to enter item ID, considering that Item/NPC loot modification is used nearly in every single mod.

### Are there alternative designs?
Nope.

### Sample usage for the new feature
```
public override void ModifyItemLoot(Item item, ItemLoot itemLoot) {
    itemLoot.Add(ItemDropRule.Common<ExampleItem>()); // Will drop all the time.
    itemLoot.Add(ItemDropRule.Common<ExampleItem>(new Fraction(5, 6))); // 83.3% chance to drop.
}
```
For new interfaces, they could be used for checking drop rule's Numerator and Denominator as well as Chance.
(1'm lazy to put an example of that, k)