### PR TITLE
Fix AssemblyManager.ForceJITOnMethod() Throwing on Interface Methods

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -391,7 +391,7 @@ namespace Terraria.ModLoader.Core
 
 				// By combining the logic of the method being virtual and also an override, by checking if GetBaseDefinition returns itself, we can determine that the original base definition is gone now.
 				// Note: GetBaseDefinition returns the calling instance if the instance's declaring type is an interface -- absoluteAquarian
-				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface == false && methodInfo.GetBaseDefinition() == methodInfo)
+				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface is true && methodInfo.GetBaseDefinition() == methodInfo)
 					throw new Exception($"{method} overrides a method which doesn't exist in any base class");
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -391,7 +391,7 @@ namespace Terraria.ModLoader.Core
 
 				// By combining the logic of the method being virtual and also an override, by checking if GetBaseDefinition returns itself, we can determine that the original base definition is gone now.
 				// Note: GetBaseDefinition returns the calling instance if the instance's declaring type is an interface -- absoluteAquarian
-				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface is true && methodInfo.GetBaseDefinition() == methodInfo)
+				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface is not true && methodInfo.GetBaseDefinition() == methodInfo)
 					throw new Exception($"{method} overrides a method which doesn't exist in any base class");
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -391,7 +391,7 @@ namespace Terraria.ModLoader.Core
 
 				// By combining the logic of the method being virtual and also an override, by checking if GetBaseDefinition returns itself, we can determine that the original base definition is gone now.
 				// Note: GetBaseDefinition returns the calling instance if the instance's declaring type is an interface -- absoluteAquarian
-				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface is not true && methodInfo.GetBaseDefinition() == methodInfo)
+				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface is false && methodInfo.GetBaseDefinition() == methodInfo)
 					throw new Exception($"{method} overrides a method which doesn't exist in any base class");
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -390,7 +390,8 @@ namespace Terraria.ModLoader.Core
 				bool isNewSlot = (methodInfo.Attributes & MethodAttributes.VtableLayoutMask) == MethodAttributes.NewSlot;
 
 				// By combining the logic of the method being virtual and also an override, by checking if GetBaseDefinition returns itself, we can determine that the original base definition is gone now.
-				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.GetBaseDefinition() == methodInfo)
+				// Note: GetBaseDefinition returns the calling instance if the instance's declaring type is an interface -- absoluteAquarian
+				if (methodInfo.IsVirtual && !isNewSlot && methodInfo.DeclaringType?.IsInterface == false && methodInfo.GetBaseDefinition() == methodInfo)
 					throw new Exception($"{method} overrides a method which doesn't exist in any base class");
 			}
 		}


### PR DESCRIPTION
### What is the bug?
The logic in `AssemblyManager.ForceJITOnMethod()` would erroneously throw errors when checking methods in `interface` types.

### How did you fix the bug?
I prevented the logic in `AssemblyManager.ForceJITOnMethod()` from throwing an exception when a method's declaring type is an interface.

### Are there alternatives to your fix?
n/a

### Other information
This pull request fixes #3158.