### PR TITLE
Fix console commands on Docker servers

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Docker/docker-compose.yml
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "2.0"
 services:
   tml:
     build:
@@ -6,6 +6,8 @@ services:
       args:
         UID: 1000
         GID: 1000
+    tty: true
+    stdin_open: true
     ports:
       - 7777:7777
     volumes:

--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/README.md
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/README.md
@@ -58,6 +58,8 @@ The server will be available on port 7777.
 
 To run without any interactivity, use `docker-compose up -d`, and include [serverconfig.txt](#automatically-selecting-a-world) in the `Terraria` directory.
 
+To attach to the server console, do `docker ps` to get the container ID and do `docker attach CTID` to attach to it. To detach from the console do `Ctrl-P Ctrl-Q` to avoid shutting down or `Ctrl-C` if you want to also shutdown the server
+
 ## Autostarting On Boot
 When using `manage-tModLoaderServer.sh`, refer to your distro's documentation. You can likely use a startup script with your init system.
 

--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/README.md
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/README.md
@@ -58,7 +58,7 @@ The server will be available on port 7777.
 
 To run without any interactivity, use `docker-compose up -d`, and include [serverconfig.txt](#automatically-selecting-a-world) in the `Terraria` directory.
 
-To attach to the server console, do `docker ps` to get the container ID and do `docker attach CTID` to attach to it. To detach from the console do `Ctrl-P Ctrl-Q` to avoid shutting down or `Ctrl-C` if you want to also shutdown the server
+To attach to the server console, run `docker ps` to get the container ID and `docker attach CTID` to attach to it. To detach from the console press `Ctrl-P Ctrl-Q` to avoid shutting down or `Ctrl-C` to detach and shutdown the server.
 
 ## Autostarting On Boot
 When using `manage-tModLoaderServer.sh`, refer to your distro's documentation. You can likely use a startup script with your init system.


### PR DESCRIPTION
### What is the bug?
On Docker servers when running or attaching to a running server no console commands can be used, presumably because STDIN isn't being kept open.

### How did you fix the bug?
Added the equivalent of `-it` to the docker-compose file.

### Are there alternatives to your fix?
You can `docker run -it ...` to run the container with the same parameters but there's no other way for compose files to handle this.
