### PR TITLE
Fix Player.Serialize bug due to extra buff slots added by mods

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5870,9 +5870,10 @@
  		}
  
  		fileIO.Write(newPlayer.voidVaultInfo);
- 		for (int num5 = 0; num5 < maxBuffs; num5++) {
-+			//TML: Don't save buffs to vanilla player
+-		for (int num5 = 0; num5 < maxBuffs; num5++) {
 -			if (Main.buffNoSave[newPlayer.buffType[num5]]) {
++		for (int num5 = 0; num5 < 44; num5++) {
++			//TML: Don't save buffs to vanilla player
 +			if (true || Main.buffNoSave[newPlayer.buffType[num5]]) {
  				fileIO.Write(0);
  				fileIO.Write(0);


### PR DESCRIPTION
### What is the bug?
Mentioned in issue #3256 
### How did you fix the bug?
By writing only 44 slots to vanilla writing buffer just as what pre-1.4.4 tModLoader (which is 22 slots instead) did, excluding extra buff slots added by mods
