### PR TITLE
Fix items falling through tiles and certain projectiles updating in non-loaded chunks in MP

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1696,6 +1696,15 @@
  			IEnumerable<Item> enumerable = recipe.requiredItem;
  			if (recipe.customShimmerResults != null)
  				enumerable = recipe.customShimmerResults;
+@@ -48004,7 +_,7 @@
+ 		if (Main.netMode == 1) {
+ 			int num = (int)(position.X + (float)(width / 2)) / 16;
+ 			int num2 = (int)(position.Y + (float)(height / 2)) / 16;
+-			if (num >= 0 && num2 >= 0 && num < Main.maxTilesX && num2 < Main.maxTilesY && Main.tile[num, num2] == null) {
++			if (num >= 0 && num2 >= 0 && num < Main.maxTilesX && num2 < Main.maxTilesY && !Main.sectionManager.TileLoaded(num, num2)) {
+ 				gravity = 0f;
+ 				velocity.X = 0f;
+ 				velocity.Y = 0f;
 @@ -48124,6 +_,8 @@
  			timeSinceItemSpawned += num7;
  		}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -942,6 +942,15 @@
  		if (myRect.Intersects(targetRect))
  			return true;
  
+@@ -12392,7 +_,7 @@
+ 		if (Main.netMode == 1 && (ProjectileID.Sets.IsAGolfBall[type] || type == 820)) {
+ 			int num = (int)(position.X + (float)(width / 2)) / 16;
+ 			int num2 = (int)(position.Y + (float)(height / 2)) / 16;
+-			if (Main.tile[num, num2] == null)
++			if (!Main.sectionManager.TileLoaded(num, num2))
+ 				return;
+ 		}
+ 
 @@ -12412,9 +_,16 @@
  			if (!noEnchantmentVisuals)
  				UpdateEnchantmentVisuals();


### PR DESCRIPTION
_This PR should be backported, as these bugs happen on stable/preview aswell. Backport should be easy apart from indentation changes, none of the fields used were changed or renamed._

### What is the bug?
In multiplayer, items which exist in places that the client has not loaded yet will fall through the world. This is most notably occuring to Fallen Stars which clip through clouds and land as items on the ground, which the player cannot pick up due to desync.
Similar fix done to certain projectiles (which prevents them from updating at all).

### How did you fix the bug?
Employ the same check used for `Player` and `NPC` to `Item` and `Projectile` (the latter only specifically does this for golf balls and Chum).

### Are there alternatives to your fix?
No.
There are plenty of other places where "client and tile is null" is done for checking if the tile is not loaded, fixing this is outside of the scope of this PR (i.e. rope placement, collision). I only fixed two very obvious ones.
