### PR TITLE
1.4.4 Default Research Unlock Value to 1, fix #3228

### DIFF
--- a/ExampleMod/Content/Items/Accessories/ExampleBeard.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleBeard.cs
@@ -11,8 +11,6 @@ namespace ExampleMod.Content.Items.Accessories
 	public class ExampleBeard : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-
 			ArmorIDs.Beard.Sets.UseHairColor[Item.beardSlot] = true;
 		}
 

--- a/ExampleMod/Content/Items/Accessories/ExampleImmunityAccessory.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleImmunityAccessory.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Accessories
 {
 	public class ExampleImmunityAccessory : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 26;
 			Item.height = 32;

--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -9,10 +9,6 @@ namespace ExampleMod.Content.Items.Accessories
 	[AutoloadEquip(EquipType.Shield)] // Load the spritesheet you create as a shield for the player when it is equipped.
 	public class ExampleShield : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 24;
 			Item.height = 28;

--- a/ExampleMod/Content/Items/Accessories/ExampleStatBonusAccessory.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleStatBonusAccessory.cs
@@ -20,10 +20,6 @@ namespace ExampleMod.Content.Items.Accessories
 		// Insert the modifier values into the tooltip localization
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(AdditiveDamageBonus, MultiplicativeDamageBonus, BaseDamageBonus, FlatDamageBonus, MeleeCritBonus, RangedAttackSpeedBonus, MagicArmorPenetration, ExampleKnockback);
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 40;
 			Item.height = 40;

--- a/ExampleMod/Content/Items/Accessories/ExampleWings.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleWings.cs
@@ -16,8 +16,6 @@ namespace ExampleMod.Content.Items.Accessories
 		}
 
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-
 			// These wings use the same values as the solar wings
 			// Fly time: 180 ticks = 3 seconds
 			// Fly speed: 9

--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -39,10 +39,6 @@ namespace ExampleMod.Content.Items.Accessories
 			});
 		}
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			int realBackSlot = Item.backSlot;
 			Item.CloneDefaults(ItemID.HiveBackpack);

--- a/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
@@ -15,10 +15,6 @@ namespace ExampleMod.Content.Items.Armor
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MaxManaIncrease, MaxMinionIncrease);
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 18; // Width of the item
 			Item.height = 18; // Height of the item

--- a/ExampleMod/Content/Items/Armor/ExampleHelmet.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHelmet.cs
@@ -10,8 +10,6 @@ namespace ExampleMod.Content.Items.Armor
 	public class ExampleHelmet : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 3;
-
 			// If your head equipment should draw hair while drawn, use one of the following:
 			// ArmorIDs.Head.Sets.DrawHead[Item.headSlot] = false; // Don't draw the head at all. Used by Space Creature Mask
 			// ArmorIDs.Head.Sets.DrawHatHair[Item.headSlot] = true; // Draw hair as if a hat was covering the top. Used by Wizards Hat

--- a/ExampleMod/Content/Items/Armor/ExampleHood.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHood.cs
@@ -9,10 +9,6 @@ namespace ExampleMod.Content.Items.Armor
 	[AutoloadEquip(EquipType.Head)]
 	public class ExampleHood : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 18; // Width of the item
 			Item.height = 18; // Height of the item

--- a/ExampleMod/Content/Items/Armor/ExampleLeggings.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleLeggings.cs
@@ -14,10 +14,6 @@ namespace ExampleMod.Content.Items.Armor
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MoveSpeedBonus);
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 18; // Width of the item
 			Item.height = 18; // Height of the item

--- a/ExampleMod/Content/Items/Armor/Vanity/MinionBossMask.cs
+++ b/ExampleMod/Content/Items/Armor/Vanity/MinionBossMask.cs
@@ -9,10 +9,6 @@ namespace ExampleMod.Content.Items.Armor.Vanity
 	[AutoloadEquip(EquipType.Head)]
 	public class MinionBossMask : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 22;
 			Item.height = 28;

--- a/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
@@ -18,10 +18,6 @@ namespace ExampleMod.Content.Items.Consumables
 		// We set this when the item is crafted. In other contexts, this will be an empty string
 		public string craftedPlayerName = string.Empty;
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 3;
-		}
-
 		public override void SetDefaults() {
 			Item.maxStack = Item.CommonMaxStack; // This item is stackable, otherwise the example wouldn't work
 			Item.consumable = true;

--- a/ExampleMod/Content/Items/ExampleDataItem.cs
+++ b/ExampleMod/Content/Items/ExampleDataItem.cs
@@ -11,10 +11,6 @@ namespace ExampleMod.Content.Items
 
 		public int timer;
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
 			TooltipLine tooltip = new TooltipLine(Mod, "ExampleMod: HotPatato", $"You have {timer / 60f:N1} seconds left!") { OverrideColor = Color.Red };
 			tooltips.Add(tooltip);

--- a/ExampleMod/Content/Items/ExampleGolfBall.cs
+++ b/ExampleMod/Content/Items/ExampleGolfBall.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items
 {
 	public class ExampleGolfBall : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// DefaultToGolfBall sets various properties common to golf balls. Hover over DefaultToGolfBall in Visual Studio to see the specific properties set.
 			// ModContent.ProjectileType<ExampleGolfBallProjectile>() is the projectile that is placed on the golf tee.

--- a/ExampleMod/Content/Items/ExampleHairDye.cs
+++ b/ExampleMod/Content/Items/ExampleHairDye.cs
@@ -19,7 +19,7 @@ namespace ExampleMod.Content.Items
 				);
 			}
 
-			Item.ResearchUnlockCount = 1;
+			Item.ResearchUnlockCount = 3;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -15,10 +15,6 @@ namespace ExampleMod.Content.Items
 
 		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 99;
-		}
-
 		public override void SetDefaults() {
 			Item.useAnimation = 30;
 			Item.useStyle = ItemUseStyleID.Swing;

--- a/ExampleMod/Content/Items/ExampleItem.cs
+++ b/ExampleMod/Content/Items/ExampleItem.cs
@@ -12,7 +12,8 @@ namespace ExampleMod.Content.Items
 		public override void SetStaticDefaults() {
 			// The text shown below some item names is called a tooltip. Tooltips are defined in the localization files. See en-US.hjson.
 
-			Item.ResearchUnlockCount = 100; // How many items are needed in order to research duplication of this item in Journey mode. See https://terraria.wiki.gg/wiki/Journey_Mode/Research_list for a list of commonly used research amounts depending on item type.
+			// How many items are needed in order to research duplication of this item in Journey mode. See https://terraria.wiki.gg/wiki/Journey_Mode#Research for a list of commonly used research amounts depending on item type. This defaults to 1, which is what most items will use, so you can omit this for most ModItems.
+			Item.ResearchUnlockCount = 100;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/ExampleMountItem.cs
+++ b/ExampleMod/Content/Items/ExampleMountItem.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items
 {
 	public class ExampleMountItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 20;
 			Item.height = 30;

--- a/ExampleMod/Content/Items/ExamplePaperAirplane.cs
+++ b/ExampleMod/Content/Items/ExamplePaperAirplane.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items
 {
 	public class ExamplePaperAirplane : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1; // How many items are needed in order to research duplication of this item in Journey mode. See https://terraria.wiki.gg/Journey_Mode/Research_list for a list of commonly used research amounts depending on item type.
-		}
-
 		public override void SetDefaults() {
 			Item.width = 22; // The item texture's width
 			Item.height = 16; // The item texture's height

--- a/ExampleMod/Content/Items/ExampleResearchPresent.cs
+++ b/ExampleMod/Content/Items/ExampleResearchPresent.cs
@@ -11,7 +11,7 @@ namespace ExampleMod.Content.Items
 			// Must be researched as many times as there are items in the game.
 			// If fully researched, and a new mod is added, it will become un-researched and require that much more
 			// Research amount will never go down or over the max limit of 9999.
-			Item.ResearchUnlockCount = Utils.Clamp(ItemLoader.ItemCount,1,9999);
+			Item.ResearchUnlockCount = Utils.Clamp(ItemLoader.ItemCount, 1, 9999);
 
 			// Use a MonoMod hook to allow our presents to run through the Sacrifice system.
 			On_CreativeUI.SacrificeItem_refItem_refInt32_bool += OnSacrificeItem;

--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -10,8 +10,6 @@ namespace ExampleMod.Content.Items
 	public class ExampleTooltipsItem : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-
 			Main.RegisterItemAnimation(Item.type, new DrawAnimationVertical(30, 4));
 			ItemID.Sets.AnimatesAsSoul[Item.type] = true; // Makes the item have an animation while in world (not held.). Use in combination with RegisterItemAnimation
 

--- a/ExampleMod/Content/Items/Placeable/ExampleHerbSeeds.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleHerbSeeds.cs
@@ -6,7 +6,7 @@ namespace ExampleMod.Content.Items.Placeable
 	public class ExampleHerbSeeds : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 20;
+			Item.ResearchUnlockCount = 25;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Placeable/ExampleLamp.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleLamp.cs
@@ -5,10 +5,6 @@ namespace ExampleMod.Content.Items.Placeable
 {
 	internal class ExampleLamp : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.ExampleLamp>());
 			Item.width = 10;

--- a/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
@@ -7,7 +7,6 @@ namespace ExampleMod.Content.Items.Placeable
 	public class ExampleMusicBox : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
 			ItemID.Sets.CanGetPrefixes[Type] = false; // music boxes can't get prefixes in vanilla
 
 			// The following code links the music box's item and tile with a music track:

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleBed.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleBed.cs
@@ -5,10 +5,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleBed : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleBed>());
 			Item.width = 28;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChair.cs
@@ -5,10 +5,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleChair : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleChair>());
 			Item.width = 12;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleChest.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleChest : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleChest>());
 			// Item.placeStyle = 1; // Use this to place the chest in its locked style

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleClock.cs
@@ -5,10 +5,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleClock : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleClock>());
 			Item.width = 26;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleDoor.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleDoor : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<ExampleDoorClosed>());
 			Item.width = 14;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleSink.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleSink.cs
@@ -5,10 +5,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleSink : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.ExampleSink>());
 			Item.width = 24;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleTable.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleTable.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleTable : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleTable>());
 			Item.width = 38;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleToilet.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleToilet.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleToilet : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.ExampleToilet>());
 			Item.width = 16;

--- a/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/ExampleWorkbench.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class ExampleWorkbench : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// ModContent.TileType<Tiles.Furniture.ExampleWorkbench>() retrieves the id of the tile that this item should place when used.
 			// DefaultToPlaceableTile handles setting various Item values that placeable items use

--- a/ExampleMod/Content/Items/Placeable/Furniture/MinionBossRelic.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/MinionBossRelic.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class MinionBossRelic : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Vanilla has many useful methods like these, use them! This substitutes setting Item.createTile and Item.placeStyle aswell as setting a few values that are common across all placeable items
 			// The place style (here by default 0) is important if you decide to have more than one relic share the same tile type (more on that in the tiles' code)

--- a/ExampleMod/Content/Items/Placeable/Furniture/MinionBossTrophy.cs
+++ b/ExampleMod/Content/Items/Placeable/Furniture/MinionBossTrophy.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Placeable.Furniture
 {
 	public class MinionBossTrophy : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Vanilla has many useful methods like these, use them! This substitutes setting Item.createTile and Item.placeStyle aswell as setting a few values that are common across all placeable items
 			Item.DefaultToPlaceableTile(ModContent.TileType<Tiles.Furniture.MinionBossTrophy>());

--- a/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleBugNet.cs
@@ -21,8 +21,6 @@ namespace ExampleMod.Content.Items.Tools
 			// This set is needed to define an item as a tool for catching NPCs at all.
 			// An additional set exists called LavaproofCatchingTool which will allow your item to freely catch the Underworld's lava critters. Use it accordingly.
 			ItemID.Sets.CatchingTool[Item.type] = true;
-
-			Item.ResearchUnlockCount = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
@@ -9,7 +9,6 @@ namespace ExampleMod.Content.Items.Tools
 	public class ExampleFishingRod : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
 			ItemID.Sets.CanFishInLava[Item.type] = true; // Allows the pole to fish in lava
 		}
 

--- a/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
@@ -8,10 +8,6 @@ namespace ExampleMod.Content.Items.Tools
 {
 	public class ExampleHamaxe : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.damage = 25;
 			Item.DamageType = DamageClass.Melee;

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -9,10 +9,6 @@ namespace ExampleMod.Content.Items.Tools
 {
 	internal class ExampleHookItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1; // Amount of this item needed to research and become available in Journey mode's duplication menu. Amount based on vanilla hooks' amount needed
-		}
-
 		public override void SetDefaults() {
 			// Copy values from the Amethyst Hook
 			Item.CloneDefaults(ItemID.AmethystHook);

--- a/ExampleMod/Content/Items/Tools/ExampleMagicMirror.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleMagicMirror.cs
@@ -19,10 +19,6 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override string Texture => $"Terraria/Images/Item_{ItemID.IceMirror}"; // Copies the texture for the Ice Mirror, make your own texture if need be.
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1; // Amount of this item needed to research and become available in Journey mode's duplication menu. Amount used based upon vanilla Magic Mirror's amount needed.
-		}
-
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.IceMirror); // Copies the defaults from the Ice Mirror.
 			Item.color = Color.Violet; // Sets the item color

--- a/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
@@ -8,10 +8,6 @@ namespace ExampleMod.Content.Items.Tools
 {
 	public class ExamplePickaxe : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.damage = 20;
 			Item.DamageType = DamageClass.Melee;

--- a/ExampleMod/Content/Items/Weapons/ExampleAdvancedFlail.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleAdvancedFlail.cs
@@ -9,8 +9,6 @@ namespace ExampleMod.Content.Items.Weapons
 	public class ExampleAdvancedFlail : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-
 			// This line will make the damage shown in the tooltip twice the actual Item.damage. This multiplier is used to adjust for the dynamic damage capabilities of the projectile.
 			// When thrown directly at enemies, the flail projectile will deal double Item.damage, matching the tooltip, but deals normal damage in other modes.
 			ItemID.Sets.ToolTipDamageMultiplier[Type] = 2f;

--- a/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCloneWeapon.cs
@@ -11,10 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 	/// </summary>
 	public class ExampleCloneWeapon : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// This method right here is the backbone of what we're doing here; by using this method, we copy all of
 			// the meowmere's SetDefault stats (such as Item.melee and Item.shoot) on to our item, so we don't have to

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomAmmoGun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomAmmoGun.cs
@@ -10,10 +10,6 @@ namespace ExampleMod.Content.Items.Weapons
 	// You can see the description of other parameters in the ExampleGun class and at https://github.com/tModLoader/tModLoader/wiki/Item-Class-Documentation
 	public class ExampleCustomAmmoGun : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 42; // The width of item hitbox
 			Item.height = 30; // The height of item hitbox

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomDamageWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomDamageWeapon.cs
@@ -10,10 +10,6 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override string Texture => "ExampleMod/Content/Items/Weapons/ExampleSword"; //TODO: remove when sprite is made for this
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DamageType = ModContent.GetInstance<ExampleDamageClass>(); // Makes our item use our custom damage type.
 			Item.width = 40;

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomResourceWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomResourceWeapon.cs
@@ -11,10 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		private int exampleResourceCost; // Add our custom resource cost
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.damage = 130;
 			Item.DamageType = DamageClass.Magic;

--- a/ExampleMod/Content/Items/Weapons/ExampleFlail.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleFlail.cs
@@ -11,8 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 	internal class ExampleFlail : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-
 			// This line will make the damage shown in the tooltip twice the actual Item.damage. This multiplier is used to adjust for the dynamic damage capabilities of the projectile.
 			// When thrown directly at enemies, the flail projectile will deal double Item.damage, matching the tooltip, but deals normal damage in other modes.
 			ItemID.Sets.ToolTipDamageMultiplier[Type] = 2f;

--- a/ExampleMod/Content/Items/Weapons/ExampleGun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleGun.cs
@@ -9,10 +9,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleGun : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Modders can use Item.DefaultToRangedWeapon to quickly set many common properties, such as: useTime, useAnimation, useStyle, autoReuse, DamageType, shoot, shootSpeed, useAmmo, and noMelee. These are all shown individually here for teaching purposes.
 

--- a/ExampleMod/Content/Items/Weapons/ExampleJoustingLance.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleJoustingLance.cs
@@ -7,10 +7,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleJoustingLance : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1; // The number of sacrifices that is required to research the item in Journey Mode.
-		}
-
 		public override void SetDefaults() {
 			// A special method that sets a variety of item parameters that make the item act like a spear weapon.
 			// To see everything DefaultToSpear() does, right click the method in Visual Studios and choose "Go To Definition" (or press F12). You can also hover over DefaultToSpear to see the documentation.

--- a/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
@@ -6,10 +6,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleMagicWeapon : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// DefaultToStaff handles setting various Item values that magic staff weapons use.
 			// Hover over DefaultToStaff in Visual Studio to read the documentation!

--- a/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMinigun.cs
@@ -7,10 +7,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleMinigun : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Modders can use Item.DefaultToRangedWeapon to quickly set many common properties, such as: useTime, useAnimation, useStyle, autoReuse, DamageType, shoot, shootSpeed, useAmmo, and noMelee.
 			// See ExampleGun.SetDefaults to see comments explaining those properties

--- a/ExampleMod/Content/Items/Weapons/ExampleModifiedProjectilesItem.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleModifiedProjectilesItem.cs
@@ -11,10 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 	{
 		public override string Texture => "ExampleMod/Content/Items/Weapons/ExampleShootingSword";
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.useTime = 20;
 			Item.useAnimation = 20;

--- a/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
@@ -13,10 +13,6 @@ namespace ExampleMod.Content.Items.Weapons
 	/// </summary>
 	public class ExampleShootingSword : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 26;
 			Item.height = 42;

--- a/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
@@ -7,10 +7,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleShortsword : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.damage = 8;
 			Item.knockBack = 4f;

--- a/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShotgun.cs
@@ -8,10 +8,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleShotgun : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Modders can use Item.DefaultToRangedWeapon to quickly set many common properties, such as: useTime, useAnimation, useStyle, autoReuse, DamageType, shoot, shootSpeed, useAmmo, and noMelee. These are all shown individually here for teaching purposes.
 

--- a/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpear.cs
@@ -11,7 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 		public override void SetStaticDefaults() {
 			ItemID.Sets.SkipsInitialUseSound[Item.type] = true; // This skips use animation-tied sound playback, so that we're able to make it be tied to use time instead in the UseItem() hook.
 			ItemID.Sets.Spears[Item.type] = true; // This allows the game to recognize our new item as a spear.
-			Item.ResearchUnlockCount = 1;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/Weapons/ExampleSpecificAmmoGun.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSpecificAmmoGun.cs
@@ -20,10 +20,6 @@ namespace ExampleMod.Content.Items.Weapons
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(FreeAmmoChance1, FreeAmmoChance2, FreeAmmoChance3, AmmoUseDamageBoost);
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Modders can use Item.DefaultToRangedWeapon to quickly set many common properties, such as: useTime, useAnimation, useStyle, autoReuse, DamageType, shoot, shootSpeed, useAmmo, and noMelee. These are all shown individually here for teaching purposes.
 

--- a/ExampleMod/Content/Items/Weapons/ExampleSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleSword.cs
@@ -8,10 +8,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleSword : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.width = 40; // The item texture's width.
 			Item.height = 40; // The item texture's height.

--- a/ExampleMod/Content/Items/Weapons/ExampleWhip.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleWhip.cs
@@ -7,10 +7,6 @@ namespace ExampleMod.Content.Items.Weapons
 {
 	public class ExampleWhip : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// This method quickly sets the whip's properties.
 			// Mouse over to see its parameters.

--- a/ExampleMod/Content/Items/Weapons/ExampleWhipAdvanced.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleWhipAdvanced.cs
@@ -10,10 +10,6 @@ namespace ExampleMod.Content.Items.Weapons
 		// The texture doesn't have the same name as the item, so this property points to it.
 		public override string Texture => "ExampleMod/Content/Items/Weapons/ExampleWhip";
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			// Call this method to quickly set some of the properties below.
 			//Item.DefaultToWhip(ModContent.ProjectileType<ExampleWhipProjectileAdvanced>(), 20, 2, 4);

--- a/ExampleMod/Content/Items/Weapons/ExampleYoyo.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleYoyo.cs
@@ -11,8 +11,6 @@ namespace ExampleMod.Content.Items.Weapons
 	public class ExampleYoyo : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1; // The amount of this item that needs to be researched to unlock it in the journey mode duplication menu.
-
 			// These are all related to gamepad controls and don't seem to affect anything else
 			ItemID.Sets.Yoyo[Item.type] = true;
 			ItemID.Sets.GamepadExtraRange[Item.type] = 15;

--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetItem.cs
@@ -8,10 +8,6 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 {
 	public class ExampleLightPetItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.damage = 0;
 			Item.useStyle = ItemUseStyleID.Swing;

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetItem.cs
@@ -8,11 +8,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 {
 	public class ExamplePetItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			// Names and descriptions of all ExamplePetX classes are defined using .hjson files in the Localization folder
-			Item.ResearchUnlockCount = 1;
-		}
-
+		// Names and descriptions of all ExamplePetX classes are defined using .hjson files in the Localization folder
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.ZephyrFish); // Copy the Defaults of the Zephyr Fish Item.
 

--- a/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetItem.cs
+++ b/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetItem.cs
@@ -6,13 +6,9 @@ using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Pets.MinionBossPet
 {
-	// You can find a simple pet example in ExampleMod\Content\Pets\ExamplePet
+	// You can find a simple pet example in the ExampleMod\Content\Pets\ExamplePet\ folder
 	public class MinionBossPetItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.DefaultToVanitypet(ModContent.ProjectileType<MinionBossPetProjectile>(), ModContent.BuffType<MinionBossPetBuff>()); // Vanilla has many useful methods like these, use them! It sets rarity and value aswell, so we have to overwrite those after
 

--- a/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedAnimatedProjectile.cs
@@ -146,10 +146,6 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override string Texture => $"Terraria/Images/Item_{ItemID.NebulaBlaze}";
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.NebulaBlaze);
 			Item.mana = 3;

--- a/ExampleMod/Content/Projectiles/ExamplePiercingProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExamplePiercingProjectile.cs
@@ -68,10 +68,6 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override string Texture => $"Terraria/Images/Item_{ItemID.FlintlockPistol}";
 
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.FlintlockPistol);
 			Item.useAmmo = AmmoID.None;

--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -40,7 +40,6 @@ namespace ExampleMod.Content.Projectiles.Minions
 	public class ExampleSimpleMinionItem : ModItem
 	{
 		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
 			ItemID.Sets.GamepadWholeScreenUseRange[Item.type] = true; // This lets the player target anywhere on the whole screen while using a controller
 			ItemID.Sets.LockOnIgnoresCollision[Item.type] = true;
 		}

--- a/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedGlowmaskTile.cs
@@ -85,10 +85,6 @@ namespace ExampleMod.Content.Tiles
 
 	internal class ExampleAnimatedGlowmaskTileItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.VoidMonolith);
 			Item.createTile = ModContent.TileType<ExampleAnimatedGlowmaskTile>();

--- a/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
+++ b/ExampleMod/Content/Tiles/ExampleAnimatedTile.cs
@@ -151,10 +151,6 @@ namespace ExampleMod.Content.Tiles
 
 	internal class ExampleAnimatedTileItem : ModItem
 	{
-		public override void SetStaticDefaults() {
-			Item.ResearchUnlockCount = 1;
-		}
-
 		public override void SetDefaults() {
 			Item.CloneDefaults(ItemID.FireflyinaBottle);
 			Item.createTile = ModContent.TileType<ExampleAnimatedTile>();

--- a/patches/tModLoader/Terraria/Item.TML.Utils.cs
+++ b/patches/tModLoader/Terraria/Item.TML.Utils.cs
@@ -8,10 +8,16 @@ partial class Item
 {
 	/// <summary>
 	/// A utility property for easily geting or setting the amount of items required for this item's current type to be researched.
+	/// <br/> By default, all modded items will have this set to 1. Set to 0 for unresearchable items, such as items that disappear on pickup. The <see href="https://terraria.wiki.gg/wiki/Journey_Mode#Research">Journey Mode Research wiki page</see> lists values for various types of items, use it as a guide for consistency.
 	/// <br/> <b>NOTE:</b> The accessed values are stored per item type, not per item instance. You're recommended to only use the setter in load-time hooks, like <see cref="ModType.SetStaticDefaults"/>.
 	/// </summary>
 	public int ResearchUnlockCount {
 		get => CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId.TryGetValue(type, out int result) ? result : 0;
-		set => CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[type] = value;
+		set {
+			if (value < 1)
+				CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId.Remove(type); // 0 would behave incorrectly, so remove.
+			else
+				CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[type] = value;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
@@ -18,8 +18,6 @@ internal abstract class DeveloperItem : ModLoaderModItem
 		displayName = displayName.Insert(displayName.IndexOf(' '), SetSuffix);
 		DisplayName.SetDefault(displayName);
 		*/
-
-		Item.ResearchUnlockCount = 1;
 	}
 
 	public override void SetDefaults()

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
@@ -34,8 +34,6 @@ internal abstract class PatreonItem : ModLoaderModItem
 
 		DisplayName.SetDefault(displayName);
 		*/
-
-		Item.ResearchUnlockCount = 1;
 	}
 
 	public override void SetDefaults()

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -49,14 +49,6 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 	/// </summary>
 	public virtual string Texture => (GetType().Namespace + "." + Name).Replace('.', '/');//GetType().FullName.Replace('.', '/');
 
-	// Deprecation date: 2022.12.XX
-	/// <inheritdoc cref="Item.ResearchUnlockCount"/>
-	[Obsolete($"Use {nameof(Item)}.{nameof(Terraria.Item.ResearchUnlockCount)} instead.", error: true)]
-	public int SacrificeTotal {
-		get => Item.ResearchUnlockCount;
-		set => Item.ResearchUnlockCount = value;
-	}
-
 	protected override Item CreateTemplateEntity() => new() { ModItem = this };
 
 	protected override void ValidateType()
@@ -131,6 +123,8 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 		if (ModContent.RequestIfExists<Texture2D>(Texture + "_Flame", out var flameTexture)) {
 			TextureAssets.ItemFlame[Item.type] = flameTexture;
 		}
+
+		Item.ResearchUnlockCount = 1;
 	}
 
 	/// <summary>


### PR DESCRIPTION
All items will now default to 1, allowing the vast majority of ModItem classes to remove
```
public override void SetStaticDefaults() {
	Item.ResearchUnlockCount = 1;
}
```
from their code.

This is left up to the modder if they wish to take advantage.

## Porting Notes:
This is almost entirely optional. The only thing is ModItems that should never exist in the inventory, or should otherwise not be researchable, now need `Item.ResearchUnlockCount = 0;` added where previously, they would be unsearchable by default.