### PR TITLE
[ExampleMod] reimplement ExampleBlock.ChangeWaterfallStyle

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Content/Tiles/ExampleBlock.cs
@@ -1,3 +1,4 @@
+using ExampleMod.Content.Biomes;
 using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
@@ -22,9 +23,8 @@ namespace ExampleMod.Content.Tiles
 			num = fail ? 1 : 3;
 		}
 
-		// todo: implement
-		// public override void ChangeWaterfallStyle(ref int style) {
-		// 	style = mod.GetWaterfallStyleSlot("ExampleWaterfallStyle");
-		// }
+		 public override void ChangeWaterfallStyle(ref int style) {
+			style = ModContent.GetInstance<ExampleWaterfallStyle>().Slot;
+		}
 	}
 }


### PR DESCRIPTION
### What is the bug?
`ExampleBlock` didn't cause waterfalls to change color.

### How did you fix the bug?
Implement `ChangeWaterfallStyle`. **Disclaimer: As per vanilla wiki, waterfalls are only visible on Quality settings above "Low"!**
![Screenshot_9](https://user-images.githubusercontent.com/15894498/218080063-a22a44b3-81ef-4d5e-8a45-890a770935ff.png)

### Are there alternatives to your fix?
`style` assignment can be changed to `Mod.Find<ModWaterfallStyle>(nameof(ExampleWaterfallStyle)).Slot` instead.
