### PR TITLE
ExampleMod: More shimmer transformations

### DIFF
--- a/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleMusicBox.cs
@@ -9,6 +9,7 @@ namespace ExampleMod.Content.Items.Placeable
 		public override void SetStaticDefaults() {
 			Item.ResearchUnlockCount = 1;
 			ItemID.Sets.CanGetPrefixes[Type] = false; // music boxes can't get prefixes in vanilla
+			ItemID.Sets.ShimmerTransformToItem[Type] = ItemID.MusicBox; // recorded music boxes transform into the basic form in shimmer
 
 			// The following code links the music box's item and tile with a music track:
 			//   When music with the given ID is playing, equipped music boxes have a chance to change their id to the given item type.

--- a/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTorch.cs
@@ -10,6 +10,8 @@ namespace ExampleMod.Content.Items.Placeable
 	{
 		public override void SetStaticDefaults() {
 			Item.ResearchUnlockCount = 100;
+
+			ItemID.Sets.ShimmerTransformToItem[Type] = ItemID.ShimmerTorch;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
+++ b/ExampleMod/Content/NPCs/ExampleCustomAISlimeNPC.cs
@@ -43,6 +43,8 @@ namespace ExampleMod.Content.NPCs
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[NPC.type] = 6; // make sure to set this for your modnpcs.
 
+			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.ShimmerSlime;
+
 			// Specify the debuffs it is immune to
 			NPCID.Sets.DebuffImmunitySets.Add(Type, new NPCDebuffImmunityData {
 				SpecificallyImmuneTo = new int[] {

--- a/ExampleMod/Content/NPCs/PartyZombie.cs
+++ b/ExampleMod/Content/NPCs/PartyZombie.cs
@@ -16,6 +16,8 @@ namespace ExampleMod.Content.NPCs
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.Zombie];
 
+			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.Skeleton;
+
 			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) { // Influences how the NPC looks in the Bestiary
 				Velocity = 1f // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 			};


### PR DESCRIPTION
### What are the changes to ExampleMod?
Based on the listing on the [terraria wiki](https://terraria.wiki.gg/wiki/Shimmer), added shimmer transformations to all EM content that it applies to (except ExamplePerson, covered in #3172) showcasing some of the available sets.

### Do these changes need additional documentation?
No

