### PR TITLE
Fixed bug problem with opening folders on linux

### DIFF
--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -34,6 +34,39 @@
  						if (num3 < 0)
  							num3 = 0;
  
+@@ -644,17 +_,32 @@
+ 			return false;
+ 		}
+ 	}
++	private static void OpenFolderXdg(string folderPath)
++	{
++		ProcessStartInfo processStartInfo = new ProcessStartInfo {
++			FileName = "xdg-open",
++			Arguments = folderPath,
++			UseShellExecute = true,
++			CreateNoWindow = true
++		};
++
++		processStartInfo.EnvironmentVariables["LD_LIBRARY_PATH"] = "/usr/lib:/lib";
++		Process.Start(processStartInfo);
++	}
+ 
+ 	public static void OpenFolder(string folderPath)
+ 	{
+ 		if (TryCreatingDirectory(folderPath)) {
+ 			if (Platform.IsLinux) {
++				/*
+ 				Process.Start(new ProcessStartInfo(folderPath) {
+ 					FileName = "open-folder",
+ 					Arguments = folderPath,
+ 					UseShellExecute = true,
+ 					CreateNoWindow = true
+ 				});
++				*/
++				OpenFolderXdg(folderPath);
+ 			}
+ 			else {
+ 				Process.Start(new ProcessStartInfo(folderPath) { UseShellExecute = true });
 @@ -669,6 +_,11 @@
  		return array;
  	}


### PR DESCRIPTION
What is the bug?
After clicking Open Sources button tmodloder opens browser.
![image](https://user-images.githubusercontent.com/38855936/227002405-ede4aa9f-c104-4f30-8966-fe12d2612316.png)

How did you fix the bug?
I changed "open-folder" command to "xdg-open".

Are there alternatives to your fix?
Probably you can use "gnome-open" command but it only work on gnome. 