### PR TITLE
Change legacy version message

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -33,7 +33,7 @@
 		"MenuModsEnabled": "{0} {^0:Mod;Mods} Enabled",
 		"MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		"AudioNotSupported": "No audio hardware found. Disabling all audio.",
-		"13InfoButton": "How to Access 1.3 tModLoader",
+		"13InfoButton": "How to Access legacy tModLoader versions",
 		"SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 
 		// Mods Menu


### PR DESCRIPTION
### What is the new feature?
This changes the message on the main menu screen from "How to access 1.3 tModLoader" to "How to access legacy tModLoader versions"

### Why should this be part of tModLoader?
The old message is inaccurate as the steps described in the guide linked now apply to both 1.3 and 1.4.3 tModLoader, not just 1.3

### Are there alternative designs?
Not really, we could enumerate every legacy version we support, but that would be additional maintenance

### Sample usage for the new feature
N/A

### ExampleMod updates
N/A