### PR TITLE
Followup Improvements to StrikeNPC, Hit and Hurt hooks

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -308,7 +308,7 @@
 +						SourceDamage = reader.Read7BitEncodedInt(),
 +						DamageType = DamageClassLoader.DamageClasses[reader.Read7BitEncodedInt()],
 +						HitDirection = reader.ReadSByte(),
-+						KnockBack = reader.ReadSingle()
++						Knockback = reader.ReadSingle()
 +					};
 +					BitsByte flags = reader.ReadByte();
 +					hit.Crit = flags[0];

--- a/patches/tModLoader/Terraria/NPC.TML.Hit.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.Hit.cs
@@ -226,7 +226,7 @@ public partial class NPC
 				SourceDamage = Math.Max((int)SourceDamage.ApplyTo(baseDamage), 1),
 				Damage = _instantKill ? 1 : GetDamage(baseDamage, crit, damageVariation, luck),
 				Crit = _critOverride ?? crit,
-				KnockBack = GetKnockback(baseKnockback),
+				Knockback = GetKnockback(baseKnockback),
 				HitDirection = HitDirectionOverride ?? HitDirection,
 				InstantKill = _instantKill,
 				HideCombatText = _combatTextHidden
@@ -290,7 +290,7 @@ public partial class NPC
 		/// The amount of knockback to apply. Should always be >= 0. <br/>
 		/// Note that <see cref="NPC.StrikeNPC(HitInfo, bool, bool)"/> has a staggered knockback falloff, and that critical strikes automatically get extra 40% knockback in excess of this value.
 		/// </summary>
-		public float KnockBack = 0;
+		public float Knockback = 0;
 
 		/// <summary>
 		/// If true, as much damage as necessary will be dealt, and damage number popups will not be shown for this hit. <br/>

--- a/patches/tModLoader/Terraria/NPC.TML.Hit.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.Hit.cs
@@ -122,6 +122,14 @@ public partial class NPC
 		/// </summary>
 		public MultipliableFloat DamageVariationScale = new();
 
+		private int _damageLimit = int.MaxValue;
+		/// <summary>
+		/// Sets an inclusive upper bound on the final damage of the hit. <br/>
+		/// Can be set by multiple mods, in which case the lowest limit will be used. <br/>
+		/// Cannot be set to less than 1
+		/// </summary>
+		public void SetMaxDamage(int limit) => _damageLimit = Math.Min(_damageLimit, Math.Max(limit, 1));
+
 		private bool? _critOverride = default;
 
 		/// <summary>
@@ -185,7 +193,7 @@ public partial class NPC
 				if (_critOverride ?? crit)
 					dmg *= CritDamage.Additive * CritDamage.Multiplicative;
 
-				return Math.Clamp((int)dmg, 1, 10);
+				return Math.Clamp((int)dmg, 1, Math.Min(_damageLimit, 10));
 			}
 
 			float damage = SourceDamage.ApplyTo(baseDamage);
@@ -206,7 +214,7 @@ public partial class NPC
 			if (_critOverride ?? crit)
 				damage = CritDamage.ApplyTo(damage);
 
-			return Math.Max((int)FinalDamage.ApplyTo(damage), 1);
+			return Math.Clamp((int)FinalDamage.ApplyTo(damage), 1, _damageLimit);
 		}
 
 		public readonly float GetKnockback(float baseKnockback) => Math.Max(Knockback.ApplyTo(baseKnockback), 0);

--- a/patches/tModLoader/Terraria/NPC.TML.Hit.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.Hit.cs
@@ -24,7 +24,7 @@ public partial class NPC
 
 		/// <summary>
 		/// If true, no amount of damage can get through the defense of this NPC, damage will be reduced to 1. <br/>
-		/// <see cref="CritDamage"/> will still apply, but only Additive and Multiplicative. Maximum crit damage will be capped at 10. <br/>
+		/// <see cref="CritDamage"/> will still apply, but only Additive and Multiplicative. Maximum crit damage will be capped at 4. <br/>
 		/// </summary>
 		public bool SuperArmor { get; init; } = false;
 
@@ -193,7 +193,7 @@ public partial class NPC
 				if (_critOverride ?? crit)
 					dmg *= CritDamage.Additive * CritDamage.Multiplicative;
 
-				return Math.Clamp((int)dmg, 1, Math.Min(_damageLimit, 10));
+				return Math.Clamp((int)dmg, 1, Math.Min(_damageLimit, 4));
 			}
 
 			float damage = SourceDamage.ApplyTo(baseDamage);

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1764,7 +1764,7 @@
  	public int checkArmorPenetration(int armorPenetration, float armorPenetrationPercent)
  	{
  		if (ichor)
-@@ -64591,26 +_,120 @@
+@@ -64591,26 +_,117 @@
  
  		return armorPenetration / 2;
  	}
@@ -1793,9 +1793,6 @@
 +		HitInfo hit;
 +		if (Damage == 9999) {
 +			hit = new HitInfo {
-+				DamageType = DamageClass.Default,
-+				SourceDamage = Damage,
-+				Damage = 0,
 +				Crit = crit,
 +				KnockBack = knockBack,
 +				HitDirection = hitDirection,

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1794,7 +1794,7 @@
 +		if (Damage == 9999) {
 +			hit = new HitInfo {
 +				Crit = crit,
-+				KnockBack = knockBack,
++				Knockback = knockBack,
 +				HitDirection = hitDirection,
 +				InstantKill = true
 +			};
@@ -1949,8 +1949,8 @@
  				if (onFire2)
  					num3 *= 1.1f;
 +			*/
-+			if (hit.KnockBack > 0) {
-+				float num3 = hit.KnockBack;
++			if (hit.Knockback > 0) {
++				float num3 = hit.Knockback;
  
  				if (num3 > 8f) {
  					float num4 = num3 - 8f;
@@ -1996,7 +1996,7 @@
 +			Damage = instantKill.Value ? 1 : (int)dmg,
 +			Crit = false,
 +			HitDirection = hitDirection,
-+			KnockBack = 0,
++			Knockback = 0,
 +			InstantKill = instantKill.Value
 +		});
 +	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1764,7 +1764,7 @@
  	public int checkArmorPenetration(int armorPenetration, float armorPenetrationPercent)
  	{
  		if (ichor)
-@@ -64591,26 +_,117 @@
+@@ -64591,26 +_,159 @@
  
  		return armorPenetration / 2;
  	}
@@ -1808,6 +1808,13 @@
 +		return hit;
 +	}
 +
++	/// <summary>
++	/// Initializes a <see cref="HitModifiers"/> calculation with the properties of this NPC, including calling <see cref="NPCLoader.ModifyIncomingHit"/>
++	/// </summary>
++	/// <param name="damageType">The DamageType of the hit.</param>
++	/// <param name="hitDirection">The direction to apply knockback. If 0, no knockback will be applied.</param>
++	/// <param name="ignoreArmorDebuffs">Ignores <see cref="ichor"/> and <see cref="betsysCurse"/>. Only used for legacy vanilla codepaths.</param>
++	/// <returns></returns>
 +	public HitModifiers GetIncomingStrikeModifiers(DamageClass damageType, int hitDirection, bool ignoreArmorDebuffs = false)
 +	{
 +		var modifiers = new HitModifiers() with {
@@ -1848,17 +1855,52 @@
 +	/// <param name="damageVariation">Whether to apply damage variation. Defaults to false.</param>
 +	/// <param name="luck">Luck modifier to produce weight damagevariation towards higher (positive) or lower (negative) values. Defaults to 0</param>
 +	/// <returns>A <see cref="HitInfo"/> for use with <see cref="StrikeNPC(HitInfo, bool, bool)"/> and <see cref="NetMessage.SendStrikeNPC"/></returns>
-+	public HitInfo SimpleStrike(int damage, int hitDirection, bool crit = false, float knockBack = 0f, DamageClass damageType = null, bool damageVariation = false, float luck = 0) {
++	public HitInfo CalculateHitInfo(int damage, int hitDirection, bool crit = false, float knockBack = 0f, DamageClass damageType = null, bool damageVariation = false, float luck = 0) {
 +		return GetIncomingStrikeModifiers(damageType, hitDirection).ToHitInfo(damage, crit, knockBack, damageVariation, luck);
++	}
++
++	/// <summary>
++	/// Calls <see cref="CalculateHitInfo"/>, <see cref="StrikeNPC(HitInfo, bool, bool)"/> and then <see cref="NetMessage.SendStrikeNPC"/> (in multiplayer) <br/>
++	/// </summary>
++	/// <param name="damage">The damage to deal to the NPC, before modifications, defense, resistances etc</param>
++	/// <param name="hitDirection">The hit direction of the resulting strike (1 or -1)</param>
++	/// <param name="crit">Defaults to false</param>
++	/// <param name="knockBack">Defaults to 0</param>
++	/// <param name="damageType">Defaults to <see cref="DamageClass.Default"/></param>
++	/// <param name="damageVariation">Whether to apply damage variation. Defaults to false.</param>
++	/// <param name="luck">Luck modifier to produce weight damagevariation towards higher (positive) or lower (negative) values. Defaults to 0</param>
++	/// <param name="noPlayerInteraction">Prevents <see cref="PlayerInteraction(int)"/> from being called in singleplayer. In multiplayer, player interaction is handled by the server.</param>
++	/// <returns>The actual health lost by the NPC. Normally this is <see cref="HitInfo.Damage"/> but it is capped at the current health of the NPC, and represents the actual damge dealt in the case of <see cref="HitInfo.InstantKill"/> </returns>
++	public int SimpleStrikeNPC(int damage, int hitDirection, bool crit = false, float knockBack = 0f, DamageClass damageType = null, bool damageVariation = false, float luck = 0, bool noPlayerInteraction = false)
++	{
++		var hit = CalculateHitInfo(damage, hitDirection, crit, knockBack, damageType, damageVariation, luck);
++		int damageDone = StrikeNPC(hit, fromNet: false, noPlayerInteraction);
++		if (Main.netMode != NetmodeID.SinglePlayer)
++			NetMessage.SendStrikeNPC(this, hit);
++
++		return damageDone;
++	}
++
++	/// <summary>
++	/// Helper method for calling <see cref="StrikeNPC(HitInfo, bool, bool)"/> with a <see cref="HitInfo.InstantKill"/> strike. <br/>
++	/// Use to butcher your own NPCs. <br/>
++	/// Not recommended for use on multiplayer clients because the net packet will trigger <see cref="PlayerInteraction"/> on the server.
++	/// </summary>
++	public void StrikeInstantKill()
++	{
++		var hit = new NPC.HitInfo() { InstantKill = true };
++		StrikeNPC(hit, noPlayerInteraction: true);
++		if (Main.netMode != NetmodeID.SinglePlayer)
++			NetMessage.SendStrikeNPC(this, hit);
 +	}
 +
 +	/// <summary>
 +	/// Directly deals damage to the NPC, spawns combat text, plays hit sound, deals knockback based on the provided <see cref="HitInfo"/><br/>
 +	/// Calls <see cref="HitEffect(HitInfo)"/> and associated hooks after dealing damage.<br/>
 +	/// Calls <see cref="checkDead"/><br/>
-+	/// Does not automatically send packets. Use <see cref="NetMessage.SendStrikeNPC(NPC, in HitInfo, int)"/> to synchronize hits.
++	/// Does not automatically send packets. Use <see cref="NetMessage.SendStrikeNPC"/> to synchronize hits.
 +	/// </summary>
-+	/// <param name="hit">The parameters of the hit. Normally obtained via <see cref="NPC.HitModifiers"/> or <see cref="SimpleStrike"/></param>
++	/// <param name="hit">The parameters of the hit. Normally obtained via <see cref="NPC.HitModifiers"/> or <see cref="CalculateHitInfo"/></param>
 +	/// <param name="fromNet">true if this strike came from another client over the network. Just changes the combat text to be darker in color.</param>
 +	/// <param name="noPlayerInteraction">Prevents <see cref="PlayerInteraction(int)"/> from being called in singleplayer. In multiplayer, player interaction is handled by the server.</param>
 +	/// <returns>The actual health lost by the NPC. Normally this is <see cref="HitInfo.Damage"/> but it is capped at the current health of the NPC, and represents the actual damge dealt in the case of <see cref="HitInfo.InstantKill"/> </returns>
@@ -1950,8 +1992,8 @@
 +		instantKill ??= dmg == 9999;
 +		HitEffect(new HitInfo {
 +			DamageType = DamageClass.Default,
-+			SourceDamage = (int)dmg,
-+			Damage = instantKill.Value ? 0 : (int)dmg,
++			SourceDamage = instantKill.Value ? 1 : (int)dmg,
++			Damage = instantKill.Value ? 1 : (int)dmg,
 +			Crit = false,
 +			HitDirection = hitDirection,
 +			KnockBack = 0,

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -193,7 +193,7 @@
 +					writer.Write7BitEncodedInt(hit.SourceDamage);
 +					writer.Write7BitEncodedInt(hit.DamageType.Type);
 +					writer.Write((sbyte)hit.HitDirection);
-+					writer.Write(hit.KnockBack);
++					writer.Write(hit.Knockback);
 +					var flags = new BitsByte(hit.Crit, hit.InstantKill, hit.HideCombatText);
 +					writer.Write(flags);
  					break;

--- a/patches/tModLoader/Terraria/Player.TML.Hurt.cs
+++ b/patches/tModLoader/Terraria/Player.TML.Hurt.cs
@@ -76,6 +76,14 @@ public partial class Player
 		/// </summary>
 		public AddableFloat ScalingArmorPenetration = new();
 
+		private int _damageLimit = int.MaxValue;
+		/// <summary>
+		/// Sets an inclusive upper bound on the final damage of the hit. <br/>
+		/// Can be set by multiple mods, in which case the lowest limit will be used. <br/>
+		/// Cannot be set to less than 1
+		/// </summary>
+		public void SetMaxDamage(int limit) => _damageLimit = Math.Min(_damageLimit, Math.Max(limit, 1));
+
 		/// <summary>
 		/// Modifiers to apply to the knockback.
 		/// Add to <see cref="StatModifier.Base"/> to increase the knockback of the strike.
@@ -130,7 +138,7 @@ public partial class Player
 			float damageReduction = defense * defenseEffectiveness;
 			damage = Math.Max(damage - damageReduction, 1);
 
-			return Math.Max((int)FinalDamage.ApplyTo(damage), 1);
+			return Math.Clamp((int)FinalDamage.ApplyTo(damage), 1, _damageLimit);
 		}
 
 		public float GetKnockback(float baseKnockback, bool knockbackImmune)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5640,7 +5640,7 @@
 +			// num was pre-variation and post buffs. Equivalent to strike.SourceDamage.
 +			// num6 is post-variation and armor pen, only used by bees and muramasa.
 +			// By switching to strike.SourceDamage for num6, we introduce a slight vanilla discrepancy, but we remove the double damage randomization, and armor penetration
-+			ApplyNPCOnHitEffects(sItem, itemRectangle, strike.SourceDamage, strike.KnockBack, npcIndex, strike.SourceDamage, dmgDone);
++			ApplyNPCOnHitEffects(sItem, itemRectangle, strike.SourceDamage, strike.Knockback, npcIndex, strike.SourceDamage, dmgDone);
  			int num7 = Item.NPCtoBanner(nPC.BannerID());
  			if (num7 >= 0)
  				lastCreatureHit = num7;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2976,7 +2976,7 @@
  
  				nPC.immune[whoAmI] = NPCImmuneTime;
  				GiveImmuneTimeForCollisionAttack(PlayerImmuneTime);
-@@ -15863,21 +_,71 @@
+@@ -15863,21 +_,91 @@
  		return num;
  	}
  
@@ -3006,8 +3006,22 @@
 +		modifiers.IncomingDamageMultiplier *= Main.expertMode ? effect.ExpertDamageReceived : effect.NormalDamageReceived;
 +	}
 +
++	/// <summary>
++	/// Deals damage to an NPC (and syncs the hit in multiplayer). <br/>
++	/// The damage will be affected by modifiers, armor pen, enemy resistances etc. <br/>
++	/// Will not apply damage class modifiers/knockback. Use <see cref="GetTotalDamage{T}"/> to adjust the damage before calling if necessary. <br/>
++	/// Will apply daamage class based armor penetration. <br/>
++	/// Will exit early with no effect if <see cref="PlayerLoader.CanHitNPC"/> returns false.
++	/// </summary>
++	/// <param name="npc">The NPC to strike</param>
++	/// <param name="damage">The damage to deal to the NPC, before modifications, defense, resistances etc</param>
++	/// <param name="knockback">The amount of knockback to apply</param>
++	/// <param name="direction">The hit direction of the resulting strike (1 or -1)</param>
++	/// <param name="crit">Whether or not the strike is a crit</param>
++	/// <param name="damageType">Defaults to <see cref="DamageClass.Default"/></param>
++	/// <param name="damageVariation">Whether to apply damage variation. Defaults to false.</param>
 -	public void ApplyDamageToNPC(NPC npc, int damage, float knockback, int direction, bool crit)
-+	public void ApplyDamageToNPC(NPC npc, int damage, float knockback, int direction, bool crit, DamageClass? damageType = null, bool damageVariation = false)
++	public void ApplyDamageToNPC(NPC npc, int damage, float knockback, int direction, bool crit = false, DamageClass? damageType = null, bool damageVariation = false)
  	{
 +		if (!PlayerLoader.CanHitNPC(this, npc))
 +			return;
@@ -3028,6 +3042,12 @@
 +		StrikeNPCDirect(npc, modifiers.ToHitInfo(damage, crit, knockback, damageVariation, luck));
 +	}
 +
++	/// <summary>
++	/// Applies a hit to an NPC via <see cref="NPC.StrikeNPC(NPC.HitInfo, bool, bool)"/>. <br/>
++	/// Also calls player based OnHit and OnKill hooks, tracks dps and net syncs the strike
++	/// </summary>
++	/// <param name="npc">The NPC to strike</param>
++	/// <param name="hit">The hit to apply</param>
 +	public void StrikeNPCDirect(NPC npc, NPC.HitInfo hit)
 +	{
  		OnHit(npc.Center.X, npc.Center.Y, npc);

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
@@ -82,6 +82,10 @@ public class ModNPCTest : ModNPC
 		return false;
 #endif
 	}
+	public void HitMemberRename(NPC npc) {
+		var hit = npc.CalculateHitInfo(0, 0);
+		hit.Knockback = 2;
+	}
 	public override bool ModifyCollisionData(Rectangle victimHitbox, ref int immunityCooldownSlot, ref MultipliableFloat damageMultiplier, ref Rectangle npcHitbox) => false;
 	public override void DrawTownAttackSwing(ref Texture2D item, ref Rectangle itemFrame, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
@@ -62,6 +62,10 @@ public class ModNPCTest : ModNPC
 	public override bool StrikeNPC(ref double damage, int defense, ref float knockback, int hitDirection, ref bool crit) {
 		return false;
 	}
+	public void HitMemberRename(NPC npc) {
+		var hit = npc.SimpleStrike(0, 0);
+		hit.KnockBack = 2;
+	}
 	public override bool ModifyCollisionData(Rectangle victimHitbox, ref int immunityCooldownSlot, ref float damageMultiplier, ref Rectangle npcHitbox) => false;
 	public override void DrawTownAttackSwing(ref Texture2D item, ref int itemSize, ref float scale, ref Vector2 offset) { }
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -244,6 +244,7 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.ModProjectile",	from: "ModifyDamageScaling",	to: "ModifyHitNPC");
 		RenameMethod("Terraria.ModLoader.GlobalProjectile",	from: "ModifyDamageScaling",	to: "ModifyHitNPC");
 		RenameMethod("Terraria.NPC",						from: "SimpleStrike",			to: "CalculateHitInfo");
+		RenameInstanceField("Terraria.NPC.HitInfo",			from: "KnockBack",				to: "Knockback");
 
 		HookRemoved("Terraria.ModLoader.ModPlayer",			"ModifyHitPvp",				"Use ModifyHurt on the receiving player and check modifiers.PvP. Use modifiers.DamageSource.SourcePlayerIndex to get the attacking player");
 		HookRemoved("Terraria.ModLoader.ModPlayer",			"ModifyHitPvpWithProj",		"Use ModifyHurt on the receiving player and check modifiers.PvP. Use modifiers.DamageSource.SourcePlayerIndex to get the attacking player");

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -243,6 +243,7 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.GlobalNPC",		from: "StrikeNPC",				to: "ModifyIncomingHit");
 		RenameMethod("Terraria.ModLoader.ModProjectile",	from: "ModifyDamageScaling",	to: "ModifyHitNPC");
 		RenameMethod("Terraria.ModLoader.GlobalProjectile",	from: "ModifyDamageScaling",	to: "ModifyHitNPC");
+		RenameMethod("Terraria.NPC",						from: "SimpleStrike",			to: "CalculateHitInfo");
 
 		HookRemoved("Terraria.ModLoader.ModPlayer",			"ModifyHitPvp",				"Use ModifyHurt on the receiving player and check modifiers.PvP. Use modifiers.DamageSource.SourcePlayerIndex to get the attacking player");
 		HookRemoved("Terraria.ModLoader.ModPlayer",			"ModifyHitPvpWithProj",		"Use ModifyHurt on the receiving player and check modifiers.PvP. Use modifiers.DamageSource.SourcePlayerIndex to get the attacking player");


### PR DESCRIPTION
### What is the new feature?

- Adds `SetMaxDamage` to `NPC.HitModifiers` and `Player.HurtModifiers` to allow limiting the maximum damage the calculation can produce.
- Adds `NPC.SimpleStrikeNPC` helper which combines the simple damage calculation, strike, and net syncing.
- Adds `NPC.StrikeInstantKill` helper method, to make instant killing NPCs easier. Mostly equivalent to the vanilla code `StrikeNPCNoInteraction(9999, 0, 0)` and also sends the packet in multiplayer.

### Sample usage for the new feature
```cs
// in AI
if (Main.netMode != NetmodeID.MultiplayerClient)
    npc.StrikeInstantKill();

// when an NPC takes damage from a custom effect
npc.SimpleStrikeNPC(damage, hitDirection);
```

If the effect comes from a `Player` (accessory etc), use `Player.ApplyDamageToNPC` or `Player.StrikeNPCDirect` instead.

### ExampleMod updates
None required

### Porting Notes
- `NPC.SimpleStrike` renamed to `NPC.CalculateHitInfo`

