### PR TITLE
[1.4.4] Fix Lucy the Axe popup text coloring

### DIFF
--- a/patches/tModLoader/Terraria/PopupText.cs.patch
+++ b/patches/tModLoader/Terraria/PopupText.cs.patch
@@ -20,6 +20,14 @@
  	public bool notActuallyAnItem {
  		get {
  			if (npcNetID == 0)
+@@ -64,6 +_,7 @@
+ 		text.rotation = 0f;
+ 		text.alpha = 1f;
+ 		text.alphaDir = -1;
++		text.rarity = 0;
+ 	}
+ 
+ 	public static int NewText(AdvancedPopupRequest request, Vector2 position)
 @@ -256,10 +_,14 @@
  				popupText2.color = new Color(5, 200, 255);
  			else if (newItem.rare == 10)


### PR DESCRIPTION
### What is the bug?
If there is an inactive `PopupText` slot which came from an item that has a modded rarity, and a message from [Lucy the Axe](https://terraria.wiki.gg/wiki/Lucy_the_Axe) happens to take that slot, its color will be the one from that rarity instead of the predetermined red color.

### How did you fix the bug?
TML added the `rarity` field to `PopupText` to handle displaying modded rarities. This rarity is however persistent between "different" popup texts. This is not an issue in regular gameplay, the only type of text in vanilla that doesn't need the rarity field is the aforementioned Lucy the Axe text, but TML forcibly applies the color if it's matching a modded rarity.
The fix simply resets the rarity in `PopupText.ResetText` to 0, preventing the modded rarity from carrying over.

### Are there alternatives to your fix?
No
