### PR TITLE
Fixed double damage space

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2308,7 +2308,7 @@
  					if (diff == 1)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num4), (byte)((float)(int)mcColor.G * num4), (byte)((float)(int)mcColor.B * num4), a);
  
-@@ -16311,47 +_,90 @@
+@@ -16311,47 +_,91 @@
  
  					if (hoverItem.expert || rare == -12)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)DiscoR * num4), (byte)((float)DiscoG * num4), (byte)((float)DiscoB * num4), a);
@@ -2395,7 +2395,8 @@
 +			if (item.damage > 0 && (!item.notAmmo || item.useStyle != 0) && (item.type < 71 || item.type > 74 || player[myPlayer].HasItem(905)) && item.DamageType.ShowStatTooltipLine(player[myPlayer], "Damage")) {
 +				LocalizedText tip;
 +				if (item.DamageType != null) {
-+					tip = new LocalizedText("", " " + item.DamageType.DisplayName.ToString().TrimStart());
++					bool addLeadingSpace = item.DamageType is not VanillaDamageClass;
++					tip = new LocalizedText("", (addLeadingSpace ? " " : "") + item.DamageType.DisplayName);
 +				}
 +				else {
 +					tip = Lang.tip[55]; // No damage class

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2395,7 +2395,7 @@
 +			if (item.damage > 0 && (!item.notAmmo || item.useStyle != 0) && (item.type < 71 || item.type > 74 || player[myPlayer].HasItem(905)) && item.DamageType.ShowStatTooltipLine(player[myPlayer], "Damage")) {
 +				LocalizedText tip;
 +				if (item.DamageType != null) {
-+					tip = new LocalizedText("", " " + item.DamageType.DisplayName);
++					tip = new LocalizedText("", " " + item.DamageType.DisplayName.ToString().TrimStart());
 +				}
 +				else {
 +					tip = Lang.tip[55]; // No damage class

--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -52,6 +52,7 @@ public abstract class DamageClass : ModType, ILocalizedModType
 	/// <summary>
 	/// This is the name that will show up when an item tooltip displays 'X [ClassName]'.
 	/// This should include the 'damage' part.
+	/// Note that vanilla entries all start with a space that will need to be trimmed if used in other contexts.
 	/// </summary>
 	public virtual LocalizedText DisplayName => this.GetLocalization(nameof(DisplayName), PrettyPrintName);
 


### PR DESCRIPTION
What is the bug?
https://github.com/tModLoader/tModLoader/issues/3254
The bug is caused by this code
```c#
item.DamageType.DisplayName
```
returning damage type name with an extra space at the beginning.

How did you fix the bug?
To fix this bug i simply added trimming to start of damage type name.

Are there alternatives to your fix?
This problem may be probably solved by changing this line
```c#
tip = new LocalizedText("", " " + item.DamageType.DisplayName);
```
to
```c#
tip = new LocalizedText("", item.DamageType.DisplayName.ToString());
```
but for safety i used trim.

Other solution is to change 
```c#
item.DamageType.DisplayName
```
behavior to not include extra space at beginning.