### PR TITLE
Resolves #3133: added a currency system accessor

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/CustomCurrencyManager.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/CustomCurrencyManager.cs.patch
@@ -8,3 +8,17 @@
  		CustomCurrencyID.DefenderMedals = RegisterCurrency(new CustomCurrencySingleCoin(3817, 999L));
  	}
  
+@@ -138,4 +_,13 @@
+ 	{
+ 		_currencies[item.shopSpecialCurrency].GetItemExpectedPrice(item, out calcForSelling, out calcForBuying);
+ 	}
++
++	/// <summary>
++	/// Attempts to retrieve a CustomCurrencySystem object with the specified id from the _currencies dictionary.
++	/// </summary>
++	/// <param name="id">The id of the currency system to retrieve.</param>
++	/// <param name="system">When this method returns, contains the retrieved CustomCurrencySystem object, or null if the retrieval failed.</param>
++	/// <returns>true if the retrieval was successful; otherwise, false.</returns>
++	public static bool TryGetCurrencySystem(int id, out CustomCurrencySystem system) => _currencies.TryGetValue(id, out system); // Resolves #3133
++	
+ }


### PR DESCRIPTION
This change simply adds a new hook to try to get a currency system given ID

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->

### What is the new feature?
Added a hook to be able to retrieve CustomCurrencySystem based off ID.

### Why should this be part of tModLoader?
`Dynamic Access to modded Currencies is currently impossible. This would allow Iteration of all Currencies.`

This PR just aims to implement the requested feature.

### Are there alternative designs?
There don't seem to be alternative designs. Currently there's no way of even accessing the `_currencies` dictionary. 

### Sample usage for the new feature
```cs
int currencyId = 123; // replace with the actual currencyId value obtained from RegisterCurrency
CustomCurrencySystem currencySystem;
if (TryGetCurrencySystem(currencyId, out currencySystem))
{
    // The currency system was found, and currencySystem now holds the corresponding CustomCurrencySystem object
    // you can now use the currencySystem object as needed
}
else
{
    // The currency system was not found, and currencySystem is null
    // handle the error condition as appropriate
}
```