### PR TITLE
Better netcode error messages for Globals

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -376,11 +376,21 @@ public static class NPCLoader
 		catch (IOException e) {
 			Logging.tML.Error(e.ToString());
 
-			string culprits = $"Above IOException error in NPC {(npc.ModNPC == null ? npc.TypeName : npc.ModNPC.FullName)} may be caused by one of these:";
+			string message = $"Above IOException error in NPC {(npc.ModNPC == null ? npc.TypeName : npc.ModNPC.FullName)} occured";
+
+			var culprits = new List<GlobalNPC>();
 			foreach (GlobalNPC g in HookReceiveExtraAI.Enumerate(npc.globalNPCs)) {
-				culprits += $"\n    {g.Name}";
+				culprits.Add(g);
 			}
-			Logging.tML.Error(culprits);
+
+			if (culprits.Count > 0) {
+				message += ", may be caused by one of these:";
+				foreach (GlobalNPC g in culprits) {
+					message += $"\n\t{g.FullName}";
+				}
+			}
+
+			Logging.tML.Error(message);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -272,11 +272,21 @@ public static class ProjectileLoader
 		catch (IOException e) {
 			Logging.tML.Error(e.ToString());
 
-			string culprits = $"Above IOException error in projectile {(projectile.ModProjectile == null ? projectile.Name : projectile.ModProjectile.FullName)} may be caused by one of these:";
+			string message = $"Above IOException error in Projectile {(projectile.ModProjectile == null ? projectile.Name : projectile.ModProjectile.FullName)} occured";
+
+			var culprits = new List<GlobalProjectile>();
 			foreach (GlobalProjectile g in HookReceiveExtraAI.Enumerate(projectile.globalProjectiles)) {
-				culprits += $"\n    {g.Name}";
+				culprits.Add(g);
 			}
-			Logging.tML.Error(culprits);
+
+			if (culprits.Count > 0) {
+				message += ", may be caused by one of these:";
+				foreach (GlobalProjectile g in culprits) {
+					message += $"\n\t{g.FullName}";
+				}
+			}
+
+			Logging.tML.Error(message);
 		}
 	}
 


### PR DESCRIPTION
### What is the new feature?
Improves the log output for errors occuring during receiving of `Projectile/NPC` data. Some before/after:

#### Handle lack of reported GlobalProjectiles
Before:
```
System.IO.IOException: Read underflow 85 of 85 compressed bits in ReceiveExtraAI, more info below
   at Terraria.ModLoader.ProjectileLoader.ReceiveExtraAI(Projectile projectile, Byte[] extraAI) in tModLoader\Terraria\ModLoader\ProjectileLoader.cs:line 241
Above IOException error in projectile CalamityMod/ExoskeletonPlasmaCannon may be caused by one of these:
```

After (now properly adjusts message if no GlobalProjectiles exist):
```
System.IO.IOException: Read underflow 85 of 85 compressed bits in ReceiveExtraAI, more info below
   at Terraria.ModLoader.ProjectileLoader.ReceiveExtraAI(Projectile projectile, Byte[] extraAI) in tModLoader\Terraria\ModLoader\ProjectileLoader.cs:line 241
Above IOException error in projectile CalamityMod/ExoskeletonPlasmaCannon occured
```

#### Show the originating mod of the GlobalProjectiles
Before:
```
System.IO.IOException: Read underflow 37 of 38 compressed bits in ReceiveExtraAI, more info below
   at Terraria.ModLoader.ProjectileLoader.ReceiveExtraAI(Projectile projectile, Byte[] extraAI) in tModLoader\Terraria\ModLoader\ProjectileLoader.cs:line 241
Above IOException error in projectile CalamityMod/ExoskeletonPlasmaCannon may be caused by one of these:
    ThoriumGlobalPro
```

After (now shows `FullName`, comma in message):
```
System.IO.IOException: Read underflow 37 of 38 compressed bits in ReceiveExtraAI, more info below
   at Terraria.ModLoader.ProjectileLoader.ReceiveExtraAI(Projectile projectile, Byte[] extraAI) in tModLoader\Terraria\ModLoader\ProjectileLoader.cs:line 241
Above IOException error in projectile CalamityMod/ExoskeletonPlasmaCannon occured, may be caused by one of these:
    ThoriumMod/ThoriumGlobalPro
```

### Why should this be part of tModLoader?
Knowing what mod certain GlobalProjectile/NPC are from helps debugging and troubleshooting.

### Are there alternative designs?
Probably

### Sample usage for the new feature
N/A

### ExampleMod updates
Not required

