### PR TITLE
Hotfix enumeration stopped error (Task edit UI) and icon disappearing

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
@@ -197,6 +197,13 @@ internal partial class UIModBrowser : UIState, IHaveBackButtonCommand
 		UpdateNeeded = false;
 		if (!Loading) _backgroundElement.RemoveChild(_loaderElement);
 		ModList.Clear();
+
+		// @WARN: Clear up mod icon request status, this should be in the UI element, not in the ModDownloadItem
+		// (but this will be nuked by the paginated browser so it's ok as a fix)
+		foreach (var item in _items) {
+			item.ModDownload.ModIconStatus = ModIconStatus.UNKNOWN;
+		}
+
 		ModList.AddRange(_items.Where(item => item.PassFilters()));
 		bool hasNoModsFoundNotif = ModList.HasChild(NoModsFoundText);
 		if (ModList.Count <= 0 && !hasNoModsFoundNotif)
@@ -229,10 +236,8 @@ internal partial class UIModBrowser : UIState, IHaveBackButtonCommand
 		SetHeading(Language.GetText("tModLoader.MenuModBrowser"));
 
 		// Remove old data
-		ModList.Clear();
 		_items.Clear();
-		ModList.Deactivate();
-
+		
 		// Asynchronous load the Mod Browser
 		Task.Run(() => {
 			InnerPopulateModBrowser(uiOnly: uiOnly);


### PR DESCRIPTION
### What is the bug?

ModBrowser crashing when enumeration gets aborted for UI in case of async editing the UI elements:
https://discord.com/channels/103110554649894912/436261964017303553/1091832257767018597

And also temporary fix of mod icon not loading due to improper usage of `ModDownloadItem` fields to store UI status.

### How did you fix the bug?

Removed `Task` editing of the UI and refreshed UI related `ModDownloadItem` fields on update performed

### Are there alternatives to your fix?

This hotfix will become obsolete as soon as the asyncronous mod browser gets implemented, although this will take some time still so this is a patch **to be backported to stable and preview**
