### PR TITLE
Fix Unloaded Mod Accessory Slot #2667

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/AccessorySlotLoader.cs
@@ -25,7 +25,9 @@ public class AccessorySlotLoader : Loader<ModAccessorySlot>
 
 	public AccessorySlotLoader() => Initialize(0);
 
-	public ModAccessorySlot Get(int id, Player player) => list[id % ModSlotPlayer(player).SlotCount];
+	// Note: Because of the weird nuance of both vanity and functional being in same array, we have to reduce down to half the size
+	private ModAccessorySlot GetIdCorrected(int id) => (id >= list.Count) ? new UnloadedAccessorySlot(id, "TEMP'd") : list[id];
+	public ModAccessorySlot Get(int id, Player player) => GetIdCorrected(id % ModSlotPlayer(player).SlotCount);
 	public ModAccessorySlot Get(int id) => Get(id, Player);
 
 	public const int MaxVanillaSlotCount = 2 + 5;
@@ -60,19 +62,19 @@ public class AccessorySlotLoader : Loader<ModAccessorySlot>
 			}
 		}
 
-		for (int modSlot = 0; modSlot < list.Count; modSlot++) {
+		for (int modSlot = 0; modSlot < ModSlotPlayer(Player).SlotCount; modSlot++) {
 			if (!Draw(skip, true, modSlot, color))
 				skip++;
 		}
 
 		// there are no slots to be drawn by us.
-		if (skip == MaxVanillaSlotCount + list.Count) {
+		if (skip == MaxVanillaSlotCount + ModSlotPlayer(Player).SlotCount) {
 			ModSlotPlayer(Player).scrollbarSlotPosition = 0;
 			return;
 		}
 
 		int accessoryPerColumn = GetAccessorySlotPerColumn();
-		int slotsToRender = list.Count + MaxVanillaSlotCount - skip;
+		int slotsToRender = ModSlotPlayer(Player).SlotCount + MaxVanillaSlotCount - skip;
 		int scrollIncrement = slotsToRender - accessoryPerColumn;
 
 		if (scrollIncrement < 0) {
@@ -189,7 +191,7 @@ public class AccessorySlotLoader : Loader<ModAccessorySlot>
 		bool customLoc = false;
 
 		if (modded) {
-			ModAccessorySlot mAccSlot = list[slot];
+			ModAccessorySlot mAccSlot = Get(slot);
 			customLoc = mAccSlot.CustomLocation.HasValue;
 			if (!customLoc && Main.EquipPage != 0)
 				return false;
@@ -209,7 +211,7 @@ public class AccessorySlotLoader : Loader<ModAccessorySlot>
 				Main.spriteBatch.Draw(value4, new Vector2(xLoc2, yLoc2), Color.White * 0.7f);
 			}
 			if (thisSlot.DrawVanitySlot)
-				DrawSlot(ModSlotPlayer(Player).exAccessorySlot, -11, slot + list.Count, flag3, xLoc, yLoc);
+				DrawSlot(ModSlotPlayer(Player).exAccessorySlot, -11, slot + ModSlotPlayer(Player).SlotCount, flag3, xLoc, yLoc);
 			if (thisSlot.DrawDyeSlot)
 				DrawSlot(ModSlotPlayer(Player).exDyesAccessory, -12, slot, flag3, xLoc, yLoc);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -74,10 +74,8 @@ public class ModAccessorySlotPlayer : ModPlayer
 		for (int i = 0; i < order.Count; i++) {
 			// Try finding the slot item goes in to
 			if (!slots.TryGetValue(order[i], out int type)) {
-				var unloaded = new UnloadedAccessorySlot(Loader.list.Count + UnloadedSlotCount++, order[i]);
-
-				slots.Add(unloaded.Name, unloaded.Type);
-				type = unloaded.Type;
+				type = Loader.list.Count + UnloadedSlotCount++;
+				slots.Add(order[i], type);
 			}
 
 			// Place loaded items in to the correct slot

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -52,6 +52,7 @@ public class ModAccessorySlotPlayer : ModPlayer
 
 	public override void SaveData(TagCompound tag)
 	{
+		// TODO, might be nice to only save acc slots which have something in them... particularly if they're unloaded. Otherwise old unloaded slots just bloat the array with empty entries forever
 		tag["order"] = slots.Keys.ToList();
 		tag["items"] = exAccessorySlot.Select(ItemIO.Save).ToList();
 		tag["dyes"] = exDyesAccessory.Select(ItemIO.Save).ToList();

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -29,13 +29,7 @@ public class ModAccessorySlotPlayer : ModPlayer
 	public ModAccessorySlotPlayer()
 	{
 		foreach (var slot in Loader.list) {
-			if (!slot.FullName.StartsWith("Terraria", StringComparison.OrdinalIgnoreCase)) {
-				slots.Add(slot.FullName, slot.Type);
-			}
-			else {
-				UnloadedSlotCount++;
-				slots.Add(slot.Name, slot.Type);
-			}
+			slots.Add(slot.FullName, slot.Type);
 		}
 
 		ResizeAccesoryArrays(slots.Count);
@@ -80,12 +74,10 @@ public class ModAccessorySlotPlayer : ModPlayer
 		for (int i = 0; i < order.Count; i++) {
 			// Try finding the slot item goes in to
 			if (!slots.TryGetValue(order[i], out int type)) {
-				var unloaded = new UnloadedAccessorySlot(Loader.list.Count, order[i]);
+				var unloaded = new UnloadedAccessorySlot(Loader.list.Count + UnloadedSlotCount++, order[i]);
 
 				slots.Add(unloaded.Name, unloaded.Type);
-				Loader.list.Add(unloaded);
 				type = unloaded.Type;
-				UnloadedSlotCount++;
 			}
 
 			// Place loaded items in to the correct slot
@@ -268,6 +260,8 @@ public class ModAccessorySlotPlayer : ModPlayer
 
 		private static void HandleVisualState(BinaryReader r, int fromWho)
 		{
+			// Does this receiving need to factor in difference between LoadedCount and Total?
+			// Shouldn't?
 			if (Main.netMode == Client)
 				fromWho = r.ReadByte();
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -13,9 +13,9 @@ public class ModAccessorySlotPlayer : ModPlayer
 	internal static AccessorySlotLoader Loader => LoaderManager.Get<AccessorySlotLoader>();
 
 	// Arrays for modded accessory slot save/load/usage. Used in DefaultPlayer.
-	internal Item[] exAccessorySlot = new Item[2];
-	internal Item[] exDyesAccessory = new Item[1];
-	internal bool[] exHideAccessory = new bool[1];
+	internal Item[] exAccessorySlot;
+	internal Item[] exDyesAccessory;
+	internal bool[] exHideAccessory;
 	internal Dictionary<string, int> slots = new Dictionary<string, int>();
 
 	// Setting toggle for stack or scroll accessories/npcHousing
@@ -32,20 +32,17 @@ public class ModAccessorySlotPlayer : ModPlayer
 			slots.Add(slot.FullName, slot.Type);
 		}
 
-		ResizeAccesoryArrays(slots.Count);
+		ResetAndSizeAccessoryArrays();
 	}
 
-	internal void ResizeAccesoryArrays(int newSize)
+	internal void ResetAndSizeAccessoryArrays()
 	{
-		if (newSize < slots.Count) {
-			return;
-		}
+		int size = slots.Count;
+		exAccessorySlot = new Item[2 * size];
+		exDyesAccessory = new Item[size];
+		exHideAccessory = new bool[size];
 
-		Array.Resize<Item>(ref exAccessorySlot, 2 * newSize);
-		Array.Resize<Item>(ref exDyesAccessory, newSize);
-		Array.Resize<bool>(ref exHideAccessory, newSize);
-
-		for (int i = 0; i < newSize; i++) {
+		for (int i = 0; i < size; i++) {
 			exDyesAccessory[i] = new Item();
 			exHideAccessory[i] = false;
 
@@ -64,25 +61,30 @@ public class ModAccessorySlotPlayer : ModPlayer
 
 	public override void LoadData(TagCompound tag)
 	{
+		// Scan the saved slot names and add ids for any unloaded slots
 		var order = tag.GetList<string>("order").ToList();
+		foreach (var name in order) {
+			if (!slots.ContainsKey(name)) {
+				slots.Add(name, slots.Count);
+				UnloadedSlotCount++;
+			}
+		}
+
+		ResetAndSizeAccessoryArrays();
+
+
 		var items = tag.GetList<TagCompound>("items").Select(ItemIO.Load).ToList();
 		var dyes = tag.GetList<TagCompound>("dyes").Select(ItemIO.Load).ToList();
 		var visible = tag.GetList<bool>("visible").ToList();
 
-		ResizeAccesoryArrays(order.Count);
-
 		for (int i = 0; i < order.Count; i++) {
-			// Try finding the slot item goes in to
-			if (!slots.TryGetValue(order[i], out int type)) {
-				type = Loader.list.Count + UnloadedSlotCount++;
-				slots.Add(order[i], type);
-			}
+			int type = slots[order[i]];
 
 			// Place loaded items in to the correct slot
 			exDyesAccessory[type] = dyes[i];
 			exHideAccessory[type] = visible[i];
 			exAccessorySlot[type] = items[i];
-			exAccessorySlot[type + order.Count] = items[i + order.Count];
+			exAccessorySlot[type + SlotCount] = items[i + order.Count];
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -23,8 +23,7 @@ public class ModAccessorySlotPlayer : ModPlayer
 	internal int scrollbarSlotPosition;
 
 	public int SlotCount => slots.Count;
-	public int LoadedSlotCount => SlotCount - UnloadedSlotCount;
-	public int UnloadedSlotCount { get; private set; } = 0;
+	public int LoadedSlotCount => Loader.TotalCount;
 
 	public ModAccessorySlotPlayer()
 	{
@@ -64,10 +63,8 @@ public class ModAccessorySlotPlayer : ModPlayer
 		// Scan the saved slot names and add ids for any unloaded slots
 		var order = tag.GetList<string>("order").ToList();
 		foreach (var name in order) {
-			if (!slots.ContainsKey(name)) {
+			if (!slots.ContainsKey(name))
 				slots.Add(name, slots.Count);
-				UnloadedSlotCount++;
-			}
 		}
 
 		ResetAndSizeAccessoryArrays();
@@ -163,7 +160,7 @@ public class ModAccessorySlotPlayer : ModPlayer
 		}
 	}
 
-	// The following netcode is adapted from ChickenBone's UtilitySlots:
+	// The following netcode is adapted from ChickenBones' UtilitySlots:
 	public override void CopyClientState(ModPlayer targetCopy)
 	{
 		var defaultInv = (ModAccessorySlotPlayer)targetCopy;

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModAccessorySlotPlayer.cs
@@ -258,8 +258,6 @@ public class ModAccessorySlotPlayer : ModPlayer
 
 		private static void HandleVisualState(BinaryReader r, int fromWho)
 		{
-			// Does this receiving need to factor in difference between LoadedCount and Total?
-			// Shouldn't?
 			if (Main.netMode == Client)
 				fromWho = r.ReadByte();
 


### PR DESCRIPTION
### What is the bug?
#2667 

### How did you fix the bug?
Updated the logic to move all unloaded slots to only exist on the ModPlayer instead of the Loader.
There is no server requirement to know about unloaded slots on a ModPLayer, and as such, no need for it to be in the Loader.

By eliminating Loader involvement, this ensures any unloaded nuances are kept contained within a single player character.

### Are there alternatives to your fix?
A complete redesign that includes consideration to this? But not really something to jump in to easily.