### PR TITLE
[ExampleMod] Fix EM not loading on servers, ExampleRecipeMaterialPlayer fixes

### DIFF
--- a/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleRecipeMaterialPlayer.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
-using System.Linq;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.ID;
@@ -16,6 +15,11 @@ namespace ExampleMod.Common.Players
 
 		// Nearby chest finding
 		public override void PostUpdateMiscEffects() {
+			if (Main.netMode == NetmodeID.Server) {
+				// We don't need to do any recipe stuff on the server
+				return;
+			}
+
 			int oldChestIndex = _chestIndexNearby;
 
 			// Gets leg position in tile coord for further chest searching
@@ -44,10 +48,15 @@ namespace ExampleMod.Common.Players
 					top--;
 				}
 
-				int chest = Chest.FindChest(left, top);
-				if (chest > 0 && !Chest.IsLocked(left, top)) {
-					_chestIndexNearby = chest;
-					break;
+				int chestIndex = Chest.FindChest(left, top);
+				if (chestIndex > -1 && !Chest.IsLocked(left, top)) {
+					Chest chest = Main.chest[chestIndex];
+					// Unopened chests in multiplayer have not initialized the items inside of them, so we check for safety if the first item is not null (assuming that all others won't be null either)
+					// Ideally, we would want to write custom netcode to request chest contents, see how a mod like Recipe Browser handles this: https://github.com/JavidPack/RecipeBrowser/blob/1.4/RecipeBrowser.cs, look for usage of packets
+					if (chest.item[0] != null) {
+						_chestIndexNearby = chestIndex;
+						break;
+					}
 				}
 			}
 
@@ -60,8 +69,8 @@ namespace ExampleMod.Common.Players
 
 		// Use items in the chest for crafting
 		public override IEnumerable<Item> AddMaterialsForCrafting(out ItemConsumedCallback itemConsumedCallback) {
-			// Ensure there is a chest nearby that is not opened by the player
-			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby)
+			// Ensure there is a chest nearby that is not opened by the player, and wasn't destroyed last tick
+			if (_chestIndexNearby is -1 || Player.chest == _chestIndexNearby || Main.chest[_chestIndexNearby] is not Chest chest)
 				return base.AddMaterialsForCrafting(out itemConsumedCallback);
 
 			// onUsedForCrafting invokes when the item is consumed, can be used to send packets in multiplayer mode
@@ -75,7 +84,7 @@ namespace ExampleMod.Common.Players
 
 			// Returns the items in the chest to use them for crafting
 			// The returned list should not be a cloned version of items otherwise items will not be consumed
-			return Main.chest[_chestIndexNearby].item;
+			return chest.item;
 		}
 	}
 }

--- a/ExampleMod/Common/UI/ExampleCoinsUI/ExampleCoinsUISystem.cs
+++ b/ExampleMod/Common/UI/ExampleCoinsUI/ExampleCoinsUISystem.cs
@@ -1,5 +1,4 @@
-﻿using ExampleMod.Common.UI;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.ModLoader;
@@ -7,6 +6,7 @@ using Terraria.UI;
 
 namespace ExampleMod.Common.UI.ExampleCoinsUI
 {
+	[Autoload(Side = ModSide.Client)] // This attribute makes this class only load on a particular side. Naturally this makes sense here since UI should only be a thing clientside. Be wary though that accessing this class serverside will error
 	public class ExampleCoinsUISystem : ModSystem
 	{
 		private UserInterface exampleCoinUserInterface;


### PR DESCRIPTION
### What are the changes to ExampleMod?
ExampleMod was unable to be loaded on the server due to `ExampleCoinsUISystem` being loaded serverside.
`ExampleRecipeMaterialPlayer` had two separate bugs:
* If the nearest chest to the player is broken, `_chestIndexNearby` would point to a `null` chest for one tick
* In multiplayer, items inside chest inventories are not initialized until the chest is interacted with, so FindRecipes would cause an exception whenever that is called (i.e. placing a tile from the inventory) and player is near such a chest.

The fixes entailed:
* Adding an `[Autoload(Side = ModSide.Client)]` attribute to `ExampleCoinsUISystem`.
* Checking `chest.item[0] != null` to verify that the chest has items initialized.
* Checking if the chest `_chestIndexNearby` points to is not `null`.

### Do these changes need additional documentation?
I added some minor documentation for the fix of `ExampleCoinsUISystem`.
I also added comments regarding the chest inventory problem in multiplayer and referred to another mod that solves this issue by using custom packets. Doing this in ExampleMod would be overkill imo.
