### PR TITLE
Fix pet drawing in player select screen for invalid items + ExampleMod showcase

### DIFF
--- a/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExampleLightPet/ExampleLightPetProjectile.cs
@@ -19,9 +19,9 @@ namespace ExampleMod.Content.Pets.ExampleLightPet
 		private static readonly float RangeHypoteneus = (float)(Math.Sqrt(2.0) * Range); // This comes from the formula for calculating the diagonal of a square (a * √2)
 		private static readonly float RangeHypoteneusSquared = RangeHypoteneus * RangeHypoteneus;
 
-		// The following 2 lines of code are ref properties (learn about them in google) to the projectile.ai array entries, which will help us make our code way more readable.
+		// The following 2 lines of code are ref properties (learn about them in google) to the Projectile.ai array entries, which will help us make our code way more readable.
 		// We're using the ai array because it's automatically synchronized by the base game in multiplayer, which saves us from writing a lot of boilerplate code.
-		// Note that the projectile.ai array is only 2 entries big. If you need more than 2 synchronized variables - you'll have to use fields and sync them manually.
+		// Note that the Projectile.ai array is only 3 entries big. If you need more than 3 synchronized variables - you'll have to use fields and sync them manually.
 		public ref float AIFadeProgress => ref Projectile.ai[0];
 		public ref float AIDashCharge => ref Projectile.ai[1];
 

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -13,7 +13,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 			// This code is needed to customize the vanity pet display in the player select screen. Quick explanation:
 			// * It uses fluent API syntax, just like Recipe
 			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the end after reaching the end, effectively "bouncing"
-			// * To stop the animation if the player is not highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
+			// * To stop the animation if the player is highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
 			// * To set offset and direction, use .WithOffset(x, y) and .WithSpriteDirection(-1)
 			// * To further customize the behavior and animation of the pet (as its AI does not run), you have access to a few vanilla presets in DelegateMethods.CharacterPreview to use via .WithCode(). You can also make your own, showcased in MinionBossPetProjectile
 			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 6)

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -10,9 +10,9 @@ namespace ExampleMod.Content.Pets.ExamplePet
 			Main.projFrames[Projectile.type] = 4;
 			Main.projPet[Projectile.type] = true;
 
-			// This code is needed to make the vanity pet display in the player select screen. Quick explanation:
+			// This code is needed to customize the vanity pet display in the player select screen. Quick explanation:
 			// * It uses fluent API syntax, just like Recipe
-			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the back after reaching the end once
+			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the end after reaching the end, effectively "bouncing"
 			// * (If your pet has a custom animation you want to use, you need to manually create a SettingsForCharacterPreview object, this is not covered here)
 			// * To stop the animation if the player is not highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
 			// * To set offset and direction, use .WithOffset(x, y) and .WithSpriteDirection(-1)

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -13,7 +13,7 @@ namespace ExampleMod.Content.Pets.ExamplePet
 			// This code is needed to customize the vanity pet display in the player select screen. Quick explanation:
 			// * It uses fluent API syntax, just like Recipe
 			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the end after reaching the end, effectively "bouncing"
-			// * To stop the animation if the player is highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
+			// * To stop the animation if the player is not highlighted/is standing, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
 			// * To set offset and direction, use .WithOffset(x, y) and .WithSpriteDirection(-1)
 			// * To further customize the behavior and animation of the pet (as its AI does not run), you have access to a few vanilla presets in DelegateMethods.CharacterPreview to use via .WithCode(). You can also make your own, showcased in MinionBossPetProjectile
 			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 6)

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -13,10 +13,9 @@ namespace ExampleMod.Content.Pets.ExamplePet
 			// This code is needed to customize the vanity pet display in the player select screen. Quick explanation:
 			// * It uses fluent API syntax, just like Recipe
 			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the end after reaching the end, effectively "bouncing"
-			// * (If your pet has a custom animation you want to use, you need to manually create a SettingsForCharacterPreview object, this is not covered here)
 			// * To stop the animation if the player is not highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
 			// * To set offset and direction, use .WithOffset(x, y) and .WithSpriteDirection(-1)
-			// * To further customize the behavior of the pet (as its AI does not run), you have access to a few vanilla presets in DelegateMethods.CharacterPreview. You can also make your own ones, showcased in MinionBossPetProjectile
+			// * To further customize the behavior and animation of the pet (as its AI does not run), you have access to a few vanilla presets in DelegateMethods.CharacterPreview to use via .WithCode(). You can also make your own, showcased in MinionBossPetProjectile
 			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 6)
 				.WithOffset(-10, -20f)
 				.WithSpriteDirection(-1)

--- a/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
+++ b/ExampleMod/Content/Pets/ExamplePet/ExamplePetProjectile.cs
@@ -9,18 +9,30 @@ namespace ExampleMod.Content.Pets.ExamplePet
 		public override void SetStaticDefaults() {
 			Main.projFrames[Projectile.type] = 4;
 			Main.projPet[Projectile.type] = true;
+
+			// This code is needed to make the vanity pet display in the player select screen. Quick explanation:
+			// * It uses fluent API syntax, just like Recipe
+			// * You start with ProjectileID.Sets.SimpleLoop, specifying the start and end frames aswell as the speed, and optionally if it should animate from the back after reaching the end once
+			// * (If your pet has a custom animation you want to use, you need to manually create a SettingsForCharacterPreview object, this is not covered here)
+			// * To stop the animation if the player is not highlighted/walking, as done by most grounded pets, add a .WhenNotSelected(0, 0) (you can customize it just like SimpleLoop)
+			// * To set offset and direction, use .WithOffset(x, y) and .WithSpriteDirection(-1)
+			// * To further customize the behavior of the pet (as its AI does not run), you have access to a few vanilla presets in DelegateMethods.CharacterPreview. You can also make your own ones, showcased in MinionBossPetProjectile
+			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 6)
+				.WithOffset(-10, -20f)
+				.WithSpriteDirection(-1)
+				.WithCode(DelegateMethods.CharacterPreview.Float);
 		}
 
 		public override void SetDefaults() {
 			Projectile.CloneDefaults(ProjectileID.ZephyrFish); // Copy the stats of the Zephyr Fish
 
-			AIType = ProjectileID.ZephyrFish; // Copy the AI of the Zephyr Fish.
+			AIType = ProjectileID.ZephyrFish; // Mimic as the Zephyr Fish during AI.
 		}
 
 		public override bool PreAI() {
 			Player player = Main.player[Projectile.owner];
 
-			player.zephyrfish = false; // Relic from aiType
+			player.zephyrfish = false; // Relic from AIType
 
 			return true;
 		}

--- a/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetProjectile.cs
+++ b/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetProjectile.cs
@@ -36,7 +36,7 @@ namespace ExampleMod.Content.Pets.MinionBossPet
 			Main.projPet[Projectile.type] = true;
 
 			// Basics of CharacterPreviewAnimations explained in ExamplePetProjectile
-			// Notice we define our own method to use in .WithCode() below
+			// Notice we define our own method to use in .WithCode() below. This technically allows us to animate the projectile manually using frameCounter and frame aswell
 			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 5)
 				.WithOffset(-2, -22f)
 				.WithCode(CharacterPreviewCustomization);

--- a/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetProjectile.cs
+++ b/ExampleMod/Content/Pets/MinionBossPet/MinionBossPetProjectile.cs
@@ -34,6 +34,31 @@ namespace ExampleMod.Content.Pets.MinionBossPet
 		public override void SetStaticDefaults() {
 			Main.projFrames[Projectile.type] = 6;
 			Main.projPet[Projectile.type] = true;
+
+			// Basics of CharacterPreviewAnimations explained in ExamplePetProjectile
+			// Notice we define our own method to use in .WithCode() below
+			ProjectileID.Sets.CharacterPreviewAnimations[Projectile.type] = ProjectileID.Sets.SimpleLoop(0, Main.projFrames[Projectile.type], 5)
+				.WithOffset(-2, -22f)
+				.WithCode(CharacterPreviewCustomization);
+		}
+
+		public static void CharacterPreviewCustomization(Projectile proj, bool walking) {
+			// Modified floating from DelegateMethods.CharacterPreview.Float, this is technically not representative of how the pet actually looks and moves ingame, but the Suspicious Grinning Eye has that too
+
+			// If you don't need to modify it, just call DelegateMethods.CharacterPreview.Float(proj, walking) directly here instead and change properties of your pet after it.
+			// You do not need this otherwise and can use the preset directly as showcased in ExamplePetProjectile
+			float half = 0.5f;
+			float timer = (float)Main.timeForVisualEffects % 60f / 60f;
+			float speed = 1f; // This is normally 2
+			proj.position.Y += 0f - half + (float)(Math.Cos(timer * MathHelper.TwoPi * speed) * half * 2f);
+
+			// We are only using this method for one specific projectile, so it's fine to cast the ModProjectile directly like this
+			MinionBossPetProjectile minion = proj.ModProjectile as MinionBossPetProjectile;
+
+			// Need to set the alpha to 1f to hide the eyes that would normally draw and show the actual pet
+			minion.AlphaForVisuals = 1f;
+
+			// You can use Projectile.isAPreviewDummy in the draw code instead, it depends if you prefer changing the conditions leading up to the drawing, or the drawing itself
 		}
 
 		public override void SetDefaults() {
@@ -52,6 +77,11 @@ namespace ExampleMod.Content.Pets.MinionBossPet
 
 			Vector2 offset = new Vector2(0, Projectile.gfxOffY); // Vertical offset when the projectile is changing elevation on tiles (does not apply to this particular projectile because it is always airbone)
 			Vector2 orbitingCenter = Projectile.Center + offset;
+
+			// Don't need to draw the eyes if the pet is fully faded in
+			if (AlphaForVisuals >= 1) {
+				return;
+			}
 
 			int eyeCount = 10;
 			for (int i = 0; i < eyeCount; i++) {

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
@@ -5,7 +5,7 @@
  		if (!_player.hideMisc[0]) {
  			Item item = _player.miscEquips[0];
 -			if (!item.IsAir) {
-+			// TML: Retrict to items that are accepted by the vanity pet slot (conditions found in ItemSlot) to counteract unloaded item/modder changing the pet item to something else
++			// TML: Restrict to items that are accepted by the vanity pet slot (conditions found in ItemSlot) to counteract unloaded item/modder changing the pet item to something else
 +			if (!item.IsAir && item.buffType > 0 && Main.vanityPet[item.buffType] && !Main.lightPet[item.buffType]) {
  				int shoot = item.shoot;
  				_petProjectiles = new Projectile[1] {

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs.patch
@@ -1,5 +1,15 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UICharacter.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UICharacter.cs
+@@ -45,7 +_,8 @@
+ 	{
+ 		if (!_player.hideMisc[0]) {
+ 			Item item = _player.miscEquips[0];
+-			if (!item.IsAir) {
++			// TML: Retrict to items that are accepted by the vanity pet slot (conditions found in ItemSlot) to counteract unloaded item/modder changing the pet item to something else
++			if (!item.IsAir && item.buffType > 0 && Main.vanityPet[item.buffType] && !Main.lightPet[item.buffType]) {
+ 				int shoot = item.shoot;
+ 				_petProjectiles = new Projectile[1] {
+ 					PreparePetProjectiles_CreatePetProjectileDummy(shoot)
 @@ -64,6 +_,9 @@
  
  	public override void Update(GameTime gameTime)


### PR DESCRIPTION
### What is the bug?
Unloaded Item in the vanity pet slot causes the game to display the player as if he has an invisible pet in the player select screen. Same applies to items that end up in that slot even if they aren't valid anymore (i.e. if a modder changes a pet item to be something else)

### How did you fix the bug?
Copy the conditions from `ItemSlot` that restrict only vanity pet items going into that slot.

### Are there alternatives to your fix?
Early return instead of changing the vanilla line, but the IsAir check would have to be duplicated probably?

### ExampleMod updates
Added support for ExampleMod vanity pets for this feature, as by default they don't animate and usually display offset from the player/clip into the player below. The examples cover a basic one (paper airplane), and an advanced one (minion pet).