### PR TITLE
IL Editing QoL Stuff

### DIFF
--- a/ExampleMod/Content/Items/Accessories/WaspNest.cs
+++ b/ExampleMod/Content/Items/Accessories/WaspNest.cs
@@ -21,7 +21,9 @@ namespace ExampleMod.Content.Items.Accessories
 
 			// Try to find where 566 is placed onto the stack
 			if (!c.TryGotoNext(i => i.MatchLdcI4(566))) {
-				return; // Patch unable to be applied
+				// Patch unable to be applied, so we let people know with this method and exit the method
+				MonoModHooks.LogILPatchFailure(ModContent.GetInstance<ExampleMod>(), il, "Unable to locate 566 on the stack");
+				return;
 			}
 
 			// Move the cursor after 566 and onto the ret op.

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -1,3 +1,5 @@
+using Mono.Cecil;
+using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MonoMod.RuntimeDetour.HookGen;
 using MonoMod.Utils;
@@ -112,5 +114,58 @@ public static class MonoModHooks
 
 		HookEndpointManager.Clear();
 		assemblyDetours.Clear();
+	}
+
+	// TODO: 'Detour' or 'On Hook'?
+	// TODO: should it require the mod as a parameter instead of logging it with tML?
+	/// <summary>
+	/// Dumps the list of currently registered IL hooks to the console. Useful for checking if a hook has been correctly added.
+	/// </summary>
+	/// <exception cref="Exception"></exception>
+	public static void DumpILHooks()
+	{
+		var ilHooksField = typeof(HookEndpointManager).GetField("ILHooks", BindingFlags.NonPublic | BindingFlags.Static);
+		object ilHooksFieldValue = ilHooksField.GetValue(null);
+		if (ilHooksFieldValue is Dictionary<(MethodBase, Delegate), ILHook> ilHooks) {
+			Logging.tML.Debug("Dump of registered IL Hooks:");
+			foreach (var item in ilHooks) {
+				Logging.tML.Debug(item.Key + ": " + item.Value);
+			}
+		}
+		else {
+			throw new Exception($"Failed to get HookEndpointManager.ILHooks: Type is {ilHooksFieldValue.GetType()}");
+		}
+	}
+
+	/// <summary>
+	/// Dumps the list of currently registered On hooks to the console. Useful for checking if a hook has been correctly added.
+	/// </summary>
+	/// <exception cref="Exception"></exception>
+	public static void DumpOnHooks()
+	{
+		var hooksField = typeof(HookEndpointManager).GetField("Hooks", BindingFlags.NonPublic | BindingFlags.Static);
+		object hooksFieldValue = hooksField.GetValue(null);
+		if (hooksFieldValue is Dictionary<(MethodBase, Delegate), Hook> detours) {
+			Logging.tML.Debug("Dump of registered Detours:");
+			foreach (var item in detours) {
+				Logging.tML.Debug(item.Key + ": " + item.Value);
+			}
+		}
+		else {
+			throw new Exception($"Failed to get HookEndpointManager.Hooks: Type is {hooksFieldValue.GetType()}");
+		}
+	}
+
+	/// <summary>
+	/// A helper method that logs to the console that an IL patch failed.
+	/// </summary>
+	/// <param name="mod"></param>
+	/// <param name="il"></param>
+	/// <param name="reason"></param>
+	public static void LogILPatchFailure(Mod mod, ILContext il, string reason)
+	{
+		// TODO: use StringRep function but for MethodDefinition instead of MethodBase
+		// TODO: should this also include a patching class where the hooks are made and a feature name?
+		mod.Logger.Warn($"Failed to IL edit method \"{il.Method.Name}\", because \"{reason}\"");
 	}
 }


### PR DESCRIPTION
https://github.com/tModLoader/tModLoader/issues/3213

Added 3 methods and 1 exception
`DumpILHooks()` will dump the list of currently registered IL hooks to the console (useful for manual hook registering with reflection)
`DumpOnHooks()` will do the same but for detours
`DumpIL(Mod mod, ILContext il)` will dump the `ILContext` to` Logs/ILDumps/{Mod Name}/{Method Name}.txt`
`ILPatchFailureException(Mod mod, ILContext il, Exception innerException)` is a convenience exception which will call `DumpIL` and wrap the inner exception with a better message

### Sample Usage for the New Feature
```c#
try {
    ILCursor c = new ILCursor(il);
    c.GotoNext(i => i.MatchLdcI4(566));
    // IL editing stuff...
});
}
catch (Exception e) {
    throw new ILPatchFailureException(ModContent.GetInstance<ExampleMod>(), il, e);
    // or
    MonoModHooks.DumpIL(ModContent.GetInstance<ExampleMod>(), il);
}
```

#### Note
Some fixes were made in followup commit 179db727e9734ad151761fe9c3060fc5c4d382ac