### PR TITLE
Add ModSystem.ClearWorld

### DIFF
--- a/ExampleMod/Common/Systems/DownedBossSystem.cs
+++ b/ExampleMod/Common/Systems/DownedBossSystem.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using Terraria;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
@@ -17,12 +15,7 @@ namespace ExampleMod.Common.Systems
 		public static bool downedMinionBoss = false;
 		// public static bool downedOtherBoss = false;
 
-		public override void OnWorldLoad() {
-			downedMinionBoss = false;
-			// downedOtherBoss = false;
-		}
-
-		public override void OnWorldUnload() {
+		public override void ClearWorld() {
 			downedMinionBoss = false;
 			// downedOtherBoss = false;
 		}

--- a/ExampleMod/Common/Systems/SimpleDataAtParticularLocations.cs
+++ b/ExampleMod/Common/Systems/SimpleDataAtParticularLocations.cs
@@ -30,7 +30,7 @@ namespace ExampleMod.Common.Systems
 		public PosData<byte>[] myMap;
 
 		// Next, we ensure we initialize the map on world load to an empty map.
-		public override void OnWorldLoad() {
+		public override void ClearWorld() {
 			myMap = new PosData<byte>[0];
 		}
 
@@ -56,11 +56,6 @@ namespace ExampleMod.Common.Systems
 				));
 			}
 			myMap = list.ToArray();
-		}
-
-		public override void OnWorldUnload() {
-			// We discard our map after unloading, because we don't need it anymore.
-			myMap = null;
 		}
 
 		// We define what we want to generate as additional location data, for this example, in PostWorldGen.

--- a/patches/tModLoader/Terraria/ModLoader/Default/LegacyUnloadedTilesSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/LegacyUnloadedTilesSystem.cs
@@ -14,7 +14,7 @@ internal partial class LegacyUnloadedTilesSystem : ModSystem
 	private static readonly List<TileInfo> infos = new List<TileInfo>();
 	private static readonly Dictionary<int, ushort> converted = new Dictionary<int, ushort>();
 
-	public override void OnWorldLoad()
+	public override void ClearWorld()
 	{
 		infos.Clear();
 		converted.Clear();

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedSystem.cs
@@ -13,7 +13,7 @@ public class UnloadedSystem : ModSystem
 	internal IList<TagCompound> unloadedBestiarySights;
 	internal IList<TagCompound> unloadedBestiaryChats;
 
-	public override void OnWorldLoad()
+	public override void ClearWorld()
 	{
 		data = new List<TagCompound>();
 		unloadedNPCs = new List<TagCompound>();
@@ -21,6 +21,13 @@ public class UnloadedSystem : ModSystem
 		unloadedBestiaryKills = new List<TagCompound>();
 		unloadedBestiarySights = new List<TagCompound>();
 		unloadedBestiaryChats = new List<TagCompound>();
+
+		TileIO.ClearWorld();
+	}
+
+	public override void Unload()
+	{
+		TileIO.ResetUnloadedTypes();
 	}
 
 	public override void SaveWorldData(TagCompound tag)

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -258,8 +258,7 @@ internal static partial class TileIO
 
 	internal static bool canPurgeOldData => false; //for deleting unloaded mod data in a save; should point to UI flag; temp false
 
-	// Called to ensure proper loading/unloaded behaviour with respect to Unloaded Placeholders
-	internal static void ResizeArrays()
+	internal static void ResetUnloadedTypes()
 	{
 		Tiles.unloadedTypes.Clear();
 		Walls.unloadedTypes.Clear();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -525,7 +525,6 @@ public static class ModContent
 		DustLoader.ResizeArrays();
 		TileLoader.ResizeArrays(unloading);
 		WallLoader.ResizeArrays(unloading);
-		TileIO.ResizeArrays();
 		ProjectileLoader.ResizeArrays();
 		NPCLoader.ResizeArrays(unloading);
 		NPCHeadLoader.ResizeAndFillArrays();
@@ -553,8 +552,6 @@ public static class ModContent
 	/// </summary>
 	internal static void CleanupModReferences()
 	{
-		WorldGen.clearWorld();
-
 		// Clear references to ModPlayer instances
 		for (int i = 0; i < Main.player.Length; i++) {
 			Main.player[i] = new Player();

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -225,6 +225,7 @@ public static class ModLoader
 	{
 		Interface.loadMods.SetLoadStage("tModLoader.MSUnloading", Mods.Length);
 
+		WorldGen.clearWorld();
 		ModContent.UnloadModContent();
 
 		Mods = new Mod[0];

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -90,7 +90,7 @@ public abstract partial class ModSystem : ModType
 	public virtual void OnWorldUnload() { }
 
 	/// <summary>
-	/// Called whenever the world is cleared. Use this reset world-related data structures before world-gen or loading in both single and multiplayer <br/>.
+	/// Called whenever the world is cleared. Use this reset world-related data structures before world-gen or loading in both single and multiplayer. <br/>
 	/// Also called just before mods are unloaded.
 	/// </summary>
 	public virtual void ClearWorld() { }

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -79,18 +79,19 @@ public abstract partial class ModSystem : ModType
 	public virtual void AddRecipeGroups() { }
 
 	/// <summary>
-	/// Called whenever a world is loaded. This can be used to initialize data structures, etc.
-	/// <br/>If you need to access your data during worldgen, initialize it in <see cref="PreWorldGen"/> instead, unless you also save it on the world, then you need both.
+	/// Called whenever a world is loaded, before <see cref="LoadWorldData"/> <br/>
+	/// If you need to initialize tile or other world related data-structures, use <see cref="ClearWorld"/> instead
 	/// </summary>
 	public virtual void OnWorldLoad() { }
 
 	/// <summary>
-	/// Called whenever a world is unloaded. Use this to deinitialize world-related data structures, etc.
+	/// Called whenever a world is unloaded.
 	/// </summary>
 	public virtual void OnWorldUnload() { }
 
 	/// <summary>
-	/// Called whenever the world is cleared. Use this reset world-related data structures before world-gen or loading
+	/// Called whenever the world is cleared. Use this reset world-related data structures before world-gen or loading in both single and multiplayer <br/>.
+	/// Also called just before mods are unloaded.
 	/// </summary>
 	public virtual void ClearWorld() { }
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -69,9 +69,7 @@ public abstract partial class ModSystem : ModType
 	/// <summary>
 	/// Override this method to do treatment about recipes once they have been setup. You shouldn't edit any recipe here.
 	/// </summary>
-	public virtual void PostSetupRecipes()
-	{
-	}
+	public virtual void PostSetupRecipes() { }
 
 	/// <summary>
 	/// Override this method to add recipe groups to the game.
@@ -90,6 +88,11 @@ public abstract partial class ModSystem : ModType
 	/// Called whenever a world is unloaded. Use this to deinitialize world-related data structures, etc.
 	/// </summary>
 	public virtual void OnWorldUnload() { }
+
+	/// <summary>
+	/// Called whenever the world is cleared. Use this reset world-related data structures before world-gen or loading
+	/// </summary>
+	public virtual void ClearWorld() { }
 
 	/// <summary>
 	/// Use this hook to modify Main.screenPosition after weapon zoom and camera lerp have taken place.

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -84,6 +84,8 @@ partial class SystemLoader
 
 	private static HookList HookOnWorldUnload = AddHook<Action>(s => s.OnWorldUnload);
 
+	private static HookList HookClearWorld = AddHook<Action>(s => s.ClearWorld);
+
 	private static HookList HookCanWorldBePlayed = AddHook<Func<PlayerFileData, WorldFileData, bool>>(s => s.CanWorldBePlayed);
 
 	private static HookList HookModifyScreenPosition = AddHook<Action>(s => s.ModifyScreenPosition);

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -152,6 +152,12 @@ public static partial class SystemLoader
 		}
 	}
 
+	public static void ClearWorld() {
+		foreach (var system in HookClearWorld.arr) {
+			system.ClearWorld();
+		}
+	}
+
 	public static bool CanWorldBePlayed(PlayerFileData playerData, WorldFileData worldData, out ModSystem rejector)
 	{
 		foreach (var system in HookCanWorldBePlayed.arr) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -344,12 +344,13 @@
  
  		for (int n = 0; n < Main.countsAsHostForGameplay.Length; n++) {
  			Main.countsAsHostForGameplay[n] = false;
-@@ -3026,6 +_,9 @@
+@@ -3026,6 +_,10 @@
  
  		setWorldSize();
  		Star.SpawnStars();
 +
 +		TileIO.ClearWorld();
++		SystemLoader.ClearWorld();
 +
  		worldCleared = true;
  	}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -344,12 +344,11 @@
  
  		for (int n = 0; n < Main.countsAsHostForGameplay.Length; n++) {
  			Main.countsAsHostForGameplay[n] = false;
-@@ -3026,6 +_,10 @@
+@@ -3026,6 +_,9 @@
  
  		setWorldSize();
  		Star.SpawnStars();
 +
-+		TileIO.ClearWorld();
 +		SystemLoader.ClearWorld();
 +
  		worldCleared = true;


### PR DESCRIPTION
### What is the new feature?

Adds `ModSystem.ClearWorld` which runs on world clear. The new best place to clear/initialize world related data structures.

### Why should this be part of tModLoader?

- Better consistency with vanilla
- No need to implement both `OnWorldLoad` and `PreWorldGen`
- Sometimes `OnWorldLoad` would be too late
- Also cleared before mod unloading, for convenience making overriding `OnWorldUnload` often optional

### Porting Notes

- Consider replacing overrides of `OnWorldLoad` with `ClearWorld` to reset world related data
- Generally no need to override `OnWorldUnload` anymore. Use `Unload` if you want to fully clean up all memory, but empty lists are nothing to worry about.

### ExampleMod updates
- `DownedBossSystem` and `SimpleDataAtParticularLocations` now use `ClearWorld` instead of `OnWorldLoad`

