### PR TITLE
[1.4.4] Call `ItemLoader.UseItem` for food quick buff

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -539,9 +539,12 @@
  		if (CountBuffs() == maxBuffs)
  			return;
  
-@@ -3238,7 +_,7 @@
+@@ -3237,8 +_,10 @@
+ 			if (num == 0)
  				num = 3600;
  
++			ItemLoader.UseItem(item, this);
++
  			AddBuff(item.buffType, num);
 -			if (item.consumable) {
 +			if (item.consumable && ItemLoader.ConsumeItem(item, this)) {


### PR DESCRIPTION
### What is the new feature?
Add (missing?) `ItemLoader.UseItem`  call for food items that were used by quick buff
### Why should this be part of tModLoader?
I was about to do something when the food is used, but I found that `UseItem` is not called when the food is used in quick buff, which makes it more difficult to add quick buff support for the use of food items
Not sure if it is a "bug fix" or a "new feature" lol