### PR TITLE
[1.4.4] Fix DustType + CreateDust interaction

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBlockType.cs
@@ -93,7 +93,6 @@ public abstract class ModBlockType : ModTexturedType
 	/// <param name="type">The dust type that will be spawned by the calling code</param>
 	public virtual bool CreateDust(int i, int j, ref int type)
 	{
-		type = DustType; // TODO: this is strange
 		return true;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -176,8 +176,7 @@ public static class WallLoader
 			hook(i, j, type, fail, ref numDust);
 		}
 	}
-	//in Terraria.WorldGen.KillWall before if statements creating dust add
-	//  if(!WallLoader.CreateDust(i, j, tile.wall, ref int num2)) { continue; }
+
 	public static bool CreateDust(int i, int j, int type, ref int dustType)
 	{
 		foreach (var hook in HookCreateDust) {
@@ -187,6 +186,7 @@ public static class WallLoader
 		}
 		return GetWall(type)?.CreateDust(i, j, ref dustType) ?? true;
 	}
+
 	//in Terraria.WorldGen.KillWall replace if (num4 > 0) with
 	//  if (WallLoader.Drop(i, j, tile.wall, ref num4) && num4 > 0)
 	public static bool Drop(int i, int j, int type, ref int dropType)

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1893,10 +1893,13 @@
  			Item.NewItem(GetItemSource_FromWallBreak(i, j), i * 16, j * 16, 16, 16, num);
  	}
  
-@@ -44268,6 +_,9 @@
+@@ -44268,6 +_,12 @@
  		if (tileCache.wall == 245)
  			num = 195;
  
++		if (WallLoader.GetWall(tileCache.wall) is ModWall modWall)
++			num = modWall.DustType;
++
 +		if (!WallLoader.CreateDust(i, j, tileCache.wall, ref num))
 +			return;
 +
@@ -2202,11 +2205,14 @@
  				}
  			}
  		}
-@@ -50136,7 +_,7 @@
+@@ -50136,7 +_,10 @@
  		if (type == 178 || (uint)(type - 426) <= 1u || (uint)(type - 430) <= 10u)
  			flag = true;
  
 -		if (num >= 0) {
++		if (TileLoader.GetTile(tileCache.type) is ModTile modTile)
++			num = modTile.DustType;
++
 +		if (TileLoader.CreateDust(i, j, tileCache.type, ref num) && num >= 0) {
  			if (tileCache.type == 627 || tileCache.type == 628 || (tileCache.type == 184 && tileCache.frameX / 22 == 10)) {
  				int num18 = Dust.NewDust(new Vector2(i * 16, j * 16), 16, 16, num, 0f, 0f, 0, new Color(Main.DiscoR, Main.DiscoG, Main.DiscoB));


### PR DESCRIPTION
### What is the bug?
`ModBlockType.CreateDust` hook has code in its method body (unusual for tml standards), which the modder has to include if he chooses to use `DustType` for his tile/wall aswell.
`WallLoder.CreateDust` had outdated "patch context" comments which I removed

### How did you fix the bug?
This PR moves the dust type assignment out of the hook.

### Are there alternatives to your fix?
No.

### Porting Notes
If you were using both `DustType` and `CreateDust` for any of your tiles/walls at once, now `CreateDust` correctly includes your `DustType` in the `type` instead of `0`.