### PR TITLE
Fixed problem with detecting dotnet on linux

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -251,7 +251,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 			return true;
 		}
 
-		if (!IsCompatibleDotnetSdkAviable()) {
+		if (!IsCompatibleDotnetSdkAvailable()) {
 			ShowWelcomeMessage("tModLoader.DownloadNetSDK", "https://github.com/tModLoader/tModLoader/wiki/tModLoader-guide-for-developers#developing-with-tmodloader", 888, PreviousUIState);
 			return true;
 		}
@@ -311,7 +311,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 		return null;
 	}
 
-	bool IsCompatibleDotnetSdkAviable()
+	bool IsCompatibleDotnetSdkAvailable()
 	{
 		if (dotnetSDKFound)
 			return true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -309,14 +309,9 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 		if (dotnetSDKFound)
 			return true;
 
-		string dotnetPath = GetSystemDotnetPath();
-		if (dotnetPath == null)
-			return false;
-
-
 		try {
 			string output = Process.Start(new ProcessStartInfo {
-				FileName = dotnetPath,
+				FileName = GetSystemDotnetPath() ?? "dotnet",
 				Arguments = "--list-sdks",
 				UseShellExecute = false,
 				RedirectStandardOutput = true

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -270,7 +270,6 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 
 	string GetCommandToFindPathOfExecutable()
 	{
-		;
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			return "where";
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -290,12 +290,19 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 			return null;
 
 		try {
-			return Process.Start(new ProcessStartInfo {
+			string dotnetPath = Process.Start(new ProcessStartInfo {
 				FileName = commandToFindPathOfExecutable,
 				Arguments = "dotnet",
 				UseShellExecute = false,
 				RedirectStandardOutput = true
 			}).StandardOutput.ReadToEnd().Trim();
+
+			if (!File.Exists(dotnetPath)) {
+				Logging.tML.Debug("Can't find SystemDotnetPath");
+				return null;
+			}
+
+			return dotnetPath;
 		}
 		catch (Exception e) {
 			Logging.tML.Debug("Finding SystemDotnetPath failed: ", e);


### PR DESCRIPTION
What is the bug?
https://github.com/tModLoader/tModLoader/issues/3237
After entering the Develop Mods tab on linux a message is shown to install dotnet 6 even though it is already installed.
The bug is caused by name collision between system dotnet and dotnet build in tmodloader.

How did you fix the bug?
I managed to fix the bug by finding dotnet in PATH and checking available sdk by running dotnet using absolute path.

Are there alternatives to your fix?
I think that one potential alternative is to rename build-in dotnet.