### PR TITLE
Add `NearShimmer` recipe condition

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -48,6 +48,9 @@ partial class TileID
 		/// <summary> Whether or not this tile counts as a lava source for crafting purposes. </summary>
 		public static bool[] CountsAsLavaSource = Factory.CreateBoolSet();
 
+		/// <summary> Whether or not this tile counts as a shimmer source for crafting purposes. </summary>
+		public static bool[] CountsAsShimmerSource = Factory.CreateBoolSet();
+
 		/// <summary> Whether or not saplings count this tile as empty when trying to grow. </summary>
 		public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 201, 233, 352, 485, 529, 530, 637, 655);
 

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -560,6 +560,7 @@
 		"NearWater": "Braucht Wasser",
 		"NearLava": "Braucht Lava",
 		"NearHoney": "Braucht Honig",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Braucht Tag",
 		"TimeNight": "Braucht Nacht",
 		"InDungeon": "Muss im Verlies-Biom sein",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -561,6 +561,7 @@
 		"NearWater": "Needs water",
 		"NearLava": "Needs lava",
 		"NearHoney": "Needs honey",
+		"NearShimmer": "Needs shimmer",
 		"TimeDay": "Needs day",
 		"TimeNight": "Needs night",
 		"InDungeon": "Needs to be in Dungeon Biome",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -560,6 +560,7 @@
 		"NearWater": "Necesita agua",
 		"NearLava": "Necesita lava",
 		"NearHoney": "Necesita miel",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Debe crearse de día",
 		"TimeNight": "Debe crearse de noche",
 		"InDungeon": "Debe crearse en la mazmorra",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -560,6 +560,7 @@
 		"NearWater": "Besoins d’eau",
 		"NearLava": "Besoins de lave",
 		"NearHoney": "Besoins de miel",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Besoins de jour",
 		"TimeNight": "Besoin de nuit",
 		"InDungeon": "Doit être dans le Biome du Donjon",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -560,6 +560,7 @@
 		"NearWater": "Wymaga Wody",
 		"NearLava": "Wymaga Lawy",
 		"NearHoney": "Miód jest niezbędny",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Wymaga dnia",
 		"TimeNight": "Wymaga nocy",
 		"InDungeon": "Musi być w biomie Lochy",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -560,6 +560,7 @@
 		"NearWater": "Precisa de água",
 		"NearLava": "Precisa de lava",
 		"NearHoney": "Precisa de mel",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Precisa do dia",
 		"TimeNight": "Precisa da noite",
 		"InDungeon": "Precisa estar no bioma do Calabouço",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -561,6 +561,7 @@
 		"NearWater": "Нужна вода",
 		"NearLava": "Нужна лава",
 		"NearHoney": "Нужен мёд",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "Только днём",
 		"TimeNight": "Только ночью",
 		"InDungeon": "Нужно находиться в Темнице",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -561,6 +561,7 @@
 		"NearWater": "需要水",
 		"NearLava": "需要岩浆",
 		"NearHoney": "需要蜂蜜",
+		//"NearShimmer": "Needs shimmer",
 		"TimeDay": "需要在白天",
 		"TimeNight": "需要在夜晚",
 		"InDungeon": "需要位于地牢环境",

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -317,9 +317,9 @@
  	public bool oldAdjWater;
  	public bool oldAdjHoney;
  	public bool oldAdjLava;
-    +	public bool oldAdjShimmer;
 -	public bool[] adjTile = new bool[TileID.Count];
 -	public bool[] oldAdjTile = new bool[TileID.Count];
++	public bool oldAdjShimmer;
 +
 +	private bool[] _adjTile = new bool[TileLoader.TileCount];
 +	public bool[] adjTile {
@@ -3409,6 +3409,16 @@
  			if (oldAdjTile[l] != adjTile[l]) {
  				flag = true;
  				break;
+@@ -27643,6 +_,9 @@
+ 		if (adjLava != oldAdjLava)
+ 			flag = true;
+ 
++		if (adjShimmer != oldAdjShimmer)
++			flag = true;
++
+ 		if (flag)
+ 			Recipe.FindRecipes();
+ 	}
 @@ -27759,7 +_,7 @@
  			waist = 0;
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3376,7 +3376,7 @@
  		alchemyTable = false;
  		int num3 = (int)((position.X + (float)(width / 2)) / 16f);
  		int num4 = (int)((position.Y + (float)height) / 16f);
-@@ -27610,16 +_,20 @@
+@@ -27610,16 +_,21 @@
  							alchemyTable = true;
  							break;
  					}
@@ -3395,6 +3395,7 @@
 -				if (Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 1)
 +				if ((Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 1) || TileID.Sets.CountsAsLavaSource[Main.tile[j, k].type])
  					adjLava = true;
++
 +				if ((Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 3) || TileID.Sets.CountsAsShimmerSource[Main.tile[j, k].type])
 +					adjShimmer = true;
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -308,10 +308,16 @@
  	public float moveSpeed = 1f;
  	public float pickSpeed = 1f;
  	public float wallSpeed = 1f;
-@@ -1243,12 +_,33 @@
+@@ -1239,16 +_,39 @@
+ 	public float runSlowdown = 0.2f;
+ 	public bool adjWater;
+ 	public bool adjHoney;
++	public bool adjShimmer;
+ 	public bool adjLava;
  	public bool oldAdjWater;
  	public bool oldAdjHoney;
  	public bool oldAdjLava;
+    +	public bool oldAdjShimmer;
 -	public bool[] adjTile = new bool[TileID.Count];
 -	public bool[] oldAdjTile = new bool[TileID.Count];
 +
@@ -3361,7 +3367,16 @@
  			oldAdjTile[i] = adjTile[i];
  			adjTile[i] = false;
  		}
-@@ -27610,15 +_,17 @@
+@@ -27580,6 +_,8 @@
+ 		adjHoney = false;
+ 		oldAdjLava = adjLava;
+ 		adjLava = false;
++		oldAdjShimmer = adjShimmer;
++		adjShimmer = false;
+ 		alchemyTable = false;
+ 		int num3 = (int)((position.X + (float)(width / 2)) / 16f);
+ 		int num4 = (int)((position.Y + (float)height) / 16f);
+@@ -27610,16 +_,20 @@
  							alchemyTable = true;
  							break;
  					}
@@ -3380,8 +3395,11 @@
 -				if (Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 1)
 +				if ((Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 1) || TileID.Sets.CountsAsLavaSource[Main.tile[j, k].type])
  					adjLava = true;
++				if ((Main.tile[j, k].liquid > 200 && Main.tile[j, k].liquidType() == 3) || TileID.Sets.CountsAsShimmerSource[Main.tile[j, k].type])
++					adjShimmer = true;
  			}
  		}
+ 
 @@ -27627,7 +_,7 @@
  			return;
  

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -27,6 +27,7 @@ public partial class Recipe
 		public static readonly Condition NearWater = new Condition(NetworkText.FromKey("RecipeConditions.NearWater"), _ => Main.LocalPlayer.adjWater || Main.LocalPlayer.adjTile[TileID.Sinks]);
 		public static readonly Condition NearLava = new Condition(NetworkText.FromKey("RecipeConditions.NearLava"), _ => Main.LocalPlayer.adjLava);
 		public static readonly Condition NearHoney = new Condition(NetworkText.FromKey("RecipeConditions.NearHoney"), _ => Main.LocalPlayer.adjHoney);
+		public static readonly Condition NearShimmer = new Condition(NetworkText.FromKey("RecipeConditions.NearShimmer"), _ => Main.LocalPlayer.adjShimmer);
 		//Time
 		public static readonly Condition TimeDay = new Condition(NetworkText.FromKey("RecipeConditions.TimeDay"), _ => Main.dayTime);
 		public static readonly Condition TimeNight = new Condition(NetworkText.FromKey("RecipeConditions.TimeNight"), _ => !Main.dayTime);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -729,7 +729,7 @@
  	{
  		for (int i = 0; i < tileIDs.Length; i++) {
  			requiredTile[i] = tileIDs[i];
-@@ -15821,12 +_,77 @@
+@@ -15821,12 +_,78 @@
  
  	private static void AddRecipe()
  	{
@@ -767,6 +767,7 @@
 +		ReplaceCondition(ref currentRecipe.needWater, Condition.NearWater);
 +		ReplaceCondition(ref currentRecipe.needLava, Condition.NearLava);
 +		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearHoney);
++		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearShimmer);
 +		ReplaceCondition(ref currentRecipe.needEverythingSeed, Condition.EverythingSeed);
 +
 +		ReplaceDecraftCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -18,7 +18,7 @@
  {
  	private struct RequiredItemEntry
  	{
-@@ -15,40 +_,56 @@
+@@ -15,40 +_,57 @@
  		public int stack;
  	}
  
@@ -49,6 +49,7 @@
 +	internal bool needWater;
 -	public bool needLava;
 +	internal bool needLava;
++	internal bool needShimmer;
 -	public bool anyWood;
 +	internal bool anyWood;
 -	public bool anyIronBar;
@@ -405,7 +406,7 @@
  			RequiredItemEntry requiredItemEntry = tempRec.requiredItemQuickLookup[i];
  			if (requiredItemEntry.itemIdOrRecipeGroup == 0)
  				break;
-@@ -441,7 +_,7 @@
+@@ -441,18 +_,19 @@
  
  	private static bool PlayerMeetsEnvironmentConditions(Player player, Recipe tempRec)
  	{
@@ -413,8 +414,16 @@
 +		bool num = !tempRec.needWater || player.adjWater /*|| player.adjTile[172]*/;
  		bool flag = !tempRec.needHoney || tempRec.needHoney == player.adjHoney;
  		bool flag2 = !tempRec.needLava || tempRec.needLava == player.adjLava;
- 		bool flag3 = !tempRec.needSnowBiome || player.ZoneSnow;
-@@ -452,7 +_,7 @@
++		bool flag3 = !tempRec.needShimmer || tempRec.needShimmer == player.adjShimmer;
+-		bool flag3 = !tempRec.needSnowBiome || player.ZoneSnow;
++		bool flag4 = !tempRec.needSnowBiome || player.ZoneSnow;
+-		bool flag4 = !tempRec.needGraveyardBiome || player.ZoneGraveyard;
++		bool flag5 = !tempRec.needGraveyardBiome || player.ZoneGraveyard;
+-		bool flag5 = !tempRec.needEverythingSeed || (Main.remixWorld && Main.getGoodWorld);
++		bool flag6 = !tempRec.needEverythingSeed || (Main.remixWorld && Main.getGoodWorld);
+-		return num && flag && flag2 && flag3 && flag4 && flag5;
++		return num && flag && flag2 && flag3 && flag4 && flag5 && flag6;
+ 	}
  
  	private static bool PlayerMeetsTileRequirements(Player player, Recipe tempRec)
  	{
@@ -767,7 +776,7 @@
 +		ReplaceCondition(ref currentRecipe.needWater, Condition.NearWater);
 +		ReplaceCondition(ref currentRecipe.needLava, Condition.NearLava);
 +		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearHoney);
-+		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearShimmer);
++		ReplaceCondition(ref currentRecipe.needShimmer, Condition.NearShimmer);
 +		ReplaceCondition(ref currentRecipe.needEverythingSeed, Condition.EverythingSeed);
 +
 +		ReplaceDecraftCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -18,7 +18,7 @@
  {
  	private struct RequiredItemEntry
  	{
-@@ -15,40 +_,57 @@
+@@ -15,40 +_,56 @@
  		public int stack;
  	}
  
@@ -49,7 +49,6 @@
 +	internal bool needWater;
 -	public bool needLava;
 +	internal bool needLava;
-+	internal bool needShimmer;
 -	public bool anyWood;
 +	internal bool anyWood;
 -	public bool anyIronBar;
@@ -406,7 +405,7 @@
  			RequiredItemEntry requiredItemEntry = tempRec.requiredItemQuickLookup[i];
  			if (requiredItemEntry.itemIdOrRecipeGroup == 0)
  				break;
-@@ -441,18 +_,19 @@
+@@ -441,7 +_,7 @@
  
  	private static bool PlayerMeetsEnvironmentConditions(Player player, Recipe tempRec)
  	{
@@ -414,16 +413,8 @@
 +		bool num = !tempRec.needWater || player.adjWater /*|| player.adjTile[172]*/;
  		bool flag = !tempRec.needHoney || tempRec.needHoney == player.adjHoney;
  		bool flag2 = !tempRec.needLava || tempRec.needLava == player.adjLava;
-+		bool flag3 = !tempRec.needShimmer || tempRec.needShimmer == player.adjShimmer;
--		bool flag3 = !tempRec.needSnowBiome || player.ZoneSnow;
-+		bool flag4 = !tempRec.needSnowBiome || player.ZoneSnow;
--		bool flag4 = !tempRec.needGraveyardBiome || player.ZoneGraveyard;
-+		bool flag5 = !tempRec.needGraveyardBiome || player.ZoneGraveyard;
--		bool flag5 = !tempRec.needEverythingSeed || (Main.remixWorld && Main.getGoodWorld);
-+		bool flag6 = !tempRec.needEverythingSeed || (Main.remixWorld && Main.getGoodWorld);
--		return num && flag && flag2 && flag3 && flag4 && flag5;
-+		return num && flag && flag2 && flag3 && flag4 && flag5 && flag6;
- 	}
+ 		bool flag3 = !tempRec.needSnowBiome || player.ZoneSnow;
+@@ -452,7 +_,7 @@
  
  	private static bool PlayerMeetsTileRequirements(Player player, Recipe tempRec)
  	{
@@ -738,7 +729,7 @@
  	{
  		for (int i = 0; i < tileIDs.Length; i++) {
  			requiredTile[i] = tileIDs[i];
-@@ -15821,12 +_,78 @@
+@@ -15821,12 +_,77 @@
  
  	private static void AddRecipe()
  	{
@@ -776,7 +767,6 @@
 +		ReplaceCondition(ref currentRecipe.needWater, Condition.NearWater);
 +		ReplaceCondition(ref currentRecipe.needLava, Condition.NearLava);
 +		ReplaceCondition(ref currentRecipe.needHoney, Condition.NearHoney);
-+		ReplaceCondition(ref currentRecipe.needShimmer, Condition.NearShimmer);
 +		ReplaceCondition(ref currentRecipe.needEverythingSeed, Condition.EverythingSeed);
 +
 +		ReplaceDecraftCondition(ref currentRecipe.crimson, Condition.CrimsonWorld);


### PR DESCRIPTION
### What is the new feature?

See issue #3276

### Why should this be part of tModLoader?

This addition allows the use of shimmer for crafting (or "decrafting") without actually using shimmer, particularly, for example, with mods that use the same item to decraft into other items, which may cause conflicts; this allows mods to add "craftable decrafting" recipes so that all players need to do is "decraft" without throwing anything in (in tandem with the example). Also see issue #3276

### Are there alternative designs?

No, but continuing the description, there could be an automatic function done to make it so when two mods change a single item for decrafting, the recipe for the item "decrafting" can appear instead.

### Sample usage for the new feature

In example recipes:
```cs
 .AddCondition(Recipe.Condition.NearShimmer)
```

### ExampleMod updates

_n/a_
<!-- If you also updated ExampleMod for your new feature, let us know here -->

### Additional notes

I think the rest of the liquid-related things in the code need to also utilize shimmer. `NeedLava` can be used as a search reference.
Can someone please help provide translations for "needs shimmer" or simply "shimmer"?