### PR TITLE
Fix bugs from throwing fields port

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4393,10 +4393,10 @@
 +					// Copied as-is from 1.3
 +					if (item.CountsAsClass(DamageClass.Throwing)) {
 +						if (ThrownCost50 && Main.rand.Next(100) < 50)
-+							flag6 = true;
++							flag6 = false;
 +
 +						if (ThrownCost33 && Main.rand.Next(100) < 33)
-+							flag6 = true;
++							flag6 = false;
 +					}
 +
  					if (item.IsACoin)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4386,6 +4386,22 @@
  							if (inventory[num15].stack <= 0)
  								inventory[num15] = new Item();
  
+@@ -33732,6 +_,15 @@
+ 							flag6 = false;
+ 					}
+ 
++					// Copied as-is from 1.3
++					if (item.CountsAsClass(DamageClass.Throwing)) {
++						if (ThrownCost50 && Main.rand.Next(100) < 50)
++							flag6 = true;
++
++						if (ThrownCost33 && Main.rand.Next(100) < 33)
++							flag6 = true;
++					}
++
+ 					if (item.IsACoin)
+ 						flag6 = true;
+ 
 @@ -33739,7 +_,7 @@
  					if (flag7.HasValue)
  						flag6 = flag7.Value;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -18,7 +18,7 @@
  {
  	private class NPCDistanceByIndexComparator : IComparer<Tuple<int, float>>
  	{
-@@ -66,70 +_,271 @@
+@@ -66,70 +_,272 @@
  	public bool arrow;
  	public int numHits;
  	public bool bobber;
@@ -33,6 +33,7 @@
 +	/// Set to true if you don't want this projectile to have a chance to recover the ammo item that shot this. For example, if you shoot the <see cref="ProjectileID.WoodenArrowFriendly"/> projectile, it will sometimes drop the <see cref="ItemID.WoodenArrow"/>  item. If your weapon shoots multiple arrows for 1 ammo, you might want to consider setting this field to prevent infinite ammo glitches.
 +	/// <br/> In <see cref="ModProjectile.Kill(int)"/>, check this and <see cref="owner"/> to decide if the item should drop: <code>if (Projectile.owner == Main.myPlayer &amp;&amp; !Projectile.noDropItem)</code> See <see href="https://github.com/tModLoader/tModLoader/blob/1.4/ExampleMod/Content/Projectiles/ExamplePaperAirplaneProjectile.cs#L146">ExamplePaperAirplaneProjectile</see> for an example of this logic.
 +	/// <br/> Set directly on the projectile instance returned from <see cref="Projectile.NewProjectile(IEntitySource, float, float, float, float, int, int, float, int, float, float, float)"/>, not in <see cref="ModProjectile.SetDefaults"/>. This ensures that the weapon spawning the projectile decides if the ammo item will spawn, which is more compatible.
++	/// <br/> Set automatically when shot from a weapon that counts as <see cref="DamageClass.Throwing"/> and <see cref="Player.AnyThrownCostReduction"/> is <see langword="true"/>.
 +	/// <br/> Defaults to <see langword="false"/>.
 +	/// </summary>
  	public bool noDropItem;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -577,10 +577,10 @@
  			if (Type == 777 || Type == 781 || Type == 794 || Type == 797 || Type == 800 || Type == 785 || Type == 788 || Type == 791 || Type == 903 || Type == 904 || Type == 905 || Type == 906 || Type == 910 || Type == 911)
  				projectile.timeLeft = 180;
 +
-+			// Copied from 1.3, adjusted to check for actual player (servers never shoot thrower projectiles)
++			// Copied from 1.3, moved from Shoot context to OnSpawn with matching logic
 +			if (Main.netMode != NetmodeID.Server) {
 +				Player throwingPlayer = Main.player[Owner];
-+				if (throwingPlayer.AnyThrownCostReduction && throwingPlayer.HeldItem.CountsAsClass(DamageClass.Throwing))
++				if (throwingPlayer.AnyThrownCostReduction && throwingPlayer.HeldItem.CountsAsClass(DamageClass.Throwing) && spawnSource is EntitySource_ItemUse_WithAmmo)
 +					projectile.noDropItem = true;
 +			}
  		}


### PR DESCRIPTION
_This PR should be backported, as these bugs happen on stable/preview aswell. Backport should be easy apart from indentation changes, none of the fields used were changed or renamed._

### What is the bug?
* in SP, landing falling stars would not "drop" the item if a thrown consumption prevention effect was enabled and the player held a throwing item
* thrown consumption prevention effects would not work for non-ammo style throwing items (everything except weapons implemented like 1.3 bone glove)

### How did you fix the bug?
* Further adjust the conditions of the "noDropItem" setting by checking for the "shot from weapon" context.
* Copy the code used in `IsAmmoFreeThisShot` to the place where non-ammo using items get consumed (mirrors vanilla logic with old throwing items (now turned ranged)).

### Are there alternatives to your fix?
No
