### PR TITLE
Freeze time fix

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/SkyManager.cs.patch
@@ -13,7 +13,7 @@
  
  	public void Reset()
  	{
-@@ -17,15 +_,20 @@
+@@ -17,15 +_,27 @@
  		}
  
  		_activeSkies.Clear();
@@ -29,9 +29,16 @@
 +		*/
 +
 +		_timePass += Main.desiredWorldEventsUpdateRate;
++
++		int timePass = (int)_timePass;
++		if (Main.desiredWorldEventsUpdateRate <= 0)
++			timePass = 1;
++
++		if (Main.forceStopWorldEvents)
++			timePass = 0;
  
 -		for (int i = 0; i < num; i++) {
-+		for (int i = 1; i <= (int)_timePass; i++) {
++		for (int i = 1; i <= timePass; i++) {
  			LinkedListNode<CustomSky> linkedListNode = _activeSkies.First;
  			while (linkedListNode != null) {
  				CustomSky value = linkedListNode.Value;

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -33,6 +33,7 @@ public partial class Main
 	public static bool Support8K = true; // provides an option to disable 8k (but leave 4k)
 	public static double desiredWorldEventsUpdateRate = 1; // dictates the speed at which world events (falling stars, fairy spawns, sandstorms, etc.) can change/happen
 	public static double timePass; // used to account for more precise time rates when deciding when to update weather
+	public static bool forceStopWorldEvents; // used to stop events that would otherwise ignore frozen time (invasions and skies)
 
 	internal static TMLContentManager AlternateContentManager;
 	public static List<TitleLinkButton> tModLoaderTitleLinks = new List<TitleLinkButton>();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1029,7 +1029,7 @@
  	}
  
  	private static string ReadLineInput()
-@@ -4958,9 +_,22 @@
+@@ -4958,9 +_,25 @@
  
  	public static void UpdateTimeRate()
  	{
@@ -1039,6 +1039,9 @@
 +		SystemLoader.ModifyTimeRate(ref dayRate, ref desiredWorldTilesUpdateRate, ref desiredWorldEventsUpdateRate);
 +		if (dayRate > 86400)
 +			dayRate = 86400;
++
++		if (desiredWorldEventsUpdateRate <= 0)
++			forceStopWorldEvents = false;
 +	}
 +
 +	public static void UpdateTimeRate_Inner()

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1029,12 +1029,13 @@
  	}
  
  	private static string ReadLineInput()
-@@ -4958,9 +_,21 @@
+@@ -4958,9 +_,22 @@
  
  	public static void UpdateTimeRate()
  	{
 +		UpdateTimeRate_Inner();
 +
++		forceStopWorldEvents = false;
 +		SystemLoader.ModifyTimeRate(ref dayRate, ref desiredWorldTilesUpdateRate, ref desiredWorldEventsUpdateRate);
 +		if (dayRate > 86400)
 +			dayRate = 86400;
@@ -5187,7 +5188,7 @@
  					RenderWalls();
  					sceneWallPos.X = screenPosition.X - (float)offScreenRange;
  					sceneWallPos.Y = screenPosition.Y - (float)offScreenRange;
-@@ -51005,9 +_,12 @@
+@@ -51005,9 +_,17 @@
  		if (gameMenu || netMode == 2)
  			bgTopY = -200;
  
@@ -5197,6 +5198,11 @@
  			num3 = 1;
 +		*/
 +		double num3 = desiredWorldEventsUpdateRate;
++		if (num3 <= 0)
++			num3 = 1;
++
++		if (Main.forceStopWorldEvents)
++			num3 = 0;
  
  		float num4 = 0.0005f * (float)num3;
  		if (gameMenu)
@@ -5482,7 +5488,7 @@
  		if (invasionType <= 0)
  			return;
  
-@@ -53170,9 +_,14 @@
+@@ -53170,9 +_,17 @@
  		if (invasionX == (double)spawnTileX)
  			return;
  
@@ -5492,7 +5498,10 @@
  			num = 1f;
 +		*/
 +		double num = desiredWorldEventsUpdateRate;
-+		if (num < 0)
++		if (num <= 0)
++			num = 1;
++
++		if (Main.forceStopWorldEvents)
 +			num = 0;
  
  		if (invasionX > (double)spawnTileX) {

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -260,7 +260,7 @@ public abstract partial class ModSystem : ModType
 	/// Called after all other time calculations. Can be used to modify the speed at which time should progress per tick in seconds, along with the rate at which the tiles in the world and the events in the world should update with it.
 	/// All fields are measured in in-game minutes per real-life second (min/sec).
 	/// You may want to consider <see cref="Main.IsFastForwardingTime"/> and CreativePowerManager.Instance.GetPower&lt;CreativePowers.FreezeTime&gt;().Enabled here.
-	/// You can also use <see cref="Main.forceStopWorldEvents"/> to stop events that happen even when the rate is 0
+	/// You can also use <see cref="Main.forceStopWorldEvents"/> to stop events that happen even when <paramref name="eventUpdateRate"/> is 0.
 	/// </summary>
 	/// <param name="timeRate">The speed at which time flows in min/sec.</param>
 	/// <param name="tileUpdateRate">The speed at which tiles in the world update in min/sec.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -259,7 +259,8 @@ public abstract partial class ModSystem : ModType
 	/// <summary>
 	/// Called after all other time calculations. Can be used to modify the speed at which time should progress per tick in seconds, along with the rate at which the tiles in the world and the events in the world should update with it.
 	/// All fields are measured in in-game minutes per real-life second (min/sec).
-	/// You may want to consider <see cref="Main.fastForwardTime"/> and CreativePowerManager.Instance.GetPower&lt;CreativePowers.FreezeTime&gt;().Enabled here.
+	/// You may want to consider <see cref="Main.IsFastForwardingTime"/> and CreativePowerManager.Instance.GetPower&lt;CreativePowers.FreezeTime&gt;().Enabled here.
+	/// You can also use <see cref="Main.forceStopWorldEvents"/> to stop events that happen even when the rate is 0
 	/// </summary>
 	/// <param name="timeRate">The speed at which time flows in min/sec.</param>
 	/// <param name="tileUpdateRate">The speed at which tiles in the world update in min/sec.</param>


### PR DESCRIPTION
### What is the bug?
Journey mode's freeze time has different behavior in tModLoader and vanilla. More specifically skies and invasions update in vanilla even when `dayRate` is 0 whereas in tModLoader they do not.

This mostly causes visual bugs like ambient objects in the sky staying frozen in place. However two more important differences caused by this bug is that in tModLoader the credits will not roll and invasions won't start when time is frozen.
### How did you fix the bug?
I reverted to the vanilla behavior of always updating at least once in these cases and added `Main.forceStopWorldEvents` as a way for modders to bypass this behavior if they still want to freeze the events

The intended use of this feature is to override `ModSystem.ModifyTimeRate` and set `eventUpdateRate` to 0 and `Main.forceStopWorldEvents` to true in order to actually freeze these events.

### Are there alternatives to your fix?
The naming could possibly be better. 
It might also be helpful if there was an additional parameter added to `ModSystem.ModifyTimeRate` for this purpose