### PR TITLE
Add ability to manually select content folder

### DIFF
--- a/patches/tModLoader/Terraria/nativefiledialog.cs.patch
+++ b/patches/tModLoader/Terraria/nativefiledialog.cs.patch
@@ -9,3 +9,12 @@
  		return result;
  	}
  
+@@ -107,7 +_,7 @@
+ 		IntPtr outPath2;
+ 		nfdresult_t result = INTERNAL_NFD_PickFolder(intPtr, out outPath2);
+ 		Marshal.FreeHGlobal((IntPtr)(void*)intPtr);
+-		outPath = UTF8_ToManaged(outPath2, freePtr: true);
++		outPath = UTF8_ToManaged(outPath2, freePtr: false);
+ 		return result;
+ 	}
+ 


### PR DESCRIPTION
### What is the new feature?
It allows you to select a content folder if one can't be found.
### Why should this be part of tModLoader?
It provides a fallback for when the folder can't be automatically detected. 
### Are there alternative designs?
It could replace the GOG portion entirely but that may be inconvenient for players. 

Continues off https://github.com/tModLoader/tModLoader/pull/3173.