### PR TITLE
More Reliable Stack Trace File Path Trimming

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
@@ -108,7 +108,6 @@ public static partial class Logging
 			if (!oom && ignoreContents.Any(s => MatchContents(traceString, s)))
 				return;
 
-			PrettifyStackTraceSources(stackTrace.GetFrames());
 			traceString = stackTrace.ToString();
 			traceString = traceString[traceString.IndexOf('\n')..];
 


### PR DESCRIPTION
This is a follow-up PR to #3305 which opted to improve the existing logic rather than using `PathMap`, since `PathMap` causes Hot Reload and Edit&Continue to fail consistently.

Furthermore, the new logic of hooking into `StackTrace::CaptureStackTrace(int, bool, Exception?)` instead of `StackTrace::.ctor(bool, Exception)` now allows the path trimming to apply to other `StackTrace` constructors, removing the need to call `Logging::PrettifyStackTraceSources(StackFrame[])` manually.