### PR TITLE
GrappleCanLatchOnTo hook

### DIFF
--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -116,6 +116,22 @@ namespace ExampleMod.Content.Items.Tools
 			grappleY += dirToPlayer.Y * hangDist;
 		}
 
+		// Can customize what tiles this hook can latch onto, or force/prevent latching alltogether, like Squirrel Hook also latching to trees
+		public override bool? GrappleCanLatchOnTo(Player player, int x, int y) {
+			// By default, the hook returns the vanilla conditions for the given tile position to be concidered "latchable" (this tile position could be air or an actuated tile!)
+			// If you want to return true here, make sure to check for Main.tile[x, y].HasUnactuatedTile (and Main.tileSolid[Main.tile[x, y].TileType] and/or Main.tile[x, y].HasTile if needed)
+
+			// We make this hook latch onto trees just like Squirrel Hook
+
+			// Tree trunks cannot be actuated so we don't need to check for that here
+			Tile tile = Main.tile[x, y];
+			if (TileID.Sets.IsATreeTrunk[tile.TileType] || tile.TileType == TileID.PalmTree) {
+				return true;
+			}
+
+			return base.GrappleCanLatchOnTo(player, x, y);
+		}
+
 		// Draws the grappling hook's chain.
 		public override bool PreDrawExtras() {
 			Vector2 playerCenter = Main.player[Projectile.owner].MountedCenter;

--- a/ExampleMod/Content/Items/Tools/ExampleHook.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHook.cs
@@ -118,7 +118,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		// Can customize what tiles this hook can latch onto, or force/prevent latching alltogether, like Squirrel Hook also latching to trees
 		public override bool? GrappleCanLatchOnTo(Player player, int x, int y) {
-			// By default, the hook returns the vanilla conditions for the given tile position to be concidered "latchable" (this tile position could be air or an actuated tile!)
+			// By default, the hook returns null to apply the vanilla conditions for the given tile position (this tile position could be air or an actuated tile!)
 			// If you want to return true here, make sure to check for Main.tile[x, y].HasUnactuatedTile (and Main.tileSolid[Main.tile[x, y].TileType] and/or Main.tile[x, y].HasTile if needed)
 
 			// We make this hook latch onto trees just like Squirrel Hook
@@ -129,7 +129,8 @@ namespace ExampleMod.Content.Items.Tools
 				return true;
 			}
 
-			return base.GrappleCanLatchOnTo(player, x, y);
+			// In any other case, behave like a normal hook
+			return null;
 		}
 
 		// Draws the grappling hook's chain.

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -545,7 +545,7 @@ Mods: {
 
 			ExampleHookItem: {
 				DisplayName: Example Hook
-				Tooltip: ""
+				Tooltip: Can grapple onto trees
 			}
 
 			ExampleMagicMirror: {

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -424,4 +424,14 @@ public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile
 	public virtual void GrappleTargetPoint(Projectile projectile, Player player, ref float grappleX, ref float grappleY)
 	{
 	}
+
+	/// <summary>
+	/// Whether or not the grappling hook can latch onto the given position in tile coordinates.
+	/// <br/>This position may be air or an actuated tile!
+	/// <br/>Return true to make it latch, false to prevent it, or null to apply vanilla conditions. Returns null by default.
+	/// </summary>
+	public virtual bool? GrappleCanLatchOnTo(Projectile projectile, Player player, int x, int y)
+	{
+		return null;
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -442,6 +442,16 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	}
 
 	/// <summary>
+	/// Whether or not the grappling hook can latch onto the given position in tile coordinates.
+	/// <br/>This position may be air or an actuated tile!
+	/// <br/>Return true to make it latch, false to prevent it, or null to apply vanilla conditions. Returns null by default.
+	/// </summary>
+	public virtual bool? GrappleCanLatchOnTo(Player player, int x, int y)
+	{
+		return null;
+	}
+
+	/// <summary>
 	/// When used in conjunction with "Projectile.hide = true", allows you to specify that this projectile should be drawn behind certain elements. Add the index to one and only one of the lists. For example, the Nebula Arcanum projectile draws behind NPCs and tiles.
 	/// </summary>
 	public virtual void DrawBehind(int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -790,6 +790,26 @@ public static class ProjectileLoader
 		}
 	}
 
+	private static HookList HookGrappleCanLatchOnTo = AddHook<Func<Projectile, Player, int, int, bool?>>(g => g.GrappleCanLatchOnTo);
+
+	public static bool? GrappleCanLatchOnTo(Projectile projectile, Player player, int x, int y)
+	{
+		bool? flag = projectile.ModProjectile?.GrappleCanLatchOnTo(player, x, y);
+
+		foreach (GlobalProjectile g in HookGrappleCanLatchOnTo.Enumerate(projectile.globalProjectiles)) {
+			bool? globalFlag = g.GrappleCanLatchOnTo(projectile, player, x, y);
+
+			if (globalFlag.HasValue) {
+				if (!globalFlag.Value)
+					return false;
+
+				flag = globalFlag;
+			}
+		}
+
+		return flag;
+	}
+
 	private static HookList HookDrawBehind = AddHook<Action<Projectile, int, List<int>, List<int>, List<int>, List<int>, List<int>>>(g => g.DrawBehind);
 
 	internal static void DrawBehind(Projectile projectile, int index, List<int> behindNPCsAndTiles, List<int> behindNPCs, List<int> behindProjectiles, List<int> overPlayers, List<int> overWiresUI)

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1305,7 +1305,7 @@
  				flag = false;
  
  			if (flag) {
-@@ -36476,7 +_,24 @@
+@@ -36476,7 +_,23 @@
  		}
  	}
  
@@ -1315,15 +1315,14 @@
 +	private bool AI_007_GrapplingHooks_CanTileBeLatchedOnTo(int x, int y)
 +	{
 +		Tile theTile = Main.tile[x, y];
++		// Code taken 1:1 from the commented out method with the same name
 +		bool vanilla = Main.tileSolid[theTile.type] | (theTile.type == 314) | (type == 865 && TileID.Sets.IsATreeTrunk[theTile.type]) | (type == 865 && theTile.type == 323);
 +
 +		// TML: Vanilla check modified by moving Tile.nactive() from its callsites into here to allow actuated or air to be grappled by mods
 +		vanilla &= theTile.nactive();
 +
-+		bool? modded = ProjectileLoader.GrappleCanLatchOnTo(this, Main.player[owner], x, y);
-+
-+		if (modded.HasValue)
-+			return modded.Value;
++		if (ProjectileLoader.GrappleCanLatchOnTo(this, Main.player[owner], x, y) is bool modOverride)
++			return modOverride;
 +
 +		return vanilla;
 +	}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1267,6 +1267,16 @@
  
  			Vector2 vector3 = base.Center - new Vector2(5f);
  			Vector2 vector4 = base.Center + new Vector2(5f);
+@@ -36334,7 +_,8 @@
+ 						continue;
+ 
+ 					Tile tile = Main.tile[l, m];
++					// TML: Moved nactive check into method, changed from tile to coords
+-					if (!tile.nactive() || !AI_007_GrapplingHooks_CanTileBeLatchedOnTo(tile) || list.Contains(new Point(l, m)) || (type == 403 && tile.type != 314) || Main.player[owner].IsBlacklistedForGrappling(new Point(l, m)))
++					if (!AI_007_GrapplingHooks_CanTileBeLatchedOnTo(l, m) || list.Contains(new Point(l, m)) || (type == 403 && tile.type != 314) || Main.player[owner].IsBlacklistedForGrappling(new Point(l, m)))
+ 						continue;
+ 
+ 					if (Main.player[owner].grapCount < 10) {
 @@ -36371,6 +_,8 @@
  						if (type >= 646 && type <= 649)
  							num17 = 4;
@@ -1285,6 +1295,41 @@
  			if (num3 < 24f)
  				Kill();
  
+@@ -36463,7 +_,8 @@
+ 				Main.tile[point4.X, point4.Y] = new Tile();
+ 
+ 			bool flag = true;
+-			if (Main.tile[point4.X, point4.Y].nactive() && AI_007_GrapplingHooks_CanTileBeLatchedOnTo(Main.tile[point4.X, point4.Y]))
++			// TML: Moved nactive check into method, changed from tile to coords
++			if (AI_007_GrapplingHooks_CanTileBeLatchedOnTo(point4.X, point4.Y))
+ 				flag = false;
+ 
+ 			if (flag) {
+@@ -36476,7 +_,24 @@
+ 		}
+ 	}
+ 
++	/*
+ 	private bool AI_007_GrapplingHooks_CanTileBeLatchedOnTo(Tile theTile) => Main.tileSolid[theTile.type] | (theTile.type == 314) | (type == 865 && TileID.Sets.IsATreeTrunk[theTile.type]) | (type == 865 && theTile.type == 323);
++	*/
++	private bool AI_007_GrapplingHooks_CanTileBeLatchedOnTo(int x, int y)
++	{
++		Tile theTile = Main.tile[x, y];
++		bool vanilla = Main.tileSolid[theTile.type] | (theTile.type == 314) | (type == 865 && TileID.Sets.IsATreeTrunk[theTile.type]) | (type == 865 && theTile.type == 323);
++
++		// TML: Vanilla check modified by moving Tile.nactive() from its callsites into here to allow actuated or air to be grappled by mods
++		vanilla &= theTile.nactive();
++
++		bool? modded = ProjectileLoader.GrappleCanLatchOnTo(this, Main.player[owner], x, y);
++
++		if (modded.HasValue)
++			return modded.Value;
++
++		return vanilla;
++	}
+ 
+ 	private void AI_147_Celeb2Rocket()
+ 	{
 @@ -36660,7 +_,7 @@
  			return;
  		}


### PR DESCRIPTION
### What is the new feature?
New `Mod/GlobalProjectile.GrappleCanLatchOnTo` hook that takes in a tile position and lets the modder customize when and what the grappling hook should latch (without manual AI modifications).

### Why should this be part of tModLoader?
This makes it possible to implement custom grappling conditions akin to Squirrel Hook.

### Are there alternative designs?
I chose to change the signature of the vanilla method to use tile coordinates instead of the tile instance. This allows for a wider range of use cases.
I also chose to move the `Tile.HasUnactuatedTile` condition into the vanilla method that handles the latching conditions, to let modders be able to make their hooks latch onto actuated tiles or even air. This should not mess with modders adding their own tiles to it, but certain checks like `Tile.HasTile` may be needed for more advanced usages. This is documented in the docs and in the ExampleMod example.

### Sample usage for the new feature
* See ExampleMod
* Hooks that latch onto other entities or arbitrary locations alltogether (i.e. a force field)

### ExampleMod updates
Made Example Hook latch onto trees like Squirrel Hook does.
