### PR TITLE
 Shimmer Recipe.Condition support + internalisation/removal of vanilla corruption/crimson versions

### DIFF
--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -27,14 +27,12 @@ public class ShimmerShowcaseCrimsonCorruption : ModItem
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.RottenChunk)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.CorruptionOnly()
 			.Register();
 
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.Vertebrae)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.CrimsonOnly()
 			.Register();
 	}
 }

--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -1,4 +1,5 @@
-﻿using Terraria.ID;
+﻿using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items;
@@ -7,11 +8,11 @@ namespace ExampleMod.Content.Items;
 The items in this file showcase customizing the decrafting feature of the Shimmer liquid.
 By default, Shimmer will tranform crafted items back into their original recipe ingredients.
 
-ShimmerShowcaseCrimsonCorruption showcases crimson and corruption specific shimmer decrafting results.
+ShimmerShowcaseConditions showcases crimson and corruption specific shimmer decrafting results.
 
 ShimmerShowcaseCustomShimmerResult showcases both preventing a recipe from being decrafted and specifying a custom shimmer decrafting result.
 */
-public class ShimmerShowcaseCrimsonCorruption : ModItem
+public class ShimmerShowcaseConditions : ModItem
 {
 	public override string Texture => "ExampleMod/Content/Items/ExampleItem";
 
@@ -22,17 +23,28 @@ public class ShimmerShowcaseCrimsonCorruption : ModItem
 
 	public override void AddRecipes() {
 		// Many items have multiple recipes. The last added recipe will usually be used for shimmer decrafting.
-		// If your recipes are crimson or corruption specific, use CorruptionOnly and CrimsonOnly to indicate which recipe should be used for decrafting with which evil world type.
+		// Recipe conditions may be used to only allow decrafting under certain conditions, here it is used to make the recipes decraftable in only their respective world types
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.RottenChunk)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.AddDecraftCondition(Recipe.Condition.CorruptWorld)
 			.Register();
 
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.Vertebrae)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.AddDecraftCondition(Recipe.Condition.CrimsonWorld)
+			.Register();
+
+		// Or in a specific biome, keep in mind that decraft order is reverse of recipe register, so this desert example has priority over the world evil
+
+		CreateRecipe()
+			.AddIngredient<ExampleItem>()
+			.AddIngredient(ItemID.Cactus)
+			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.AddDecraftCondition(Recipe.Condition.InDesert)
 			.Register();
 	}
 }

--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -28,14 +28,14 @@ public class ShimmerShowcaseConditions : ModItem
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.RottenChunk)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddDecraftCondition(Recipe.Condition.CorruptWorld)
+			.AddShimmerCondition(Recipe.Condition.CorruptWorld)
 			.Register();
 
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.Vertebrae)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddDecraftCondition(Recipe.Condition.CrimsonWorld)
+			.AddShimmerCondition(Recipe.Condition.CrimsonWorld)
 			.Register();
 
 		// Or in a specific biome, keep in mind that decraft order is reverse of recipe register, so this desert example has priority over the world evil
@@ -44,7 +44,7 @@ public class ShimmerShowcaseConditions : ModItem
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.Cactus)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddDecraftCondition(Recipe.Condition.InDesert)
+			.AddShimmerCondition(Recipe.Condition.InDesert)
 			.Register();
 	}
 }

--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -22,29 +22,30 @@ public class ShimmerShowcaseConditions : ModItem
 	}
 
 	public override void AddRecipes() {
+
+		// Keep in mind that decraft order is reverse of recipe register, so this desert example has priority over the world evil
+
+		CreateRecipe()
+			.AddIngredient<ExampleItem>()
+			.AddIngredient(ItemID.Cactus)
+			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.AddDecraftCondition(Recipe.Condition.InDesert)
+			.Register();
+
 		// Many items have multiple recipes. The last added recipe will usually be used for shimmer decrafting.
 		// Recipe conditions may be used to only allow decrafting under certain conditions, here it is used to make the recipes decraftable in only their respective world types
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.RottenChunk)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddShimmerCondition(Recipe.Condition.CorruptWorld)
+			.AddDecraftCondition(Recipe.Condition.CorruptWorld)
 			.Register();
 
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.Vertebrae)
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddShimmerCondition(Recipe.Condition.CrimsonWorld)
-			.Register();
-
-		// Or in a specific biome, keep in mind that decraft order is reverse of recipe register, so this desert example has priority over the world evil
-
-		CreateRecipe()
-			.AddIngredient<ExampleItem>()
-			.AddIngredient(ItemID.Cactus)
-			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.AddShimmerCondition(Recipe.Condition.InDesert)
+			.AddDecraftCondition(Recipe.Condition.CrimsonWorld)
 			.Register();
 	}
 }
@@ -59,28 +60,20 @@ public class ShimmerShowcaseCustomShimmerResult : ModItem
 	}
 
 	public override void AddRecipes() {
+		// By default, the first added recipe will be used for shimmer decrafting. We can use DisableShimmer() to tell the game to ignore this recipe and use the below recipe instead.
+		CreateRecipe()
+			.AddIngredient<ExampleItem>()
+			.AddIngredient(ItemID.PadThai)
+			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.DisableDecraft()
+			.Register();
+
 		// AddCustomShimmerResult can be used to change the decrafting results. Rather that return 1 ExampleItem, decrafting this item will return 1 Rotten Egg and 3 Chain.
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
 			.AddCustomShimmerResult(ItemID.RottenEgg)
 			.AddCustomShimmerResult(ItemID.Chain, 3)
-			.Register();
-
-		// By default, the last added recipe will be used for shimmer decrafting unless crimson or corruption specific recipes are found. We can use DisableShimmer() to tell the game to ignore this recipe and use the above recipe instead.
-		CreateRecipe()
-			.AddIngredient<ExampleItem>()
-			.AddIngredient(ItemID.PadThai)
-			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.DisableShimmer()
-			.Register();
-
-		//Another method of changing priority is using .SetShimmerPriority, setting it to -1 puts it bellow the unset 0 of both others here
-		CreateRecipe()
-			.AddIngredient<ExampleItem>()
-			.AddIngredient(ItemID.GoldenDelight)
-			.AddTile<Tiles.Furniture.ExampleWorkbench>()
-			.SetShimmerPriority(-1)
 			.Register();
 	}
 }

--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -60,7 +60,7 @@ public class ShimmerShowcaseCustomShimmerResult : ModItem
 	}
 
 	public override void AddRecipes() {
-		// By default, the first added recipe will be used for shimmer decrafting. We can use DisableShimmer() to tell the game to ignore this recipe and use the below recipe instead.
+		// By default, the first added recipe will be used for shimmer decrafting. We can use DisableDecraft() to tell the game to ignore this recipe and use the below recipe instead.
 		CreateRecipe()
 			.AddIngredient<ExampleItem>()
 			.AddIngredient(ItemID.PadThai)

--- a/ExampleMod/Content/Items/ShimmerShowcase.cs
+++ b/ExampleMod/Content/Items/ShimmerShowcase.cs
@@ -74,5 +74,13 @@ public class ShimmerShowcaseCustomShimmerResult : ModItem
 			.AddTile<Tiles.Furniture.ExampleWorkbench>()
 			.DisableShimmer()
 			.Register();
+
+		//Another method of changing priority is using .SetShimmerPriority, setting it to -1 puts it bellow the unset 0 of both others here
+		CreateRecipe()
+			.AddIngredient<ExampleItem>()
+			.AddIngredient(ItemID.GoldenDelight)
+			.AddTile<Tiles.Furniture.ExampleWorkbench>()
+			.SetShimmerPriority(-1)
+			.Register();
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -22,16 +22,19 @@
  			return -1;
  
  		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
-@@ -22,7 +_,15 @@
+@@ -22,7 +_,18 @@
  		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
  			return ItemID.Sets.IsCraftedCorruption[type];
  
-+		//Deliberately preserving the "last first" order of the previous implementation
++		//Deliberately preserving the "last first" order of the previous implementation, adding manual priority support
 +		int recipe = recipeIndecies[recipeIndecies.Length -1];
 +
 +		foreach (int posRec in recipeIndecies) {
-+			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec]))
-+				recipe = posRec;
++			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec])) {
++				if (Main.recipe[posRec].shimmerPriority >= Main.recipe[recipe].shimmerPriority)
++					recipe = posRec;
++
++			}
 +		}
 +
 -		return num;

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -21,7 +21,7 @@
 +		*/
 +
 +		foreach (int recipeIndex in ItemID.Sets.CraftingRecipeIndices[type]) {
-+			if (RecipeLoader.DecraftAvailable(Main.recipe[recipeIndex]) && recipeIndex >= 0)
++			if (RecipeLoader.DecraftAvailable(Main.recipe[recipeIndex]))
 +				return recipeIndex;
 +		}
 +

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -6,7 +6,7 @@
  
  namespace Terraria.GameContent;
  
-@@ -12,8 +_,15 @@
+@@ -12,15 +_,34 @@
  
  	public static int GetDecraftingRecipeIndex(int type)
  	{
@@ -21,11 +21,14 @@
 +		if (recipeIndecies[0] < 0)
  			return -1;
  
++		/*  automatically replaced with corresponding Decrafting Conditions
  		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
-@@ -22,6 +_,16 @@
+ 			return ItemID.Sets.IsCraftedCrimson[type];
+ 
  		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
  			return ItemID.Sets.IsCraftedCorruption[type];
- 
++		*/
++
 +		//Deliberately preserving the "last first" order of the previous implementation, adding manual priority support
 +		int num = recipeIndecies[recipeIndecies.Length -1];
 +
@@ -35,10 +38,9 @@
 +					num = posRec;
 +			}
 +		}
-+
+ 
  		return num;
  	}
- 
 @@ -35,6 +_,9 @@
  			return true;
  

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -1,0 +1,18 @@
+--- src/TerrariaNetCore/Terraria/GameContent/ShimmerTransforms.cs
++++ src/tModLoader/Terraria/GameContent/ShimmerTransforms.cs
+@@ -1,4 +_,5 @@
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.GameContent;
+ 
+@@ -35,6 +_,9 @@
+ 			return true;
+ 
+ 		if (!NPC.downedGolemBoss && RecipeSets.PostGolem[decraftingRecipeIndex])
++			return true;
++
++		if (!RecipeLoader.ShimmerAvailable(Main.recipe[decraftingRecipeIndex]))
+ 			return true;
+ 
+ 		return false;

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -6,41 +6,29 @@
  
  namespace Terraria.GameContent;
  
-@@ -12,15 +_,34 @@
+@@ -12,6 +_,7 @@
  
  	public static int GetDecraftingRecipeIndex(int type)
  	{
 +		/*
-+		vanilla:
  		int num = ItemID.Sets.IsCrafted[type];
  		if (num < 0)
-+		return false;
-+		*/
-+
-+		int[] recipeIndecies = ItemID.Sets.IsCrafted[type];
-+		if (recipeIndecies[0] < 0)
  			return -1;
- 
-+		/*  automatically replaced with corresponding Decrafting Conditions
- 		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
- 			return ItemID.Sets.IsCraftedCrimson[type];
- 
- 		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
+@@ -23,6 +_,14 @@
  			return ItemID.Sets.IsCraftedCorruption[type];
-+		*/
-+
-+		//Deliberately preserving the "last first" order of the previous implementation, adding manual priority support
-+		int num = recipeIndecies[recipeIndecies.Length -1];
-+
-+		foreach (int posRec in recipeIndecies) {
-+			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec])) {
-+				if (Main.recipe[posRec].shimmerPriority >= Main.recipe[num].shimmerPriority)
-+					num = posRec;
-+			}
-+		}
  
  		return num;
++		*/
++
++		foreach (int recipeIndex in ItemID.Sets.CraftingRecipeIndices[type]) {
++			if (RecipeLoader.DecraftAvailable(Main.recipe[recipeIndex]) && recipeIndex >= 0)
++				return recipeIndex;
++		}
++
++		return -1;
  	}
+ 
+ 	public static bool IsItemTransformLocked(int type)
 @@ -35,6 +_,9 @@
  			return true;
  

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -22,7 +22,7 @@
  			return -1;
  
  		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
-@@ -22,7 +_,18 @@
+@@ -22,7 +_,17 @@
  		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
  			return ItemID.Sets.IsCraftedCorruption[type];
  
@@ -33,7 +33,6 @@
 +			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec])) {
 +				if (Main.recipe[posRec].shimmerPriority >= Main.recipe[recipe].shimmerPriority)
 +					recipe = posRec;
-+
 +			}
 +		}
 +

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -30,7 +30,7 @@
 +		int recipe = recipeIndecies[recipeIndecies.Length -1];
 +
 +		foreach (int posRec in recipeIndecies) {
-+			if (!RecipeLoader.DecraftAvailable(Main.recipe[posRec]))
++			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec]))
 +				recipe = posRec;
 +		}
 +

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -6,13 +6,46 @@
  
  namespace Terraria.GameContent;
  
+@@ -12,8 +_,15 @@
+ 
+ 	public static int GetDecraftingRecipeIndex(int type)
+ 	{
++		/*
++		vanilla:
+ 		int num = ItemID.Sets.IsCrafted[type];
+ 		if (num < 0)
++		return false;
++		*/
++
++		int[] recipeIndecies = ItemID.Sets.IsCrafted[type];
++		if (recipeIndecies[0] < 0)
+ 			return -1;
+ 
+ 		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
+@@ -22,7 +_,15 @@
+ 		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
+ 			return ItemID.Sets.IsCraftedCorruption[type];
+ 
++		//Deliberately preserving the "last first" order of the previous implementation
++		int recipe = recipeIndecies[recipeIndecies.Length -1];
++
++		foreach (int posRec in recipeIndecies) {
++			if (!RecipeLoader.DecraftAvailable(Main.recipe[posRec]))
++				recipe = posRec;
++		}
++
+-		return num;
++		return recipe;
+ 	}
+ 
+ 	public static bool IsItemTransformLocked(int type)
 @@ -35,6 +_,9 @@
  			return true;
  
  		if (!NPC.downedGolemBoss && RecipeSets.PostGolem[decraftingRecipeIndex])
 +			return true;
 +
-+		if (!RecipeLoader.ShimmerAvailable(Main.recipe[decraftingRecipeIndex]))
++		if (!RecipeLoader.DecraftAvailable(Main.recipe[decraftingRecipeIndex]))
  			return true;
  
  		return false;

--- a/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShimmerTransforms.cs.patch
@@ -22,25 +22,23 @@
  			return -1;
  
  		if (WorldGen.crimson && ItemID.Sets.IsCraftedCrimson[type] >= 0)
-@@ -22,7 +_,17 @@
+@@ -22,6 +_,16 @@
  		if (!WorldGen.crimson && ItemID.Sets.IsCraftedCorruption[type] >= 0)
  			return ItemID.Sets.IsCraftedCorruption[type];
  
 +		//Deliberately preserving the "last first" order of the previous implementation, adding manual priority support
-+		int recipe = recipeIndecies[recipeIndecies.Length -1];
++		int num = recipeIndecies[recipeIndecies.Length -1];
 +
 +		foreach (int posRec in recipeIndecies) {
 +			if (RecipeLoader.DecraftAvailable(Main.recipe[posRec])) {
-+				if (Main.recipe[posRec].shimmerPriority >= Main.recipe[recipe].shimmerPriority)
-+					recipe = posRec;
++				if (Main.recipe[posRec].shimmerPriority >= Main.recipe[num].shimmerPriority)
++					num = posRec;
 +			}
 +		}
 +
--		return num;
-+		return recipe;
+ 		return num;
  	}
  
- 	public static bool IsItemTransformLocked(int type)
 @@ -35,6 +_,9 @@
  			return true;
  

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -25,7 +25,7 @@
  		public static List<int> ItemsThatAreProcessedAfterNormalContentSample = new List<int> {
  			1533,
  			1534,
-@@ -303,8 +_,12 @@
+@@ -303,17 +_,26 @@
  				}
  			}
  		});
@@ -36,10 +36,14 @@
 +		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. Inner array contains multiple results for multiple recipes in order of creation</summary>
 +		public static int[][] IsCrafted = Factory.CreateCustomSet<int[]>(new int[1] {-1});
 +
++		/* automatically replaced with corresponding Decrafting Conditions
  		public static int[] IsCraftedCrimson = Factory.CreateIntSet();
  		public static int[] IsCraftedCorruption = Factory.CreateIntSet();
++		*/
++
  		public static bool[] IgnoresEncumberingStone = Factory.CreateBoolSet(58, 184, 1734, 1735, 1867, 1868, 3453, 3454, 3455, 4143);
-@@ -313,7 +_,9 @@
+ 		public static float[] ToolTipDamageMultiplier = Factory.CreateFloatSet(1f, 162f, 2f, 801f, 2f, 163f, 2f, 220f, 2f, 389f, 2f, 1259f, 2f, 4272f, 2f, 5011f, 2f, 5012f, 2f);
+ 		public static bool[] IsAPickup = Factory.CreateBoolSet(58, 184, 1734, 1735, 1867, 1868, 3453, 3454, 3455);
  		public static bool[] IsDrill = Factory.CreateBoolSet(388, 1231, 385, 386, 2779, 1196, 1189, 2784, 3464, 1203, 2774, 579);
  		public static bool[] IsChainsaw = Factory.CreateBoolSet(387, 3098, 1232, 383, 384, 2778, 1197, 1190, 2783, 3463, 1204, 2773, 2342, 579);
  		public static bool[] IsPaintScraper = Factory.CreateBoolSet(1100, 1545);

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -32,8 +32,9 @@
 +
 +		/// <summary> Indicates that an item should show the material tooltip. Typically this means that the item is used in at least 1 recipe, but some items such as coins and void bag hide the tooltip for aesthetic reasons. </summary>
  		public static bool[] IsAMaterial = Factory.CreateBoolSet();
+-		public static int[] IsCrafted = Factory.CreateIntSet();
 +		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. If multiple recipes craft the same item, the recipe added last will be returned. </summary>
- 		public static int[] IsCrafted = Factory.CreateIntSet();
++		public static int[][] IsCrafted = Factory.CreateCustomSet<int[]>(new int[1] {-1});
 +
  		public static int[] IsCraftedCrimson = Factory.CreateIntSet();
  		public static int[] IsCraftedCorruption = Factory.CreateIntSet();

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -33,7 +33,7 @@
 +		/// <summary> Indicates that an item should show the material tooltip. Typically this means that the item is used in at least 1 recipe, but some items such as coins and void bag hide the tooltip for aesthetic reasons. </summary>
  		public static bool[] IsAMaterial = Factory.CreateBoolSet();
 -		public static int[] IsCrafted = Factory.CreateIntSet();
-+		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. If multiple recipes craft the same item, the recipe added last will be returned. </summary>
++		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. Inner array contains multiple results for multiple recipes in order of creation</summary>
 +		public static int[][] IsCrafted = Factory.CreateCustomSet<int[]>(new int[1] {-1});
 +
  		public static int[] IsCraftedCrimson = Factory.CreateIntSet();

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -34,7 +34,7 @@
  		public static bool[] IsAMaterial = Factory.CreateBoolSet();
 -		public static int[] IsCrafted = Factory.CreateIntSet();
 +		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. Inner array contains multiple results for multiple recipes in order of creation</summary>
-+		public static int[][] CraftingRecipeIndices; // = Factory.CreateCustomSet<int[]>(Array.Empty<int>()); written over during load
++		public static int[][] CraftingRecipeIndices;
 +
 +		/* automatically replaced with corresponding Decrafting Conditions
  		public static int[] IsCraftedCrimson = Factory.CreateIntSet();

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -34,7 +34,7 @@
  		public static bool[] IsAMaterial = Factory.CreateBoolSet();
 -		public static int[] IsCrafted = Factory.CreateIntSet();
 +		/// <summary> Indicates that this item is the result of at least 1 recipe that isn't disabled or set to not decraftable. The value corresponds to the index of the Recipe that results in this item in <see cref="Main.recipe"/> array. Inner array contains multiple results for multiple recipes in order of creation</summary>
-+		public static int[][] IsCrafted = Factory.CreateCustomSet<int[]>(new int[1] {-1});
++		public static int[][] CraftingRecipeIndices; // = Factory.CreateCustomSet<int[]>(Array.Empty<int>()); written over during load
 +
 +		/* automatically replaced with corresponding Decrafting Conditions
  		public static int[] IsCraftedCrimson = Factory.CreateIntSet();

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -545,7 +545,7 @@
 		"InHive": "Muss in einem Bienennest sein",
 		"InGemCave": "Muss in einer Edelsteinhöhle sein",
 		"InLihzardTemple": "Muss im Lihzahrdtempel sein",
-		"InGraveyardBiome": "Muss im Friedhof-Biom sein",
+		"InGraveyardBiome": "Muss im Friedhof-Biom sein"
 		//"EverythingSeed": "Needs to be an Everything world",
 		//"CrimsonWorld": "Needs to be a Crimson World",
 		//"CorruptWorld": "Needs to be a Corrupt World"

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -545,7 +545,10 @@
 		"InHive": "Muss in einem Bienennest sein",
 		"InGemCave": "Muss in einer Edelsteinhöhle sein",
 		"InLihzardTemple": "Muss im Lihzahrdtempel sein",
-		"InGraveyardBiome": "Muss im Friedhof-Biom sein"
+		"InGraveyardBiome": "Muss im Friedhof-Biom sein",
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -546,7 +546,9 @@
 		"InGemCave": "Needs to be in Gem Cave",
 		"InLihzardTemple": "Needs to be in Lihzard Temple",
 		"InGraveyardBiome": "Needs to be in Graveyard Biome",
-		"EverythingSeed": "Needs to be an Everything world"
+		"EverythingSeed": "Needs to be an Everything world",
+		"CrimsonWorld": "Needs to be a Crimson World",
+		"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -546,6 +546,9 @@
 		"InGemCave": "Debe crearse en una cueva de gemas",
 		"InLihzardTemple": "Debe crearse en el templo de la selva",
 		"InGraveyardBiome": "Debe crearse en el bioma de cementerio"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -546,6 +546,9 @@
 		"InGemCave": "Doit être dans la Grotte des Gemmes",
 		"InLihzardTemple": "Doit être dans le Temple de Lihzahrd",
 		"InGraveyardBiome": "Doit être dans le Biome du Cimetière"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		// "Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -547,7 +547,10 @@
 		// "InHive": "Needs to be in Hive",
 		// "InGemCave": "Needs to be in Gem Cave",
 		// "InLihzardTemple": "Needs to be in Lihzard Temple",
-		// "InGraveyardBiome": "Needs to be in Graveyard Biome"
+		// "InGraveyardBiome": "Needs to be in Graveyard Biome",
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		// "Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -546,6 +546,9 @@
 		"InGemCave": "Musi być w jaskini kamieni szlachetnych",
 		"InLihzardTemple": "Musi być w Świątyni Jaszczura",
 		"InGraveyardBiome": "Musi być na cmentarzu"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		// "Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -546,6 +546,9 @@
 		"InGemCave": "Precisa estar na Caverna de Joias",
 		"InLihzardTemple": "Precisa estar no Templo Lagharto",
 		"InGraveyardBiome": "Precisa estar no bioma de Cemitério"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -546,6 +546,9 @@
 		"InGemCave": "Нужна самоцветная пещера",
 		"InLihzardTemple": "Нужен Храм Джунглей",
 		"InGraveyardBiome": "Нужно кладбище"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -547,6 +547,9 @@
 		"InGemCave": "需要位于宝石洞内",
 		"InLihzardTemple": "需要位于丛林神庙内",
 		"InGraveyardBiome": "需要位于墓地环境"
+		//"EverythingSeed": "Needs to be an Everything world",
+		//"CrimsonWorld": "Needs to be a Crimson World",
+		//"CorruptWorld": "Needs to be a Corrupt World"
 	},
 	"TitleLinks": {
 		"Patreon": "Patreon"

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -169,7 +169,6 @@ public static class RecipeLoader
 		return recipe.DecraftConditions.All(c => c.RecipeAvailable(recipe));
 	}
 
-
 	/// <summary>
 	/// recipe.OnCraftHooks followed by Calls ItemLoader.OnCreate with a RecipeCreationContext
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -160,6 +160,17 @@ public static class RecipeLoader
 	}
 
 	/// <summary>
+	/// Returns whether or not the conditions are met for this recipe to be available for the player to use.
+	/// </summary>
+	/// <param name="recipe">The recipe to check.</param>
+	/// <returns>Whether or not the conditions are met for this recipe.</returns>
+	public static bool ShimmerAvailable(Recipe recipe)
+	{
+		return recipe.ShimmerConditions.All(c => c.RecipeAvailable(recipe));
+	}
+
+
+	/// <summary>
 	/// recipe.OnCraftHooks followed by Calls ItemLoader.OnCreate with a RecipeCreationContext
 	/// </summary>
 	/// <param name="item">The item crafted.</param>

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -160,13 +160,13 @@ public static class RecipeLoader
 	}
 
 	/// <summary>
-	/// Returns whether or not the conditions are met for this recipe to be available for the player to use.
+	/// Returns whether or not the conditions are met for this recipe to be transformed/decrafted.
 	/// </summary>
 	/// <param name="recipe">The recipe to check.</param>
 	/// <returns>Whether or not the conditions are met for this recipe.</returns>
-	public static bool ShimmerAvailable(Recipe recipe)
+	public static bool DecraftAvailable(Recipe recipe)
 	{
-		return recipe.ShimmerConditions.All(c => c.RecipeAvailable(recipe));
+		return recipe.DecraftConditions.All(c => c.RecipeAvailable(recipe));
 	}
 
 

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -166,7 +166,7 @@ public static class RecipeLoader
 	/// <returns>Whether or not the conditions are met for this recipe.</returns>
 	public static bool DecraftAvailable(Recipe recipe)
 	{
-		return recipe.DecraftConditions.All(c => c.RecipeAvailable(recipe));
+		return recipe.ShimmerConditions.All(c => c.RecipeAvailable(recipe));
 	}
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RecipeLoader.cs
@@ -160,13 +160,13 @@ public static class RecipeLoader
 	}
 
 	/// <summary>
-	/// Returns whether or not the conditions are met for this recipe to be transformed/decrafted.
+	/// Returns whether or not the conditions are met for this recipe to be shimmered/decrafted.
 	/// </summary>
 	/// <param name="recipe">The recipe to check.</param>
 	/// <returns>Whether or not the conditions are met for this recipe.</returns>
 	public static bool DecraftAvailable(Recipe recipe)
 	{
-		return recipe.ShimmerConditions.All(c => c.RecipeAvailable(recipe));
+		return recipe.DecraftConditions.All(c => c.RecipeAvailable(recipe));
 	}
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -70,7 +70,7 @@ public partial class Recipe
 
 	public bool HasCondition(Condition condition) => Conditions.Contains(condition);
 
-	public bool HasShimmerCondition(Condition condition) => DecraftConditions.Contains(condition);
+	public bool HasShimmerCondition(Condition condition) => ShimmerConditions.Contains(condition);
 	#endregion
 
 	#region TryGetX
@@ -138,7 +138,7 @@ public partial class Recipe
 
 	public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
 
-	public bool RemoveShimmerCondition(Condition condition) => DecraftConditions.Remove(condition);
+	public bool RemoveShimmerCondition(Condition condition) => ShimmerConditions.Remove(condition);
 
 	public void DisableRecipe()
 	{

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -69,6 +69,8 @@ public partial class Recipe
 	public bool HasTile<T>() where T : ModTile => HasTile(ModContent.TileType<T>());
 
 	public bool HasCondition(Condition condition) => Conditions.Contains(condition);
+
+	public bool HasShimmerCondition(Condition condition) => ShimmerConditions.Contains(condition);
 	#endregion
 
 	#region TryGetX
@@ -135,6 +137,7 @@ public partial class Recipe
 	public bool RemoveRecipeGroup(int groupID) => acceptedGroups.Remove(groupID);
 
 	public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
+	public bool RemoveShimmerCondition(Condition condition) => ShimmerConditions.Remove(condition);
 
 	public void DisableRecipe()
 	{

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -70,7 +70,7 @@ public partial class Recipe
 
 	public bool HasCondition(Condition condition) => Conditions.Contains(condition);
 
-	public bool HasShimmerCondition(Condition condition) => ShimmerConditions.Contains(condition);
+	public bool HasShimmerCondition(Condition condition) => DecraftConditions.Contains(condition);
 	#endregion
 
 	#region TryGetX
@@ -137,7 +137,7 @@ public partial class Recipe
 	public bool RemoveRecipeGroup(int groupID) => acceptedGroups.Remove(groupID);
 
 	public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
-	public bool RemoveShimmerCondition(Condition condition) => ShimmerConditions.Remove(condition);
+	public bool RemoveShimmerCondition(Condition condition) => DecraftConditions.Remove(condition);
 
 	public void DisableRecipe()
 	{

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -70,7 +70,7 @@ public partial class Recipe
 
 	public bool HasCondition(Condition condition) => Conditions.Contains(condition);
 
-	public bool HasShimmerCondition(Condition condition) => ShimmerConditions.Contains(condition);
+	public bool HasShimmerCondition(Condition condition) => DecraftConditions.Contains(condition);
 	#endregion
 
 	#region TryGetX
@@ -138,7 +138,7 @@ public partial class Recipe
 
 	public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
 
-	public bool RemoveShimmerCondition(Condition condition) => ShimmerConditions.Remove(condition);
+	public bool RemoveShimmerCondition(Condition condition) => DecraftConditions.Remove(condition);
 
 	public void DisableRecipe()
 	{

--- a/patches/tModLoader/Terraria/Recipe.Extensions.cs
+++ b/patches/tModLoader/Terraria/Recipe.Extensions.cs
@@ -137,6 +137,7 @@ public partial class Recipe
 	public bool RemoveRecipeGroup(int groupID) => acceptedGroups.Remove(groupID);
 
 	public bool RemoveCondition(Condition condition) => Conditions.Remove(condition);
+
 	public bool RemoveShimmerCondition(Condition condition) => DecraftConditions.Remove(condition);
 
 	public void DisableRecipe()

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -103,7 +102,7 @@ public partial class Recipe
 
 	public readonly Mod Mod;
 	public readonly List<Condition> Conditions = new List<Condition>();
-	public readonly List<Condition> DecraftConditions = new List<Condition>();
+	public readonly List<Condition> ShimmerConditions = new List<Condition>();
 
 	public delegate void OnCraftCallback(Recipe recipe, Item item, List<Item> consumedItems, Item destinationStack);
 	public delegate void ConsumeItemCallback(Recipe recipe, int type, ref int amount);
@@ -302,17 +301,17 @@ public partial class Recipe
 	/// </summary>
 	/// <param name="condition">The predicate delegate condition.</param>
 	/// <param name="description">A description of this condition. Use NetworkText.FromKey, or NetworkText.FromLiteral for this.</param>
-	public Recipe AddDecraftCondition(NetworkText description, Predicate<Recipe> condition) => AddDecraftCondition(new Condition(description, condition));
+	public Recipe AddShimmerCondition(NetworkText description, Predicate<Recipe> condition) => AddShimmerCondition(new Condition(description, condition));
 
 	/// <summary>
 	/// Adds an array of conditions that will determine whether or not the recipe can be decrafted/changed in shimmer. The conditions can be unrelated to items or tiles (for example, biome or time).
 	/// </summary>
 	/// <param name="conditions">An array of conditions.</param>
-	public Recipe AddDecraftCondition(params Condition[] conditions) => AddDecraftCondition((IEnumerable<Condition>)conditions);
+	public Recipe AddShimmerCondition(params Condition[] conditions) => AddShimmerCondition((IEnumerable<Condition>)conditions);
 
-	public Recipe AddDecraftCondition(Condition condition)
+	public Recipe AddShimmerCondition(Condition condition)
 	{
-		DecraftConditions.Add(condition);
+		ShimmerConditions.Add(condition);
 		return this;
 	}
 
@@ -320,9 +319,9 @@ public partial class Recipe
 	/// Adds a collection of conditions that will determine whether or not the recipe can be decrafted/changed in shimmer. The conditions can be unrelated to items or tiles (for example, biome or time).
 	/// </summary>
 	/// <param name="conditions">A collection of conditions.</param>
-	public Recipe AddDecraftCondition(IEnumerable<Condition> conditions)
+	public Recipe AddShimmerCondition(IEnumerable<Condition> conditions)
 	{
-		DecraftConditions.AddRange(conditions);
+		ShimmerConditions.AddRange(conditions);
 		return this;
 	}
 
@@ -332,8 +331,8 @@ public partial class Recipe
 	public Recipe CopyConditionsToShimmer()
 	{
 		foreach (Condition condition in Conditions) {
-			if (!DecraftConditions.Contains(condition)) {
-				DecraftConditions.Add(condition);
+			if (!ShimmerConditions.Contains(condition)) {
+				ShimmerConditions.Add(condition);
 			}
 		}
 		return this;
@@ -460,6 +459,8 @@ public partial class Recipe
 		clone.requiredTile = new List<int>(requiredTile.ToArray());
 		clone.acceptedGroups = new List<int>(acceptedGroups.ToArray());
 		clone.notDecraftable = notDecraftable;
+		clone.crimson = crimson;
+		clone.corruption = corruption;
 
 		// These fields shouldn't be true, but are here just in case.
 		clone.needHoney = needHoney;
@@ -481,8 +482,8 @@ public partial class Recipe
 			clone.AddCondition(condition);
 		}
 
-		foreach (Condition condition in DecraftConditions) {
-			clone.AddDecraftCondition(condition);
+		foreach (Condition condition in ShimmerConditions) {
+			clone.AddShimmerCondition(condition);
 		}
 
 		// A subsequent call to Register() will re-add this hook if Bottles is a required tile, so we remove

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -63,7 +63,10 @@ public partial class Recipe
 		public static readonly Condition InGemCave = new Condition(NetworkText.FromKey("RecipeConditions.InGemCave"), _ => Main.LocalPlayer.ZoneGemCave);
 		public static readonly Condition InLihzhardTemple = new Condition(NetworkText.FromKey("RecipeConditions.InLihzardTemple"), _ => Main.LocalPlayer.ZoneLihzhardTemple);
 		public static readonly Condition InGraveyardBiome = new Condition(NetworkText.FromKey("RecipeConditions.InGraveyardBiome"), _ => Main.LocalPlayer.ZoneGraveyard);
+		//WorldType
 		public static readonly Condition EverythingSeed = new Condition(NetworkText.FromKey("RecipeConditions.EverythingSeed"), _ => Main.remixWorld && Main.getGoodWorld);
+		public static readonly Condition CrimsonWorld = new Condition(NetworkText.FromKey("RecipeConditions.CrimsonWorld"), _ => WorldGen.crimson);
+		public static readonly Condition CorruptWorld = new Condition(NetworkText.FromKey("RecipeConditions.CorruptWorld"), _ => !WorldGen.crimson);
 
 		#endregion
 
@@ -80,6 +83,8 @@ public partial class Recipe
 
 		public bool RecipeAvailable(Recipe recipe) => Predicate(recipe);
 	}
+
+
 
 	public static class ConsumptionRules
 	{
@@ -100,7 +105,7 @@ public partial class Recipe
 
 	public readonly Mod Mod;
 	public readonly List<Condition> Conditions = new List<Condition>();
-	public readonly List<Condition> ShimmerConditions = new List<Condition>();
+	public readonly List<Condition> DecraftConditions = new List<Condition>();
 
 	public delegate void OnCraftCallback(Recipe recipe, Item item, List<Item> consumedItems, Item destinationStack);
 	public delegate void ConsumeItemCallback(Recipe recipe, int type, ref int amount);
@@ -299,17 +304,17 @@ public partial class Recipe
 	/// </summary>
 	/// <param name="condition">The predicate delegate condition.</param>
 	/// <param name="description">A description of this condition. Use NetworkText.FromKey, or NetworkText.FromLiteral for this.</param>
-	public Recipe AddShimmerCondition(NetworkText description, Predicate<Recipe> condition) => AddShimmerCondition(new Condition(description, condition));
+	public Recipe AddDecraftCondition(NetworkText description, Predicate<Recipe> condition) => AddDecraftCondition(new Condition(description, condition));
 
 	/// <summary>
 	/// Adds an array of conditions that will determine whether or not the recipe can be decrafted/changed in shimmer. The conditions can be unrelated to items or tiles (for example, biome or time).
 	/// </summary>
 	/// <param name="conditions">An array of conditions.</param>
-	public Recipe AddShimmerCondition(params Condition[] conditions) => AddShimmerCondition((IEnumerable<Condition>)conditions);
+	public Recipe AddDecraftCondition(params Condition[] conditions) => AddDecraftCondition((IEnumerable<Condition>)conditions);
 
-	public Recipe AddShimmerCondition(Condition condition)
+	public Recipe AddDecraftCondition(Condition condition)
 	{
-		ShimmerConditions.Add(condition);
+		DecraftConditions.Add(condition);
 		return this;
 	}
 
@@ -317,9 +322,9 @@ public partial class Recipe
 	/// Adds a collection of conditions that will determine whether or not the recipe can be decrafted/changed in shimmer. The conditions can be unrelated to items or tiles (for example, biome or time).
 	/// </summary>
 	/// <param name="conditions">A collection of conditions.</param>
-	public Recipe AddShimmerCondition(IEnumerable<Condition> conditions)
+	public Recipe AddDecraftCondition(IEnumerable<Condition> conditions)
 	{
-		ShimmerConditions.AddRange(conditions);
+		DecraftConditions.AddRange(conditions);
 		return this;
 	}
 
@@ -329,8 +334,8 @@ public partial class Recipe
 	public Recipe CopyConditionsToShimmer()
 	{
 		foreach (Condition condition in Conditions) {
-			if (!ShimmerConditions.Contains(condition)) {
-				ShimmerConditions.Add(condition);
+			if (!DecraftConditions.Contains(condition)) {
+				DecraftConditions.Add(condition);
 			}
 		}
 		return this;
@@ -338,6 +343,20 @@ public partial class Recipe
 	public Recipe DisableShimmer()
 	{
 		notDecraftable = true;
+		return this;
+	}
+
+	[Obsolete("Replaced by the conditions system")]
+	public Recipe CrimsonOnly()
+	{
+		crimson = true;
+		return this;
+	}
+
+	[Obsolete("Replaced by the conditions system")]
+	public Recipe CorruptionOnly()
+	{
+		corruption = true;
 		return this;
 	}
 
@@ -465,8 +484,8 @@ public partial class Recipe
 			clone.AddCondition(condition);
 		}
 
-		foreach (Condition condition in ShimmerConditions) {
-			clone.AddShimmerCondition(condition);
+		foreach (Condition condition in DecraftConditions) {
+			clone.AddDecraftCondition(condition);
 		}
 
 		// A subsequent call to Register() will re-add this hook if Bottles is a required tile, so we remove

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -84,8 +84,6 @@ public partial class Recipe
 		public bool RecipeAvailable(Recipe recipe) => Predicate(recipe);
 	}
 
-
-
 	public static class ConsumptionRules
 	{
 		/// <summary> Gives 1/3 chance for every ingredient to not be consumed, if used at an alchemy table. (!) This behavior is already automatically given to all items that can be made at a placed bottle tile. </summary>
@@ -356,20 +354,6 @@ public partial class Recipe
 	public Recipe EnableShimmer()
 	{
 		notDecraftable = false;
-		return this;
-	}
-
-	[Obsolete("Replaced by the conditions system")]
-	public Recipe CrimsonOnly()
-	{
-		crimson = true;
-		return this;
-	}
-
-	[Obsolete("Replaced by the conditions system")]
-	public Recipe CorruptionOnly()
-	{
-		corruption = true;
 		return this;
 	}
 

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -340,9 +340,22 @@ public partial class Recipe
 		}
 		return this;
 	}
+
+	/// <summary>
+	/// Sets a check that is used during load to prevent shimmer being used for this recipe, not for on the fly use
+	/// </summary>
 	public Recipe DisableShimmer()
 	{
 		notDecraftable = true;
+		return this;
+	}
+
+	/// <summary>
+	/// resets a check that is used during load to prevent shimmer being used for this recipe, not for on the fly use
+	/// </summary>
+	public Recipe EnableShimmer()
+	{
+		notDecraftable = false;
 		return this;
 	}
 

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -18,7 +18,7 @@
  {
  	private struct RequiredItemEntry
  	{
-@@ -15,40 +_,52 @@
+@@ -15,40 +_,58 @@
  		public int stack;
  	}
  
@@ -68,11 +68,17 @@
 -	public bool needEverythingSeed;
 +	internal bool needEverythingSeed;
 -	public bool notDecraftable;
-+	internal bool notDecraftable;
++
++	// Following fields made internal, automatically replaced with corresponding Decrafting Conditions
 -	public bool crimson;
 +	internal bool crimson;
 -	public bool corruption;
 +	internal bool corruption;
++
++	// Following fields made internal, use DisableShimmer() and EnableShimmer()
++	internal bool notDecraftable;
++
++	public int shimmerPriority = 0;
 +
  	private static bool _hasDelayedFindRecipes;
  	private static Dictionary<int, int> _ownedItems = new Dictionary<int, int>();
@@ -150,7 +156,7 @@
  	{
  		if (customShimmerResults == null)
  			customShimmerResults = new List<Item>();
-@@ -120,9 +_,10 @@
+@@ -120,9 +_,19 @@
  		item.SetDefaults(itemType);
  		item.stack = itemStack;
  		customShimmerResults.Add(item);
@@ -158,6 +164,15 @@
 +		return this;
  	}
  
++	/// <summary>
++	/// Sets the priority of this recipe over other recipes for the same item, highest first, defaults to 0
++	/// </summary>
++	public Recipe SetShimmerPriority(int priority)
++	{
++		shimmerPriority = priority;
++		return this;
++	}
++
 +	/*
  	public Recipe()
  	{

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -75,7 +75,7 @@
 -	public bool corruption;
 +	internal bool corruption;
 +
-+	// Following fields made internal, use DisableShimmer()
++	// Following fields made internal, use DisableDecraft()
 +	internal bool notDecraftable;
 +
  	private static bool _hasDelayedFindRecipes;

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -428,7 +428,7 @@
  			}
  
  			Main.recipe[i].createItem.material = ItemID.Sets.IsAMaterial[Main.recipe[i].createItem.type];
-@@ -14585,17 +_,47 @@
+@@ -14585,19 +_,58 @@
  
  	public static void UpdateWhichItemsAreMaterials()
  	{
@@ -473,9 +473,22 @@
 +			if (Main.recipe[i].Disabled)
 +				continue;
 +
- 			if (!Main.recipe[i].notDecraftable)
- 				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
++			/*Vanilla:
+-			if (!Main.recipe[i].notDecraftable)
++			 * if (!Main.recipe[i].notDecraftable)
+-				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
++			 * ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
++			 */
++
++			if (!Main.recipe[i].notDecraftable) {
++				if (ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] == -1)
++					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] = i;
++
++				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type].Append(i);
++			}
  
+ 			if (Main.recipe[i].crimson)
+ 				ItemID.Sets.IsCraftedCrimson[Main.recipe[i].createItem.type] = i;
 @@ -15747,23 +_,23 @@
  	{
  		int num = numRecipes;

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -18,7 +18,7 @@
  {
  	private struct RequiredItemEntry
  	{
-@@ -15,40 +_,58 @@
+@@ -15,40 +_,56 @@
  		public int stack;
  	}
  
@@ -75,10 +75,8 @@
 -	public bool corruption;
 +	internal bool corruption;
 +
-+	// Following fields made internal, use DisableShimmer() and EnableShimmer()
++	// Following fields made internal, use DisableShimmer()
 +	internal bool notDecraftable;
-+
-+	public int shimmerPriority = 0;
 +
  	private static bool _hasDelayedFindRecipes;
  	private static Dictionary<int, int> _ownedItems = new Dictionary<int, int>();
@@ -156,7 +154,7 @@
  	{
  		if (customShimmerResults == null)
  			customShimmerResults = new List<Item>();
-@@ -120,9 +_,19 @@
+@@ -120,9 +_,10 @@
  		item.SetDefaults(itemType);
  		item.stack = itemStack;
  		customShimmerResults.Add(item);
@@ -164,15 +162,6 @@
 +		return this;
  	}
  
-+	/// <summary>
-+	/// Sets the priority of this recipe over other recipes for the same item, highest first, defaults to 0
-+	/// </summary>
-+	public Recipe SetShimmerPriority(int priority)
-+	{
-+		shimmerPriority = priority;
-+		return this;
-+	}
-+
 +	/*
  	public Recipe()
  	{
@@ -386,6 +375,37 @@
  				array[j].Refresh();
  			}
  		}
+@@ -1727,12 +_,14 @@
+ 		currentRecipe.requiredItem[1].SetDefaults(316);
+ 		currentRecipe.requiredItem[2].SetDefaults(68);
+ 		currentRecipe.requiredTile[0] = 13;
++		currentRecipe.corruption = true; //TML
+ 		AddRecipe();
+ 		currentRecipe.createItem.SetDefaults(300);
+ 		currentRecipe.requiredItem[0].SetDefaults(126);
+ 		currentRecipe.requiredItem[1].SetDefaults(316);
+ 		currentRecipe.requiredItem[2].SetDefaults(1330);
+ 		currentRecipe.requiredTile[0] = 13;
++		currentRecipe.crimson = true; //TML
+ 		AddRecipe();
+ 		currentRecipe.createItem.SetDefaults(301);
+ 		currentRecipe.requiredItem[0].SetDefaults(126);
+@@ -14415,6 +_,7 @@
+ 		currentRecipe.requiredItem[2].SetDefaults(521);
+ 		currentRecipe.requiredItem[2].stack = 6;
+ 		currentRecipe.requiredTile[0] = 134;
++		currentRecipe.corruption = true; //TML
+ 		currentRecipe.anyIronBar = true;
+ 		AddRecipe();
+ 		currentRecipe.createItem.SetDefaults(556);
+@@ -14425,6 +_,7 @@
+ 		currentRecipe.requiredItem[2].SetDefaults(521);
+ 		currentRecipe.requiredItem[2].stack = 6;
+ 		currentRecipe.requiredTile[0] = 134;
++		currentRecipe.crimson = true; //TML
+ 		currentRecipe.anyIronBar = true;
+ 		AddRecipe();
+ 		currentRecipe.createItem.SetDefaults(557);
 @@ -14518,10 +_,18 @@
  		AddRecipe();
  		CreateReverseWallRecipes();
@@ -443,7 +463,7 @@
  			}
  
  			Main.recipe[i].createItem.material = ItemID.Sets.IsAMaterial[Main.recipe[i].createItem.type];
-@@ -14585,25 +_,66 @@
+@@ -14585,17 +_,47 @@
  
  	public static void UpdateWhichItemsAreMaterials()
  	{
@@ -484,34 +504,29 @@
  
  	public static void UpdateWhichItemsAreCrafted()
  	{
++		List<int>[] recipeLists = new List<int>[ItemLoader.ItemCount];
  		for (int i = 0; i < numRecipes; i++) {
-+			if (Main.recipe[i].Disabled)
-+				continue;
 +
-+			/*Vanilla:
--			if (!Main.recipe[i].notDecraftable)
-+			 * if (!Main.recipe[i].notDecraftable)
--				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
-+			 * ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
-+			 */
++			/*
+ 			if (!Main.recipe[i].notDecraftable)
+ 				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
  
-+			if (!Main.recipe[i].notDecraftable) {
-+				if (ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] == -1)
-+					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = new int[1] { i};
-+				else
-+					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type].Append(i).ToArray();
-+			}
-+
-+			/* autoreplaced with conditions
- 			if (Main.recipe[i].crimson)
- 				ItemID.Sets.IsCraftedCrimson[Main.recipe[i].createItem.type] = i;
+@@ -14604,7 +_,15 @@
  
  			if (Main.recipe[i].corruption)
  				ItemID.Sets.IsCraftedCorruption[Main.recipe[i].createItem.type] = i;
 +			*/
++
++			Recipe recipe = Main.recipe[i];
++
++			if (!recipe.notDecraftable && !recipe.Disabled)
++				(recipeLists[recipe.createItem.type] ??= new()).Add(i);
  		}
++
++		ItemID.Sets.CraftingRecipeIndices = recipeLists.Select(l => (l ??= new()).ToArray()).ToArray();
  	}
  
+ 	private static void AddSolarFurniture()
 @@ -15747,23 +_,23 @@
  	{
  		int num = numRecipes;
@@ -608,10 +623,10 @@
 +			field = false;
 +		}
 +
-+		static void ReplaceShimmerCondition(ref bool field, Recipe.Condition cond)
++		static void ReplaceDecraftCondition(ref bool field, Recipe.Condition cond)
 +		{
 +			if (field)
-+				currentRecipe.AddShimmerCondition(cond);
++				currentRecipe.AddDecraftCondition(cond);
 +
 +			field = false;
 +		}
@@ -623,8 +638,8 @@
 +		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearHoney);
 +		ReplaceCondition(ref currentRecipe.needEverythingSeed, Condition.EverythingSeed);
 +
-+		ReplaceShimmerCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);
-+		ReplaceShimmerCondition(ref currentRecipe.corruption, Condition.CorruptWorld);
++		ReplaceDecraftCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);
++		ReplaceDecraftCondition(ref currentRecipe.corruption, Condition.CorruptWorld);
 +
 +		currentRecipe.requiredItem.RemoveAll(item => item.IsAir);
 +		currentRecipe.requiredTile.RemoveAll(tile => tile == -1);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -443,7 +443,7 @@
  			}
  
  			Main.recipe[i].createItem.material = ItemID.Sets.IsAMaterial[Main.recipe[i].createItem.type];
-@@ -14585,19 +_,58 @@
+@@ -14585,25 +_,66 @@
  
  	public static void UpdateWhichItemsAreMaterials()
  	{
@@ -494,16 +494,24 @@
 -				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
 +			 * ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = i;
 +			 */
-+
+ 
 +			if (!Main.recipe[i].notDecraftable) {
 +				if (ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] == -1)
 +					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = new int[1] { i};
 +				else
 +					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type].Append(i).ToArray();
 +			}
- 
++
++			/* autoreplaced with conditions
  			if (Main.recipe[i].crimson)
  				ItemID.Sets.IsCraftedCrimson[Main.recipe[i].createItem.type] = i;
+ 
+ 			if (Main.recipe[i].corruption)
+ 				ItemID.Sets.IsCraftedCorruption[Main.recipe[i].createItem.type] = i;
++			*/
+ 		}
+ 	}
+ 
 @@ -15747,23 +_,23 @@
  	{
  		int num = numRecipes;
@@ -575,7 +583,7 @@
  	{
  		for (int i = 0; i < tileIDs.Length; i++) {
  			requiredTile[i] = tileIDs[i];
-@@ -15821,12 +_,60 @@
+@@ -15821,12 +_,71 @@
  
  	private static void AddRecipe()
  	{
@@ -600,12 +608,23 @@
 +			field = false;
 +		}
 +
++		static void ReplaceShimmerCondition(ref bool field, Recipe.Condition cond)
++		{
++			if (field)
++				currentRecipe.AddShimmerCondition(cond);
++
++			field = false;
++		}
++
 +		ReplaceCondition(ref currentRecipe.needGraveyardBiome, Condition.InGraveyardBiome);
 +		ReplaceCondition(ref currentRecipe.needSnowBiome, Condition.InSnow);
 +		ReplaceCondition(ref currentRecipe.needWater, Condition.NearWater);
 +		ReplaceCondition(ref currentRecipe.needLava, Condition.NearLava);
 +		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearHoney);
 +		ReplaceCondition(ref currentRecipe.needEverythingSeed, Condition.EverythingSeed);
++
++		ReplaceShimmerCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);
++		ReplaceShimmerCondition(ref currentRecipe.corruption, Condition.CorruptWorld);
 +
 +		currentRecipe.requiredItem.RemoveAll(item => item.IsAir);
 +		currentRecipe.requiredTile.RemoveAll(tile => tile == -1);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -482,9 +482,9 @@
 +
 +			if (!Main.recipe[i].notDecraftable) {
 +				if (ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] == -1)
-+					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type][0] = i;
-+
-+				ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type].Append(i);
++					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = new int[1] { i};
++				else
++					ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type] = ItemID.Sets.IsCrafted[Main.recipe[i].createItem.type].Append(i).ToArray();
 +			}
  
  			if (Main.recipe[i].crimson)

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -69,14 +69,14 @@
 +	internal bool needEverythingSeed;
 -	public bool notDecraftable;
 +
-+	// Following fields made internal, automatically replaced with corresponding Decrafting Conditions
 -	public bool crimson;
-+	internal bool crimson;
--	public bool corruption;
-+	internal bool corruption;
-+
 +	// Following fields made internal, use DisableDecraft()
+-	public bool corruption;
 +	internal bool notDecraftable;
++
++	// Following fields made internal, automatically replaced with corresponding Decrafting Conditions
++	internal bool crimson;
++	internal bool corruption;
 +
  	private static bool _hasDelayedFindRecipes;
  	private static Dictionary<int, int> _ownedItems = new Dictionary<int, int>();


### PR DESCRIPTION
### What is the new feature?
- Added support for the recipe condition systems to shimmer decrafting
- Added EnableShimmer for the rare cases it is needed
- Added the ability to set a priority to shimmer crafting

### Why should this be part of tModLoader?
To allow modders to add conditions to shimmer item transforms, like biome, world type, etc..

### Are there alternative designs?
probably, a complete new custom condition system is an option, but I can't think of anything the condition class would find usefull that wouldn't also be usefull in Shimmer, using the Recipe implementation keeps all the already coded conditions in for the shimmer. Along side this a seperate Condition system could be implemented using Recipe.ICondition anyway making the change rather easy down the line so for now I think it's best to use what's existing.

### Sample usage for the new feature

```
CreateRecipe()
	.AddIngredient<ExampleItem>()
	.AddIngredient(ItemID.Vertebrae)
	.AddTile<Tiles.Furniture.ExampleWorkbench>()
	.AddDecraftCondition(Recipe.Condition.CrimsonWorld)
	.Register();

CreateRecipe()
	.AddIngredient<ExampleItem>()
	.AddIngredient(ItemID.Cactus)
	.AddTile<Tiles.Furniture.ExampleWorkbench>()
	.AddDecraftCondition(Recipe.Condition.InDesert)
	.SetShimmerPriority(-1)
	.Register();
```

In the above example, the desert would take priority over the crimson, decrafting to a cactus in the desert, and a vertibrae in the crimson, right now this priority works through mainly convenience.

### ExampleMod updates
yes I did


This is mainly here for feedback and updates as I work,  #3090 