### PR TITLE
Fix manage script not moving mods if --check-dir is set

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -241,7 +241,9 @@ function install_mods {
 	mkdir -p $mods_path
 
 	# If someone has .tmod files this will install them
-	if [[ -f "*.tmod" ]]; then
+	local count
+	count=$(ls -1 ./*.tmod 2>/dev/null | wc -l)
+	if [ $count != 0 ]; then
 		echo "Copying .tmod files to the mods directory"
 		cp ./*.tmod $mods_path
 	fi


### PR DESCRIPTION
Management script does not move mods when --check-dir is set, due to globs not working with -f in test. Changed it to just use ls and wc to count the number of *.tmod files, and then check it is above 0.

Resolves https://github.com/tModLoader/tModLoader/issues/3223


