### PR TITLE
Attempt to fix #3035

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -197,7 +197,6 @@ internal class GlobalInstantiationArrayPool<T>
 
 	static GlobalInstantiationArrayPool()
 	{
-		// honestly, this should go in 'OnResizeArrays'
-		TypeCaching.OnClear += () => LoaderUtils.ResetStaticMembers(typeof(GlobalInstantiationArrayPool<T>), false);
+
 	}
 }


### PR DESCRIPTION
### What is the bug?
(see #3035)
GlobalInstantiationArrayPool<T> leaks memory in registering TypeCaching.OnClear actions.
### How did you fix the bug?
This does not fully fix it since it doesn't solve the underlying problem of the ArrayPools not being reset but it turns the problem from a multiplying growth to a linear growth since only the rented memory is leaked.
LoaderUtils.ResetStaticMembers is not appropriate for resetting the ArrayPools since from my understanding, it creates them again but somehow keeps the references alive. This needs to be further investigated.
### Are there alternatives to your fix?
Yes, fixing the root issue. This is a mitigation against ~15 reloads making the game use gigabytes of leaked memory.
