### PR TITLE
Better Preview Warnings

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -126,12 +126,19 @@ namespace Terraria.ModLoader.Core
 			return true;
 		}
 
-		internal static bool IsModNotPreviewSupported(LocalMod mod) {
-			return BuildInfo.IsPreview && IsModFromSteam(mod.modFile.path) && !mod.properties.playableOnPreview;
+		internal static bool ApplyPreviewChecks(LocalMod mod) {
+			return BuildInfo.IsPreview && IsModFromSteam(mod.modFile.path);
 		}
 
+		// Used to Warn Players that the mod was built on Stable or earlier, and may not work on Preview.
+		internal static bool CheckStableBuildOnPreview(LocalMod mod) {
+			return ApplyPreviewChecks(mod) && mod.properties.buildVersion.MajorMinor() <= BuildInfo.stableVersion.MajorMinor();
+		}
+
+		// Used to Hide Preview built versions of Mods from being displayed as the available mod in 1.4-Preview tModLoader.
+		// Primarily intended to allow for publishing your mod ahead of a monthly breaking change build
 		internal static bool SkipModForPreviewNotPlayable(LocalMod mod) {
-			return IsModNotPreviewSupported(mod) && mod.properties.buildVersion.MajorMinor() > BuildInfo.stableVersion;
+			return ApplyPreviewChecks(mod) && !mod.properties.playableOnPreview && mod.properties.buildVersion.MajorMinor() > BuildInfo.stableVersion;
 		}
 
 		internal static bool IsModFromSteam(string modPath) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -161,10 +161,10 @@ namespace Terraria.ModLoader.UI
 			}
 
 			
-			if (ModOrganizer.IsModNotPreviewSupported(_mod)) {
-				_keyImage = new UIHoverImage(Main.Assets.Request<Texture2D>(TextureAssets.Item[ItemID.LavaSkull].Name), Language.GetTextValue("tModLoader.ModHasIndicatedPreviewNotSupported")) {
-					Left = { Pixels = -72, Percent = 1f },
-					Top = { Pixels = -1 }
+			if (ModOrganizer.CheckStableBuildOnPreview(_mod)) {
+				_keyImage = new UIHoverImage(Main.Assets.Request<Texture2D>(TextureAssets.Item[ItemID.LavaSkull].Name), Language.GetTextValue("No Preview Build. Enable At Own Risk")) {
+					Left = { Pixels = 4, Percent = 0.2f },
+					Top = { Pixels = 0, Percent = 0.5f }
 				};
 
 				Append(_keyImage);


### PR DESCRIPTION
### What is the new feature?
Initializes a simple new Warning on the "Enabled" button for any mod built on Stable that is showing up for usage on 1.4-preview tmodloader. 

### Why should this be part of tModLoader?
This is intended to reduce the number of players reporting that a mod isn't working, just because they are on preview. 
Not all mods intend to develop on both stable and preview, and reasonably so. 

### Are there alternative designs?
It is proposed that in addition we could add a formal UI text popup message to have players confirm they want to enable it given that it won't always work. 

A due note that the current design assumes the mod was never tested on preview by the modder. If it was tested and does work, then the icon would be misleading. 
There is likely some design work that can be done around that as well.

### Sample usage for the new feature
![image](https://user-images.githubusercontent.com/59670736/211166835-9f4efcda-0eb2-4ed1-bb5b-f15761229518.png)


