### PR TITLE
Provide HurtInfo argument to FreeDodge and ConsumableDodge (#3356)

### DIFF
--- a/ExampleMod/Common/Players/ExampleDamageModificationPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleDamageModificationPlayer.cs
@@ -79,12 +79,13 @@ namespace ExampleMod.Common.Players
 			}
 		}
 
-		public override bool ConsumableDodge(PlayerDeathReason damageSource, int cooldownCounter) {
+		public override bool ConsumableDodge(Player.HurtInfo info) {
 			if (exampleDodge) {
 				ExampleDodgeEffects();
 				return true;
 			}
-			return base.ConsumableDodge(damageSource, cooldownCounter);
+
+			return false;
 		}
 
 		// ExampleDodgeEffects() will be called from ConsumableDodge and HandleExampleDodgeMessage to sync the effect.

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -338,10 +338,8 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// If dodge is determined on the local player, the hit will not be sent across the network. <br/>
 	/// If visual indication of the dodge is required on remote clients, you will need to send your own packet.
 	/// </summary>
-	/// <param name="damageSource">The source of the damage (projectile, NPC, etc)</param>
-	/// <param name="cooldownCounter">The <see cref="ImmunityCooldownID"/> of the hit</param>
 	/// <returns>True to completely ignore the hit</returns>
-	public virtual bool FreeDodge(PlayerDeathReason damageSource, int cooldownCounter)
+	public virtual bool FreeDodge(Player.HurtInfo info)
 	{
 		return false;
 	}
@@ -355,10 +353,8 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// If dodge is determined on the local player, the hit will not be sent across the network. <br/>
 	/// You may need to send your own packet to synchronize the consumption of the effect, or application of the cooldown in multiplayer.
 	/// </summary>
-	/// <param name="damageSource">The source of the damage (projectile, NPC, etc)</param>
-	/// <param name="cooldownCounter">The <see cref="ImmunityCooldownID"/> of the hit</param>
 	/// <returns>True to completely ignore the hit</returns>
-	public virtual bool ConsumableDodge(PlayerDeathReason damageSource, int cooldownCounter)
+	public virtual bool ConsumableDodge(Player.HurtInfo info)
 	{
 		return false;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -392,22 +392,22 @@ public static class PlayerLoader
 		return false;
 	}
 
-	private static HookList HookFreeDodge = AddHook<Func<PlayerDeathReason, int, bool>>(p => p.FreeDodge);
-	public static bool FreeDodge(Player player, PlayerDeathReason damageSource, int cooldownCounter)
+	private static HookList HookFreeDodge = AddHook<Func<Player.HurtInfo, bool>>(p => p.FreeDodge);
+	public static bool FreeDodge(Player player, in Player.HurtInfo info)
 	{
 		foreach (var modPlayer in HookFreeDodge.Enumerate(player.modPlayers)) {
-			if (modPlayer.FreeDodge(damageSource, cooldownCounter))
+			if (modPlayer.FreeDodge(info))
 				return true;
 		}
 
 		return false;
 	}
 
-	private static HookList HookConsumableDodge = AddHook<Func<PlayerDeathReason, int, bool>>(p => p.ConsumableDodge);
-	public static bool ConsumableDodge(Player player, PlayerDeathReason damageSource, int cooldownCounter)
+	private static HookList HookConsumableDodge = AddHook<Func<Player.HurtInfo, bool>>(p => p.ConsumableDodge);
+	public static bool ConsumableDodge(Player player, in Player.HurtInfo info)
 	{
 		foreach (var modPlayer in HookConsumableDodge.Enumerate(player.modPlayers)) {
-			if (modPlayer.ConsumableDodge(damageSource, cooldownCounter))
+			if (modPlayer.ConsumableDodge(info))
 				return true;
 		}
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4333,7 +4333,7 @@
 +	}
 +
 +	// out param and extras from above added
-+	public double Hurt(PlayerDeathReason damageSource, int Damage, int hitDirection, out Player.HurtInfo info, bool pvp = false, bool quiet = false, int cooldownCounter = -1, bool dodgeable = true, float armorPenetration = 0, float scalingArmorPenetration = 0, float knockback = 4.5f)
++	public double Hurt(PlayerDeathReason damageSource, int Damage, int hitDirection, out HurtInfo info, bool pvp = false, bool quiet = false, int cooldownCounter = -1, bool dodgeable = true, float armorPenetration = 0, float scalingArmorPenetration = 0, float knockback = 4.5f)
 +	{
 +		info = default;
 +
@@ -4349,26 +4349,11 @@
  		bool flag = !immune;
  		bool flag2 = false;
  		int hitContext = cooldownCounter;
-@@ -29531,6 +_,9 @@
+@@ -29530,7 +_,34 @@
+ 		}
  
  		if (flag) {
- 			if (dodgeable) {
-+				if (whoAmI == Main.myPlayer && PlayerLoader.FreeDodge(this, damageSource, cooldownCounter))
-+					return 0.0;
-+
- 				if (whoAmI == Main.myPlayer && blackBelt && Main.rand.Next(10) == 0) {
- 					NinjaDodge();
- 					return 0.0;
-@@ -29545,24 +_,67 @@
- 					ShadowDodge();
- 					return 0.0;
- 				}
-+
-+				if (whoAmI == Main.myPlayer && PlayerLoader.ConsumableDodge(this, damageSource, cooldownCounter))
-+					return 0.0;
- 			}
- 
-+			Player.HurtModifiers modifiers = new() {
++			HurtModifiers modifiers = new() {
 +				DamageSource = damageSource,
 +				PvP = pvp,
 +				CooldownCounter = cooldownCounter,
@@ -4391,6 +4376,23 @@
 +
 +			ApplyVanillaHurtEffectModifiers(ref modifiers);
 +			info = modifiers.ToHurtInfo(Damage, statDefense, pvp ? 0.5f : DefenseEffectiveness.Value, knockback, noKnockback);
++
+ 			if (dodgeable) {
++				if (whoAmI == Main.myPlayer && PlayerLoader.FreeDodge(this, info))
++					return 0.0;
++
+ 				if (whoAmI == Main.myPlayer && blackBelt && Main.rand.Next(10) == 0) {
+ 					NinjaDodge();
+ 					return 0.0;
+@@ -29545,24 +_,44 @@
+ 					ShadowDodge();
+ 					return 0.0;
+ 				}
++
++				if (whoAmI == Main.myPlayer && PlayerLoader.ConsumableDodge(this, info))
++					return 0.0;
+ 			}
+ 
 +			Hurt(info, quiet);
 +			return info.Damage;
 +		}

--- a/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.Expected.cs
@@ -115,4 +115,7 @@ public class ModPlayerTest : ModPlayer
 	public override void ModifyHitPvpWithProj(Projectile proj, Player target, ref int damage, ref bool crit)/* tModPorter Note: Removed. Use ModifyHurt on the receiving player and check modifiers.PvP. Use modifiers.DamageSource.SourcePlayerIndex to get the attacking player */ { }
 	public override void OnHitPvpWithProj(Projectile proj, Player target, int damage, bool crit)/* tModPorter Note: Removed. Use OnHurt on the receiving player and check info.PvP. Use info.DamageSource.SourcePlayerIndex to get the attacking player */ { }
 #endif
+
+	public override bool FreeDodge(Player.HurtInfo info) => false;
+	public override bool ConsumableDodge(Player.HurtInfo info) => false;
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModPlayerTest.cs
@@ -89,4 +89,7 @@ public class ModPlayerTest : ModPlayer
 	public override void OnHitPvp(Item item, Player target, int damage, bool crit) { }
 	public override void ModifyHitPvpWithProj(Projectile proj, Player target, ref int damage, ref bool crit) { }
 	public override void OnHitPvpWithProj(Projectile proj, Player target, int damage, bool crit) { }
+
+	public override bool FreeDodge(PlayerDeathReason damageSource, int cooldownCounter) => false;
+	public override bool ConsumableDodge(PlayerDeathReason damageSource, int cooldownCounter) => false;
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -233,6 +233,8 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.ModPlayer",			"OnHitByNPC");
 		ChangeHookSignature("Terraria.ModLoader.ModPlayer",			"ModifyHitByProjectile");
 		ChangeHookSignature("Terraria.ModLoader.ModPlayer",			"OnHitByProjectile");
+		ChangeHookSignature("Terraria.ModLoader.ModPlayer",			"FreeDodge");
+		ChangeHookSignature("Terraria.ModLoader.ModPlayer",			"ConsumableDodge");
 
 		RenameMethod("Terraria.ModLoader.ModPlayer",		from: "CanHitNPC",				to: "CanHitNPCWithItem");
 		RenameMethod("Terraria.ModLoader.ModPlayer",		from: "ModifyHitNPC",			to: "ModifyHitNPCWithItem");


### PR DESCRIPTION
### What is the new feature?

Changes `ModPlayer.FreeDodge` and `ConsumableDodge` to run after `ModifyHurt` hooks, and provides a `HurtInfo` parameter.

### Why should this be part of tModLoader?

Allows dodging attacks based on the results of the damage calculations.

### Are there alternative designs?

A separate `CanHurt` hook could be added, but it would not be as effective as the `Free/Consumable` split we have for dodges.

### Sample usage for the new feature

```cs
public override bool ConsumableDodge(Player.HurtInfo info) {
	if (dodgeNextBigHit && info.Damage > 100) {
		ConsumeDodgeAndShowEffects();
		return true;
	}

	return false;
}
```
