### PR TITLE
[1.4.4] Add TileID.Sets.AvoidedByMeteorLanding

### DIFF
--- a/ExampleMod/Content/Tiles/ExamplePylonTile.cs
+++ b/ExampleMod/Content/Tiles/ExamplePylonTile.cs
@@ -58,7 +58,7 @@ namespace ExampleMod.Content.Tiles
 
 			TileID.Sets.InteractibleByNPCs[Type] = true;
 			TileID.Sets.PreventsSandfall[Type] = true;
-			TileID.Sets.AvoidedByMeteorGeneration[Type] = true;
+			TileID.Sets.AvoidedByMeteorLanding[Type] = true;
 
 			// Adds functionality for proximity of pylons; if this is true, then being near this tile will count as being near a pylon for the teleportation process.
 			AddToArray(ref TileID.Sets.CountsAsPylon);

--- a/ExampleMod/Content/Tiles/ExamplePylonTile.cs
+++ b/ExampleMod/Content/Tiles/ExamplePylonTile.cs
@@ -58,6 +58,7 @@ namespace ExampleMod.Content.Tiles
 
 			TileID.Sets.InteractibleByNPCs[Type] = true;
 			TileID.Sets.PreventsSandfall[Type] = true;
+			TileID.Sets.AvoidedByMeteorGeneration[Type] = true;
 
 			// Adds functionality for proximity of pylons; if this is true, then being near this tile will count as being near a pylon for the teleportation process.
 			AddToArray(ref TileID.Sets.CountsAsPylon);

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -51,6 +51,10 @@ partial class TileID
 		/// <summary> Whether or not saplings count this tile as empty when trying to grow. </summary>
 		public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 201, 233, 352, 485, 529, 530, 637, 655);
 
+		/// <summary> Whether or not this solid tile prevents a meteor from landing near it.</summary>
+		/// <remarks> Note: Chests and Dungeon tiles are not in this set, but also prevent landing (handled through <see cref="BasicChest"/> and <see cref="Main.tileDungeon"/>)</remarks>
+		public static bool[] AvoidedByMeteorGeneration = Factory.CreateBoolSet(226, 470, 475, 448, 597);
+
 		/// <summary>
 		/// Whether or not this tile will prevent sand/slush from falling beneath it.
 		/// </summary>

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -53,7 +53,7 @@ partial class TileID
 
 		/// <summary> Whether or not this tile prevents a meteor from landing near it.</summary>
 		/// <remarks> Note: Chests and Dungeon tiles are not in this set, but also prevent landing (handled through <see cref="BasicChest"/> and <see cref="Main.tileDungeon"/>)</remarks>
-		public static bool[] AvoidedByMeteorGeneration = Factory.CreateBoolSet(226, 470, 475, 448, 597);
+		public static bool[] AvoidedByMeteorLanding = Factory.CreateBoolSet(226, 470, 475, 448, 597);
 
 		/// <summary>
 		/// Whether or not this tile will prevent sand/slush from falling beneath it.

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -51,7 +51,7 @@ partial class TileID
 		/// <summary> Whether or not saplings count this tile as empty when trying to grow. </summary>
 		public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 201, 233, 352, 485, 529, 530, 637, 655);
 
-		/// <summary> Whether or not this solid tile prevents a meteor from landing near it.</summary>
+		/// <summary> Whether or not this tile prevents a meteor from landing near it.</summary>
 		/// <remarks> Note: Chests and Dungeon tiles are not in this set, but also prevent landing (handled through <see cref="BasicChest"/> and <see cref="Main.tileDungeon"/>)</remarks>
 		public static bool[] AvoidedByMeteorGeneration = Factory.CreateBoolSet(226, 470, 475, 448, 597);
 

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -135,6 +135,23 @@
  		}
  
  		if (x < roomX1)
+@@ -2323,12 +_,15 @@
+ 						return false;
+ 
+ 					switch (Main.tile[m, n].type) {
++						case ushort _ when TileID.Sets.AvoidedByMeteorGeneration[Main.tile[m, n].type]:
++						/*
+ 						case 226:
+ 						case 470:
+ 						case 475:
+ 						case 488:
+ 						case 597:
++						*/
+-							return false;
++						return false;
+ 					}
+ 				}
+ 			}
 @@ -2440,8 +_,13 @@
  	{
  		Main.bottomWorld = Main.maxTilesY * 16;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -139,7 +139,7 @@
  						return false;
  
  					switch (Main.tile[m, n].type) {
-+						case ushort _ when TileID.Sets.AvoidedByMeteorGeneration[Main.tile[m, n].type]:
++						case ushort _ when TileID.Sets.AvoidedByMeteorLanding[Main.tile[m, n].type]:
 +						/*
  						case 226:
  						case 470:

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -135,7 +135,7 @@
  		}
  
  		if (x < roomX1)
-@@ -2323,12 +_,15 @@
+@@ -2323,11 +_,14 @@
  						return false;
  
  					switch (Main.tile[m, n].type) {
@@ -147,11 +147,9 @@
  						case 488:
  						case 597:
 +						*/
--							return false;
-+						return false;
+ 							return false;
  					}
  				}
- 			}
 @@ -2440,8 +_,13 @@
  	{
  		Main.bottomWorld = Main.maxTilesY * 16;


### PR DESCRIPTION
### What is the new feature?
Adds a TileID set which marks a tile to be avoided by meteor generation.

### Why should this be part of tModLoader?
Currently, only modded chests and dungeon tiles are avoided by a meteor. Tiles that either generate on the surface or should never be tampered with their surroundings by a meteor are hardcoded (includes pylons, hat rack/mannequin, lihzard brick etc.).
The spirit of this set is to avoid meteor landing near important structures or the player's bases.

### Are there alternative designs?
~~This is as straightforward as it gets. Naming could be changed to `PreventsMeteorGeneration` or `AvoidedBy/PreventsMeteorLanding`.~~ Decided on `AvoidedByMeteorLanding`
This is also very different from the existing set called `GetsDestroyedForMeteors`, there is no overlap here.

### Sample usage for the new feature
For modded pylons or important tiles that generate on the surface.
Some mod could likely add Ebonstone into this set which would prevent meteors from landing in corruption chasms.

### ExampleMod updates
ExamplePylon was updated to use this set.

### Porting notes
Add `TileID.Sets.AvoidedByMeteorGeneration[Type] = true;` to your modded pylons.