### PR TITLE
[1.4.4] Reorder ClearEdges to clear modded tiles

### DIFF
--- a/patches/tModLoader/Terraria/Map/WorldMap.cs.patch
+++ b/patches/tModLoader/Terraria/Map/WorldMap.cs.patch
@@ -16,13 +16,12 @@
  			Main.MapFileMetadata = FileMetadata.FromCurrentSettings(FileType.Map);
  			return;
  		}
-@@ -101,6 +_,9 @@
+@@ -99,6 +_,8 @@
+ 					MapHelper.LoadMapVersion1(binaryReader, num);
+ 				else
  					MapHelper.LoadMapVersion2(binaryReader, num);
- 
- 				ClearEdges();
 +
 +				MapIO.ReadModFile(text, isCloudSave);
-+
+ 
+ 				ClearEdges();
  				Main.clearMap = true;
- 				Main.loadMap = true;
- 				Main.loadMapLock = true;


### PR DESCRIPTION
### What is the bug?
[Image of map edge](https://media.discordapp.net/attachments/337688881543512065/1061712905118175313/image.png?width=49&height=670)
If a map reveal tool is used (HEROs Mod for example), the entire map is revealed, including the edge. if the world is saved and entered again, an edge appears, but modded tiles will appear on the edge.

### How did you fix the bug?
Reorder `ClearEdges` to come after modded map loading.

### Are there alternatives to your fix?
No
