### PR TITLE
[1.4.4] WIP: Reworked Biome Block Counting for Vanilla Biomes

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -85,5 +85,24 @@ partial class TileID
 		public static int[] RemixJungleBiome = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 225, 1);
 		public static int[] RemixCrimsonBiome = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10, 195, 1);
 		public static int[] RemixCorruptBiome = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10, 474, 1);
+
+		/// Functions to simplify modders adding a tile to the crimson, corruption, or jungle regardless of a remix world or not. Can still add manually as needed.
+		public static void AddCrimsonTile(ushort type, int strength = 1)
+		{
+			CrimsonBiome[type] = strength;
+			RemixCrimsonBiome[type] = strength;
+		}
+
+		public static void AddCorruptionTile(ushort type, int strength = 1)
+		{
+			CorruptBiome[type] = strength;
+			RemixCorruptBiome[type] = strength;
+		}
+
+		public static void AddJungleTile(ushort type, int strength = 1)
+		{
+			JungleBiome[type] = strength;
+			RemixJungleBiome[type] = strength;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -72,9 +72,7 @@ partial class TileID
 		/// </summary>
 		public static bool[] WallsMergeWith = Factory.CreateBoolSet(Glass);
 
-		/// <summary>
 		/// New created sets to facilitate vanilla biome block counting including modded blocks. To replace the current hardcoded counts in SceneMetrics.cs
-		/// </summary>
 		public static int[] CorruptBiome = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10);
 		public static int[] HallowBiome = Factory.CreateIntSet(0, 109, 1, 492, 1, 110, 1, 113, 1, 117, 1, 116, 1, 164, 1, 403, 1, 402, 1);
 		public static int[] CrimsonBiome = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10);
@@ -82,9 +80,10 @@ partial class TileID
 		public static int[] JungleBiome = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 226, 1, 225, 1);
 		public static int[] MushroomBiome = Factory.CreateIntSet(0, 70, 1, 71, 1, 72, 1, 528, 1);
 		public static int[] SandBiome = Factory.CreateIntSet(0, 53, 1, 112, 1, 116, 1, 234, 1, 397, 1, 398, 1, 402, 1, 399, 1, 396, 1, 400, 1, 403, 1, 401, 1);
+		public static int[] DungeonBiome = Factory.CreateIntSet(0, 41, 1, 43, 1, 44, 1, 481, 1, 482, 1, 483, 1);
 
-		public static int[] RemixJungle = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 225, 1);
-		public static int[] RemixCrimson = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10, 195, 1);
-		public static int[] RemixCorrupt = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10, 474, 1);
+		public static int[] RemixJungleBiome = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 225, 1);
+		public static int[] RemixCrimsonBiome = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10, 195, 1);
+		public static int[] RemixCorruptBiome = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10, 474, 1);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -71,5 +71,20 @@ partial class TileID
 		/// Tiles that are interpreted as a wall by nearby walls during framing, causing them to frame as if merging with this adjacent tile. Prevents wall from drawing within bounds for transparant tiles.
 		/// </summary>
 		public static bool[] WallsMergeWith = Factory.CreateBoolSet(Glass);
+
+		/// <summary>
+		/// New created sets to facilitate vanilla biome block counting including modded blocks. To replace the current hardcoded counts in SceneMetrics.cs
+		/// </summary>
+		public static int[] CorruptBiome = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10);
+		public static int[] HallowBiome = Factory.CreateIntSet(0, 109, 1, 492, 1, 110, 1, 113, 1, 117, 1, 116, 1, 164, 1, 403, 1, 402, 1);
+		public static int[] CrimsonBiome = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10);
+		public static int[] SnowBiome = Factory.CreateIntSet(0, 147, 1, 148, 1, 161, 1, 162, 1, 164, 1, 163, 1, 200, 1);
+		public static int[] JungleBiome = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 226, 1, 225, 1);
+		public static int[] MushroomBiome = Factory.CreateIntSet(0, 70, 1, 71, 1, 72, 1, 528, 1);
+		public static int[] SandBiome = Factory.CreateIntSet(0, 53, 1, 112, 1, 116, 1, 234, 1, 397, 1, 398, 1, 402, 1, 399, 1, 396, 1, 400, 1, 403, 1, 401, 1);
+
+		public static int[] RemixJungle = Factory.CreateIntSet(0, 60, 1, 61, 1, 62, 1, 74, 1, 225, 1);
+		public static int[] RemixCrimson = Factory.CreateIntSet(0, 199, 1, 203, 1, 200, 1, 401, 1, 399, 1, 234, 1, 352, 1, 27, -10, 195, 1);
+		public static int[] RemixCorrupt = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10, 474, 1);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1022,7 +1022,7 @@ public static class TileLoader
 	public static void RecountTiles(SceneMetrics metrics)
 	{
 		// reset every tile count
-		metrics.HolyTileCount = metrics.EvilTileCount = metrics.BloodTileCount = metrics.SnowTileCount = metrics.JungleTileCount = metrics.MushroomTileCount = metrics.SandTileCount = 0;
+		metrics.HolyTileCount = metrics.EvilTileCount = metrics.BloodTileCount = metrics.SnowTileCount = metrics.JungleTileCount = metrics.MushroomTileCount = metrics.SandTileCount = metrics.DungeonTileCount = 0;
 
 		// loop through all tiles, skipping ones not onscreen, and add each to the biome tile counts from their respective sets
 		for (int i = 0; i < TileCount; i++) {
@@ -1032,25 +1032,15 @@ public static class TileLoader
 			if (tileCount == 0)
 				continue;
 
-			int hallow = TileID.Sets.HallowBiome[i];
-			if (hallow != 0)
-				metrics.HolyTileCount += tileCount * hallow;
-
-			int snow = TileID.Sets.SnowBiome[i];
-			if (snow != 0)
-				metrics.SnowTileCount += tileCount * snow;
-
-			int mushroom = TileID.Sets.MushroomBiome[i];
-			if (mushroom != 0)
-				metrics.MushroomTileCount += tileCount * mushroom;
-
-			int sand = TileID.Sets.SandBiome[i];
-			if (sand != 0)
-				metrics.SandTileCount += tileCount * sand;
+			metrics.HolyTileCount += tileCount * TileID.Sets.HallowBiome[i];
+			metrics.SnowTileCount += tileCount * TileID.Sets.SnowBiome[i];
+			metrics.MushroomTileCount += tileCount * TileID.Sets.MushroomBiome[i];
+			metrics.SandTileCount += tileCount * TileID.Sets.SandBiome[i];
+			metrics.DungeonTileCount += tileCount * TileID.Sets.DungeonBiome[i];
 
 			int crimson, corrupt, jungle = 0;
 
-			// handles if the world is using the remix seed or not, which slightly changes which blocks count
+			// handles if the world is using the remix seed or not, which slightly changes which blocks are counted
 			if (!Main.remixWorld) {
 				corrupt = TileID.Sets.CorruptBiome[i];
 				crimson = TileID.Sets.CrimsonBiome[i];
@@ -1058,40 +1048,33 @@ public static class TileLoader
 			}
 
 			else {
-				corrupt = TileID.Sets.RemixCorrupt[i];
-				crimson = TileID.Sets.RemixCrimson[i];
-				jungle = TileID.Sets.RemixJungle[i];
+				corrupt = TileID.Sets.RemixCorruptBiome[i];
+				crimson = TileID.Sets.RemixCrimsonBiome[i];
+				jungle = TileID.Sets.RemixJungleBiome[i];
 			}
 
-			if (corrupt != 0)
-				metrics.EvilTileCount += tileCount * corrupt;
-
-			if (crimson != 0)
-				metrics.BloodTileCount += tileCount * crimson;
-
-			if (jungle != 0)
-				metrics.JungleTileCount += tileCount * jungle;
+			metrics.EvilTileCount += tileCount * corrupt;
+			metrics.BloodTileCount += tileCount * crimson;
+			metrics.JungleTileCount += tileCount * jungle;
 		}
 	}
 
-	/// <summary>
-	/// Function calls to simplify modders adding a tile to the biomes regardless of a remix world or not. Can still add manually as needed.
-	/// </summary>
+	/// Functions to simplify modders adding a tile to the crimson, corruption, or jungle regardless of a remix world or not. Can still add manually as needed.
 	public static void AddCrimsonTile(ushort type, int strength = 1)
 	{
 		TileID.Sets.CrimsonBiome[type] = strength;
-		TileID.Sets.RemixCrimson[type] = strength;
+		TileID.Sets.RemixCrimsonBiome[type] = strength;
 	}
 
 	public static void AddCorruptionTile(ushort type, int strength = 1)
 	{
 		TileID.Sets.CorruptBiome[type] = strength;
-		TileID.Sets.RemixCorrupt[type] = strength;
+		TileID.Sets.RemixCorruptBiome[type] = strength;
 	}
 
 	public static void AddJungleTile(ushort type, int strength = 1)
 	{
 		TileID.Sets.JungleBiome[type] = strength;
-		TileID.Sets.RemixJungle[type] = strength;
+		TileID.Sets.RemixJungleBiome[type] = strength;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1058,23 +1058,4 @@ public static class TileLoader
 			metrics.JungleTileCount += tileCount * jungle;
 		}
 	}
-
-	/// Functions to simplify modders adding a tile to the crimson, corruption, or jungle regardless of a remix world or not. Can still add manually as needed.
-	public static void AddCrimsonTile(ushort type, int strength = 1)
-	{
-		TileID.Sets.CrimsonBiome[type] = strength;
-		TileID.Sets.RemixCrimsonBiome[type] = strength;
-	}
-
-	public static void AddCorruptionTile(ushort type, int strength = 1)
-	{
-		TileID.Sets.CorruptBiome[type] = strength;
-		TileID.Sets.RemixCorruptBiome[type] = strength;
-	}
-
-	public static void AddJungleTile(ushort type, int strength = 1)
-	{
-		TileID.Sets.JungleBiome[type] = strength;
-		TileID.Sets.RemixJungleBiome[type] = strength;
-	}
 }

--- a/patches/tModLoader/Terraria/SceneMetrics.cs.patch
+++ b/patches/tModLoader/Terraria/SceneMetrics.cs.patch
@@ -180,8 +180,8 @@
  		MushroomTileCount = _tileCounts[70] + _tileCounts[71] + _tileCounts[72] + _tileCounts[528];
 +		*/
  		MeteorTileCount = _tileCounts[37];
- 		DungeonTileCount = _tileCounts[41] + _tileCounts[43] + _tileCounts[44] + _tileCounts[481] + _tileCounts[482] + _tileCounts[483];
 +		/*
+ 		DungeonTileCount = _tileCounts[41] + _tileCounts[43] + _tileCounts[44] + _tileCounts[481] + _tileCounts[482] + _tileCounts[483];
  		SandTileCount = _tileCounts[53] + _tileCounts[112] + _tileCounts[116] + _tileCounts[234] + _tileCounts[397] + _tileCounts[398] + _tileCounts[402] + _tileCounts[399] + _tileCounts[396] + _tileCounts[400] + _tileCounts[403] + _tileCounts[401];
 +		*/
  		PartyMonolithCount = _tileCounts[455];

--- a/patches/tModLoader/Terraria/SceneMetrics.cs.patch
+++ b/patches/tModLoader/Terraria/SceneMetrics.cs.patch
@@ -166,6 +166,33 @@
  	}
  
  	private void ExportTileCountsToMain()
+@@ -300,6 +_,7 @@
+ 
+ 		ShimmerTileCount = _liquidCounts[3];
+ 		HoneyBlockCount = _tileCounts[229];
++		/*
+ 		HolyTileCount = _tileCounts[109] + _tileCounts[492] + _tileCounts[110] + _tileCounts[113] + _tileCounts[117] + _tileCounts[116] + _tileCounts[164] + _tileCounts[403] + _tileCounts[402];
+ 		SnowTileCount = _tileCounts[147] + _tileCounts[148] + _tileCounts[161] + _tileCounts[162] + _tileCounts[164] + _tileCounts[163] + _tileCounts[200];
+ 		if (Main.remixWorld) {
+@@ -314,12 +_,18 @@
+ 		}
+ 
+ 		MushroomTileCount = _tileCounts[70] + _tileCounts[71] + _tileCounts[72] + _tileCounts[528];
++		*/
+ 		MeteorTileCount = _tileCounts[37];
+ 		DungeonTileCount = _tileCounts[41] + _tileCounts[43] + _tileCounts[44] + _tileCounts[481] + _tileCounts[482] + _tileCounts[483];
++		/*
+ 		SandTileCount = _tileCounts[53] + _tileCounts[112] + _tileCounts[116] + _tileCounts[234] + _tileCounts[397] + _tileCounts[398] + _tileCounts[402] + _tileCounts[399] + _tileCounts[396] + _tileCounts[400] + _tileCounts[403] + _tileCounts[401];
++		*/
+ 		PartyMonolithCount = _tileCounts[455];
+ 		GraveyardTileCount = _tileCounts[85];
+ 		GraveyardTileCount -= _tileCounts[27] / 2;
++
++		TileLoader.RecountTiles(this);
++
+ 		if (_tileCounts[27] > 0)
+ 			HasSunflower = true;
+ 
 @@ -388,6 +_,9 @@
  		Array.Clear(NPCBannerBuff, 0, NPCBannerBuff.Length);
  		hasBanner = false;


### PR DESCRIPTION
Note: This is a re-request of [#3166](https://github.com/tModLoader/tModLoader/pull/3166), as I've since correctly rebased my own work over to 1.4.4 and wanted the commit history to look cleaner. 

### What is the new feature?

This is an attempt to partially address the issue discussed in [Issue#1339](https://github.com/tModLoader/tModLoader/issues/1399).

This is a slight rework of the way Terraria handles counting biome related blocks with concern to vanilla biomes. Instead of using the hardcoded tile numbers, the newly added counting mechanism uses the tile ID sets to allow for modders to add their own tiles to said sets and easily make a **modded** block count as part of a **vanilla** biome.

### Why should this be part of tModLoader?

This small addition allows modders to more easily make their own blocks count as part of vanilla biomes. If a modder wished to make a new stone type of block that counted to the game as being a part of the Hallow biome, for example, it was previously difficult to do so (perhaps even impossible). 

### Are there alternative designs?

This is where I ask for feedback. This is my first time attempting contribution to a large-scale project such as tModLoader and I would love pointers and feedback from anyone more familiar with the codebase. While very simple in approach, the current way I do this feels dangerous to me, as it essentially loops through every single tile in the game for every single frame of gameplay and it feels this could get bloated with how many tiles are added by a large number of mods. 

I would also appreciate any advice on if my code feels logical in its placement and usage, as well as my adherence to the style guide, as I had a larger patch than actual changes due to trying to keep my code legible to at least myself. There may very well be a better way to do this, but I wanted to at least get the ball rolling as this is a feature of interest to me for my own modding endeavors. (I am on the Discord server if you wish to chat with my directly as well: Username is Golden Guardian). 

During my rebasing some minor formatting changes seem to also have been added, but I was not aware of making those changes at all so any advice on how to fix that or if I need to would be appreciated. (I did ensure I am following the configs laid out in the wiki)

### Sample usage for the new feature

The example I used above is good, but one I created for the purposes of testing my changes was to make a block that counted as both Snow and Hallow. This was to test if this implementation did not mess up any of vanilla Terraria's usual biome considerations. The expected result is that a small amount of the block would count as a Hallowed biome, and a much larger amount would count as both Hallowed and Snow. 

This was in fact the result and my own usage of this would be to further expand a mod allowing for Snow to be a tile that the Crimson, Corruption, and Hallow would spread to, not just ice. This could also allow modders to create entirely new structures within biomes constructed entirely of mod tiles without fearing overwriting the biome.