### PR TITLE
PostSetupTileMerge hook, fixes related to tile merging

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
@@ -22,6 +22,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileSolid[Type] = true;
 			Main.tileNoAttach[Type] = true;
 			Main.tileLavaDeath[Type] = true;
+			TileID.Sets.BlockMergesWithMergeAllBlockOverride[Type] = false;
 			TileID.Sets.NotReallySolid[Type] = true;
 			TileID.Sets.DrawsWalls[Type] = true;
 			TileID.Sets.HasOutlines[Type] = true;

--- a/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDoorClosed.cs
@@ -22,7 +22,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 			Main.tileSolid[Type] = true;
 			Main.tileNoAttach[Type] = true;
 			Main.tileLavaDeath[Type] = true;
-			TileID.Sets.BlockMergesWithMergeAllBlockOverride[Type] = false;
 			TileID.Sets.NotReallySolid[Type] = true;
 			TileID.Sets.DrawsWalls[Type] = true;
 			TileID.Sets.HasOutlines[Type] = true;

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -76,6 +76,12 @@ partial class TileID
 		/// </summary>
 		public static bool[] WallsMergeWith = Factory.CreateBoolSet(Glass);
 
+		// Values taken from Main.SetupTileMerge
+		/// <summary>
+		/// The value a tile forces to be set for <see cref="BlockMergesWithMergeAllBlock"/> regardless of default conditions (see its documentation). null by default.
+		/// </summary>
+		public static bool?[] BlockMergesWithMergeAllBlockOverride = Factory.CreateCustomSet<bool?>(null, 10, false, 387, false, 541, false);
+
 		/// New created sets to facilitate vanilla biome block counting including modded blocks. To replace the current hardcoded counts in SceneMetrics.cs
 		public static int[] CorruptBiome = Factory.CreateIntSet(0, 23, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10);
 		public static int[] HallowBiome = Factory.CreateIntSet(0, 109, 1, 492, 1, 110, 1, 113, 1, 117, 1, 116, 1, 164, 1, 403, 1, 402, 1);

--- a/patches/tModLoader/Terraria/ID/TileID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/TileID.cs.patch
@@ -24,3 +24,14 @@
  		public static bool[] IceSkateSlippery = Factory.CreateBoolSet(161, 162, 127, 163, 164, 200, 659);
  		public static bool[] DontDrawTileSliced = Factory.CreateBoolSet(false, 137, 235, 388, 476, 160, 138, 664, 665, 630, 631);
  		public static bool[] AllowsSaveCompressionBatching = Factory.CreateBoolSet(true, 520, 423);
+@@ -248,6 +_,10 @@
+ 		public static bool[] TouchDamageBleeding = Factory.CreateBoolSet(48, 232);
+ 		public static int[] TouchDamageImmediate = Factory.CreateIntSet(0, 32, 10, 69, 17, 80, 6, 352, 10, 655, 100, 48, 60, 232, 80, 484, 25);
+ 		public static bool[] Falling = Factory.CreateBoolSet(53, 234, 112, 116, 224, 123, 330, 331, 332, 333, 495);
++		/// <summary>
++		/// Set to true automatically for all tiles that are <see cref="Main.tileSolid"/> and not <see cref="Main.tileSolidTop"/>. These tiles will merge with other tiles that are <see cref="Main.tileBlendAll"/>.
++		/// <br/>You can modify this in <see cref="ModTile.PostSetupTileMerge"/>.
++		/// </summary>
+ 		public static bool[] BlockMergesWithMergeAllBlock = Factory.CreateBoolSet();
+ 		public static bool[] OreMergesWithMud = Factory.CreateBoolSet(7, 166, 6, 167, 9, 168, 8, 169, 22, 204, 37, 58, 107, 221, 108, 222, 111, 223);
+ 		public static bool[] Ore = Factory.CreateBoolSet(7, 166, 6, 167, 9, 168, 8, 169, 22, 204, 37, 58, 107, 221, 108, 222, 111, 223, 211);

--- a/patches/tModLoader/Terraria/ID/TileID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/TileID.cs.patch
@@ -24,13 +24,14 @@
  		public static bool[] IceSkateSlippery = Factory.CreateBoolSet(161, 162, 127, 163, 164, 200, 659);
  		public static bool[] DontDrawTileSliced = Factory.CreateBoolSet(false, 137, 235, 388, 476, 160, 138, 664, 665, 630, 631);
  		public static bool[] AllowsSaveCompressionBatching = Factory.CreateBoolSet(true, 520, 423);
-@@ -248,6 +_,10 @@
+@@ -248,6 +_,11 @@
  		public static bool[] TouchDamageBleeding = Factory.CreateBoolSet(48, 232);
  		public static int[] TouchDamageImmediate = Factory.CreateIntSet(0, 32, 10, 69, 17, 80, 6, 352, 10, 655, 100, 48, 60, 232, 80, 484, 25);
  		public static bool[] Falling = Factory.CreateBoolSet(53, 234, 112, 116, 224, 123, 330, 331, 332, 333, 495);
++		// Conditions taken from Main.SetupTileMerge
 +		/// <summary>
 +		/// Set to true automatically for all tiles that are <see cref="Main.tileSolid"/> and not <see cref="Main.tileSolidTop"/>. These tiles will merge with other tiles that are <see cref="Main.tileBlendAll"/>.
-+		/// <br/>You can modify this in <see cref="ModTile.PostSetupTileMerge"/>.
++		/// <br/>You can force a value to be assigned using <see cref="BlockMergesWithMergeAllBlockOverride"/> in <see cref="ModType.SetStaticDefaults"/>, as this is set is populated afterwards, ignoring edits to it.
 +		/// </summary>
  		public static bool[] BlockMergesWithMergeAllBlock = Factory.CreateBoolSet();
  		public static bool[] OreMergesWithMud = Factory.CreateBoolSet(7, 166, 6, 167, 9, 168, 8, 169, 22, 204, 37, 58, 107, 221, 108, 222, 111, 223);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -448,7 +448,7 @@
  	{
  		int count = TileID.Count;
  		tileMerge = new bool[count][];
-@@ -2842,12 +_,23 @@
+@@ -2842,12 +_,29 @@
  			tileMerge[i] = new bool[count];
  		}
  
@@ -459,7 +459,13 @@
 +	{
 -		for (int j = 0; j < TileID.Count; j++) {
 +		for (int j = 0; j < count; j++) {
++			// TML: moved these cases into BlockMergesWithMergeAllBlockOverride
  			bool flag = j == 10 || j == 387 || j == 541;
++			if (TileID.Sets.BlockMergesWithMergeAllBlockOverride[j] is bool mergeOverride) {
++				TileID.Sets.BlockMergesWithMergeAllBlock[j] = mergeOverride;
++				continue;
++			}
++
  			TileID.Sets.BlockMergesWithMergeAllBlock[j] = !flag && tileSolid[j] && !tileSolidTop[j];
  		}
  	}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -433,7 +433,7 @@
  
  	public static string playerPathName => ActivePlayerFileData.Path;
  
-@@ -2831,6 +_,8 @@
+@@ -2831,10 +_,13 @@
  		}
  
  		result.X = num;
@@ -442,7 +442,25 @@
  		return result;
  	}
  
-@@ -2848,6 +_,12 @@
++	// TML: Internal for vanilla content specifically, added count parameter to public method and removed tileMerge reset (handled by ResizeArrays)
+-	public static void SetupTileMerge()
++	internal static void SetupTileMerge()
+ 	{
+ 		int count = TileID.Count;
+ 		tileMerge = new bool[count][];
+@@ -2842,12 +_,23 @@
+ 			tileMerge[i] = new bool[count];
+ 		}
+ 
++		SetupTileMerge(count);
++	}
++
++	public static void SetupTileMerge(int count)
++	{
+-		for (int j = 0; j < TileID.Count; j++) {
++		for (int j = 0; j < count; j++) {
+ 			bool flag = j == 10 || j == 387 || j == 541;
+ 			TileID.Sets.BlockMergesWithMergeAllBlock[j] = !flag && tileSolid[j] && !tileSolidTop[j];
  		}
  	}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -433,7 +433,7 @@
  
  	public static string playerPathName => ActivePlayerFileData.Path;
  
-@@ -2831,10 +_,13 @@
+@@ -2831,6 +_,8 @@
  		}
  
  		result.X = num;
@@ -442,29 +442,28 @@
  		return result;
  	}
  
-+	// TML: Internal for vanilla content specifically, added count parameter to public method and removed tileMerge reset (handled by ResizeArrays)
--	public static void SetupTileMerge()
-+	internal static void SetupTileMerge()
- 	{
- 		int count = TileID.Count;
- 		tileMerge = new bool[count][];
-@@ -2842,12 +_,29 @@
+@@ -2842,12 +_,34 @@
  			tileMerge[i] = new bool[count];
  		}
  
-+		SetupTileMerge(count);
++		SetupAllBlockMerge();
 +	}
 +
-+	public static void SetupTileMerge(int count)
++	// internal split to be called by TileLoader, to avoid tileMerge reset (handled by ResizeArrays)
++	internal static void SetupAllBlockMerge()
 +	{
 -		for (int j = 0; j < TileID.Count; j++) {
-+		for (int j = 0; j < count; j++) {
++		for (int j = 0; j < TileLoader.TileCount; j++) {
 +			// TML: moved these cases into BlockMergesWithMergeAllBlockOverride
  			bool flag = j == 10 || j == 387 || j == 541;
 +			if (TileID.Sets.BlockMergesWithMergeAllBlockOverride[j] is bool mergeOverride) {
 +				TileID.Sets.BlockMergesWithMergeAllBlock[j] = mergeOverride;
 +				continue;
 +			}
++
++			// TML: 10 is the closed door tile, so make modded closed doors also match. This code runs after they have set their OpenDoorID
++			if (TileLoader.IsClosedDoor(j))
++				flag = true;
 +
  			TileID.Sets.BlockMergesWithMergeAllBlock[j] = !flag && tileSolid[j] && !tileSolidTop[j];
  		}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -277,8 +277,7 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// Allows you to set <see cref="TileID.Sets.BlockMergesWithMergeAllBlock"/> to false if you don't want a tile to merge with other tiles in <see cref="Main.tileBlendAll"/> (Echo Block does this).
-	/// <br/>Can be used to adjust other tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
+	/// Can be used to adjust tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
 	/// </summary>
 	public virtual void PostSetupTileMerge()
 	{

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using Terraria.DataStructures;
+using Terraria.ID;
 
 namespace Terraria.ModLoader;
 
@@ -272,6 +273,14 @@ public abstract class GlobalTile : GlobalBlockType
 	/// <param name="type"></param>
 	/// <param name="style"></param>
 	public virtual void ChangeWaterfallStyle(int type, ref int style)
+	{
+	}
+
+	/// <summary>
+	/// Allows you to set <see cref="TileID.Sets.BlockMergesWithMergeAllBlock"/> to false if you don't want a tile to merge with other tiles in <see cref="Main.tileBlendAll"/> (Echo Block does this).
+	/// <br/>Can be used to adjust other tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
+	/// </summary>
+	public virtual void PostSetupTileMerge()
 	{
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -325,6 +325,7 @@ public static class ModContent
 		BuffLoader.FinishSetup();
 		ItemLoader.FinishSetup();
 		NPCLoader.FinishSetup();
+		TileLoader.FinishSetup();
 		PrefixLoader.FinishSetup();
 		ProjectileLoader.FinishSetup();
 		PylonLoader.FinishSetup();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -305,6 +305,7 @@ public static class ModContent
 		});
 
 		ContentSamples.Initialize();
+		TileLoader.PostSetupContent();
 
 		Interface.loadMods.SetLoadStage("tModLoader.MSPostSetupContent", ModLoader.Mods.Length);
 		LoadModContent(token, mod => {
@@ -325,7 +326,6 @@ public static class ModContent
 		BuffLoader.FinishSetup();
 		ItemLoader.FinishSetup();
 		NPCLoader.FinishSetup();
-		TileLoader.FinishSetup();
 		PrefixLoader.FinishSetup();
 		ProjectileLoader.FinishSetup();
 		PylonLoader.FinishSetup();

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -457,8 +457,7 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Allows you to set <see cref="TileID.Sets.BlockMergesWithMergeAllBlock"/> to false if you don't want your tile to merge with other tiles in <see cref="Main.tileBlendAll"/> (Echo Block does this).
-	/// <br/>Can be used to adjust other tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
+	/// Can be used to adjust tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
 	/// </summary>
 	public virtual void PostSetupTileMerge()
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -457,6 +457,14 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Allows you to set <see cref="TileID.Sets.BlockMergesWithMergeAllBlock"/> to false if you don't want your tile to merge with other tiles in <see cref="Main.tileBlendAll"/> (Echo Block does this).
+	/// <br/>Can be used to adjust other tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
+	/// </summary>
+	public virtual void PostSetupTileMerge()
+	{
+	}
+
+	/// <summary>
 	/// Return true if this Tile corresponds to a chest that is locked. Prevents Quick Stacking items into the chest.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -244,7 +244,7 @@ public static class TileLoader
 
 	internal static void PostSetupContent()
 	{
-		Main.SetupTileMerge(TileCount);
+		Main.SetupAllBlockMerge();
 		PostSetupTileMerge();
 	}
 
@@ -377,18 +377,21 @@ public static class TileLoader
 		return -1;
 	}
 
+	/// <inheritdoc cref="IsClosedDoor(int)"/>
+	public static bool IsClosedDoor(Tile tile) => IsClosedDoor(tile.type);
+
 	/// <summary>
 	/// Returns true if the tile is a vanilla or modded closed door.
 	/// </summary>
-	public static bool IsClosedDoor(Tile tile)
+	public static bool IsClosedDoor(int type)
 	{
-		ModTile modTile = GetTile(tile.type);
+		ModTile modTile = GetTile(type);
 
 		if (modTile != null) {
 			return modTile.OpenDoorID > -1;
 		}
 
-		return tile.type == TileID.ClosedDoor;
+		return type == TileID.ClosedDoor;
 	}
 
 	public static string ContainerName(int type, int frameX, int frameY) => GetTile(type)?.ContainerName(frameY, frameY)?.Value ?? string.Empty;
@@ -1023,8 +1026,7 @@ public static class TileLoader
 			hook();
 		}
 
-		for (int i = 0; i < tiles.Count; i++) {
-			ModTile modTile = tiles[i];
+		foreach (var modTile in tiles) {
 			modTile.PostSetupTileMerge();
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -242,7 +242,7 @@ public static class TileLoader
 		}
 	}
 
-	internal static void FinishSetup()
+	internal static void PostSetupContent()
 	{
 		Main.SetupTileMerge(TileCount);
 		PostSetupTileMerge();

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -89,6 +89,7 @@ public static class TileLoader
 	private delegate void DelegateChangeWaterfallStyle(int type, ref int style);
 	private static DelegateChangeWaterfallStyle[] HookChangeWaterfallStyle;
 	private static Action<int, int, int, Item>[] HookPlaceInWorld;
+	private static Action[] HookPostSetupTileMerge;
 
 	internal static int ReserveTileID()
 	{
@@ -234,10 +235,17 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook(ref HookFloorVisuals, globalTiles, g => g.FloorVisuals);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateChangeWaterfallStyle>(ref HookChangeWaterfallStyle, globalTiles, g => g.ChangeWaterfallStyle);
 		ModLoader.BuildGlobalHook(ref HookPlaceInWorld, globalTiles, g => g.PlaceInWorld);
+		ModLoader.BuildGlobalHook(ref HookPostSetupTileMerge, globalTiles, g => g.PostSetupTileMerge);
 
 		if (!unloading) {
 			loaded = true;
 		}
+	}
+
+	internal static void FinishSetup()
+	{
+		Main.SetupTileMerge(TileCount);
+		PostSetupTileMerge();
 	}
 
 	internal static void Unload()
@@ -1007,6 +1015,18 @@ public static class TileLoader
 		}
 
 		GetTile(type)?.PlaceInWorld(i, j, item);
+	}
+
+	public static void PostSetupTileMerge()
+	{
+		foreach (var hook in HookPostSetupTileMerge) {
+			hook();
+		}
+
+		for (int i = 0; i < tiles.Count; i++) {
+			ModTile modTile = tiles[i];
+			modTile.PostSetupTileMerge();
+		}
 	}
 
 	public static bool IsLockedChest(int i, int j, int type)


### PR DESCRIPTION
### What is the new feature?
`Mod/GlobalTile.PostSetupTileMerge` hook to go with a restructuring of `Main.SetupTileMerge` to cover modded tiles (fixing a bug with `TileID.Sets.BlockMergesWithMergeAllBlock` not being automatically assigned to modded tiles (**i.e. closed doors, implicit tml support added here**), and the set being reset without a reassignment, causing Smooth Marble Block to not merge with certain vanilla tiles), and allow safer dynamic changes to tile merging.
To implement behavior similar to Echo Block and closed trap doors without overriding the hook, a new `BlockMergesWithMergeAllBlockOverride` set is added, allowing changing this specific behavior all through the commonly used `SetStaticDefaults` before vanilla automatically assigns it to the formerly mentioned set.
For implicit modded closed door support, an overload for `TileLoader.IsClosedDoor` was required.

### Why should this be part of tModLoader?
* Calling the code used in `Main.SetupTileMerge` by tml manually after mods finished loading is required for compatibility with vanilla/other mods.
* Safe timing (not "undefined" in the case of `SetStaticDefaults`) where it's guaranteed that most mods have set tile related properties for all their tiles so other mods can poll for this state and do dynamic checks (similar to what vanilla does with `TileID.Sets.BlockMergesWithMergeAllBlock`) based on that data.

### Are there alternative designs?
The split done to `Main.SetupTileMerge` could be handled differently, I chose the parameter appoach as it keeps the method names the same. Another design would be to rename the internal one to "VanillaSetupTileMerge", and copy (and or redirect to) the method that uses fixed `TileLoader.TileCount` for the kept `Main.SetupTileMerge` (without parameter).
The main reason for the split is so that no patch should be made on the callsites, and so that `Main.tileMerge` isn't reset again.

Since vanilla doors don't merge with `tileBlendAll` tiles, tml could automatically support it using `TileLoader.IsClosedDoor`. This would not account for trap doors though, which tml has no support for.

### Sample usage for the new feature
Bugfix showcase with Example Block having `Main.tileBlendAll[Type] = true`:
Before the PR:
![Screenshot_3](https://user-images.githubusercontent.com/15894498/218076101-e33ef021-6f75-4691-bafd-6f9c95b2b626.png)

After the PR:
![Screenshot_4](https://user-images.githubusercontent.com/15894498/218076192-0e58c6df-756a-4670-b9ba-adaa1f940ad8.png)

Set showcase (disabling wood merging with the previously set "merge all" Example Block):
```cs
public class asd : GlobalTile
{
	public override void SetStaticDefaults() {
		TileID.Sets.BlockMergesWithMergeAllBlockOverride[TileID.WoodBlock] = false;
	}
}
```
![Screenshot_5](https://user-images.githubusercontent.com/15894498/218076437-e1018cc7-f806-4390-8d9b-81e120be3987.png)


### ExampleMod updates
ExampleDoorClosed is implicitely not merging, just like vanilla doors. No code changes required.
