### PR TITLE
[1.4.4] `ModPlayer.AddMaterialsForCrafting` Method

### DIFF
--- a/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
@@ -59,7 +59,7 @@ namespace ExampleMod.Common.Players
 		}
 
 		// Use items in the chest for crafting
-		public override IEnumerable<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting) {
+		public override IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback onUsedForCrafting) {
 			// Ensure there is a chest nearby that is not opened by the player
 			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby)
 				return base.AddMaterialsForCrafting(out onUsedForCrafting);

--- a/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
@@ -8,7 +8,7 @@ using Terraria.ID;
 namespace ExampleMod.Common.Players
 {
 	// This class showcases how to use items in the chest player stands on (if exists)
-	// for crafting (consuming items from piggy bank), even if it is not opened by the player
+	// for crafting, even if it is not opened by the player
 	// One use of this is allowing items in your custom bank to be used for crafting
 	public class ExampleRecipeMaterialPlayer : ModPlayer
 	{
@@ -45,7 +45,7 @@ namespace ExampleMod.Common.Players
 				}
 
 				int chest = Chest.FindChest(left, top);
-				if (chest > 0) {
+				if (chest > 0 && !Chest.IsLocked(left, top)) {
 					_chestIndexNearby = chest;
 					break;
 				}
@@ -59,14 +59,14 @@ namespace ExampleMod.Common.Players
 		}
 
 		// Use items in the chest for crafting
-		public override IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback onUsedForCrafting) {
+		public override IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback itemConsumedCallback) {
 			// Ensure there is a chest nearby that is not opened by the player
 			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby)
-				return base.AddMaterialsForCrafting(out onUsedForCrafting);
+				return base.AddMaterialsForCrafting(out itemConsumedCallback);
 
 			// onUsedForCrafting invokes when the item is consumed, can be used to send packets in multiplayer mode
 			// If there is no need for this, just set it to null
-			onUsedForCrafting = (_, index) => {
+			itemConsumedCallback = (_, index) => {
 				if (Main.netMode is NetmodeID.MultiplayerClient) {
 					// Sync chest data
 					NetMessage.SendData(MessageID.SyncChestItem, number: _chestIndexNearby, number2: index);

--- a/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
@@ -59,7 +59,7 @@ namespace ExampleMod.Common.Players
 		}
 
 		// Use items in the chest for crafting
-		public override List<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting) {
+		public override IEnumerable<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting) {
 			// Ensure there is a chest nearby that is not opened by the player
 			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby)
 				return base.AddMaterialsForCrafting(out onUsedForCrafting);
@@ -75,7 +75,7 @@ namespace ExampleMod.Common.Players
 
 			// Returns the items in the chest to use them for crafting
 			// The returned list should not be a cloned version of items otherwise items will not be consumed
-			return Main.chest[_chestIndexNearby].item.ToList();
+			return Main.chest[_chestIndexNearby].item;
 		}
 	}
 }

--- a/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+
+namespace ExampleMod.Common.Players
+{
+	// This class showcases how to use items in the chest player stands on (if exists)
+	// for crafting (consuming items from piggy bank), even if it is not opened by the player
+	// One use of this is allowing items in your custom bank to be used for crafting
+	public class ExampleRecipeMaterialPlayer : ModPlayer
+	{
+		private int _chestIndexNearby = -1;
+
+		// Nearby chest finding
+		public override void PostUpdateMiscEffects() {
+			int oldChestIndex = _chestIndexNearby;
+
+			// Gets leg position in tile coord for further chest searching
+			var legPosition = Player.Bottom - new Vector2(0f, 20f);
+			var legPositionInTile = legPosition.ToTileCoordinates();
+
+			_chestIndexNearby = -1;
+			// Find a possible chest nearby
+			for (int x = -1; x <= 1; x++) {
+				var tile = Main.tile[legPositionInTile.X + x, legPositionInTile.Y];
+
+				// Dressers are excluded to make search code simpler
+				if (!tile.HasTile || !TileID.Sets.IsAContainer[tile.TileType] || tile.TileType is TileID.Dressers) {
+					continue;
+				}
+
+				// Gets the left-top position for the chest
+				int left = legPositionInTile.X + x;
+				int top = legPositionInTile.Y;
+
+				if (tile.TileFrameX % 36 != 0) {
+					left--;
+				}
+
+				if (tile.TileFrameY != 0) {
+					top--;
+				}
+
+				int chest = Chest.FindChest(left, top);
+				if (chest > 0) {
+					_chestIndexNearby = chest;
+					break;
+				}
+			}
+
+			// If the nearby chest changed, call FindRecipes to refresh available recipes
+			// Since FindRecipes takes a long time to run, we should try to avoid calling it frequently
+			if (oldChestIndex != _chestIndexNearby) {
+				Recipe.FindRecipes();
+			}
+		}
+
+		// Use items in the chest for crafting
+		public override List<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting) {
+			// Ensure there is a chest nearby that is not opened by the player
+			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby)
+				return base.AddMaterialsForCrafting(out onUsedForCrafting);
+
+			// onUsedForCrafting invokes when the item is consumed, can be used to send packets in multiplayer mode
+			// If there is no need for this, just set it to null
+			onUsedForCrafting = (_, index) => {
+				if (Main.netMode is NetmodeID.MultiplayerClient) {
+					// Sync chest data
+					NetMessage.SendData(MessageID.SyncChestItem, number: _chestIndexNearby, number2: index);
+				}
+			};
+
+			// Returns the items in the chest to use them for crafting
+			// The returned list should not be a cloned version of items otherwise items will not be consumed
+			return Main.chest[_chestIndexNearby].item.ToList();
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
@@ -92,6 +92,12 @@ public class HookList<T> where T : class
 	public FilteredSpanEnumerator<T> Enumerate(List<T> instances) =>
 		Enumerate(CollectionsMarshal.AsSpan(instances));
 
+	public IEnumerable<T> EnumerateSlow(IReadOnlyList<T> instances)
+	{
+		foreach (var i in indices)
+			yield return instances[i];
+	}
+
 	public void Update<U>(IList<U> instances) where U : IIndexed
 	{
 		indices = instances.WhereMethodIsOverridden(method).Select(g => (int)g.Index).ToArray();

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -27,7 +27,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	public override ModPlayer NewInstance(Player entity)
 	{
 		var inst = base.NewInstance(entity);
-
+		
 		inst.Index = Index;
 
 		return inst;
@@ -41,7 +41,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	protected override void ValidateType()
 	{
 		base.ValidateType();
-
+		
 		LoaderUtils.MustOverrideTogether(this, p => SaveData, p => LoadData);
 		LoaderUtils.MustOverrideTogether(this, p => p.clientClone, p => p.SendClientChanges);
 	}
@@ -1120,9 +1120,9 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// </summary>
 	/// <param name="onUsedForCrafting">The action that gets invoked when the item is consumed</param>
 	/// <returns>An list of the items that may be used as crafting materials. If you want to add nothing, return new List&lt;Item&gt;().</returns>
-	public virtual List<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting)
+	public virtual IEnumerable<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting)
 	{
 		onUsedForCrafting = null;
-		return new List<Item>();
+		return null;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1115,12 +1115,19 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
+	/// An action to be invoked when an item is partially or fully consumed
+	/// </summary>
+	/// <param name="item">The item that has been consumed. May have been set to air if the item was fully consumed.</param>
+	/// <param name="index">The index of the item enumerated in IEnumerable&lt;Item&gt;</param>
+	public delegate void ItemConsumedCallback(Item item, int index);
+
+	/// <summary>
 	/// Called when Recipe.FindRecipes is called or the player is crafting an item
 	/// You can use this method to add items as the materials that may be used for crafting items
 	/// </summary>
 	/// <param name="onUsedForCrafting">The action that gets invoked when the item is consumed</param>
-	/// <returns>An list of the items that may be used as crafting materials. If you want to add nothing, return new List&lt;Item&gt;().</returns>
-	public virtual IEnumerable<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting)
+	/// <returns>A list of the items that may be used as crafting materials or null if none are available.</returns>
+	public virtual IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback onUsedForCrafting)
 	{
 		onUsedForCrafting = null;
 		return null;

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -27,7 +27,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	public override ModPlayer NewInstance(Player entity)
 	{
 		var inst = base.NewInstance(entity);
-		
+
 		inst.Index = Index;
 
 		return inst;
@@ -41,7 +41,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	protected override void ValidateType()
 	{
 		base.ValidateType();
-		
+
 		LoaderUtils.MustOverrideTogether(this, p => SaveData, p => LoadData);
 		LoaderUtils.MustOverrideTogether(this, p => p.clientClone, p => p.SendClientChanges);
 	}
@@ -1112,5 +1112,17 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// <param name="mediumCoreDeath">Whether you are setting up a mediumcore player's inventory after their death.</param>
 	public virtual void ModifyStartingInventory(IReadOnlyDictionary<string, List<Item>> itemsByMod, bool mediumCoreDeath)
 	{
+	}
+
+	/// <summary>
+	/// Called when Recipe.FindRecipes is called or the player is crafting an item
+	/// You can use this method to add items as the materials that may be used for crafting items
+	/// </summary>
+	/// <param name="onUsedForCrafting">The action that gets invoked when the item is consumed</param>
+	/// <returns>An list of the items that may be used as crafting materials. If you want to add nothing, return new List&lt;Item&gt;().</returns>
+	public virtual List<Item> AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting)
+	{
+		onUsedForCrafting = null;
+		return new List<Item>();
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1125,11 +1125,11 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// Called when Recipe.FindRecipes is called or the player is crafting an item
 	/// You can use this method to add items as the materials that may be used for crafting items
 	/// </summary>
-	/// <param name="onUsedForCrafting">The action that gets invoked when the item is consumed</param>
+	/// <param name="itemConsumedCallback">The action that gets invoked when the item is consumed</param>
 	/// <returns>A list of the items that may be used as crafting materials or null if none are available.</returns>
-	public virtual IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback onUsedForCrafting)
+	public virtual IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback itemConsumedCallback)
 	{
-		onUsedForCrafting = null;
+		itemConsumedCallback = null;
 		return null;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1006,7 +1006,7 @@ public static class PlayerLoader
 			modPlayer.ModifyFishingAttempt(ref attempt);
 		}
 
-		attempt.rolledItemDrop = attempt.rolledEnemySpawn = 0; // Reset, modders need to use CatchFish for this
+		attempt.rolledItemDrop = attempt.rolledEnemySpawn = 0; // Reset, modders need to use CatchFish for this 
 	}
 
 	private delegate void DelegateCatchFish(FishingAttempt attempt, ref int itemDrop, ref int enemySpawn, ref AdvancedPopupRequest sonar, ref Vector2 sonarPosition);
@@ -1272,7 +1272,7 @@ public static class PlayerLoader
 	}
 
 	private delegate bool DelegateModifyNurseHeal(NPC npc, ref int health, ref bool removeDebuffs, ref string chatText);
-
+	
 	private static readonly HookList HookModifyNurseHeal = AddHook<DelegateModifyNurseHeal>(p => p.ModifyNurseHeal);
 
 	public static bool ModifyNurseHeal(Player player, NPC npc, ref int health, ref bool removeDebuffs, ref string chat)
@@ -1331,19 +1331,22 @@ public static class PlayerLoader
 	/// The action that gets invoked when the item is consumed
 	/// </summary>
 	/// <param name="item">The item that is consumed for crafting</param>
-	/// <param name="index">The index of the item in the List&lt;Item&gt;</param>
+	/// <param name="index">The index number of the item enumerated in IEnumerable&lt;Item&gt;</param>
 	public delegate void ActionOnUsedForCrafting(Item item, int index);
-	private delegate List<Item> DelegateFindMaterialsFrom(out ActionOnUsedForCrafting onUsedForCrafting);
+	private delegate IEnumerable<Item> DelegateFindMaterialsFrom(out ActionOnUsedForCrafting onUsedForCrafting);
 	private static HookList HookAddCraftingMaterials = AddHook<DelegateFindMaterialsFrom>(p => p.AddMaterialsForCrafting);
 
-	public static Dictionary<List<Item>, ActionOnUsedForCrafting> GetModdedCraftingMaterials(Player player)
+	public static Dictionary<IEnumerable<Item>, ActionOnUsedForCrafting> GetModdedCraftingMaterials(Player player)
 	{
-		var items = new Dictionary<List<Item>, ActionOnUsedForCrafting>();
+		var itemsMap = new Dictionary<IEnumerable<Item>, ActionOnUsedForCrafting>();
 
 		foreach (var modPlayer in HookAddCraftingMaterials.Enumerate(player.modPlayers)) {
-			items.Add(modPlayer.AddMaterialsForCrafting(out var onUsedForCrafting), onUsedForCrafting);
+			var items = modPlayer.AddMaterialsForCrafting(out var onUsedForCrafting);
+			if (items != null) {
+				itemsMap.Add(items, onUsedForCrafting);
+			}
 		}
 
-		return items;
+		return itemsMap;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1006,7 +1006,7 @@ public static class PlayerLoader
 			modPlayer.ModifyFishingAttempt(ref attempt);
 		}
 
-		attempt.rolledItemDrop = attempt.rolledEnemySpawn = 0; // Reset, modders need to use CatchFish for this 
+		attempt.rolledItemDrop = attempt.rolledEnemySpawn = 0; // Reset, modders need to use CatchFish for this
 	}
 
 	private delegate void DelegateCatchFish(FishingAttempt attempt, ref int itemDrop, ref int enemySpawn, ref AdvancedPopupRequest sonar, ref Vector2 sonarPosition);
@@ -1272,7 +1272,7 @@ public static class PlayerLoader
 	}
 
 	private delegate bool DelegateModifyNurseHeal(NPC npc, ref int health, ref bool removeDebuffs, ref string chatText);
-	
+
 	private static readonly HookList HookModifyNurseHeal = AddHook<DelegateModifyNurseHeal>(p => p.ModifyNurseHeal);
 
 	public static bool ModifyNurseHeal(Player player, NPC npc, ref int health, ref bool removeDebuffs, ref string chat)
@@ -1325,5 +1325,25 @@ public static class PlayerLoader
 			.OrderBy(kv => kv.Key == "Terraria" ? "" : kv.Key)
 			.SelectMany(kv => kv.Value)
 			.ToList();
+	}
+
+	/// <summary>
+	/// The action that gets invoked when the item is consumed
+	/// </summary>
+	/// <param name="item">The item that is consumed for crafting</param>
+	/// <param name="index">The index of the item in the List&lt;Item&gt;</param>
+	public delegate void ActionOnUsedForCrafting(Item item, int index);
+	private delegate List<Item> DelegateFindMaterialsFrom(out ActionOnUsedForCrafting onUsedForCrafting);
+	private static HookList HookAddCraftingMaterials = AddHook<DelegateFindMaterialsFrom>(p => p.AddMaterialsForCrafting);
+
+	public static Dictionary<List<Item>, ActionOnUsedForCrafting> GetModdedCraftingMaterials(Player player)
+	{
+		var items = new Dictionary<List<Item>, ActionOnUsedForCrafting>();
+
+		foreach (var modPlayer in HookAddCraftingMaterials.Enumerate(player.modPlayers)) {
+			items.Add(modPlayer.AddMaterialsForCrafting(out var onUsedForCrafting), onUsedForCrafting);
+		}
+
+		return items;
 	}
 }

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -162,7 +162,7 @@
  	public Recipe()
  	{
  		for (int i = 0; i < maxRequirements; i++) {
-@@ -131,17 +_,25 @@
+@@ -131,17 +_,23 @@
  			acceptedGroups[i] = -1;
  		}
  	}
@@ -179,8 +179,6 @@
  	{
 +		//TML: Just in case something throws or breaks and the 'clear after craft' doesn't run.
 +		RecipeLoader.ConsumedItems.Clear();
-+
-+		Dictionary<List<Item>, PlayerLoader.ActionOnUsedForCrafting> moddedMaterials = PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer);
 +
  		Item[] array = null;
  		Item item = null;
@@ -277,7 +275,7 @@
  					item.stack -= num;
  					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
  						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
-@@ -235,12 +_,29 @@
+@@ -235,12 +_,31 @@
  					num = 0;
  				}
  				else {
@@ -292,14 +290,16 @@
  			}
 +
 +			ModdedMaterials: ;
-+			foreach ((List<Item> items, PlayerLoader.ActionOnUsedForCrafting consumedAction) in moddedMaterials) {
-+				for (int i = 0; i < items.Count; i++) {
++			foreach ((IEnumerable<Item> items, PlayerLoader.ActionOnUsedForCrafting consumedAction) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
++				int index = 0; // For the 'index' parameter of the action 'consumedAction'
++				foreach (var materialItem in items) {
 +					if (num <= 0)
 +						goto End;
 +
-+					ConsumeForCraft(items[i], item2, ref num, () => {
-+						consumedAction?.Invoke(items[i], i);
++					ConsumeForCraft(materialItem, item2, ref num, () => {
++						consumedAction?.Invoke(materialItem, index);
 +					});
++					index++;
 +				}
 +			}
 +
@@ -429,13 +429,12 @@
  			if (!player.adjTile[tempRec.requiredTile[i]])
  				return false;
  		}
-@@ -483,6 +_,11 @@
+@@ -483,6 +_,10 @@
  			CollectItems(currentInventory, 40);
  		}
  
-+		Dictionary<List<Item>, ActionOnUsedForCrafting> moddedMaterials = PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer);
-+		foreach ((List<Item> items, _) in moddedMaterials) {
-+			CollectItems(items.ToArray(), items.Count);
++		foreach ((IEnumerable<Item> items, _) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
++			CollectItems(items.ToArray(), items.Count());
 +		}
 +
  		AddFakeCountsForItemGroups();

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -162,7 +162,7 @@
  	public Recipe()
  	{
  		for (int i = 0; i < maxRequirements; i++) {
-@@ -131,17 +_,23 @@
+@@ -131,17 +_,25 @@
  			acceptedGroups[i] = -1;
  		}
  	}
@@ -180,6 +180,8 @@
 +		//TML: Just in case something throws or breaks and the 'clear after craft' doesn't run.
 +		RecipeLoader.ConsumedItems.Clear();
 +
++		Dictionary<List<Item>, PlayerLoader.ActionOnUsedForCrafting> moddedMaterials = PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer);
++
  		Item[] array = null;
  		Item item = null;
 -		Item item2 = null;
@@ -192,7 +194,7 @@
  			int num = item2.stack;
  			if (alchemy && Main.player[Main.myPlayer].alchemyTable) {
  				if (num > 1) {
-@@ -158,9 +_,12 @@
+@@ -158,25 +_,36 @@
  				}
  			}
  
@@ -205,8 +207,11 @@
  			array = Main.player[Main.myPlayer].inventory;
  			for (int k = 0; k < 58; k++) {
  				item = array[k];
-@@ -169,10 +_,15 @@
+ 				if (num <= 0)
+ 					break;
  
++				ConsumeForCraft(item, item2, ref num);
++				/*
  				if (item.IsTheSameAs(item2) || useWood(item.type, item2.type) || useSand(item.type, item2.type) || useFragment(item.type, item2.type) || useIronBar(item.type, item2.type) || usePressurePlate(item.type, item2.type) || AcceptedByItemGroups(item.type, item2.type)) {
  					if (item.stack > num) {
 +						RecipeLoader.ConsumedItems.Add(item.Clone());
@@ -221,7 +226,48 @@
  						num -= item.stack;
  						array[k] = new Item();
  					}
-@@ -228,6 +_,9 @@
+ 				}
++				*/
+ 			}
+ 
+ 			if (Main.player[Main.myPlayer].chest != -1) {
+@@ -196,6 +_,11 @@
+ 					if (num <= 0)
+ 						break;
+ 
++					ConsumeForCraft(item, item2, ref num, () => {
++						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
++							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
++					});
++					/*
+ 					if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
+ 						continue;
+ 
+@@ -212,11 +_,13 @@
+ 						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
+ 							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
+ 					}
++					*/
+ 				}
+ 			}
+ 
+ 			if (!Main.player[Main.myPlayer].useVoidBag() || Main.player[Main.myPlayer].chest == -5)
+-				continue;
++				goto ModdedMaterials;
++				// continue;
+ 
+ 			array = Main.player[Main.myPlayer].bank4.item;
+ 			for (int m = 0; m < 40; m++) {
+@@ -224,10 +_,18 @@
+ 				if (num <= 0)
+ 					break;
+ 
++				ConsumeForCraft(item, item2, ref num, () => {
++					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
++						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
++				});
++				/*
+ 				if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
  					continue;
  
  				if (item.stack > num) {
@@ -231,7 +277,7 @@
  					item.stack -= num;
  					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
  						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
-@@ -235,6 +_,8 @@
+@@ -235,12 +_,29 @@
  					num = 0;
  				}
  				else {
@@ -240,10 +286,57 @@
  					num -= item.stack;
  					array[m] = new Item();
  					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
-@@ -248,7 +_,7 @@
+ 						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
+ 				}
++				*/
+ 			}
++
++			ModdedMaterials: ;
++			foreach ((List<Item> items, PlayerLoader.ActionOnUsedForCrafting consumedAction) in moddedMaterials) {
++				for (int i = 0; i < items.Count; i++) {
++					if (num <= 0)
++						goto End;
++
++					ConsumeForCraft(items[i], item2, ref num, () => {
++						consumedAction?.Invoke(items[i], i);
++					});
++				}
++			}
++
++			End: ;
+ 		}
+ 
+ 		AchievementsHelper.NotifyItemCraft(this);
+@@ -248,7 +_,33 @@
  		FindRecipes();
  	}
  
++	// Added by TML. Replaces multiple vanilla crafting code.
++	private void ConsumeForCraft(Item item, Item requiredItem, ref int stackRequired, Action consumedAction = null)
++	{
++		if (!item.IsTheSameAs(requiredItem) && !useWood(item.type, requiredItem.type) && !useSand(item.type, requiredItem.type) && !useIronBar(item.type, requiredItem.type) && !usePressurePlate(item.type, requiredItem.type) && !useFragment(item.type, requiredItem.type) && !AcceptedByItemGroups(item.type, requiredItem.type))
++			return;
++
++		if (item.stack > stackRequired) {
++			RecipeLoader.ConsumedItems.Add(item.Clone());
++			RecipeLoader.ConsumedItems[^1].stack = stackRequired;
++
++			item.stack -= stackRequired;
++
++			consumedAction?.Invoke();
++
++			stackRequired = 0;
++		}
++		else {
++			RecipeLoader.ConsumedItems.Add(item);
++
++			stackRequired -= item.stack;
++			item.TurnToAir();
++
++			consumedAction?.Invoke();
++		}
++	}
++
 -	public bool useWood(int invType, int reqType)
 +	private bool useWood(int invType, int reqType)
  	{
@@ -285,19 +378,17 @@
  	{
  		if (!anyPressurePlate)
  			return false;
-@@ -381,8 +_,15 @@
- 			Recipe recipe = Main.recipe[i];
+@@ -382,7 +_,14 @@
  			if (recipe.createItem.type == 0)
  				break;
--
-+				
+ 
 +			if (recipe.Disabled)
 +				continue;
-+			
++
 +			bool requirementsMet = false;
  			if (PlayerMeetsTileRequirements(localPlayer, recipe) && PlayerMeetsEnvironmentConditions(localPlayer, recipe) && CollectedEnoughItemsToCraftRecipeNew(recipe))
 +				requirementsMet = true;
-+			
++
 +			if (requirementsMet && RecipeLoader.RecipeAvailable(recipe))
  				AddToAvailableRecipes(i);
  		}
@@ -338,6 +429,18 @@
  			if (!player.adjTile[tempRec.requiredTile[i]])
  				return false;
  		}
+@@ -483,6 +_,11 @@
+ 			CollectItems(currentInventory, 40);
+ 		}
+ 
++		Dictionary<List<Item>, ActionOnUsedForCrafting> moddedMaterials = PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer);
++		foreach ((List<Item> items, _) in moddedMaterials) {
++			CollectItems(items.ToArray(), items.Count);
++		}
++
+ 		AddFakeCountsForItemGroups();
+ 	}
+ 
 @@ -516,7 +_,10 @@
  			if (recipe.createItem.type == 0)
  				break;

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -328,7 +328,7 @@
 +			stackRequired = 0;
 +		}
 +		else {
-+			RecipeLoader.ConsumedItems.Add(item);
++			RecipeLoader.ConsumedItems.Add(item.Clone());
 +
 +			stackRequired -= item.stack;
 +			item.TurnToAir();

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -233,15 +233,15 @@
  					if (num <= 0)
  						break;
  
-+					ConsumeForCraft(item, item2, ref num, () => {
++					if (ConsumeForCraft(item, item2, ref num)) {
 +						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
 +							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
-+					});
++					}
 +					/*
  					if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
  						continue;
  
-@@ -212,11 +_,13 @@
+@@ -212,11 +_,12 @@
  						if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
  							NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, l);
  					}
@@ -251,19 +251,16 @@
  
  			if (!Main.player[Main.myPlayer].useVoidBag() || Main.player[Main.myPlayer].chest == -5)
 -				continue;
-+				goto ModdedMaterials;
-+				// continue;
++				goto ModdedMaterials; // continue;
  
  			array = Main.player[Main.myPlayer].bank4.item;
  			for (int m = 0; m < 40; m++) {
-@@ -224,10 +_,18 @@
+@@ -224,10 +_,16 @@
  				if (num <= 0)
  					break;
  
-+				ConsumeForCraft(item, item2, ref num, () => {
-+					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
-+						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
-+				});
++				// tML note, the net syncing code is redundant (vanilla bug) and doesn't need to be called. Void bag is synced like player inventory
++				ConsumeForCraft(item, item2, ref num);
 +				/*
  				if (!item.IsTheSameAs(item2) && !useWood(item.type, item2.type) && !useSand(item.type, item2.type) && !useIronBar(item.type, item2.type) && !usePressurePlate(item.type, item2.type) && !useFragment(item.type, item2.type) && !AcceptedByItemGroups(item.type, item2.type))
  					continue;
@@ -275,7 +272,7 @@
  					item.stack -= num;
  					if (Main.netMode == 1 && Main.player[Main.myPlayer].chest >= 0)
  						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
-@@ -235,12 +_,31 @@
+@@ -235,11 +_,31 @@
  					num = 0;
  				}
  				else {
@@ -287,54 +284,47 @@
  						NetMessage.SendData(32, -1, -1, null, Main.player[Main.myPlayer].chest, m);
  				}
 +				*/
- 			}
-+
-+			ModdedMaterials: ;
-+			foreach ((IEnumerable<Item> items, PlayerLoader.ActionOnUsedForCrafting consumedAction) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
-+				int index = 0; // For the 'index' parameter of the action 'consumedAction'
-+				foreach (var materialItem in items) {
-+					if (num <= 0)
-+						goto End;
-+
-+					ConsumeForCraft(materialItem, item2, ref num, () => {
-+						consumedAction?.Invoke(materialItem, index);
-+					});
-+					index++;
-+				}
 +			}
 +
-+			End: ;
++			ModdedMaterials:
++			foreach ((var items, var onConsumedCallback) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
++				if (num <= 0)
++					break;
++
++				int index = 0;
++				foreach (var materialItem in items) {
++					if (num <= 0)
++						break;
++
++					if (ConsumeForCraft(materialItem, item2, ref num))
++						onConsumedCallback?.Invoke(materialItem, index);
++
++					index++;
++				}
+ 			}
  		}
  
- 		AchievementsHelper.NotifyItemCraft(this);
-@@ -248,7 +_,33 @@
+@@ -248,7 +_,26 @@
  		FindRecipes();
  	}
  
 +	// Added by TML. Replaces multiple vanilla crafting code.
-+	private void ConsumeForCraft(Item item, Item requiredItem, ref int stackRequired, Action consumedAction = null)
++	private bool ConsumeForCraft(Item item, Item requiredItem, ref int stackRequired)
 +	{
-+		if (!item.IsTheSameAs(requiredItem) && !useWood(item.type, requiredItem.type) && !useSand(item.type, requiredItem.type) && !useIronBar(item.type, requiredItem.type) && !usePressurePlate(item.type, requiredItem.type) && !useFragment(item.type, requiredItem.type) && !AcceptedByItemGroups(item.type, requiredItem.type))
-+			return;
++		if (item.stack == 0 || !item.IsTheSameAs(requiredItem) && !AcceptedByItemGroups(item.type, requiredItem.type))
++			return false;
 +
-+		if (item.stack > stackRequired) {
-+			RecipeLoader.ConsumedItems.Add(item.Clone());
-+			RecipeLoader.ConsumedItems[^1].stack = stackRequired;
++		var consumed = item.Clone();
++		consumed.stack = Math.Min(item.stack, stackRequired);
++		RecipeLoader.ConsumedItems.Add(consumed);
 +
-+			item.stack -= stackRequired;
++		item.stack -= consumed.stack;
++		stackRequired -= consumed.stack;
 +
-+			consumedAction?.Invoke();
-+
-+			stackRequired = 0;
-+		}
-+		else {
-+			RecipeLoader.ConsumedItems.Add(item.Clone());
-+
-+			stackRequired -= item.stack;
++		if (item.stack == 0)
 +			item.TurnToAir();
 +
-+			consumedAction?.Invoke();
-+		}
++		return true;
 +	}
 +
 -	public bool useWood(int invType, int reqType)
@@ -433,13 +423,31 @@
  			CollectItems(currentInventory, 40);
  		}
  
-+		foreach ((IEnumerable<Item> items, _) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
-+			CollectItems(items.ToArray(), items.Count());
++		foreach ((var items, _) in PlayerLoader.GetModdedCraftingMaterials(Main.LocalPlayer)) {
++			CollectItems(items);
 +		}
 +
  		AddFakeCountsForItemGroups();
  	}
  
+@@ -496,8 +_,17 @@
+ 
+ 	private static void CollectItems(Item[] currentInventory, int slotCap)
+ 	{
++		CollectItems(currentInventory.Take(slotCap));
++	}
++
++	// Added by TML
++	private static void CollectItems(IEnumerable<Item> items)
++	{
++		/*
+ 		for (int i = 0; i < slotCap; i++) {
+ 			Item item = currentInventory[i];
++			*/
++		foreach (var item in items) {
+ 			if (item.stack > 0) {
+ 				int num = item.stack;
+ 				if (_ownedItems.TryGetValue(item.netID, out var value))
 @@ -516,7 +_,10 @@
  			if (recipe.createItem.type == 0)
  				break;


### PR DESCRIPTION
### What is the new feature?
Allow modders to use their own items for crafting by overriding the method `ModPlayer.AddMaterialsForCrafting(out PlayerLoader.ActionOnUsedForCrafting onUsedForCrafting)`
### Why should this be part of tModLoader?
Modders may want to use their own items for crafting in certain situation
### Sample usage for the new feature
You can craft with items in the chest which you opened in vanilla
For mods they can add a custom void bag, which you can craft with its contents
### ExampleMod updates
You can now craft with items in the chest you stand by (if exists), despite not opening it