### PR TITLE
Fixes #3032

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -616,7 +616,7 @@ namespace Terraria.ModLoader.Core
 
 			if (TryReadManifest(parentDir, out var info)) {
 				// Is a mod on Steam Workshop
-				SteamedWraps.UninstallWorkshopItem(new Steamworks.PublishedFileId_t(info.workshopEntryId));
+				SteamedWraps.UninstallWorkshopItem(new Steamworks.PublishedFileId_t(info.workshopEntryId), parentDir);
 			}
 			else {
 				// Is a Mod in Mods Folder


### PR DESCRIPTION
Bug Fix for Issue #3032 where GOG is unable to reinstall a mod because the ACF file is no longer cleaning itself.

This issue results from the sequence of events wherein the SteamGameServer is still running while we cleanup the file.
The game server will restore the acf file based on what it had done during the game, independent to our changes.

The resulting fix is to cleanup the acf file after the GameServer is shutdown, thus having the restoration occur before our cleanup.