### PR TITLE
Fix content folder path on Mac with GOG version

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -179,10 +179,10 @@ namespace Terraria
 				vanillaContentFolder = Path.Combine(Steam.GetSteamTerrariaInstallDir(), "Content");
 			}
 			else {
-				vanillaContentFolder = "../Terraria/Content"; // Side-by-Side Manual Install
+				vanillaContentFolder = Platform.IsOSX ? "../Terraria/Terraria.app/Contents/Resources/Content" : "../Terraria/Content"; // Side-by-Side Manual Install
 
 				if (!Directory.Exists(vanillaContentFolder)) {
-					vanillaContentFolder = "../Content"; // Nested Manual Install
+					vanillaContentFolder = Platform.IsOSX ? "../Terraria.app/Contents/Resources/Content" : "../Content"; // Nested Manual Install
 				}
 				Logging.tML.Info("Content folder of Terraria GOG Install Location assumed to be: " + Path.GetFullPath(vanillaContentFolder));
 			}


### PR DESCRIPTION
### What is the bug?
tModLoader fails to find the content folder on Mac if you have the GOG version of the game but works correctly with the Steam version.
### How did you fix the bug?
I changed vanillaContentFolder to the correct one on Mac.
### Are there alternatives to your fix?
Not that I know of
