### PR TITLE
Fix Town NPC Melee Swinging Source Rectangle

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3181,6 +3181,15 @@
  			Vector2 vector4 = DrawPlayerItemPos(1f, itemtype);
  			GetItemDrawFrame(itemtype, out var itemTexture, out var value2);
  			int num12 = (int)vector4.X - num11;
+@@ -22027,7 +_,7 @@
+ 			int num13 = 32;
+ 			float num14 = 0f;
+ 			Vector2 zero = Vector2.Zero;
+-			short num15 = 4;
++			int num15 = 4; // TML: Changed short to int.
+ 			if (n.type == 207) {
+ 				num15 = 3349;
+ 				num14 = 0.15f;
 @@ -22048,6 +_,7 @@
  			}
  			else if (n.type == 441) {
@@ -3192,9 +3201,9 @@
 @@ -22058,6 +_,9 @@
  			}
  
- 			GetItemDrawFrame(num15, out var itemTexture2, out var rectangle3);
++			NPCLoader.DrawTownAttackSwing(n, ref num15, ref num13, ref num14, ref zero);
 +
-+			NPCLoader.DrawTownAttackSwing(n, ref itemTexture2, ref num13, ref num14, ref zero);
+ 			GetItemDrawFrame(num15, out var itemTexture2, out var rectangle3);
 +
  			Tuple<Vector2, float> swingStats = n.GetSwingStats(NPCID.Sets.AttackTime[n.type] * 2, (int)n.ai[1], n.spriteDirection, num13, num13);
  			Vector2 vector6 = swingStats.Item1 + (swingStats.Item1 - n.Center) * num14 + zero;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3181,15 +3181,6 @@
  			Vector2 vector4 = DrawPlayerItemPos(1f, itemtype);
  			GetItemDrawFrame(itemtype, out var itemTexture, out var value2);
  			int num12 = (int)vector4.X - num11;
-@@ -22027,7 +_,7 @@
- 			int num13 = 32;
- 			float num14 = 0f;
- 			Vector2 zero = Vector2.Zero;
--			short num15 = 4;
-+			int num15 = 4; // TML: Changed short to int.
- 			if (n.type == 207) {
- 				num15 = 3349;
- 				num14 = 0.15f;
 @@ -22048,6 +_,7 @@
  			}
  			else if (n.type == 441) {
@@ -3201,9 +3192,9 @@
 @@ -22058,6 +_,9 @@
  			}
  
-+			NPCLoader.DrawTownAttackSwing(n, ref num15, ref num13, ref num14, ref zero);
-+
  			GetItemDrawFrame(num15, out var itemTexture2, out var rectangle3);
++
++			NPCLoader.DrawTownAttackSwing(n, ref itemTexture2, ref rectangle3, ref num13, ref num14, ref zero);
 +
  			Tuple<Vector2, float> swingStats = n.GetSwingStats(NPCID.Sets.AttackTime[n.type] * 2, (int)n.ai[1], n.spriteDirection, num13, num13);
  			Vector2 vector6 = swingStats.Item1 + (swingStats.Item1 - n.Center) * num14 + zero;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -751,15 +751,9 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	{
 	}
 
-	/// <summary>
-	/// Allows you to customize how a town NPC's weapon is drawn when the NPC is swinging it (the NPC must have an attack type of 3). Item is the Texture2D instance of the item to be drawn (use Main.itemTexture[id of item]), itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
-	/// </summary>
-	/// <param name="npc"></param>
-	/// <param name="item"></param>
-	/// <param name="itemSize"></param>
-	/// <param name="scale"></param>
-	/// <param name="offset"></param>
-	public virtual void DrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
+
+	/// <inheritdoc cref="ModNPC.DrawTownAttackSwing" />
+	public virtual void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -759,7 +759,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	/// <param name="itemSize"></param>
 	/// <param name="scale"></param>
 	/// <param name="offset"></param>
-	public virtual void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset)
+	public virtual void DrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -788,13 +788,14 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). Item is the ID of the item to be drawn, itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
+	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). <paramref name="item"/> is the Texture2D instance of the item to be drawn, <paramref name="itemFrame"/> is the section of the texture to draw, <paramref name="itemSize"/> is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), <paramref name="scale"/> is the multiplier for the item's drawing size, and <paramref name="offset"/> is the offset from which to draw the item from its normal position. The item texture can be any texture, but if it is an item texture you can use  <see cref="Main.GetItemDrawFrame(int, out Texture2D, out Rectangle)"/> to set <paramref name="item"/> and <paramref name="itemFrame"/> easily.
 	/// </summary>
 	/// <param name="item"></param>
+	/// <param name="itemFrame"></param>
 	/// <param name="itemSize"></param>
 	/// <param name="scale"></param>
 	/// <param name="offset"></param>
-	public virtual void DrawTownAttackSwing(ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
+	public virtual void DrawTownAttackSwing(ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -788,7 +788,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). Item is the ID of the item to be draw, itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
+	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). Item is the ID of the item to be drawn, itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
 	/// </summary>
 	/// <param name="item"></param>
 	/// <param name="itemSize"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -794,7 +794,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	/// <param name="itemSize"></param>
 	/// <param name="scale"></param>
 	/// <param name="offset"></param>
-	public virtual void DrawTownAttackSwing(ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset)
+	public virtual void DrawTownAttackSwing(ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -788,7 +788,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). Item is the Texture2D instance of the item to be drawn (use Main.itemTexture[id of item]), itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
+	/// Allows you to customize how this town NPC's weapon is drawn when this NPC is swinging it (this NPC must have an attack type of 3). Item is the ID of the item to be draw, itemSize is the width and height of the item's hitbox (the same values for TownNPCAttackSwing), scale is the multiplier for the item's drawing size, and offset is the offset from which to draw the item from its normal position.
 	/// </summary>
 	/// <param name="item"></param>
 	/// <param name="itemSize"></param>

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -1337,15 +1337,15 @@ public static class NPCLoader
 		}
 	}
 
-	private delegate void DelegateDrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset);
+	private delegate void DelegateDrawTownAttackSwing(NPC npc, ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset);
 	private static HookList HookDrawTownAttackSwing = AddHook<DelegateDrawTownAttackSwing>(g => g.DrawTownAttackSwing);
 
-	public static void DrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
+	public static void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
-		npc.ModNPC?.DrawTownAttackSwing(ref item, ref itemSize, ref scale, ref offset);
+		npc.ModNPC?.DrawTownAttackSwing(ref item, ref itemFrame, ref itemSize, ref scale, ref offset);
 
 		foreach (GlobalNPC g in HookDrawTownAttackSwing.Enumerate(npc.globalNPCs)) {
-			g.DrawTownAttackSwing(npc, ref item, ref itemSize, ref scale, ref offset);
+			g.DrawTownAttackSwing(npc, ref item, ref itemFrame, ref itemSize, ref scale, ref offset);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -1337,10 +1337,10 @@ public static class NPCLoader
 		}
 	}
 
-	private delegate void DelegateDrawTownAttackSwing(NPC npc, ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset);
+	private delegate void DelegateDrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset);
 	private static HookList HookDrawTownAttackSwing = AddHook<DelegateDrawTownAttackSwing>(g => g.DrawTownAttackSwing);
 
-	public static void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset)
+	public static void DrawTownAttackSwing(NPC npc, ref int item, ref int itemSize, ref float scale, ref Vector2 offset)
 	{
 		npc.ModNPC?.DrawTownAttackSwing(ref item, ref itemSize, ref scale, ref offset);
 

--- a/tModPorter/tModPorter.Tests/TestData/GlobalNPCTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalNPCTest.Expected.cs
@@ -51,4 +51,5 @@ public class GlobalNPCTest : GlobalNPC
 #endif
 	}
 	public override bool ModifyCollisionData(NPC npc, Rectangle victimHitbox, ref int immunityCooldownSlot, ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox) => false;
+	public override void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/GlobalNPCTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalNPCTest.cs
@@ -41,4 +41,5 @@ public class GlobalNPCTest : GlobalNPC
 		return false;
 	}
 	public override bool ModifyCollisionData(NPC npc, Rectangle victimHitbox, ref int immunityCooldownSlot, ref float damageMultiplier, ref Rectangle npcHitbox) => false;
+	public override void DrawTownAttackSwing(NPC npc, ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
@@ -80,4 +80,5 @@ public class ModNPCTest : ModNPC
 #endif
 	}
 	public override bool ModifyCollisionData(Rectangle victimHitbox, ref int immunityCooldownSlot, ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox) => false;
+	public override void DrawTownAttackSwing(ref int item, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
@@ -80,5 +80,5 @@ public class ModNPCTest : ModNPC
 #endif
 	}
 	public override bool ModifyCollisionData(Rectangle victimHitbox, ref int immunityCooldownSlot, ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox) => false;
-	public override void DrawTownAttackSwing(ref int item, ref int itemSize, ref float scale, ref Vector2 offset) { }
+	public override void DrawTownAttackSwing(ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
@@ -60,4 +60,5 @@ public class ModNPCTest : ModNPC
 		return false;
 	}
 	public override bool ModifyCollisionData(Rectangle victimHitbox, ref int immunityCooldownSlot, ref float damageMultiplier, ref Rectangle npcHitbox) => false;
+	public override void DrawTownAttackSwing(ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -502,5 +502,7 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.GlobalBuff", from: "ModifyBuffTip", to: "ModifyBuffText");
 		ChangeHookSignature("Terraria.ModLoader.ModBuff", "ModifyBuffText");
 		ChangeHookSignature("Terraria.ModLoader.GlobalBuff", "ModifyBuffText");
+
+		ChangeHookSignature("Terraria.ModLoader.ModNPC", "DrawTownAttackSwing");
 	}
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -504,5 +504,6 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.GlobalBuff", "ModifyBuffText");
 
 		ChangeHookSignature("Terraria.ModLoader.ModNPC", "DrawTownAttackSwing");
+		ChangeHookSignature("Terraria.ModLoader.GlobalNPC", "DrawTownAttackSwing");
 	}
 }


### PR DESCRIPTION
### What is the bug?

Setting any texture for a Town NPC's melee swinging will always draw as a 36x36 sprite. Even if the sprite is not that size. Smaller sprites will have their edges "extended" and larger sprites will be cut off. The only way for a modder to fix this is to IL edit (or detour the entirety of `Main.DrawNPCExtras()`).

The bug is that the source rectangle for the drawing of the item is always set as a 36x36 rectangle and does not update the size to match the texture that the modder set.

The Exotic Scimitar has a resolution of 40x48, so it gets cut off.
![Capture](https://user-images.githubusercontent.com/11262234/226156912-e78b4957-7e67-4dea-a3d2-9df5bab3d494.PNG)

The following is the current code. Comments have been added and variables have been renamed to make it easier to understand.
```cs
// In Main.DrawNPCExtras()
// If the Town NPC has the melee attack type and is about to attack.
if (NPCID.Sets.AttackType[n.type] == 3 && n.ai[0] == 15f) {
	int itemSize = 32;
	float scale = 0f;
	Vector2 offset = Vector2.Zero;
	short itemType = 4; // The default item is an Iron Broadsword. It has a resolution of 36x36.
	
	// Set values for vanilla NPCs. Modded NPCs don't apply so skipping this section.
	...
	// After the values for the vanilla NPCs have been set...

	// Get the item frame. This also loads the texture with Main.instance.LoadItem(itemType).
	GetItemDrawFrame(itemType, out var itemTexture2, out var rectangle3);
	// rectangle3 = (0, 0, 36, 36)

	// Load the values for the Modded NPCs...
	NPCLoader.DrawTownAttackSwing(n, ref itemTexture2, ref itemSize, ref scale, ref offset); 
	// Modder loads their new texture, sets the itemSize, etc.
	// Uh oh, rectangle3 is never updated to the new texture!!!!

	Tuple<Vector2, float> swingStats = n.GetSwingStats(NPCID.Sets.AttackTime[n.type] * 2, (int)n.ai[1], n.spriteDirection, itemSize, itemSize);
	Vector2 drawPos = swingStats.Item1 + (swingStats.Item1 - n.Center) * scale + offset;
	Vector2 origin = rectangle3.Size() * new Vector2((n.spriteDirection != 1) ? 1 : 0, 1f);
	
	spriteBatch.Draw(itemTexture2,	// Texture
		new Vector2((int)(drawPos.X - screenPosition.X), (int)(drawPos.Y - screenPosition.Y)), // position
		rectangle3, // source rectangle. Wait, this is still the source rectangle for the Iron Broadsword!!!
		n.GetAlpha(npcColor), // color
		swingStats.Item2, // rotation
		origin, // origin. This is now also incorrect because it used the source rectangle for the Iron Broadsword.
		n.scale, // scale
		npcSpriteEffect ^ SpriteEffects.FlipHorizontally, // sprite effects
		0f);
}
```

### How did you fix the bug?

I fixed the bug by swapping `GetItemDrawFrame()` and `NPCLoader.DrawTownAttackSwing()`. I changed `NPCLoader.DrawTownAttackSwing()`'s `ref Texture2D item` to `ref int item` and had it modify the item type instead of the item texture.

`DrawTownAttackSwing(ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset)` -> `DrawTownAttackSwing(ref int item, ref int itemSize, ref float scale, ref Vector2 offset)`

`GetItemDrawFrame()` already loads the new texture with `Main.instance.LoadItem(itemType)`, so there is no need for the modder to do it themselves.

This change not only fixes the bug, but it also make it easier for modders and more in line with [`DrawTownAttackGun()`](https://docs.tmodloader.net/docs/preview/class_mod_n_p_c.html#a6420c889d630d0cd51591ee4706829bb). Instead of the modder needing to load an item's texture and then passing the Texture2D, they can just pass the item type.

I also added it to tModPorter and it worked when I tested it on one of my mods (Tell me if I did it wrong, though).

The fix in action:
![Capture 2](https://user-images.githubusercontent.com/11262234/226157302-48effce7-16a3-4e6a-9524-7da07f436e9e.PNG) ![Capture 4](https://user-images.githubusercontent.com/11262234/226157305-33e1033b-379e-4187-b656-19af6a067a0e.PNG)

### Are there alternatives to your fix?

Recalculate the source rectangle instead of modifying the item type itself. I didn't choose this way because the Texture2D variable is from the `out` of `GetItemDrawFrame`. So, `NPCLoader.DrawTownAttackSwing` couldn't be called before then.

There is still the oddity of `itemSize` only being 1D instead of 2D. `GetSwingStats()` can take both an `itemWidth` and `itemHeight`, but `itemSize` is passed for both. This is how it is in vanilla, and it doesn't make that much of a difference, so I don't think it really matters.