### PR TITLE
Fixes setting npcCatchable true forcing NPC.friendly to falce

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -364,7 +364,7 @@
  	public static bool[] tileFrameImportant = new bool[TileID.Count];
  	public static bool[] tilePile = new bool[TileID.Count];
  	public static bool[] tileBlendAll = new bool[TileID.Count];
-@@ -942,6 +_,12 @@
+@@ -942,6 +_,13 @@
  	public static int[] grasshopperCageFrameCounter = new int[cageFrames];
  	public static bool[] tileSand = new bool[TileID.Count];
  	public static bool[] tileFlame = new bool[TileID.Count];
@@ -373,6 +373,7 @@
 +	/// Used to denote an NPC as being catchable by bug nets and similar.<br/>
 +	/// Contrary to its name, this array isn't actually used for catching logic at all.<br/>
 +	/// It is instead used to determine if an NPC can be released back into the world after being caught.<br/>
++	/// These NPC will be forced <see cref="NPC.friendly"/> for 1.5 seconds if naturally spawned.<br/>
 +	/// </summary>
  	public static bool[] npcCatchable = new bool[NPCID.Count];
  	public static int[] tileFrame = new int[TileID.Count];

--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -46,6 +46,8 @@ public partial class NPC : IEntityWithGlobals<GlobalNPC>
 	/// </summary>
 	public IBigProgressBar BossBar { get; set; }
 
+	private bool catchableNPCOriginallyFriendly; // TML: Fix #3299, Allow npcCatchable to work with friendly npc.
+
 	public NPC()
 	{
 		thisEntitySourceCache = new EntitySource_Parent(this);

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2193,7 +2193,7 @@
  	private void SubAI_HandleTemporaryCatchableNPCPlayerInvulnerability()
  	{
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		// TML: changed catchableNPCTempImmunityCounter logic to not assume npcCatchable npc should be friendly.
++		// TML: changed logic to not assume npcCatchable npc should not be friendly after invulnerability period. Also only run code during period to prevent undoing intentional changes to friendly in AI code.
 +		if (type >= 0 && Main.npcCatchable[type] && catchableNPCTempImmunityCounter > 0) {
  			if (releaseOwner != 255 || SpawnedFromStatue)
  				catchableNPCTempImmunityCounter = 0;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -15,7 +15,7 @@
  {
  	private const int NPC_TARGETS_START = 300;
  	public bool IsABestiaryIconDummy;
-@@ -65,8 +_,19 @@
+@@ -65,8 +_,22 @@
  	public int altTexture;
  	public int townNpcVariationIndex;
  	public Vector2 netOffset = Vector2.Zero;
@@ -27,6 +27,9 @@
 +	/// Bug nets and other catching tools will only work on NPCs with this field set to something greater than 0.
 +	/// </summary>
 +	public int catchItem; //TML: Changed from short to int for convenience and consistency purposes.
++	/// <summary>
++	/// Identifies the player who released this NPC into the world. Used mainly for released critters. Helps limit how many critters a player can release. Default to 255, indicating that the npc was not released by a player.
++	/// </summary>
  	public short releaseOwner = 255;
 +
 +	/// <summary>
@@ -409,6 +412,18 @@
  	public float value;
  	public int extraValue;
  	public bool dontTakeDamage;
+@@ -290,6 +_,11 @@
+ 	public bool oldHomeless;
+ 	public int oldHomeTileX = -1;
+ 	public int oldHomeTileY = -1;
++	/// <summary>
++	/// Indicates that an NPC is friendly to players. If true, a player won't damage the NPC and the NPC won't deal contact damage to players, unless otherwise forced. <br/>
++	/// Mostly set to true for town npc and rescuable town npc. <br/>
++	/// Naturally spawned critter NPC that are <see cref="Main.npcCatchable"/> will automatically be friendly for 1.5 seconds after spawning. <br/>
++	/// </summary>
+ 	public bool friendly;
+ 	public bool closeDoor;
+ 	public int doorX;
 @@ -382,7 +_,9 @@
  	private static bool dayTimeHax;
  	private static bool rainingHax;
@@ -747,7 +762,7 @@
  			getTenthAnniversaryAdjustments();
  
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		if (type >= 0 && Main.npcCatchable[type]) { 
++		if (type >= 0 && Main.npcCatchable[type]) {
  			catchableNPCTempImmunityCounter = 90;
 +			catchableNPCOriginallyFriendly = friendly; 
  			friendly = true;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2118,7 +2118,7 @@
  		UpdateNPC_BuffSetFlags();
  		UpdateNPC_SoulDrainDebuff();
  		UpdateNPC_BuffClearExpiredBuffs();
-@@ -72653,15 +_,16 @@
+@@ -72653,20 +_,13 @@
  		justHit = false;
  	}
  
@@ -2128,17 +2128,21 @@
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
 -			if (releaseOwner != 255 || SpawnedFromStatue)
 -				catchableNPCTempImmunityCounter = 0;
-+		if (type >= 0 && Main.npcCatchable[type]) {
-+			if (releaseOwner == 255 || SpawnedFromStatue || catchableNPCTempImmunityCounter < 0)
-+				return;
- 
+-
++		if (type >= 0 && Main.npcCatchable[type] && !(releaseOwner == 255 || SpawnedFromStatue || catchableNPCTempImmunityCounter < 0)) {
  			bool num = friendly;
-+			catchableNPCTempImmunityCounter--;
- 			if (catchableNPCTempImmunityCounter > 0) {
+-			if (catchableNPCTempImmunityCounter > 0) {
 -				catchableNPCTempImmunityCounter--;
- 				friendly = true;
- 			}
- 			else {
+-				friendly = true;
+-			}
+-			else {
+-				friendly = false;
+-			}
++			catchableNPCTempImmunityCounter--;
++			friendly = catchableNPCTempImmunityCounter > 0;
+ 
+ 			if (num != friendly)
+ 				netUpdate = true;
 @@ -72760,6 +_,8 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -663,15 +663,66 @@
  		setFrameSize = false;
  		netSkip = -2;
  		realLife = -1;
-@@ -2238,7 +_,7 @@
- 		onFire3 = false;
- 		justHit = false;
- 		dontTakeDamage = false;
--		catchableNPCTempImmunityCounter = 0;
-+		catchableNPCTempImmunityCounter = -1;
- 		npcSlots = 1f;
- 		lavaImmune = false;
- 		lavaWet = false;
+@@ -6970,7 +_,9 @@
+ 			DeathSound = SoundID.NPCDeath1;
+ 			npcSlots = 0.1f;
+ 			catchItem = 2002;
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 		}
+ 		else if (type == 358) {
+ 			width = 12;
+@@ -7216,7 +_,9 @@
+ 			lifeMax = 5;
+ 			HitSound = SoundID.NPCHit1;
+ 			DeathSound = SoundID.NPCDeath1;
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 			catchItem = 2740;
+ 			npcSlots = 0.1f;
+ 		}
+@@ -7680,7 +_,9 @@
+ 			lifeMax = 5;
+ 			HitSound = SoundID.NPCHit1;
+ 			DeathSound = SoundID.NPCDeath1;
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 			catchItem = 2893;
+ 			npcSlots = 0.1f;
+ 			rarity = 3;
+@@ -7709,7 +_,9 @@
+ 			DeathSound = SoundID.NPCDeath1;
+ 			npcSlots = 0.1f;
+ 			catchItem = 2895;
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 			rarity = 3;
+ 		}
+ 		else if (type == 449) {
+@@ -7936,7 +_,9 @@
+ 			DeathSound = SoundID.NPCDeath1;
+ 			npcSlots = 0.1f;
+ 			catchItem = (short)(3191 + type - 484);
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 		}
+ 		else if (type == 488) {
+ 			width = 18;
+@@ -9994,7 +_,9 @@
+ 			DeathSound = SoundID.NPCDeath1;
+ 			npcSlots = 0.1f;
+ 			catchItem = 4363;
++			/* TML: Fix #3299
+ 			friendly = true;
++			*/
+ 		}
+ 		else if (type == 607) {
+ 			noGravity = true;
 @@ -10793,13 +_,18 @@
  			catchItem = 2121;
  		}
@@ -691,13 +742,14 @@
  		if (spawnparams.sizeScaleOverride.HasValue) {
  			int num3 = (int)((float)width * scale);
  			int num4 = (int)((float)height * scale);
-@@ -10841,12 +_,12 @@
+@@ -10841,12 +_,13 @@
  		else if (Main.tenthAnniversaryWorld)
  			getTenthAnniversaryAdjustments();
  
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		if (type >= 0 && Main.npcCatchable[type] && !friendly) {
++		if (type >= 0 && Main.npcCatchable[type]) { 
  			catchableNPCTempImmunityCounter = 90;
++			catchableNPCOriginallyFriendly = friendly; 
  			friendly = true;
  		}
  
@@ -2118,7 +2170,7 @@
  		UpdateNPC_BuffSetFlags();
  		UpdateNPC_SoulDrainDebuff();
  		UpdateNPC_BuffClearExpiredBuffs();
-@@ -72653,20 +_,13 @@
+@@ -72653,19 +_,21 @@
  		justHit = false;
  	}
  
@@ -2126,23 +2178,23 @@
  	private void SubAI_HandleTemporaryCatchableNPCPlayerInvulnerability()
  	{
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
--			if (releaseOwner != 255 || SpawnedFromStatue)
--				catchableNPCTempImmunityCounter = 0;
--
-+		if (type >= 0 && Main.npcCatchable[type] && !(releaseOwner == 255 || SpawnedFromStatue || catchableNPCTempImmunityCounter < 0)) {
++		// TML: changed catchableNPCTempImmunityCounter logic to not assume npcCatchable npc should be friendly.
++		if (type >= 0 && Main.npcCatchable[type] && catchableNPCTempImmunityCounter > 0) {
+ 			if (releaseOwner != 255 || SpawnedFromStatue)
+ 				catchableNPCTempImmunityCounter = 0;
+ 
  			bool num = friendly;
--			if (catchableNPCTempImmunityCounter > 0) {
--				catchableNPCTempImmunityCounter--;
--				friendly = true;
--			}
--			else {
--				friendly = false;
--			}
 +			catchableNPCTempImmunityCounter--;
-+			friendly = catchableNPCTempImmunityCounter > 0;
+ 			if (catchableNPCTempImmunityCounter > 0) {
+-				catchableNPCTempImmunityCounter--;
+ 				friendly = true;
+ 			}
+ 			else {
+-				friendly = false;
++				friendly = catchableNPCOriginallyFriendly;
+ 			}
  
  			if (num != friendly)
- 				netUpdate = true;
 @@ -72760,6 +_,8 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -663,6 +663,15 @@
  		setFrameSize = false;
  		netSkip = -2;
  		realLife = -1;
+@@ -2238,7 +_,7 @@
+ 		onFire3 = false;
+ 		justHit = false;
+ 		dontTakeDamage = false;
+-		catchableNPCTempImmunityCounter = 0;
++		catchableNPCTempImmunityCounter = -1;
+ 		npcSlots = 1f;
+ 		lavaImmune = false;
+ 		lavaWet = false;
 @@ -10793,13 +_,18 @@
  			catchItem = 2121;
  		}
@@ -687,7 +696,7 @@
  			getTenthAnniversaryAdjustments();
  
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
-+		if (type >= 0 && Main.npcCatchable[type]) {
++		if (type >= 0 && Main.npcCatchable[type] && !friendly) {
  			catchableNPCTempImmunityCounter = 90;
  			friendly = true;
  		}
@@ -2109,15 +2118,27 @@
  		UpdateNPC_BuffSetFlags();
  		UpdateNPC_SoulDrainDebuff();
  		UpdateNPC_BuffClearExpiredBuffs();
-@@ -72655,7 +_,7 @@
+@@ -72653,15 +_,16 @@
+ 		justHit = false;
+ 	}
  
++
  	private void SubAI_HandleTemporaryCatchableNPCPlayerInvulnerability()
  	{
 -		if (type >= 0 && type < NPCID.Count && Main.npcCatchable[type]) {
+-			if (releaseOwner != 255 || SpawnedFromStatue)
+-				catchableNPCTempImmunityCounter = 0;
 +		if (type >= 0 && Main.npcCatchable[type]) {
- 			if (releaseOwner != 255 || SpawnedFromStatue)
- 				catchableNPCTempImmunityCounter = 0;
++			if (releaseOwner == 255 || SpawnedFromStatue || catchableNPCTempImmunityCounter < 0)
++				return;
  
+ 			bool num = friendly;
++			catchableNPCTempImmunityCounter--;
+ 			if (catchableNPCTempImmunityCounter > 0) {
+-				catchableNPCTempImmunityCounter--;
+ 				friendly = true;
+ 			}
+ 			else {
 @@ -72760,6 +_,8 @@
  		}
  	}


### PR DESCRIPTION
### What is the bug?
As stated in #3299, NPCs that have Main.npcCatchable[Type] = true are forcebly changed to NPC.friendly = false.

### How did you fix the bug?
The issue was a system for making the player immune to damage from a released enemy that would otherwise damage them setting every NPC to unfriendly after the timer. I'm pretty sure it's a vannila issue because the function is mostly the same there but there might be some other catch for it that was removed. fixed by modifying the system to only run when the npc was unfriendly to begin with, leving the NPC as is.

### Are there alternatives to your fix?
N/A

Another small note because I'm quite confused about it, I may have made un unintentional change? Or just fixed a bug that was so hidden by this bug?
I changed:
` 			if (releaseOwner != 255 || SpawnedFromStatue)`
to:
`+			if (releaseOwner == 255 || SpawnedFromStatue || catchableNPCTempImmunityCounter < 0)`

What I'm not sure about is releaseOwner != 255 in the original, this was the tag for not running the timer system (but still set friendly to false), which would be checking if the npc *was* released not if it wasn't, I'm not sure if I'm interpretting something wrong or if it's just the whole function is a mess.

Anyway, now it just works by waiting 90 frames where a released npc is friendly if it was not otherwise, which I'm pretty sure was the intention.