### PR TITLE
[1.4.4] Add ItemID.Sets.OreDropsFromSlime

### DIFF
--- a/ExampleMod/Content/Items/Placeable/ExampleOre.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleOre.cs
@@ -9,6 +9,10 @@ namespace ExampleMod.Content.Items.Placeable
 		public override void SetStaticDefaults() {
 			Item.ResearchUnlockCount = 100;
 			ItemID.Sets.SortingPriorityMaterials[Item.type] = 58;
+
+			// This ore can spawn in slime bodies like other pre-boss ores. (copper, tin, iron, etch)
+			// It will drop in amount from 3 to 13.
+			ItemID.Sets.OreDropsFromSlime[Type] = (3, 13);
 		}
 
 		public override void SetDefaults() {

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -18,6 +18,24 @@
  		ItemDropAttemptResult result = default(ItemDropAttemptResult);
  		result.State = ItemDropAttemptResultState.Success;
  		return result;
+@@ -47,7 +_,7 @@
+ 				amountDroppedMinimum = 20;
+ 				amountDroppedMaximum = 45;
+ 				break;
+-			case 11:
++			/*case 11:
+ 			case 12:
+ 			case 13:
+ 			case 14:
+@@ -57,7 +_,7 @@
+ 			case 702:
+ 				amountDroppedMinimum = 3;
+ 				amountDroppedMaximum = 13;
+-				break;
++				break;*/
+ 			case 71:
+ 				amountDroppedMinimum = 50;
+ 				amountDroppedMaximum = 99;
 @@ -75,6 +_,10 @@
  				amountDroppedMinimum = 2;
  				amountDroppedMaximum = 5;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -1,5 +1,14 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs
+@@ -15,7 +_,7 @@
+ 	public bool CanDrop(DropAttemptInfo info)
+ 	{
+ 		if (info.npc.type == 1 && info.npc.ai[1] > 0f)
+-			return info.npc.ai[1] < (float)ItemID.Count;
++			return info.npc.ai[1] < (float)Terraria.ModLoader.ItemLoader.ItemCount;
+ 
+ 		return false;
+ 	}
 @@ -24,7 +_,7 @@
  	{
  		int itemId = (int)info.npc.ai[1];
@@ -9,3 +18,14 @@
  		ItemDropAttemptResult result = default(ItemDropAttemptResult);
  		result.State = ItemDropAttemptResultState.Success;
  		return result;
+@@ -75,6 +_,10 @@
+ 				amountDroppedMinimum = 2;
+ 				amountDroppedMaximum = 5;
+ 				break;
++		}
++		if (ItemID.Sets.OreDropsFromSlime.TryGetValue(itemId, out var minMaxStack)) { // TML
++			amountDroppedMinimum = minMaxStack.minStack;
++			amountDroppedMaximum = minMaxStack.maxStack;
+ 		}
+ 	}
+ 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -18,21 +18,19 @@
  		ItemDropAttemptResult result = default(ItemDropAttemptResult);
  		result.State = ItemDropAttemptResultState.Success;
  		return result;
-@@ -47,7 +_,7 @@
+@@ -47,6 +_,7 @@
  				amountDroppedMinimum = 20;
  				amountDroppedMaximum = 45;
  				break;
--			case 11:
-+			/*case 11:
++			/*
+ 			case 11:
  			case 12:
  			case 13:
- 			case 14:
-@@ -57,7 +_,7 @@
- 			case 702:
+@@ -58,6 +_,7 @@
  				amountDroppedMinimum = 3;
  				amountDroppedMaximum = 13;
--				break;
-+				break;*/
+ 				break;
++			*/
  			case 71:
  				amountDroppedMinimum = 50;
  				amountDroppedMaximum = 99;

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -74,5 +74,20 @@ partial class ItemID
 			{ Diamond, (3, 7) },
 			{ Amber, (3, 7) }
 		};
+
+		/// <summary>
+		/// Dictionary for defining what ores can spawn as bonus drop inside slime body. All items in this dictionary are equally likely to roll, and will drop with a stack size between minStack and maxStack (exclusive).
+		/// <br/>Stack sizes with less than 1 or where minStack is not strictly smaller than maxStack will lead to exceptions being thrown.
+		/// </summary>
+		public static Dictionary<int, (int minStack, int maxStack)> OreDropsFromSlime = new() {
+			{ CopperOre, (3, 13) },
+			{ TinOre, (3, 13) },
+			{ IronOre, (3, 13) },
+			{ LeadOre, (3, 13) },
+			{ SilverOre, (3, 13) },
+			{ TungstenOre, (3, 13) },
+			{ GoldOre, (3, 13) },
+			{ PlatinumOre, (3, 13) },
+		};
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -145,12 +145,25 @@ public static class ItemLoader
 		}
 
 		ValidateGeodeDropsSet();
+		ValidateSlimeOreDropsSet();
 	}
 
 	internal static void ValidateGeodeDropsSet()
 	{
 		foreach (var pair in ItemID.Sets.GeodeDrops) {
 			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.GeodeDrops)}'";
+			if (pair.Value.minStack < 1)
+				throw new Exception($"{exceptionCommon} must have minStack bigger than 0");
+
+			if (pair.Value.maxStack <= pair.Value.minStack)
+				throw new Exception($"{exceptionCommon} must have maxStack bigger than minStack");
+		}
+	}
+
+	internal static void ValidateSlimeOreDropsSet()
+	{
+		foreach (var pair in ItemID.Sets.OreDropsFromSlime) {
+			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.OreDropsFromSlime)}'";
 			if (pair.Value.minStack < 1)
 				throw new Exception($"{exceptionCommon} must have minStack bigger than 0");
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -144,11 +144,10 @@ public static class ItemLoader
 			ContentSamples.ItemsByType[item.Type].RebuildTooltip();
 		}
 
-		ValidateGeodeDropsSet();
-		ValidateSlimeOreDropsSet();
+		ValidateDropsSet();
 	}
 
-	internal static void ValidateGeodeDropsSet()
+	internal static void ValidateDropsSet()
 	{
 		foreach (var pair in ItemID.Sets.GeodeDrops) {
 			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.GeodeDrops)}'";
@@ -158,10 +157,7 @@ public static class ItemLoader
 			if (pair.Value.maxStack <= pair.Value.minStack)
 				throw new Exception($"{exceptionCommon} must have maxStack bigger than minStack");
 		}
-	}
 
-	internal static void ValidateSlimeOreDropsSet()
-	{
 		foreach (var pair in ItemID.Sets.OreDropsFromSlime) {
 			string exceptionCommon = $"{Lang.GetItemNameValue(pair.Key)} registered in 'ItemID.Sets.{nameof(ItemID.Sets.OreDropsFromSlime)}'";
 			if (pair.Value.minStack < 1)

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1412,22 +1412,22 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59944,6 +_,7 @@
- 			}
+@@ -59945,6 +_,7 @@
  		}
  	}
-+	/*
  
++	/*
  	public static int GetStackForSlimeItemDrop(int item)
  	{
-@@ -59979,6 +_,7 @@
+ 		int num = 1;
+@@ -59978,6 +_,7 @@
+ 
  		return num;
  	}
- 
 +	*/
+ 
  	public bool ExcludedFromDeathTally()
  	{
- 		if (netID < 0) {
 @@ -60090,7 +_,8 @@
  		return false;
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1172,6 +1172,14 @@
  								bool flag26 = WorldGen.OpenDoor(num194, num195 - 1, direction);
  								if (!flag26) {
  									ai[3] = num56;
+@@ -45741,6 +_,7 @@
+ 						return 58;
+ 				}
+ 			case 2:
++				return Main.rand.Next(System.Linq.Enumerable.ToList(ItemID.Sets.OreDropsFromSlime.Keys)); // TML
+ 				if (Main.rand.Next(2) == 0)
+ 					return Main.rand.Next(11, 15);
+ 				return Main.rand.Next(699, 703);
 @@ -46035,7 +_,7 @@
  							Tile tileSafely = Framing.GetTileSafely(i, j);
  							bool flag2 = tileSafely.active() && Main.tileSolid[tileSafely.type] && !Main.tileFrameImportant[tileSafely.type];
@@ -1398,6 +1406,17 @@
 +			DoDeathEvents_CelebrateBossDeath(typeName);
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
+ 		}
+@@ -59957,8 +_,8 @@
+ 		else if (item == 965) {
+ 			num = Main.rand.Next(20, 46);
+ 		}
+-		else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
+-			num = Main.rand.Next(3, 9);
++		else if (ItemID.Sets.OreDropsFromSlime.TryGetValue(item, out var minMaxStack) || (item >= 11 && item <= 14) || (item >= 699 && item <= 702)) { // ore drops check from TML
++			return Main.rand.Next(minMaxStack.minStack, minMaxStack.maxStack);
+ 			if (Main.rand.Next(2) == 0)
+ 				num += 5;
  		}
 @@ -60090,7 +_,8 @@
  		return false;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1172,16 +1172,16 @@
  								bool flag26 = WorldGen.OpenDoor(num194, num195 - 1, direction);
  								if (!flag26) {
  									ai[3] = num56;
-@@ -45741,9 +_,10 @@
+@@ -45741,9 +_,12 @@
  						return 58;
  				}
  			case 2:
 +				return Main.rand.Next(System.Linq.Enumerable.ToList(ItemID.Sets.OreDropsFromSlime.Keys)); // TML
--				if (Main.rand.Next(2) == 0)
-+				/*if (Main.rand.Next(2) == 0)
++				/*
+ 				if (Main.rand.Next(2) == 0)
  					return Main.rand.Next(11, 15);
--				return Main.rand.Next(699, 703);
-+				return Main.rand.Next(699, 703);*/
+ 				return Main.rand.Next(699, 703);
++				*/
  			default:
  				switch (Main.rand.Next(3)) {
  					case 0:
@@ -1412,21 +1412,23 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59957,10 +_,13 @@
+@@ -59957,11 +_,16 @@
  		else if (item == 965) {
  			num = Main.rand.Next(20, 46);
  		}
--		else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
-+		/*else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
++		/*
+ 		else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
  			num = Main.rand.Next(3, 9);
  			if (Main.rand.Next(2) == 0)
  				num += 5;
-+		}*/
+ 		}
++		*/
 +		else if (ItemID.Sets.OreDropsFromSlime.TryGetValue(item, out var minMaxStack)) {
 +			num = Main.rand.Next(minMaxStack.minStack, minMaxStack.maxStack + 1);
- 		}
++		}
  		else {
  			switch (item) {
+ 				case 71:
 @@ -60090,7 +_,8 @@
  		return false;
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1412,23 +1412,24 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59957,11 +_,16 @@
- 		else if (item == 965) {
- 			num = Main.rand.Next(20, 46);
+@@ -59945,6 +_,7 @@
  		}
-+		/*
- 		else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
- 			num = Main.rand.Next(3, 9);
- 			if (Main.rand.Next(2) == 0)
- 				num += 5;
- 		}
-+		*/
-+		else if (ItemID.Sets.OreDropsFromSlime.TryGetValue(item, out var minMaxStack)) {
-+			num = Main.rand.Next(minMaxStack.minStack, minMaxStack.maxStack + 1);
-+		}
- 		else {
- 			switch (item) {
- 				case 71:
+ 	}
+ 
++	/*
+ 	public static int GetStackForSlimeItemDrop(int item)
+ 	{
+ 		int num = 1;
+@@ -59978,7 +_,8 @@
+ 
+ 		return num;
+ 	}
+-
++	*/
++	
+ 	public bool ExcludedFromDeathTally()
+ 	{
+ 		if (netID < 0) {
 @@ -60090,7 +_,8 @@
  		return false;
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1412,20 +1412,18 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59944,7 +_,7 @@
+@@ -59944,6 +_,7 @@
  			}
  		}
  	}
--
 +	/*
+ 
  	public static int GetStackForSlimeItemDrop(int item)
  	{
- 		int num = 1;
-@@ -59978,7 +_,7 @@
- 
+@@ -59979,6 +_,7 @@
  		return num;
  	}
--
+ 
 +	*/
  	public bool ExcludedFromDeathTally()
  	{

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1412,21 +1412,21 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59945,6 +_,7 @@
+@@ -59944,7 +_,7 @@
+ 			}
  		}
  	}
- 
+-
 +	/*
  	public static int GetStackForSlimeItemDrop(int item)
  	{
  		int num = 1;
-@@ -59978,7 +_,8 @@
+@@ -59978,7 +_,7 @@
  
  		return num;
  	}
 -
 +	*/
-+	
  	public bool ExcludedFromDeathTally()
  	{
  		if (netID < 0) {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1172,14 +1172,19 @@
  								bool flag26 = WorldGen.OpenDoor(num194, num195 - 1, direction);
  								if (!flag26) {
  									ai[3] = num56;
-@@ -45741,6 +_,7 @@
+@@ -45741,9 +_,10 @@
  						return 58;
  				}
  			case 2:
 +				return Main.rand.Next(System.Linq.Enumerable.ToList(ItemID.Sets.OreDropsFromSlime.Keys)); // TML
- 				if (Main.rand.Next(2) == 0)
+-				if (Main.rand.Next(2) == 0)
++				/*if (Main.rand.Next(2) == 0)
  					return Main.rand.Next(11, 15);
- 				return Main.rand.Next(699, 703);
+-				return Main.rand.Next(699, 703);
++				return Main.rand.Next(699, 703);*/
+ 			default:
+ 				switch (Main.rand.Next(3)) {
+ 					case 0:
 @@ -46035,7 +_,7 @@
  							Tile tileSafely = Framing.GetTileSafely(i, j);
  							bool flag2 = tileSafely.active() && Main.tileSolid[tileSafely.type] && !Main.tileFrameImportant[tileSafely.type];
@@ -1407,17 +1412,21 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(7);
  		}
-@@ -59957,8 +_,8 @@
+@@ -59957,10 +_,13 @@
  		else if (item == 965) {
  			num = Main.rand.Next(20, 46);
  		}
 -		else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
--			num = Main.rand.Next(3, 9);
-+		else if (ItemID.Sets.OreDropsFromSlime.TryGetValue(item, out var minMaxStack) || (item >= 11 && item <= 14) || (item >= 699 && item <= 702)) { // ore drops check from TML
-+			return Main.rand.Next(minMaxStack.minStack, minMaxStack.maxStack);
++		/*else if ((item >= 11 && item <= 14) || (item >= 699 && item <= 702)) {
+ 			num = Main.rand.Next(3, 9);
  			if (Main.rand.Next(2) == 0)
  				num += 5;
++		}*/
++		else if (ItemID.Sets.OreDropsFromSlime.TryGetValue(item, out var minMaxStack)) {
++			num = Main.rand.Next(minMaxStack.minStack, minMaxStack.maxStack + 1);
  		}
+ 		else {
+ 			switch (item) {
 @@ -60090,7 +_,8 @@
  		return false;
  	}


### PR DESCRIPTION
Implements #3283 

### What is the new feature?
`ItemID.Sets.OreDropsFromSlime` is a `Dictionary<int, (int minStack, int maxStack)>` which allows modders to add or change the ores that can appear and drop from slimes.

### Why should this be part of tModLoader?
In vanilla, slimes can generate ores inside their bodies with equal drop chance and with fixed range stack size. Modifying or adding to this behavior requires IL editing and/or detouring.
The way `ItemID.Sets.OreDropsFromSlime` is implemented lets the modder add their own loot (usually pre-boss ores) combined with a custom stack size.

### Are there alternative designs?
- Some way to specify "weight" of each item in the pool (i.e. a mod wants to make Platinum Ore rarer without changing the stack size).
- The `(3, 13)` could be a `static readonly` in `Item` so that if vanilla/tml change it in a later update, and mods use it for their own items, they will get the updated stack range.

### Sample usage for the new feature
```
ItemID.Sets.OreDropsFromSlime.Remove(ItemID.SilverOre);
ItemID.Sets.OreDropsFromSlime[Type] = (3, 13); //Inside a ModItem class
ItemID.Sets.OreDropsFromSlime[ModContent.ItemType<ExampleOre>()] = (3, 13);
ItemID.Sets.OreDropsFromSlime[ItemID.SilverOre] = (12, 34);
```

### ExampleMod updates
The only change in ExampleMod is making ExampleOre to be able to drop from slimes.