### PR TITLE
Fix ProjectileLoader.ReceiveExtraAI not being called (consistently)

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -262,7 +262,7 @@
  					num37 = -1;
  
  				array[2] = (bitsByte3[0] ? reader.ReadSingle() : 0f);
-+				byte[] extraAI = bitsByte3[2] ? ProjectileLoader.ReadExtraAI(reader) : null;
++				byte[] extraAI = bitsByte3[1] ? ProjectileLoader.ReadExtraAI(reader) : null;
 +
  				if (Main.netMode == 2) {
  					if (num36 == 949) {

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -142,7 +142,7 @@
  					break;
  				}
  				case 24:
-@@ -673,12 +_,16 @@
+@@ -673,7 +_,7 @@
  					if (projectile.knockBack != 0f)
  						bitsByte23[5] = true;
  
@@ -151,15 +151,18 @@
  						bitsByte23[7] = true;
  
  					if (projectile.originalDamage != 0)
- 						bitsByte23[6] = true;
- 
-+					byte[] extraAI = !ModNet.AllowVanillaClients ? ProjectileLoader.WriteExtraAI(projectile) : null;
-+					bool hasExtraAI = extraAI?.Length > 0;
-+					bitsByte23[2] = hasExtraAI; // This bit is unused by vanilla.
-+
+@@ -682,6 +_,11 @@
  					if ((byte)bitsByte24 != 0)
  						bitsByte23[2] = true;
  
++					byte[] extraAI = !ModNet.AllowVanillaClients ? ProjectileLoader.WriteExtraAI(projectile) : null;
++					bool hasExtraAI = extraAI?.Length > 0;
++					bitsByte23[2] |= hasExtraAI; // This bit is used for continuation of sending BitsBytes.
++					bitsByte24[1] = hasExtraAI; // This bit is unused by vanilla, but this BitsByte is only sent if the bit in the BitsByte above is set
++
+ 					writer.Write(bitsByte23);
+ 					if (bitsByte23[2])
+ 						writer.Write(bitsByte24);
 @@ -710,11 +_,20 @@
  					if (bitsByte24[0])
  						writer.Write(projectile.ai[2]);

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -142,7 +142,7 @@
  					break;
  				}
  				case 24:
-@@ -673,7 +_,7 @@
+@@ -673,12 +_,16 @@
  					if (projectile.knockBack != 0f)
  						bitsByte23[5] = true;
  
@@ -151,18 +151,15 @@
  						bitsByte23[7] = true;
  
  					if (projectile.originalDamage != 0)
-@@ -682,6 +_,11 @@
- 					if ((byte)bitsByte24 != 0)
- 						bitsByte23[2] = true;
+ 						bitsByte23[6] = true;
  
 +					byte[] extraAI = !ModNet.AllowVanillaClients ? ProjectileLoader.WriteExtraAI(projectile) : null;
 +					bool hasExtraAI = extraAI?.Length > 0;
-+					bitsByte23[2] |= hasExtraAI; // This bit is used for continuation of sending BitsBytes.
-+					bitsByte24[1] = hasExtraAI; // This bit is unused by vanilla, but this BitsByte is only sent if the bit in the BitsByte above is set
++					bitsByte24[1] = hasExtraAI; // This bit is unused by vanilla
 +
- 					writer.Write(bitsByte23);
- 					if (bitsByte23[2])
- 						writer.Write(bitsByte24);
+ 					if ((byte)bitsByte24 != 0)
+ 						bitsByte23[2] = true;
+ 
 @@ -710,11 +_,20 @@
  					if (bitsByte24[0])
  						writer.Write(projectile.ai[2]);


### PR DESCRIPTION
### What is the bug?
1.4.4 introduced `Projectile.ai[2]`. Netcode wise, this now overlaps with the previous implementation of `XExtraAI`, causing ReceiveExtraAI to only be called for projectiles that have `ai[2] != 0f`.

### How did you fix the bug?
On the **sender** side:
* `bitsByte23[2]` was originally unused before 1.4.4 so TML used that for flagging if `extraAI` exists. Now, this flag is used for continuation of sending more flags (and by extension, data attached to those flags). Vanilla sets `bitsByte23[2]` to true if `bitsByte24` contains anything (vanilla populates `bitsByte24[0]` with `ai[2] != 0f`)
* TML now utilizes the mostly free `bitsByte24`, and flags `bitsByte24[1]` with `hasExtraAI`. Vanilla then takes care of setting `bitsByte23[2]` as required.

On the **receiver** side:
* TML accesses `bitsByte3[1]` to read the sent `hasExtraAI` (which corresponds to `bitsByte24[1]`)

This way, it adds no additional overhead while not modifying vanilla netcode order.

### Are there alternatives to your fix?
This seems like the cleanest solution to me. TML could optionally start with the flags from 7 instead of the first free one, this avoids compatibility issues in the long run until vanilla maxes out the BitsByte.
