### PR TITLE
Replace MonoMod Hooking of StackTrace with PathMap Usage in Projects

### DIFF
--- a/patches/tModLoader/ReLogic/ReLogic.csproj.patch
+++ b/patches/tModLoader/ReLogic/ReLogic.csproj.patch
@@ -1,10 +1,11 @@
 --- src/TerrariaNetCore/ReLogic/ReLogic.csproj
 +++ src/tModLoader/ReLogic/ReLogic.csproj
-@@ -6,9 +_,10 @@
+@@ -6,9 +_,11 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © Re-Logic 2017</Copyright>
  		<RootNamespace>ReLogic</RootNamespace>
 +		<GenerateDocumentationFile>true</GenerateDocumentationFile>
++		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
  	</PropertyGroup>
  	<ItemGroup>
 -		<Reference Include="../Terraria/Libraries/Common/Ionic.Zip.CF.dll" />

--- a/patches/tModLoader/Terraria/ModLoader/Engine/LoggingHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/LoggingHooks.cs
@@ -13,7 +13,6 @@ internal static class LoggingHooks
 	internal static void Init()
 	{
 		FixBrokenConsolePipeError();
-		PrettifyStackTraceSources();
 		HookWebRequests();
 		HookProcessStart();
 	}
@@ -47,25 +46,6 @@ internal static class LoggingHooks
 			Logging.tML.Debug($"Process.Start (UseShellExecute = {self.StartInfo.UseShellExecute}): \"{self.StartInfo.FileName}\" {self.StartInfo.Arguments}");
 			return orig(self);
 		}));
-	}
-
-	// On .NET, hook the StackTrace constructor
-	private delegate void ctor_StackTrace(StackTrace self, Exception e, bool fNeedFileInfo);
-	private delegate void hook_StackTrace(ctor_StackTrace orig, StackTrace self, Exception e, bool fNeedFileInfo);
-	private static void HookStackTraceEx(ctor_StackTrace orig, StackTrace self, Exception e, bool fNeedFileInfo)
-	{
-		orig(self, e, fNeedFileInfo);
-		if (fNeedFileInfo)
-			Logging.PrettifyStackTraceSources(self.GetFrames());
-	}
-
-	private static Hook stackTraceCtorHook;
-	private static void PrettifyStackTraceSources()
-	{
-		if (Logging.f_fileName == null)
-			return;
-
-		stackTraceCtorHook = new Hook(typeof(StackTrace).GetConstructor(new[] { typeof(Exception), typeof(bool) }), new hook_StackTrace(HookStackTraceEx));
 	}
 
 	private delegate ValueTask<HttpResponseMessage> orig_SendAsyncCore(object self, HttpRequestMessage request, Uri? proxyUri, bool async, bool doRequestAuth, bool isProxyConnect, CancellationToken cancellationToken);

--- a/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
@@ -108,7 +108,6 @@ public static partial class Logging
 			if (!oom && ignoreContents.Any(s => MatchContents(traceString, s)))
 				return;
 
-			PrettifyStackTraceSources(stackTrace.GetFrames());
 			traceString = stackTrace.ToString();
 			traceString = traceString[traceString.IndexOf('\n')..];
 

--- a/patches/tModLoader/Terraria/ModLoader/Logging.Utilities.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.Utilities.cs
@@ -7,42 +7,6 @@ namespace Terraria.ModLoader;
 
 public static partial class Logging
 {
-	private const BindingFlags InstanceNonPublic = BindingFlags.Instance | BindingFlags.NonPublic;
-	
-	internal static readonly FieldInfo f_fileName = typeof(StackFrame).GetField("_fileName", InstanceNonPublic) ?? typeof(StackFrame).GetField("strFileName", InstanceNonPublic);
-
-	private static readonly Assembly terrariaAssembly = Assembly.GetExecutingAssembly();
-
-	public static void PrettifyStackTraceSources(StackFrame[] frames)
-	{
-		if (frames == null)
-			return;
-
-		foreach (var frame in frames) {
-			string filename = frame.GetFileName();
-			var assembly = frame.GetMethod()?.DeclaringType?.Assembly;
-
-			if (filename == null || assembly == null)
-				continue;
-
-			string trim;
-
-			if (AssemblyManager.GetAssemblyOwner(assembly, out string modName))
-				trim = modName;
-			else if (assembly == terrariaAssembly)
-				trim = "tModLoader";
-			else
-				continue;
-
-			int index = filename.LastIndexOf(trim, StringComparison.InvariantCultureIgnoreCase);
-
-			if (index > 0) {
-				filename = filename.Substring(index);
-				f_fileName.SetValue(frame, filename);
-			}
-		}
-	}
-
 	private static void TryFreeingMemory()
 	{
 		// In case of OOM, unload the Main.tile array and do immediate garbage collection.

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -7,24 +_,27 @@
+@@ -7,24 +_,28 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -9,7 +9,7 @@
 +		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 +		<UseAppHost>false</UseAppHost>
  		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
- 	</PropertyGroup>
+-	</PropertyGroup>
 -	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
 -		<AssemblyName>$(AssemblyName)Server</AssemblyName>
 -	</PropertyGroup>
@@ -19,6 +19,8 @@
 -	<!-- Avoid overwriting Terraria(Server).exe (if it's not Debug it's release) -->
 -	<PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
 -		<AssemblyName>$(AssemblyName)Release</AssemblyName>
++		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
++	</PropertyGroup>
 +	<PropertyGroup>
 +		<tMLVersion Condition="'$(TmlVersion)' == ''">9999.0</tMLVersion>
 +		<StableVersion Condition="'$(stableVersion)' == ''">0.0</StableVersion>

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -7,6 +7,7 @@
 		<tMLName>tModLoader</tMLName>
 		<tMLPath>$(tMLName).dll</tMLPath>
 		<tMLServerPath>$(tMLPath) -server</tMLServerPath>
+		<PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
 		<!-- TML stable version define placeholder -->
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
### What is the bug?
The old logic which added method detours to `StackTrace::.ctor(Exception, bool)` would sometimes not properly trim the file paths due to the constructor being inlined.

### How did you fix the bug?
I changed the `.csproj` sources to use the `PathMap` attribute, which does this at the PDB level.  I also included it in `tModLoader.targets` so that all mods built after this change will also easily support this.

### Are there alternatives to your fix?
n/a