### PR TITLE
Workshop Improvements Pack 3

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1191,17 +1191,6 @@
  
  		protected IEnumerator LoadContent_Deferred() {
  			yield return null;
-@@ -8485,6 +_,10 @@
- 			CacheSupportedDisplaySizes();
- 			ContentSamples.RebuildItemCreativeSortingIDsAfterRecipesAreSetUp();
- 			ContentSamples.CommonlyUsedContentSamples.PrepareAfterEverythingElseLoaded();
-+
-+			// Populate Mod Browser to have it ready to go for player - Solxan
-+			// Saves 10 seconds wait in exchange for ~ 15 MB RAM @ 3,300 mods (~4.5 kB per mod). 15 MB persists after opening anyways.
-+			WorkshopHelper.QueryHelper.QueryWorkshop();
- 		}
- 
- 		private IEnumerator LoadMusic_InSteps() {
 @@ -8892,6 +_,8 @@
  
  					if (SceneMetrics.ActiveMusicBox == 86)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1191,6 +1191,17 @@
  
  		protected IEnumerator LoadContent_Deferred() {
  			yield return null;
+@@ -8485,6 +_,10 @@
+ 			CacheSupportedDisplaySizes();
+ 			ContentSamples.RebuildItemCreativeSortingIDsAfterRecipesAreSetUp();
+ 			ContentSamples.CommonlyUsedContentSamples.PrepareAfterEverythingElseLoaded();
++
++			// Populate Mod Browser to have it ready to go for player - Solxan
++			// Saves 10 seconds wait in exchange for ~ 15 MB RAM @ 3,300 mods (~4.5 kB per mod). 15 MB persists after opening anyways.
++			WorkshopHelper.QueryHelper.QueryWorkshop();
+ 		}
+ 
+ 		private IEnumerator LoadMusic_InSteps() {
 @@ -8892,6 +_,8 @@
  
  					if (SceneMetrics.ActiveMusicBox == 86)

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIWorkshopDownload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIWorkshopDownload.cs
@@ -1,8 +1,6 @@
 ﻿using System.Diagnostics;
-using System.Linq;
 using Terraria.Audio;
 using Terraria.Localization;
-using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader.UI.DownloadManager
 {

--- a/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIWorkshopDownload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/DownloadManager/UIWorkshopDownload.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics;
+using System.Linq;
 using Terraria.Audio;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader.UI.DownloadManager
 {
@@ -35,16 +37,6 @@ namespace Terraria.ModLoader.UI.DownloadManager
 		}
 
 		public void Leave(bool refreshBrowser) {
-			// Due to issues with Steam moving files from downloading folder to installed folder,
-			// there can be some latency in detecting it's installed. - Solxan
-			System.Threading.Thread.Sleep(50);
-
-			// Re-populate the mod Browser so that the "Installed" information refreshes.
-			if (refreshBrowser) {
-				Interface.modBrowser.PopulateModBrowser();
-				Interface.modBrowser.UpdateNeeded = true;
-			}
-
 			// Exit
 			ReturnToPreviousMenu();
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
@@ -184,8 +184,7 @@ namespace Terraria.ModLoader.UI
 			SoundEngine.PlaySound(SoundID.MenuClose);
 
 			ModOrganizer.DeleteMod(_localMod);
-
-			Task.Run(() => { Interface.modBrowser.InnerPopulateModBrowser(); });
+			ModBrowser.UIModBrowser.CleanupDeletedItem(_modName);
 
 			Main.menuMode = _gotoMenu;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -497,7 +497,7 @@ namespace Terraria.ModLoader.UI
 		private void DeleteMod(UIMouseEvent evt, UIElement listeningElement) {
 			ModOrganizer.DeleteMod(_mod);
 
-			Interface.modsMenu.needsMBRefresh = true;
+			UIModBrowser.CleanupDeletedItem(ModName);
 
 			CloseDialog(evt, listeningElement);
 			Interface.modsMenu.Activate();

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -44,7 +44,6 @@ namespace Terraria.ModLoader.UI
 		private UIAutoScaleTextTextPanel<string> buttonMP;
 		private CancellationTokenSource _cts;
 		private bool forceReloadHidden => ModLoader.autoReloadRequiredModsLeavingModsScreen && !ModCompile.DeveloperMode;
-		internal bool needsMBRefresh = false;
 
 		public override void OnInitialize() {
 			uIElement = new UIElement {
@@ -278,11 +277,6 @@ namespace Terraria.ModLoader.UI
 			}
 
 			ConfigManager.OnChangedAll();
-
-			if (needsMBRefresh) {
-				Task.Run(() => { Interface.modBrowser.InnerPopulateModBrowser(); });
-				needsMBRefresh = false;
-			}
 
 			(this as IHaveBackButtonCommand).HandleBackButtonUsage();
 		}

--- a/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
@@ -378,7 +378,7 @@ namespace Terraria.Social.Steam
 			}
 			else {
 				// A warning here that you will need to restart the game for item to be removed completely from Steam's runtime cache.
-				Utils.LogAndConsoleErrorMessage(Language.GetTextValue("tModLoader.SteamRejectUpdate"));
+				Utils.LogAndConsoleErrorMessage(Language.GetTextValue("tModLoader.SteamRejectUpdate",publishId));
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -193,7 +193,7 @@ namespace Terraria.Social.Steam
 			internal static ModDownloadItem FindModDownloadItem(string modName)
 			=> Items.FirstOrDefault(x => x.ModName.Equals(modName, StringComparison.OrdinalIgnoreCase));
 
-			internal static bool QueryWorkshop(bool startupPreload = false) {
+			internal static bool QueryWorkshop() {
 				HiddenModCount = IncompleteModCount = 0;
 				TotalItemsQueried = 0;
 				Items.Clear();
@@ -201,9 +201,6 @@ namespace Terraria.Social.Steam
 				AQueryInstance.InstalledMods = ModOrganizer.FindWorkshopMods();
 
 				if (!SteamedWraps.SteamAvailable) {
-					if (startupPreload)
-						return false;
-
 					if (!SteamedWraps.TryInitViaGameServer()) {
 						Utils.ShowFancyErrorMessage(Language.GetTextValue("tModLoader.NoWorkshopAccess"), 0);
 						return false;
@@ -215,21 +212,16 @@ namespace Terraria.Social.Steam
 					}
 				}
 
-				if (!new AQueryInstance() { preload = startupPreload }.QueryAllWorkshopItems())
+				if (!new AQueryInstance().QueryAllWorkshopItems())
 					return false;
 
 				AQueryInstance.InstalledMods = null;
 				return true;
 			}
 
-			internal static bool HandleError(EResult eResult, bool preloading) {
+			internal static bool HandleError(EResult eResult) {
 				if (eResult == EResult.k_EResultOK || eResult == EResult.k_EResultNone)
 					return true;
-
-				if (preloading) {
-					Items.Clear();
-					return false;
-				}
 
 				if (eResult == EResult.k_EResultAccessDenied) {
 					Utils.ShowFancyErrorMessage("Error: Access to Steam Workshop was denied.", 0);
@@ -321,7 +313,6 @@ namespace Terraria.Social.Steam
 				protected uint _queryReturnCount;
 				protected string _nextCursor;
 				internal List<ulong> ugcChildren = new List<ulong>();
-				internal bool preload;
 
 				internal static IReadOnlyList<LocalMod> InstalledMods;
 
@@ -405,7 +396,7 @@ namespace Terraria.Social.Steam
 					}
 					while (_primaryQueryResult == EResult.k_EResultNone);
 
-					return HandleError(_primaryQueryResult, preload);
+					return HandleError(_primaryQueryResult);
 				}
 
 				private void ProcessPageResult() {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -15,7 +15,7 @@ namespace Terraria.Social.Steam
 	{
 		public override List<string> GetListOfMods() => _downloader.ModPaths;
 
-		//TODO: Revisit this. It feels wrong.
+		//TODO: Revisit this. Creates a lot of 'slowness' when publishing due to needing to jump through re-querying the mod browser.
 		public override bool TryGetInfoForMod(TmodFile modFile, out FoundWorkshopEntryInfo info) {
 			info = null;
 			if(!WorkshopHelper.QueryHelper.CheckWorkshopConnection()) {
@@ -23,10 +23,15 @@ namespace Terraria.Social.Steam
 				return false;
 			}
 
+			// If mod is already installed, then we can view it's 
 			var existing = CheckIfUploaded(modFile);
 			if (existing == null)
 				return false;
 
+			// Update the subscribed mod to be the latest version published
+			SteamedWraps.Download(new Steamworks.PublishedFileId_t(ulong.Parse(existing.PublishId)), forceUpdate: true);
+
+			// Grab the tags from workshop.json
 			string searchFolder = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
 
 			return ModOrganizer.TryReadManifest(searchFolder, out info);
@@ -64,13 +69,11 @@ namespace Terraria.Social.Steam
 				ulong existingID = WorkshopHelper.QueryHelper.GetSteamOwner(currPublishID);
 				var currID = Steamworks.SteamUser.GetSteamID();
 
+				// Reject posting the mod if you don't 'own' the mod copy. NOTE: Steam doesn't support updating via contributor role anyways.
 				if (existingID != currID.m_SteamID) {
 					IssueReporter.ReportInstantUploadProblem("tModLoader.ModAlreadyUploaded");
 					return false;
 				}
-
-				// Update the subscribed mod to be the latest version published
-				SteamedWraps.Download(new Steamworks.PublishedFileId_t(currPublishID), forceUpdate: true);
 
 				// Publish by updating the files available on the current published version
 				workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{existing.PublishId}");
@@ -108,11 +111,7 @@ namespace Terraria.Social.Steam
 				string modPath = Path.Combine(contentFolderPath, modFile.Name + ".tmod");
 
 				// Solxan: File.Copy sometimes fails to delete the file that it needs to replace.
-				// This mitigates that issue by forcing the deletion before copying.
 				//TODO: But why though? Needs deeper look later.
-				if (File.Exists(modPath))
-					File.Delete(modPath);
-
 				File.Copy(modFile.path, modPath, true);
 
 				// Cleanup Old Folders

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -23,12 +23,11 @@ namespace Terraria.Social.Steam
 				return false;
 			}
 
-			// If mod is already installed, then we can view it's 
 			var existing = CheckIfUploaded(modFile);
 			if (existing == null)
 				return false;
 
-			// Update the subscribed mod to be the latest version published
+			// Update the subscribed mod to be the latest version published, so keeps all versions (stable, preview) together
 			SteamedWraps.Download(new Steamworks.PublishedFileId_t(ulong.Parse(existing.PublishId)), forceUpdate: true);
 
 			// Grab the tags from workshop.json


### PR DESCRIPTION
Several improvements related to Steam Workshop ingame to make it less painful.

1) Changed deleting items to not trigger a full re-poll of workshop
2) Changed downloading items to not trigger a full re-poll of workshop
3) Moved the update check in publishing to occur prior to publish screen, further isolating it from later file.copy calls

Related: #2848 , closes #2799 , #2696, #1795