### PR TITLE
Chest and dresser swap fix

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -504,7 +504,7 @@ public static class TileLoader
 				Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 16, 16, modTile.ItemDrop, 1, false, -1);
 			}
 
-			return false;
+			return modTile.ChestDrop > 0 || modTile.DresserDrop > 0;
 		}
 
 		return true;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2075,6 +2075,17 @@
  		KillTile_GetItemDrops(x, y, tileCache, out var dropItem, out var dropItemStack, out var secondaryItem, out var secondaryItemStack, includeLargeObjectDrops);
  		if (!Main.getGoodWorld || tileCache.active()) {
  			if (dropItem > 0) {
+@@ -45780,6 +_,10 @@
+ 		secondaryItemStack = 1;
+ 		int num = 0;
+ 		if (includeLargeObjectDrops) {
++			var modTile = TileLoader.GetTile(tileCache.type);
++			if (modTile != null)
++				dropItem = modTile.ChestDrop > 0 ? modTile.ChestDrop : modTile.DresserDrop;
++
+ 			switch (tileCache.type) {
+ 				case 21:
+ 				case 467:
 @@ -46858,13 +_,17 @@
  						case 234:
  							dropItem = 911;


### PR DESCRIPTION
### What is the bug?
See #2643 
### How did you fix the bug?
Allowed `TileLoader.Drop` to return true if the tile has a `ChestDrop` or `DresserDrop` so that `KillTile_GetItemDrops` actually gets called for modded chests and dressers. Then set `dropItem` accordingly.
### Are there alternatives to your fix?
A more general solution would be to have a hook that allows for a multi-tile drop. That can be used specifically for block swap since the only alternative is `ModTile.KillMultiTile` which doesn't really work since block swapping doesn't actually "kill" the tile. 
