### PR TITLE
GetItemDrops hook and redesigns to support Block Swap feature

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleFishingCrate.cs
+++ b/ExampleMod/Content/Tiles/ExampleFishingCrate.cs
@@ -13,6 +13,7 @@ namespace ExampleMod.Content.Tiles
 			Main.tileFrameImportant[Type] = true;
 			Main.tileSolidTop[Type] = true;
 			Main.tileTable[Type] = true;
+			ItemDrop = ModContent.ItemType<Items.Consumables.ExampleFishingCrate>();
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x2);
@@ -28,10 +29,6 @@ namespace ExampleMod.Content.Tiles
 
 		public override bool CreateDust(int i, int j, ref int type) {
 			return false;
-		}
-
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 32, 32, ModContent.ItemType<Items.Consumables.ExampleFishingCrate>());
 		}
 	}
 }

--- a/ExampleMod/Content/Tiles/ExampleLamp.cs
+++ b/ExampleMod/Content/Tiles/ExampleLamp.cs
@@ -25,6 +25,7 @@ namespace ExampleMod.Content.Tiles
 			Main.tileWaterDeath[Type] = true;
 			Main.tileLavaDeath[Type] = true;
 			// Main.tileFlame[Type] = true; // This breaks it.
+			ItemDrop = ModContent.ItemType<Items.Placeable.ExampleLamp>();
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style1xX);
@@ -40,10 +41,6 @@ namespace ExampleMod.Content.Tiles
 			if (!Main.dedServ) {
 				flameTexture = ModContent.Request<Texture2D>("ExampleMod/Content/Tiles/ExampleLamp_Flame"); // We could also reuse Main.FlameTexture[] textures, but using our own texture is nice.
 			}
-		}
-
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 16, 48, ModContent.ItemType<Items.Placeable.ExampleLamp>());
 		}
 
 		public override void HitWire(int i, int j) {

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChair.cs
@@ -30,6 +30,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			DustType = ModContent.DustType<Sparkle>();
 			AdjTiles = new int[] { TileID.Chairs };
+			ItemDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChair>();
 
 			// Names
 			AddMapEntry(new Color(200, 200, 200), Language.GetText("MapObject.Chair"));
@@ -52,10 +53,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) {
 			num = fail ? 1 : 3;
-		}
-
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 16, 32, ModContent.ItemType<Items.Placeable.Furniture.ExampleChair>());
 		}
 
 		public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) {

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -31,6 +31,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			DustType = ModContent.DustType<Sparkle>();
 			AdjTiles = new int[] { TileID.Containers };
 			ChestDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
+			ItemDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 
 			// Names
 			ContainerName.SetDefault("Example Chest");
@@ -54,6 +55,13 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.newTile.LavaDeath = false;
 			TileObjectData.newTile.AnchorBottom = new AnchorData(AnchorType.SolidTile | AnchorType.SolidWithTop | AnchorType.SolidSide, TileObjectData.newTile.Width, 0);
 			TileObjectData.addTile(Type);
+		}
+
+		public override void GetItemDrops(int i, int j, ref int dropItem, ref int dropItemStack, ref int secondaryItem, ref int secondaryItemStack) {
+			Tile tile = Main.tile[i, j];
+			int style = TileObjectData.GetTileStyle(tile);
+			if (style == 0)
+				dropItem = ModContent.ItemType<Items.Placeable.Furniture.ExampleChest>();
 		}
 
 		public override ushort GetMapOption(int i, int j) {
@@ -107,7 +115,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 		}
 
 		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 32, 32, ChestDrop);
+			// We override KillMultiTile to handle additional logic other than the item drop. In this case, unregistering the Chest from the world
 			Chest.DestroyChest(i, j);
 		}
 

--- a/ExampleMod/Content/Tiles/Furniture/ExampleToilet.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleToilet.cs
@@ -31,6 +31,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			DustType = ModContent.DustType<Sparkle>();
 			AdjTiles = new int[] { TileID.Toilets }; // Condider adding TileID.Chairs to AdjTiles to mirror "(regular) Toilet" and "Golden Toilet" behavior for crafting stations
+			ItemDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleToilet>();
 
 			// Names
 			AddMapEntry(new Color(200, 200, 200), Language.GetText("MapObject.Toilet"));
@@ -53,10 +54,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int i, int j, bool fail, ref int num) {
 			num = fail ? 1 : 3;
-		}
-
-		public override void KillMultiTile(int i, int j, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 16, 32, ModContent.ItemType<Items.Placeable.Furniture.ExampleToilet>());
 		}
 
 		public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) {

--- a/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleWorkbench.cs
@@ -21,6 +21,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			DustType = ModContent.DustType<Dusts.Sparkle>();
 			AdjTiles = new int[] { TileID.WorkBenches };
+			ItemDrop = ModContent.ItemType<Items.Placeable.Furniture.ExampleWorkbench>();
 
 			// Placement
 			TileObjectData.newTile.CopyFrom(TileObjectData.Style2x1);
@@ -37,10 +38,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 		public override void NumDust(int x, int y, bool fail, ref int num) {
 			num = fail ? 1 : 3;
-		}
-
-		public override void KillMultiTile(int x, int y, int frameX, int frameY) {
-			Item.NewItem(new EntitySource_TileBreak(x, y), x * 16, y * 16, 32, 16, ModContent.ItemType<Items.Placeable.Furniture.ExampleWorkbench>());
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -230,6 +230,10 @@ public abstract class ModTile : ModBlockType
 		return true;
 	}
 
+	public virtual void GetItemDrops(int i, int j, ref int dropItem, ref int dropItemStack, ref int secondaryItem, ref int secondaryItemStack)
+	{
+	}
+
 	/// <summary>
 	/// Allows you to determine whether or not the tile at the given coordinates can be hit by anything. Returns true by default. blockDamaged currently has no use.
 	/// </summary>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3869,6 +3869,24 @@
  					for (int i = 0; i < num2; i++) {
  						WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  					}
+@@ -30833,8 +_,17 @@
+ 		if (TileID.Sets.Platforms[tile.type] && tile.type == createTile)
+ 			return tile.frameY != num * 18;
+ 
++		if (TileID.Sets.Torch[tile.type] && TileID.Sets.Torch[createTile]) {
++			if (tile.frameY == num * 22)
++				return tile.type != createTile;
++
++			return true;
++		}
++
++		/*
+ 		if (tile.type == 4 && tile.type == createTile)
+ 			return tile.frameY != num * 22;
++		*/
+ 
+ 		if (tile.type == 215 && tile.type == createTile)
+ 			return tile.frameX / 54 != num;
 @@ -30964,8 +_,12 @@
  			PlaceThing_Tiles_PlaceIt_UnslopeForSolids();
  			PlaceThing_Tiles_PlaceIt_KillGrassForSolids();

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1974,6 +1974,15 @@
  		for (int i = 0; i < num; i++) {
  			KillTile_MakeTileDust(x, y, tileSafely);
  		}
+@@ -44647,7 +_,7 @@
+ 		if (TileID.Sets.Platforms[t.type])
+ 			t.frameY = (short)(targetStyle * 18);
+ 
+-		if (t.type == 4)
++		if (TileID.Sets.Torch[t.type])
+ 			t.frameY = (short)(targetStyle * 22);
+ 
+ 		t.ClearBlockPaintAndCoating();
 @@ -44729,7 +_,7 @@
  	public static bool WouldTileReplacementWork(ushort attemptingToReplaceWith, int x, int y)
  	{
@@ -1992,6 +2001,15 @@
  		bool flag6 = !ReplaceTile_IsValidDresser(attemptingToReplaceWith) || !ReplaceTile_IsValidDresser(tile.type);
  		return !(num && flag2 && flag3 && flag && flag4 && flag5 && flag6);
  	}
+@@ -44767,7 +_,7 @@
+ 		return false;
+ 	}
+ 
+-	private static bool ReplaceTile_IsValidTorch(int type) => type == 4;
++	private static bool ReplaceTile_IsValidTorch(int type) => TileID.Sets.Torch[type];
+ 	private static bool ReplaceTile_IsValidCampfire(int type) => type == 215;
+ 	private static bool ReplaceTile_IsValidChest(int type) => TileID.Sets.BasicChest[type];
+ 	private static bool ReplaceTile_IsValidDresser(int type) => TileID.Sets.BasicDresser[type];
 @@ -44973,14 +_,26 @@
  					else if (i % 3 == 1) {
  						treeFrame += 3;
@@ -2065,16 +2083,32 @@
  		for (int k = 0; k < num16; k++) {
  			KillTile_MakeTileDust(i, j, tile);
  		}
-@@ -45758,6 +_,9 @@
+@@ -45756,9 +_,14 @@
  
- 	private static void KillTile_DropItems(int x, int y, Tile tileCache, bool includeLargeObjectDrops = false)
+ 	private static Player GetPlayerForTile(int x, int y) => Main.player[Player.FindClosest(new Vector2(x, y) * 16f, 16, 16)];
+ 
+-	private static void KillTile_DropItems(int x, int y, Tile tileCache, bool includeLargeObjectDrops = false)
++	internal static void KillTile_DropItems(int x, int y, Tile tileCache, bool includeLargeObjectDrops = false, bool includeAllModdedLargeObjectDrops = false)
  	{
 +		if (!TileLoader.Drop(x, y, Main.tile[x, y].type))
 +			return;
 +
- 		KillTile_GetItemDrops(x, y, tileCache, out var dropItem, out var dropItemStack, out var secondaryItem, out var secondaryItemStack, includeLargeObjectDrops);
+-		KillTile_GetItemDrops(x, y, tileCache, out var dropItem, out var dropItemStack, out var secondaryItem, out var secondaryItemStack, includeLargeObjectDrops);
++		KillTile_GetItemDrops(x, y, tileCache, out var dropItem, out var dropItemStack, out var secondaryItem, out var secondaryItemStack, includeLargeObjectDrops, includeAllModdedLargeObjectDrops);
++
++		// TODO: support centering spawn location for multitiles
  		if (!Main.getGoodWorld || tileCache.active()) {
  			if (dropItem > 0) {
+ 				int num = Item.NewItem(GetItemSource_FromTileBreak(x, y), x * 16, y * 16, 16, 16, dropItem, dropItemStack, noBroadcast: false, -1);
+@@ -45772,7 +_,7 @@
+ 		}
+ 	}
+ 
+-	public static void KillTile_GetItemDrops(int x, int y, Tile tileCache, out int dropItem, out int dropItemStack, out int secondaryItem, out int secondaryItemStack, bool includeLargeObjectDrops = false)
++	public static void KillTile_GetItemDrops(int x, int y, Tile tileCache, out int dropItem, out int dropItemStack, out int secondaryItem, out int secondaryItemStack, bool includeLargeObjectDrops = false, bool includeAllModdedLargeObjectDrops = false)
+ 	{
+ 		dropItem = 0;
+ 		dropItemStack = 1;
 @@ -46858,13 +_,17 @@
  						case 234:
  							dropItem = 911;
@@ -2093,6 +2127,15 @@
  				}
  
  				break;
+@@ -47806,6 +_,8 @@
+ 			case 665:
+ 				break;
+ 		}
++
++		TileLoader.GetItemDrops(x, y, tileCache, ref dropItem, ref dropItemStack, ref secondaryItem, ref secondaryItemStack, includeLargeObjectDrops, includeAllModdedLargeObjectDrops);
+ 	}
+ 
+ 	private static void SetGemTreeDrops(int gemType, int seedType, Tile tileCache, ref int dropItem, ref int secondaryItem)
 @@ -47881,7 +_,12 @@
  
  					if (Main.tile[i, k] != null) {


### PR DESCRIPTION
Currently, multitiles (tiles bigger than 1x1) don't use ModTile.DropItem because the existing logic would drop that item multiple times when the multitile was mined.

To support the Block Swap feature, this PR splits up the act of mining a tile into more parts to allow multitiles to be less boilerplate. 

Remove:
```
public override void KillMultiTile(int i, int j, int frameX, int frameY) {
	Item.NewItem(new EntitySource_TileBreak(i, j), i * 16, j * 16, 32, 32, ModContent.ItemType<Items.Consumables.ExampleFishingCrate>());
}
```

Add:
```
ItemDrop = ModContent.ItemType<Items.Consumables.ExampleFishingCrate>();
```

For tiles that have multiple styles, modders can override GetItemDrops and assign to `dropItem`. Manually spawning the item is no longer necessary. 

For Tiles like ExampleChest, KillMultiTile is still used, but only for cleaning up TileEntities or Chest objects. 

The ModTile/GlobalTile.Drop method was handling several inconsistent duties, preventing vanilla multitiles from dropping items and preventing 1x1 tiles from dropping. Drop was also responsible for spawning ModItem.ItemDrop. Drop no longer spawns ModItem.ItemDrop, that is handled by code shared with vanilla code now. Drop's purpose is now solely preventing item drops from tiles.

# Migration
Modders can keep their code as is, but can move from KillMultiTile to ItemDrop for multitiles for cleaner code. It is currently only required if they want to support block swap for chests or support proper usage of Drop hook.

Modders using Drop hook or the KillMultiTile hook for choosing the item drop should move to GetItemDrops.