### PR TITLE
Family Share Manual Launch Script

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
@@ -51,7 +51,8 @@ namespace Terraria.ModLoader.Engine
 		internal static void SetAppId(AppId_t appId) {
 			var steam_appid_path = "steam_appid.txt";
 
-			if (Environment.GetEnvironmentVariable("SteamClientLaunch") != "1") {
+			// Family Share & GoG, Dev Enviroments rely on steam_appid.txt to know what the game is in Steam
+			if (Environment.GetEnvironmentVariable("SteamClientLaunch") != "1" || Social.Steam.SteamedWraps.FamilyShared) {
 				File.WriteAllText(steam_appid_path, appId.ToString());
 				return;
 			}
@@ -61,6 +62,8 @@ namespace Terraria.ModLoader.Engine
 			}
 			catch (IOException) { }
 
+			//Solxan: While testing family share, noticed this inherently fails if game is not initiated from the 'start' button in Steam.
+			// Not normally a problem, as family share should be pathing to game server anyways
 			if (Environment.GetEnvironmentVariable("SteamAppId") != appId.ToString()) {
 				throw new Exception("Cannot overwrite steam env. SteamAppId=" + Environment.GetEnvironmentVariable("SteamAppId"));
 			}

--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.bat
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /D "%~dp0"
+set SteamClientLaunch=1
+start-tModLoader.bat

--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export SteamClientLaunch=1
+chmod a+x ./start-tModLoader.sh
+./start-tModLoader.sh


### PR DESCRIPTION
This partially addresses #881 for 1.4.

The way it works is to add 'SteamClientLaunch' as an extra variable during the launch scripts, which then triggers the TerrariaClient, which can then flag that it is FamilyShare, and finally path to the correct launch methods.

Looking for an A-OK before putting on Stable as it is kinda hacky.