### PR TITLE
Fix 1.4.4 specific bugs caused by vanilla ID count restrictions

### DIFF
--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -1,5 +1,22 @@
 --- src/TerrariaNetCore/Terraria/Collision.cs
 +++ src/tModLoader/Terraria/Collision.cs
+@@ -3,6 +_,7 @@
+ using Microsoft.Xna.Framework;
+ using Terraria.DataStructures;
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria;
+ 
+@@ -1030,7 +_,7 @@
+ 		if (tile == null || !tile.active() || tile.inActive() || !Main.tileSolid[tile.type])
+ 			return false;
+ 
+-		if (treatPlatformsAsNonSolid && tile.type > 0 && tile.type <= TileID.Count && (TileID.Sets.Platforms[tile.type] || tile.type == 380))
++		if (treatPlatformsAsNonSolid && tile.type > 0 && tile.type <= TileLoader.TileCount && (TileID.Sets.Platforms[tile.type] || tile.type == 380))
+ 			return false;
+ 
+ 		int num = tile.blockType();
 @@ -2614,7 +_,10 @@
  			tile = Main.tile[num2, num3];
  			tile2 = Main.tile[num2, num3 - 1];

--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -13,7 +13,7 @@
  			return false;
  
 -		if (treatPlatformsAsNonSolid && tile.type > 0 && tile.type <= TileID.Count && (TileID.Sets.Platforms[tile.type] || tile.type == 380))
-+		if (treatPlatformsAsNonSolid && tile.type > 0 && tile.type <= TileLoader.TileCount && (TileID.Sets.Platforms[tile.type] || tile.type == 380))
++		if (treatPlatformsAsNonSolid && tile.type > 0 && (TileID.Sets.Platforms[tile.type] || tile.type == 380))
  			return false;
  
  		int num = tile.blockType();

--- a/patches/tModLoader/Terraria/DelegateMethods.cs.patch
+++ b/patches/tModLoader/Terraria/DelegateMethods.cs.patch
@@ -13,7 +13,7 @@
  			return false;
  
 -		if (tile2.type < 0 || tile2.type >= TileID.Count)
-+		if (tile2.type < 0 || tile2.type >= TileLoader.TileCount)
++		if (tile2.type < 0)
  			return false;
  
  		if (Main.tileSolid[tile2.type] && !TileID.Sets.Platforms[tile2.type])

--- a/patches/tModLoader/Terraria/DelegateMethods.cs.patch
+++ b/patches/tModLoader/Terraria/DelegateMethods.cs.patch
@@ -1,0 +1,19 @@
+--- src/TerrariaNetCore/Terraria/DelegateMethods.cs
++++ src/tModLoader/Terraria/DelegateMethods.cs
+@@ -5,6 +_,7 @@
+ using Terraria.Enums;
+ using Terraria.Graphics.Shaders;
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria;
+ 
+@@ -386,7 +_,7 @@
+ 		if (tile2 == null)
+ 			return false;
+ 
+-		if (tile2.type < 0 || tile2.type >= TileID.Count)
++		if (tile2.type < 0 || tile2.type >= TileLoader.TileCount)
+ 			return false;
+ 
+ 		if (Main.tileSolid[tile2.type] && !TileID.Sets.Platforms[tile2.type])

--- a/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
@@ -17,3 +17,21 @@
  		for (int i = position.X; i < position.X + 2; i++) {
  			for (int j = position.Y - 4; j <= position.Y; j++) {
  				Tile tile = Main.tile[i, j];
+@@ -267,7 +_,7 @@
+ 		int y = position.Y;
+ 		for (int i = 0; i < 20; i++) {
+ 			Tile tile = Main.tile[x + i * directionX, y];
+-			if ((!tile.active() || tile.type < 0 || tile.type >= TileID.Count || !TileID.Sets.IsAContainer[tile.type]) && tile.active() && Main.tileSolid[tile.type]) {
++			if ((!tile.active() || tile.type < 0 || tile.type >= TileLoader.TileCount || !TileID.Sets.IsAContainer[tile.type]) && tile.active() && Main.tileSolid[tile.type]) {
+ 				if (i >= 5 && !tile.actuator() && !Main.tileFrameImportant[tile.type] && TileID.Sets.CanBeClearedDuringGeneration[tile.type]) {
+ 					_dartTrapPlacementSpots.Add(new DartTrapPlacementAttempt(position, directionX, x, y, i, tile));
+ 					return true;
+@@ -331,7 +_,7 @@
+ 	private bool IsGoodSpotsForExplosive(int x, int y)
+ 	{
+ 		Tile tile = Main.tile[x, y];
+-		if (tile.active() && tile.type >= 0 && tile.type < TileID.Count && TileID.Sets.IsAContainer[tile.type])
++		if (tile.active() && tile.type >= 0 && tile.type < TileLoader.TileCount && TileID.Sets.IsAContainer[tile.type])
+ 			return false;
+ 
+ 		if (tile.active() && Main.tileSolid[tile.type] && !Main.tileFrameImportant[tile.type] && !Main.tileSolidTop[tile.type])

--- a/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Biomes/DeadMansChestBiome.cs.patch
@@ -22,7 +22,7 @@
  		for (int i = 0; i < 20; i++) {
  			Tile tile = Main.tile[x + i * directionX, y];
 -			if ((!tile.active() || tile.type < 0 || tile.type >= TileID.Count || !TileID.Sets.IsAContainer[tile.type]) && tile.active() && Main.tileSolid[tile.type]) {
-+			if ((!tile.active() || tile.type < 0 || tile.type >= TileLoader.TileCount || !TileID.Sets.IsAContainer[tile.type]) && tile.active() && Main.tileSolid[tile.type]) {
++			if ((!tile.active() || tile.type < 0 || !TileID.Sets.IsAContainer[tile.type]) && tile.active() && Main.tileSolid[tile.type]) {
  				if (i >= 5 && !tile.actuator() && !Main.tileFrameImportant[tile.type] && TileID.Sets.CanBeClearedDuringGeneration[tile.type]) {
  					_dartTrapPlacementSpots.Add(new DartTrapPlacementAttempt(position, directionX, x, y, i, tile));
  					return true;
@@ -31,7 +31,7 @@
  	{
  		Tile tile = Main.tile[x, y];
 -		if (tile.active() && tile.type >= 0 && tile.type < TileID.Count && TileID.Sets.IsAContainer[tile.type])
-+		if (tile.active() && tile.type >= 0 && tile.type < TileLoader.TileCount && TileID.Sets.IsAContainer[tile.type])
++		if (tile.active() && tile.type >= 0 && TileID.Sets.IsAContainer[tile.type])
  			return false;
  
  		if (tile.active() && Main.tileSolid[tile.type] && !Main.tileFrameImportant[tile.type] && !Main.tileSolidTop[tile.type])

--- a/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
@@ -26,6 +26,24 @@
  					break;
  				case 314:
  					if (providedInfo.player.gravDir == 1f)
+@@ -732,7 +_,7 @@
+ 
+ 	private static void Step_Boulders(SmartCursorUsageInfo providedInfo, ref int focusedX, ref int focusedY)
+ 	{
+-		if (providedInfo.item.createTile <= -1 || providedInfo.item.createTile >= TileID.Count || !TileID.Sets.Boulders[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
++		if (providedInfo.item.createTile <= -1 || providedInfo.item.createTile >= TileLoader.TileCount || !TileID.Sets.Boulders[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
+ 			return;
+ 
+ 		_targets.Clear();
+@@ -875,7 +_,7 @@
+ 				for (int k = i; k <= i + 1; k++) {
+ 					for (int l = j - 1; l <= j; l++) {
+ 						Tile tile3 = Main.tile[k, l];
+-						if (tile3.active() && (tile3.type < 0 || tile3.type >= TileID.Count || Main.tileSolid[tile3.type] || !WorldGen.CanCutTile(k, l, TileCuttingContext.TilePlacement)))
++						if (tile3.active() && (tile3.type < 0 || tile3.type >= TileLoader.TileCount || Main.tileSolid[tile3.type] || !WorldGen.CanCutTile(k, l, TileCuttingContext.TilePlacement)))
+ 							flag = false;
+ 					}
+ 				}
 @@ -1654,11 +_,13 @@
  				if ((tile.active() && !Main.tileCut[tile.type] && !TileID.Sets.BreakableWhenPlacing[tile.type]) || (tile2.active() && !Main.tileCut[tile2.type] && !TileID.Sets.BreakableWhenPlacing[tile2.type]) || (tile4.active() && TileID.Sets.CommonSapling[tile4.type]) || (tile5.active() && TileID.Sets.CommonSapling[tile5.type]) || (tile6.active() && TileID.Sets.CommonSapling[tile6.type]) || (tile7.active() && TileID.Sets.CommonSapling[tile7.type]) || (tile8.active() && TileID.Sets.CommonSapling[tile8.type]) || (tile9.active() && TileID.Sets.CommonSapling[tile9.type]) || !tile3.active() || !WorldGen.SolidTile2(tile3))
  					continue;

--- a/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
@@ -26,6 +26,24 @@
  					break;
  				case 314:
  					if (providedInfo.player.gravDir == 1f)
+@@ -251,7 +_,7 @@
+ 			return;
+ 
+ 		int type = providedInfo.item.type;
+-		if (type < 0 || type >= ItemID.Count || !ItemID.Sets.GrassSeeds[type])
++		if (type < 0 || type >= ItemLoader.ItemCount || !ItemID.Sets.GrassSeeds[type])
+ 			return;
+ 
+ 		_targets.Clear();
+@@ -672,7 +_,7 @@
+ 	private static void Step_BlocksLines(SmartCursorUsageInfo providedInfo, ref int focusedX, ref int focusedY)
+ 	{
+ 		int type = providedInfo.item.type;
+-		if (type < 0 || type >= ItemID.Count || !Player.SmartCursorSettings.SmartBlocksEnabled || providedInfo.item.createTile <= -1 || type == 213 || type == 5295 || ItemID.Sets.GrassSeeds[type] || !Main.tileSolid[providedInfo.item.createTile] || Main.tileSolidTop[providedInfo.item.createTile] || Main.tileFrameImportant[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
++		if (type < 0 || type >= ItemLoader.ItemCount || !Player.SmartCursorSettings.SmartBlocksEnabled || providedInfo.item.createTile <= -1 || type == 213 || type == 5295 || ItemID.Sets.GrassSeeds[type] || !Main.tileSolid[providedInfo.item.createTile] || Main.tileSolidTop[providedInfo.item.createTile] || Main.tileFrameImportant[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
+ 			return;
+ 
+ 		_targets.Clear();
 @@ -732,7 +_,7 @@
  
  	private static void Step_Boulders(SmartCursorUsageInfo providedInfo, ref int focusedX, ref int focusedY)
@@ -92,6 +110,15 @@
  					switch (tile10.type) {
  						case 2:
  						case 23:
+@@ -2183,7 +_,7 @@
+ 			return;
+ 
+ 		int type = providedInfo.item.type;
+-		if (type < 0 || type >= ItemID.Count)
++		if (type < 0 || type >= ItemLoader.ItemCount)
+ 			return;
+ 
+ 		int reachableStartX = providedInfo.reachableStartX;
 @@ -2269,7 +_,7 @@
  		int reachableEndY = providedInfo.reachableEndY;
  		_ = providedInfo.screenTargetX;

--- a/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
@@ -31,7 +31,7 @@
  
  		int type = providedInfo.item.type;
 -		if (type < 0 || type >= ItemID.Count || !ItemID.Sets.GrassSeeds[type])
-+		if (type < 0 || type >= ItemLoader.ItemCount || !ItemID.Sets.GrassSeeds[type])
++		if (type < 0 || !ItemID.Sets.GrassSeeds[type])
  			return;
  
  		_targets.Clear();
@@ -40,7 +40,7 @@
  	{
  		int type = providedInfo.item.type;
 -		if (type < 0 || type >= ItemID.Count || !Player.SmartCursorSettings.SmartBlocksEnabled || providedInfo.item.createTile <= -1 || type == 213 || type == 5295 || ItemID.Sets.GrassSeeds[type] || !Main.tileSolid[providedInfo.item.createTile] || Main.tileSolidTop[providedInfo.item.createTile] || Main.tileFrameImportant[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
-+		if (type < 0 || type >= ItemLoader.ItemCount || !Player.SmartCursorSettings.SmartBlocksEnabled || providedInfo.item.createTile <= -1 || type == 213 || type == 5295 || ItemID.Sets.GrassSeeds[type] || !Main.tileSolid[providedInfo.item.createTile] || Main.tileSolidTop[providedInfo.item.createTile] || Main.tileFrameImportant[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
++		if (type < 0 || !Player.SmartCursorSettings.SmartBlocksEnabled || providedInfo.item.createTile <= -1 || type == 213 || type == 5295 || ItemID.Sets.GrassSeeds[type] || !Main.tileSolid[providedInfo.item.createTile] || Main.tileSolidTop[providedInfo.item.createTile] || Main.tileFrameImportant[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
  			return;
  
  		_targets.Clear();
@@ -49,7 +49,7 @@
  	private static void Step_Boulders(SmartCursorUsageInfo providedInfo, ref int focusedX, ref int focusedY)
  	{
 -		if (providedInfo.item.createTile <= -1 || providedInfo.item.createTile >= TileID.Count || !TileID.Sets.Boulders[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
-+		if (providedInfo.item.createTile <= -1 || providedInfo.item.createTile >= TileLoader.TileCount || !TileID.Sets.Boulders[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
++		if (providedInfo.item.createTile <= -1 || !TileID.Sets.Boulders[providedInfo.item.createTile] || focusedX != -1 || focusedY != -1)
  			return;
  
  		_targets.Clear();
@@ -58,7 +58,7 @@
  					for (int l = j - 1; l <= j; l++) {
  						Tile tile3 = Main.tile[k, l];
 -						if (tile3.active() && (tile3.type < 0 || tile3.type >= TileID.Count || Main.tileSolid[tile3.type] || !WorldGen.CanCutTile(k, l, TileCuttingContext.TilePlacement)))
-+						if (tile3.active() && (tile3.type < 0 || tile3.type >= TileLoader.TileCount || Main.tileSolid[tile3.type] || !WorldGen.CanCutTile(k, l, TileCuttingContext.TilePlacement)))
++						if (tile3.active() && (tile3.type < 0 || Main.tileSolid[tile3.type] || !WorldGen.CanCutTile(k, l, TileCuttingContext.TilePlacement)))
  							flag = false;
  					}
  				}
@@ -115,7 +115,7 @@
  
  		int type = providedInfo.item.type;
 -		if (type < 0 || type >= ItemID.Count)
-+		if (type < 0 || type >= ItemLoader.ItemCount)
++		if (type < 0)
  			return;
  
  		int reachableStartX = providedInfo.reachableStartX;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1723,6 +1723,15 @@
  		if (!shimmered && ItemID.Sets.ItemNoGravity[type]) {
  			velocity.X *= 0.95f;
  			if ((double)velocity.X < 0.1 && (double)velocity.X > -0.1)
+@@ -48553,7 +_,7 @@
+ 		Rectangle hitbox = base.Hitbox;
+ 		for (int j = 0; j < 200; j++) {
+ 			NPC nPC = Main.npc[j];
+-			if (nPC.active && flag && nPC.type >= 0 && nPC.type < NPCID.Count && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type] && hitbox.Intersects(nPC.Hitbox)) {
++			if (nPC.active && flag && nPC.type >= 0 && nPC.type < NPCLoader.NPCCount && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type] && hitbox.Intersects(nPC.Hitbox)) {
+ 				flag3 = true;
+ 				NPC.TransformCopperSlime(j);
+ 				break;
 @@ -48669,14 +_,26 @@
  				num2 *= 2;
  

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1728,7 +1728,7 @@
  		for (int j = 0; j < 200; j++) {
  			NPC nPC = Main.npc[j];
 -			if (nPC.active && flag && nPC.type >= 0 && nPC.type < NPCID.Count && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type] && hitbox.Intersects(nPC.Hitbox)) {
-+			if (nPC.active && flag && nPC.type >= 0 && nPC.type < NPCLoader.NPCCount && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type] && hitbox.Intersects(nPC.Hitbox)) {
++			if (nPC.active && flag && nPC.type >= 0 && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type] && hitbox.Intersects(nPC.Hitbox)) {
  				flag3 = true;
  				NPC.TransformCopperSlime(j);
  				break;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -675,7 +675,7 @@
  			getTenthAnniversaryAdjustments();
  
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		if (type >= 0 && type < NPCLoader.NPCCount && Main.npcCatchable[type]) {
++		if (type >= 0 && Main.npcCatchable[type]) {
  			catchableNPCTempImmunityCounter = 90;
  			friendly = true;
  		}
@@ -699,7 +699,7 @@
  		else if (!unlockedSlimeCopperSpawn && Main.npc.IndexInRange(npcIndex)) {
  			NPC nPC = Main.npc[npcIndex];
 -			if (nPC.type >= 0 && nPC.type < NPCID.Count && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type]) {
-+			if (nPC.type >= 0 && nPC.type < NPCLoader.NPCCount && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type]) {
++			if (nPC.type >= 0 && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type]) {
  				unlockedSlimeCopperSpawn = true;
  				NetMessage.SendData(7);
  				Vector2 vector = nPC.velocity;
@@ -1438,9 +1438,9 @@
  			return false;
  
 -		if (tile.wall < 0 || tile.wall >= WallID.Count || !wallTypes[tile.wall]) {
-+		if (tile.wall < 0 || tile.wall >= WallLoader.WallCount || !wallTypes[tile.wall]) {
 -			if (tile2.wall >= 0 && tile2.wall < WallID.Count)
-+			if (tile2.wall >= 0 && tile2.wall < WallLoader.WallCount)
++		if (tile.wall < 0 || !wallTypes[tile.wall]) {
++			if (tile2.wall >= 0)
  				return wallTypes[tile2.wall];
  
  			return false;
@@ -1814,7 +1814,7 @@
  	private void SubAI_HandleTemporaryCatchableNPCPlayerInvulnerability()
  	{
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		if (type >= 0 && type < NPCLoader.NPCCount && Main.npcCatchable[type]) {
++		if (type >= 0 && Main.npcCatchable[type]) {
  			if (releaseOwner != 255 || SpawnedFromStatue)
  				catchableNPCTempImmunityCounter = 0;
  

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1433,6 +1433,17 @@
  			switch (Type) {
  				case 583:
  				case 584:
+@@ -60465,8 +_,8 @@
+ 		if (tile == null || tile2 == null)
+ 			return false;
+ 
+-		if (tile.wall < 0 || tile.wall >= WallID.Count || !wallTypes[tile.wall]) {
++		if (tile.wall < 0 || tile.wall >= WallLoader.WallCount || !wallTypes[tile.wall]) {
+-			if (tile2.wall >= 0 && tile2.wall < WallID.Count)
++			if (tile2.wall >= 0 && tile2.wall < WallLoader.WallCount)
+ 				return wallTypes[tile2.wall];
+ 
+ 			return false;
 @@ -60513,6 +_,8 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -670,7 +670,13 @@
  		if (spawnparams.sizeScaleOverride.HasValue) {
  			int num3 = (int)((float)width * scale);
  			int num4 = (int)((float)height * scale);
-@@ -10846,7 +_,7 @@
+@@ -10841,12 +_,12 @@
+ 		else if (Main.tenthAnniversaryWorld)
+ 			getTenthAnniversaryAdjustments();
+ 
+-		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
++		if (type >= 0 && type < NPCLoader.NPCCount && Main.npcCatchable[type]) {
+ 			catchableNPCTempImmunityCounter = 90;
  			friendly = true;
  		}
  
@@ -688,6 +694,15 @@
  		defDefense = defense;
  		defDamage = damage;
  		life = lifeMax;
+@@ -11823,7 +_,7 @@
+ 		}
+ 		else if (!unlockedSlimeCopperSpawn && Main.npc.IndexInRange(npcIndex)) {
+ 			NPC nPC = Main.npc[npcIndex];
+-			if (nPC.type >= 0 && nPC.type < NPCID.Count && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type]) {
++			if (nPC.type >= 0 && nPC.type < NPCLoader.NPCCount && NPCID.Sets.CanConvertIntoCopperSlimeTownNPC[nPC.type]) {
+ 				unlockedSlimeCopperSpawn = true;
+ 				NetMessage.SendData(7);
+ 				Vector2 vector = nPC.velocity;
 @@ -11877,7 +_,8 @@
  			if (flag)
  				vector3 = vector;
@@ -1783,6 +1798,15 @@
  		UpdateNPC_BuffSetFlags();
  		UpdateNPC_SoulDrainDebuff();
  		UpdateNPC_BuffClearExpiredBuffs();
+@@ -72655,7 +_,7 @@
+ 
+ 	private void SubAI_HandleTemporaryCatchableNPCPlayerInvulnerability()
+ 	{
+-		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
++		if (type >= 0 && type < NPCLoader.NPCCount && Main.npcCatchable[type]) {
+ 			if (releaseOwner != 255 || SpawnedFromStatue)
+ 				catchableNPCTempImmunityCounter = 0;
+ 
 @@ -72760,6 +_,8 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2145,7 +2145,7 @@
  				if (tile == null)
  					return;
  
-+				if (tile.type > TileID.Count) {
++				if (tile.type >= TileID.Count) {
 +					if (tile.active() && TileID.Sets.Torch[tile.type])
 +						NearbyModTorch.Add(tile.type);
 +

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -590,7 +590,7 @@
  				int num20 = genRand.Next(minValue2, maxValue2);
  				Tile tile2 = Main.tile[num19, num20];
 -				if (tile2.active() && tile2.type >= 0 && tile2.type < TileID.Count) {
-+				if (tile2.active() && tile2.type >= 0 && tile2.type < TileLoader.TileCount) {
++				if (tile2.active() && tile2.type >= 0) {
  					bool flag2 = TileID.Sets.Dirt[tile2.type];
  					if (notTheBees)
  						flag2 = flag2 || TileID.Sets.Mud[tile2.type];
@@ -728,7 +728,7 @@
  	public static bool DefaultTreeWallTest(int wallType)
  	{
 -		if (wallType >= 0 && wallType < WallID.Count && WallID.Sets.AllowsPlantsToGrow[wallType])
-+		if (wallType >= 0 && wallType < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[wallType])
++		if (wallType >= 0 && WallID.Sets.AllowsPlantsToGrow[wallType])
  			return true;
  
  		return false;
@@ -1189,7 +1189,7 @@
  			int num = tile.frameX / 18;
  			Tile tile2 = Main.tile[i, y + 1];
 -			if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileID.Count)
-+			if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileLoader.TileCount)
++			if (tile2 == null || !tile2.active() || tile2.type < 0)
  				return;
  
  			ushort type = tile2.type;
@@ -1198,7 +1198,7 @@
  			for (int j = num; j < num + 2; j++) {
  				Tile tile2 = Main.tile[j, y + 1];
 -				if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileID.Count)
-+				if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileLoader.TileCount)
++				if (tile2 == null || !tile2.active() || tile2.type < 0)
  					continue;
  
  				ushort type2 = tile2.type;
@@ -1706,7 +1706,7 @@
  	public static bool TryKillingTreesAboveIfTheyWouldBecomeInvalid(int i, int j, int newFloorType)
  	{
 -		if (newFloorType < 0 || newFloorType >= TileID.Count)
-+		if (newFloorType < 0 || newFloorType >= TileLoader.TileCount)
++		if (newFloorType < 0)
  			return false;
  
  		if (!InWorld(i, j, 2))
@@ -1862,7 +1862,7 @@
  							tile.frameX = (short)(num2 * 18);
  						}
 -						else if (tile.wall >= 0 && tile.wall < WallID.Count && WallID.Sets.AllowsPlantsToGrow[tile.wall] && Main.tile[i, j + 1].wall >= 0 && Main.tile[i, j + 1].wall < WallID.Count && WallID.Sets.AllowsPlantsToGrow[Main.tile[i, j + 1].wall]) {
-+						else if (tile.wall >= 0 && tile.wall < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[tile.wall] && Main.tile[i, j + 1].wall >= 0 && Main.tile[i, j + 1].wall < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[Main.tile[i, j + 1].wall]) {
++						else if (tile.wall >= 0 && WallID.Sets.AllowsPlantsToGrow[tile.wall] && Main.tile[i, j + 1].wall >= 0 && Main.tile[i, j + 1].wall < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[Main.tile[i, j + 1].wall]) {
  							if (genRand.Next(50) == 0 || ((num == 24 || num == 201) && genRand.Next(40) == 0)) {
  								tile.active(active: true);
  								tile.type = (ushort)num;
@@ -2320,7 +2320,7 @@
  
  		int type = Main.tile[i, j].type;
 -		if (type > 0 && type < TileID.Count && TileID.Sets.CanGrowCrystalShards[type] && ((double)j > Main.rockLayer || Main.remixWorld) && genRand.Next(5) == 0) {
-+		if (type > 0 && type < TileLoader.TileCount && TileID.Sets.CanGrowCrystalShards[type] && ((double)j > Main.rockLayer || Main.remixWorld) && genRand.Next(5) == 0) {
++		if (type > 0 && TileID.Sets.CanGrowCrystalShards[type] && ((double)j > Main.rockLayer || Main.remixWorld) && genRand.Next(5) == 0) {
  			int num = genRand.Next(4);
  			int num2 = 0;
  			int num3 = 0;
@@ -2420,7 +2420,7 @@
  
  		ushort type = tile.type;
 -		if (type < 0 || type >= TileID.Count)
-+		if (type < 0 || type >= TileLoader.TileCount)
++		if (type < 0)
  			return false;
  
  		if (type != 70 && type != 633 && !TileID.Sets.Conversion.Grass[type])
@@ -2429,7 +2429,7 @@
  
  		ushort type = tile.type;
 -		if (type < 0 || type >= TileID.Count)
-+		if (type < 0 || type >= TileLoader.TileCount)
++		if (type < 0)
  			return false;
  
  		if (type != 0 && type != 70 && type != 633 && type != 59 && type != 225 && !TileID.Sets.Conversion.Grass[type] && !TileID.Sets.Conversion.Stone[type] && !Main.tileMoss[type])
@@ -2479,7 +2479,7 @@
  											Tile tile3 = Main.tile[i, j + 1];
  											_ = Main.tile[i, j].frameY / 34;
 -											if (tile3 == null || !tile3.active() || (tile3.type >= 0 && tile3.type < TileID.Count && !TileID.Sets.Conversion.Sand[tile3.type]))
-+											if (tile3 == null || !tile3.active() || (tile3.type >= 0 && tile3.type < TileLoader.TileCount && !TileID.Sets.Conversion.Sand[tile3.type]))
++											if (tile3 == null || !tile3.active() || (tile3.type >= 0 && !TileID.Sets.Conversion.Sand[tile3.type]))
  												KillTile(i, j);
  
  											break;
@@ -2488,11 +2488,11 @@
  													Tile tile2 = Main.tile[i, j - 1];
  													Tile tile3 = Main.tile[i, j + 1];
 -													if (tile2 != null && tile2.type >= 0 && tile2.type < TileID.Count && Main.tileRope[tile2.type])
-+													if (tile2 != null && tile2.type >= 0 && tile2.type < TileLoader.TileCount && Main.tileRope[tile2.type])
++													if (tile2 != null && tile2.type >= 0 && Main.tileRope[tile2.type])
  														TileFrame(i, j - 1);
  
 -													if (tile3 != null && tile3.type >= 0 && tile3.type < TileID.Count && Main.tileRope[tile3.type])
-+													if (tile3 != null && tile3.type >= 0 && tile3.type < TileLoader.TileCount && Main.tileRope[tile3.type])
++													if (tile3 != null && tile3.type >= 0 && Main.tileRope[tile3.type])
  														TileFrame(i, j + 1);
  
  													break;
@@ -2688,7 +2688,7 @@
  									TileMergeAttempt(num, TileID.Sets.Conversion.Grass, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  
 -								if (num >= 0 && num < TileID.Count && TileID.Sets.Mud[num])
-+								if (num >= 0 && num < TileLoader.TileCount && TileID.Sets.Mud[num])
++								if (num >= 0 && TileID.Sets.Mud[num])
  									TileMergeAttempt(num, TileID.Sets.OreMergesWithMud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  								else if (TileID.Sets.OreMergesWithMud[num])
  									TileMergeAttempt(num, TileID.Sets.Mud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
@@ -2716,10 +2716,10 @@
  									}
  
 -									if (num32 >= 0 && num32 < TileID.Count && TileID.Sets.Dirt[num32])
-+									if (num32 >= 0 && num32 < TileLoader.TileCount && TileID.Sets.Dirt[num32])
++									if (num32 >= 0 && TileID.Sets.Dirt[num32])
  										TileMergeAttempt(-2, TileID.Sets.Dirt, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
 -									else if (num32 >= 0 && num32 < TileID.Count && TileID.Sets.Mud[num32])
-+									else if (num32 >= 0 && num32 < TileLoader.TileCount && TileID.Sets.Mud[num32])
++									else if (num32 >= 0 && TileID.Sets.Mud[num32])
  										TileMergeAttempt(-2, TileID.Sets.Mud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  									else
  										TileMergeAttempt(-2, num32, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
@@ -2750,7 +2750,7 @@
  		if (!tile.nactive())
  			result = true;
 -		else if (tile.type >= 0 && tile.type < TileID.Count && !Main.tileSolid[tile.type])
-+		else if (tile.type >= 0 && tile.type < TileLoader.TileCount && !Main.tileSolid[tile.type])
++		else if (tile.type >= 0 && !Main.tileSolid[tile.type])
  			result = true;
  
  		return result;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -106,6 +106,18 @@
  		if (type == 160) {
  			if (!NPC.unlockedTruffleSpawn && (double)roomY2 > Main.worldSurface)
  				return false;
+@@ -1733,9 +_,9 @@
+ 
+ 	public static void CheckAchievement_RealEstateAndTownSlimes()
+ 	{
+-		bool[] array = new bool[NPCID.Count];
++		bool[] array = new bool[NPCLoader.NPCCount];
+ 		for (int i = 0; i < 200; i++) {
+-			if (Main.npc[i].active && Main.npc[i].type >= 0 && Main.npc[i].type < NPCID.Count)
++			if (Main.npc[i].active && Main.npc[i].type >= 0 && Main.npc[i].type < NPCLoader.NPCCount)
+ 				array[Main.npc[i].type] = true;
+ 		}
+ 
 @@ -1932,7 +_,7 @@
  		int num = 0;
  		int num2 = 50;
@@ -585,6 +597,15 @@
  				else if (getGoodWorldGen)
  					num36 *= 2.0;
  
+@@ -13803,7 +_,7 @@
+ 				int num19 = genRand.Next(minValue, maxValue);
+ 				int num20 = genRand.Next(minValue2, maxValue2);
+ 				Tile tile2 = Main.tile[num19, num20];
+-				if (tile2.active() && tile2.type >= 0 && tile2.type < TileID.Count) {
++				if (tile2.active() && tile2.type >= 0 && tile2.type < TileLoader.TileCount) {
+ 					bool flag2 = TileID.Sets.Dirt[tile2.type];
+ 					if (notTheBees)
+ 						flag2 = flag2 || TileID.Sets.Mud[tile2.type];
 @@ -13850,11 +_,22 @@
  			progress.Message = Lang.gen[87].Value;
  		});
@@ -714,6 +735,15 @@
  		}
  
  		if ((Main.tile[i - 1, j - 1].liquid != 0 || Main.tile[i, j - 1].liquid != 0 || Main.tile[i + 1, j - 1].liquid != 0) && !notTheBees)
+@@ -18172,7 +_,7 @@
+ 
+ 	public static bool DefaultTreeWallTest(int wallType)
+ 	{
+-		if (wallType >= 0 && wallType < WallID.Count && WallID.Sets.AllowsPlantsToGrow[wallType])
++		if (wallType >= 0 && wallType < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[wallType])
+ 			return true;
+ 
+ 		return false;
 @@ -18921,10 +_,12 @@
  		int num6 = genRand.Next(3);
  		bool flag3 = false;
@@ -1166,6 +1196,24 @@
  		destroyObject = false;
  	}
  
+@@ -31653,7 +_,7 @@
+ 
+ 			int num = tile.frameX / 18;
+ 			Tile tile2 = Main.tile[i, y + 1];
+-			if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileID.Count)
++			if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileLoader.TileCount)
+ 				return;
+ 
+ 			ushort type = tile2.type;
+@@ -31766,7 +_,7 @@
+ 			num5 += (tile.frameY / 18 - 1) * 52;
+ 			for (int j = num; j < num + 2; j++) {
+ 				Tile tile2 = Main.tile[j, y + 1];
+-				if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileID.Count)
++				if (tile2 == null || !tile2.active() || tile2.type < 0 || tile2.type >= TileLoader.TileCount)
+ 					continue;
+ 
+ 				ushort type2 = tile2.type;
 @@ -31810,6 +_,9 @@
  		if (Main.tile[num + 1, y].type == type)
  			KillTile(num + 1, y);
@@ -1665,6 +1713,15 @@
  		if (num4 != 2 && num4 != type && ((Main.tile[i, j].frameX == 0 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 22 && Main.tile[i, j].frameY <= 130) || (Main.tile[i, j].frameX == 44 && Main.tile[i, j].frameY <= 130)))
  			KillTile(i, j);
  
+@@ -39303,7 +_,7 @@
+ 
+ 	public static bool TryKillingTreesAboveIfTheyWouldBecomeInvalid(int i, int j, int newFloorType)
+ 	{
+-		if (newFloorType < 0 || newFloorType >= TileID.Count)
++		if (newFloorType < 0 || newFloorType >= TileLoader.TileCount)
+ 			return false;
+ 
+ 		if (!InWorld(i, j, 2))
 @@ -39342,6 +_,28 @@
  		return true;
  	}
@@ -1699,30 +1756,55 @@
  				switch (conversionType) {
  					case 4:
 -						if (type <= TileID.Count && wall <= WallID.Count) {
-+						if (true || type <= TileID.Count && wall <= WallID.Count) {
++						if (type <= TileLoader.TileCount && wall <= WallLoader.WallCount) {
  							if (WallID.Sets.Conversion.Grass[wall] && wall != 81) {
  								tile.wall = 81;
  								SquareWallFrame(k, l);
-@@ -39444,8 +_,10 @@
+@@ -39444,7 +_,7 @@
  						}
  						continue;
  					case 2:
-+						/*
- 						if (type > TileID.Count || wall > WallID.Count)
+-						if (type > TileID.Count || wall > WallID.Count)
++						if (type >= TileLoader.TileCount || wall >= WallLoader.WallCount)
  							continue;
-+						*/
  						if (WallID.Sets.Conversion.Grass[wall] && wall != 70) {
  							tile.wall = 70;
- 							SquareWallFrame(k, l);
 @@ -39538,7 +_,7 @@
  						}
  						continue;
  					case 1:
 -						if (type <= TileID.Count && wall <= WallID.Count) {
-+						if (true || type <= TileID.Count && wall <= WallID.Count) {
++						if (type <= TileLoader.TileCount && wall <= WallLoader.WallCount) {
  							if (WallID.Sets.Conversion.Grass[wall] && wall != 69) {
  								tile.wall = 69;
  								SquareWallFrame(k, l);
+@@ -39645,7 +_,7 @@
+ 						}
+ 						continue;
+ 					case 5:
+-						if (type < 0 || type > TileID.Count || wall < 0 || wall > WallID.Count)
++						if (type < 0 || type >= TileLoader.TileCount || wall < 0 || wall >= WallLoader.WallCount)
+ 							continue;
+ 						if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.NewWall1[wall] || WallID.Sets.Conversion.NewWall2[wall] || WallID.Sets.Conversion.NewWall3[wall] || WallID.Sets.Conversion.NewWall4[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 187) {
+ 							tile.wall = 187;
+@@ -39685,7 +_,7 @@
+ 						}
+ 						continue;
+ 					case 6:
+-						if (type < 0 || type > TileID.Count || wall < 0 || wall > WallID.Count)
++						if (type < 0 || type >= TileLoader.TileCount || wall < 0 || wall >= WallLoader.WallCount)
+ 							continue;
+ 						if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.NewWall1[wall] || WallID.Sets.Conversion.NewWall2[wall] || WallID.Sets.Conversion.NewWall3[wall] || WallID.Sets.Conversion.NewWall4[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 71) {
+ 							tile.wall = 71;
+@@ -39716,7 +_,7 @@
+ 						}
+ 						continue;
+ 					case 7:
+-						if (type < 0 || type > TileID.Count || wall < 0 || wall > WallID.Count)
++						if (type < 0 || type >= TileLoader.TileCount || wall < 0 || wall >= WallLoader.WallCount)
+ 							continue;
+ 						if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 1) {
+ 							tile.wall = 1;
 @@ -40114,7 +_,7 @@
  		if ((!Main.remixWorld || !((double)j > Main.worldSurface)) && num3 / 255 > cactusWaterLimit)
  			return;
@@ -1787,6 +1869,15 @@
  						case 24:
  						case 27:
  						case 32:
+@@ -42313,7 +_,7 @@
+ 
+ 							tile.frameX = (short)(num2 * 18);
+ 						}
+-						else if (tile.wall >= 0 && tile.wall < WallID.Count && WallID.Sets.AllowsPlantsToGrow[tile.wall] && Main.tile[i, j + 1].wall >= 0 && Main.tile[i, j + 1].wall < WallID.Count && WallID.Sets.AllowsPlantsToGrow[Main.tile[i, j + 1].wall]) {
++						else if (tile.wall >= 0 && tile.wall < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[tile.wall] && Main.tile[i, j + 1].wall >= 0 && Main.tile[i, j + 1].wall < WallLoader.WallCount && WallID.Sets.AllowsPlantsToGrow[Main.tile[i, j + 1].wall]) {
+ 							if (genRand.Next(50) == 0 || ((num == 24 || num == 201) && genRand.Next(40) == 0)) {
+ 								tile.active(active: true);
+ 								tile.type = (ushort)num;
 @@ -42505,7 +_,7 @@
  						SquareTileFrame(i, j);
  					}
@@ -2236,6 +2327,15 @@
  		return false;
  	}
  
+@@ -50555,7 +_,7 @@
+ 			return;
+ 
+ 		int type = Main.tile[i, j].type;
+-		if (type > 0 && type < TileID.Count && TileID.Sets.CanGrowCrystalShards[type] && ((double)j > Main.rockLayer || Main.remixWorld) && genRand.Next(5) == 0) {
++		if (type > 0 && type < TileLoader.TileCount && TileID.Sets.CanGrowCrystalShards[type] && ((double)j > Main.rockLayer || Main.remixWorld) && genRand.Next(5) == 0) {
+ 			int num = genRand.Next(4);
+ 			int num2 = 0;
+ 			int num3 = 0;
 @@ -52049,9 +_,20 @@
  
  	public static void UpdateWorld()
@@ -2327,6 +2427,24 @@
  		int num = i - 1;
  		int num2 = i + 2;
  		int num3 = j - 1;
+@@ -53002,7 +_,7 @@
+ 			return false;
+ 
+ 		ushort type = tile.type;
+-		if (type < 0 || type >= TileID.Count)
++		if (type < 0 || type >= TileLoader.TileCount)
+ 			return false;
+ 
+ 		if (type != 70 && type != 633 && !TileID.Sets.Conversion.Grass[type])
+@@ -53061,7 +_,7 @@
+ 			return false;
+ 
+ 		ushort type = tile.type;
+-		if (type < 0 || type >= TileID.Count)
++		if (type < 0 || type >= TileLoader.TileCount)
+ 			return false;
+ 
+ 		if (type != 0 && type != 70 && type != 633 && type != 59 && type != 225 && !TileID.Sets.Conversion.Grass[type] && !TileID.Sets.Conversion.Stone[type] && !Main.tileMoss[type])
 @@ -53111,6 +_,9 @@
  
  	private static void UpdateWorld_UndergroundTile(int i, int j, bool checkNPCSpawns, int wallDist)
@@ -2368,6 +2486,28 @@
  								CheckTorch(i, j);
  								break;
  							case 442:
+@@ -59474,7 +_,7 @@
+ 
+ 											Tile tile3 = Main.tile[i, j + 1];
+ 											_ = Main.tile[i, j].frameY / 34;
+-											if (tile3 == null || !tile3.active() || (tile3.type >= 0 && tile3.type < TileID.Count && !TileID.Sets.Conversion.Sand[tile3.type]))
++											if (tile3 == null || !tile3.active() || (tile3.type >= 0 && tile3.type < TileLoader.TileCount && !TileID.Sets.Conversion.Sand[tile3.type]))
+ 												KillTile(i, j);
+ 
+ 											break;
+@@ -59531,10 +_,10 @@
+ 													Minecart.FrameTrack(i, j, pound: false);
+ 													Tile tile2 = Main.tile[i, j - 1];
+ 													Tile tile3 = Main.tile[i, j + 1];
+-													if (tile2 != null && tile2.type >= 0 && tile2.type < TileID.Count && Main.tileRope[tile2.type])
++													if (tile2 != null && tile2.type >= 0 && tile2.type < TileLoader.TileCount && Main.tileRope[tile2.type])
+ 														TileFrame(i, j - 1);
+ 
+-													if (tile3 != null && tile3.type >= 0 && tile3.type < TileID.Count && Main.tileRope[tile3.type])
++													if (tile3 != null && tile3.type >= 0 && tile3.type < TileLoader.TileCount && Main.tileRope[tile3.type])
+ 														TileFrame(i, j + 1);
+ 
+ 													break;
 @@ -59791,7 +_,10 @@
  														if (num != 354 && num != 406 && num != 412 && num != 355 && num != 452 && num != 455 && num != 491 && num != 499 && num != 642) {
  															switch (num) {
@@ -2555,6 +2695,15 @@
  											TileMergeAttempt(-2, 147, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  											break;
  										case 162:
+@@ -60829,7 +_,7 @@
+ 								else if (TileID.Sets.Ore[num])
+ 									TileMergeAttempt(num, TileID.Sets.Conversion.Grass, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
+ 
+-								if (num >= 0 && num < TileID.Count && TileID.Sets.Mud[num])
++								if (num >= 0 && num < TileLoader.TileCount && TileID.Sets.Mud[num])
+ 									TileMergeAttempt(num, TileID.Sets.OreMergesWithMud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
+ 								else if (TileID.Sets.OreMergesWithMud[num])
+ 									TileMergeAttempt(num, TileID.Sets.Mud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
 @@ -60848,11 +_,18 @@
  									tileMergeCullCache.CullBottomRight |= tile7 != null && tile7.invisibleBlock() != flag2;
  								}
@@ -2574,6 +2723,18 @@
  										num32 = 59;
  									}
  									else if (Main.tileMoss[num]) {
+@@ -61903,9 +_,9 @@
+ 										}
+ 									}
+ 
+-									if (num32 >= 0 && num32 < TileID.Count && TileID.Sets.Dirt[num32])
++									if (num32 >= 0 && num32 < TileLoader.TileCount && TileID.Sets.Dirt[num32])
+ 										TileMergeAttempt(-2, TileID.Sets.Dirt, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
+-									else if (num32 >= 0 && num32 < TileID.Count && TileID.Sets.Mud[num32])
++									else if (num32 >= 0 && num32 < TileLoader.TileCount && TileID.Sets.Mud[num32])
+ 										TileMergeAttempt(-2, TileID.Sets.Mud, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
+ 									else
+ 										TileMergeAttempt(-2, num32, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
 @@ -62292,7 +_,10 @@
  										}
  									}
@@ -2596,6 +2757,15 @@
  										TileMergeAttempt(num, -2, ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  										tileMergeCullCache.Cull(ref up, ref down, ref left, ref right, ref upLeft, ref upRight, ref downLeft, ref downRight);
  									}
+@@ -63768,7 +_,7 @@
+ 
+ 		if (!tile.nactive())
+ 			result = true;
+-		else if (tile.type >= 0 && tile.type < TileID.Count && !Main.tileSolid[tile.type])
++		else if (tile.type >= 0 && tile.type < TileLoader.TileCount && !Main.tileSolid[tile.type])
+ 			result = true;
+ 
+ 		return result;
 @@ -63800,7 +_,7 @@
  			return false;
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -106,18 +106,6 @@
  		if (type == 160) {
  			if (!NPC.unlockedTruffleSpawn && (double)roomY2 > Main.worldSurface)
  				return false;
-@@ -1733,9 +_,9 @@
- 
- 	public static void CheckAchievement_RealEstateAndTownSlimes()
- 	{
--		bool[] array = new bool[NPCID.Count];
-+		bool[] array = new bool[NPCLoader.NPCCount];
- 		for (int i = 0; i < 200; i++) {
--			if (Main.npc[i].active && Main.npc[i].type >= 0 && Main.npc[i].type < NPCID.Count)
-+			if (Main.npc[i].active && Main.npc[i].type >= 0 && Main.npc[i].type < NPCLoader.NPCCount)
- 				array[Main.npc[i].type] = true;
- 		}
- 
 @@ -1932,7 +_,7 @@
  		int num = 0;
  		int num2 = 50;


### PR DESCRIPTION
### What is the bug?
Many of these fixes are 1.4.4 specific because it added alot of bound checks to array accesses where there haven't been any in 1.4.3.6, for whatever reason (Can be seen by comparing the Sea Oats (ID 529) `TileFrame` code in 1.4.3.6 and 1.4.4(.9)).
@Chicken-Bones could you please elaborate on this odd decision? At first I thought it's something TEdit related (tiles/walls loading with invalid types) but it seems that most of these bound checks are referring to new 1.4.4 content or codebase changes, or aren't tile related at all.
Vanilla also did these bound checks wrong in certain places, mainly in `WorldGen.Convert`: it would let a type of `Count` (for tile and wall respectively) through to the arrays, which would IOOB.

#### List of bugs:
Things explicitely tested and confirmed are checkmarked, the rest is derived from the code itself and not tested.
* wrong type check on modded torch detection (highly unlikely that this ever happens, but assuming a modded torch got the ID of `TileID.Count`, it would not count as one)
* [x] Toxic flask projectile wouldn't count modded platforms as solid, and would stop spreading upon touching them instead of going through
* [x] Dirt Bomb would not properly spread dirt when modded platforms are in the way
* Dead Man's Chest would ignore modded containers when deciding where to generate
* modded boulders would ignore other players standing in the way when trying to place them with smart cursor
* modded foliage would block Pumpkin Seed placement
* modded dirt/mud would not get replaced by "Dirtiest Block" during worldgen, and wouldn't merge with most tiles
* certain ambient objects (Small Piles, Sea Oats) would not properly destroy themselves if anchored to (suitable) modded tiles and TileFrame is called
* custom biome conversions that call `WorldGen.TryKillingTreesAboveIfTheyWouldBecomeInvalid` would not work with a modded tile type specified
* biome conversions back to normal (snow, sand, dirt) would not work for modded tiles despite being listed in the Conversions sets
* [x] Non-solid modded tiles would not cause sand above them to get converted to hardened sand of the specific biome (if for some reason a sand tile ended up resting on a non-solid tile), which would end up collapsing the sand pillar above them
* [x] Modded tiles in `TileID.Sets.CanGrowCrystalShards` would not grow Crystal Shards
* Modded ropes don't interact properly with railtracks
* Abigails Flower and Glow Tulip would only grow on vanilla grasses
* [x] vanilla foliage and trees would not grow infront of modded walls explicitely marked as `WallID.Sets.AllowsPlantsToGrow`
* [x] vanilla UG desert enemies would not spawn infront of modded walls explicitely marked as `WallID.Sets.AllowsUndergroundDesertEnemiesToSpawn`
* modded slimes that can transform into the copper town slime will never transform
* modded critters do not have the 1.5 second immunity when spawned
* [x] smart cursor would not work with modded blocks

**Some changes were omitted (please comment on if these should stay as is or get changed):**
* [x] Fertilizer currently doesn't grow modded trees, its projectile checks for `TileID.Count` before accessing `TileID.Sets.CommonSapling`, then calls `WorldGen.AttemptToGrowTreeFromSapling`, the latter has no support for modded to my knowledge, so I left it as is.
* [x] Pumpkins only grow on specific, hardcoded grasses (normal and hallow + mowed variants). If they end up on modded tiles they don't break automatically via TileFrame. For some reason there is an upper bounds check even though there are no arrays being accessed?
* `ProjectileID.Sets.StormTiger` has a count check in one place. I didn't change this as setting modded NPCs to this set would not make sense (Even though `ProjectileID.Sets.StardustDragon` is used in a similar way but does not have any checks)
* The code that enables info accessories from the Void Bag is guarded by a count check, but that code has no mod compatibility at all, so  I left it as is.

### Are there alternatives to your fix?
If there is no real reason why these boundary checks were added in the first place, they can simply be omitted (as done already in many places). I'll await CBs reply.
