### PR TITLE
Added field for items to not change player direction on shoot

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShootingSword.cs
@@ -36,6 +36,9 @@ namespace ExampleMod.Content.Items.Weapons
 
 			// If you want melee speed to only affect the swing speed of the weapon and not the shoot speed (not recommended)
 			// Item.attackSpeedOnlyAffectsWeaponAnimation = true;
+
+			// Normally shooting a projectile makes the player face the projectile, but if you don't want that (like the beam sword) use this line of code
+			// Item.ChangePlayerDirectionOnShoot = false;
 		}
 		// This method gets called when firing your weapon/sword.
 		public override bool Shoot(Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, Vector2 velocity, int type, int damage, float knockback) {

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -87,6 +87,11 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	/// </summary>
 	public bool StopAnimationOnHurt { get; set; }
 
+	/// <summary>
+	/// When true, shooting any projectile from this item will make the player face the projectile. Defaults to true.
+	/// </summary>
+	public bool ChangePlayerDirectionOnShoot { get; set; }
+
 	private DamageClass _damageClass = DamageClass.Default;
 	/// <summary>
 	/// The damage type of this Item. Assign to DamageClass.Melee/Ranged/Magic/Summon/Throwing for vanilla classes, or <see cref="ModContent.GetInstance"/> for custom damage types.

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -88,9 +88,11 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	public bool StopAnimationOnHurt { get; set; }
 
 	/// <summary>
-	/// When true, shooting any projectile from this item will make the player face the projectile. Defaults to true.
+	/// When true, shooting any projectile from this item will make the owner face the projectile. Defaults to true.<br/>
+	/// The only 2 vanilla items that change this from true to false are the Grand Design and Beam Sword<br/>
+	/// This is different to <see cref="Item.useTurn"/>. Item.useTurn will prevent the player from changing their direction while the animation is playing if it is set to true.<br/>
 	/// </summary>
-	public bool ChangePlayerDirectionOnShoot { get; set; }
+	public bool ChangePlayerDirectionOnShoot { get; set; } = true;
 
 	private DamageClass _damageClass = DamageClass.Default;
 	/// <summary>

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1244,7 +1244,7 @@
  				knockBack = 6.5f;
  				melee = true;
  				value = sellPrice(0, 3);
-+				ChangePlayerDirectionOnShoot = false;
++				ChangePlayerDirectionOnShoot = false;// Added by tML
  				break;
  			case 724:
  				autoReuse = true;
@@ -1288,7 +1288,7 @@
  				rare = 2;
  				UseSound = SoundID.Item64;
  				mech = true;
-+				ChangePlayerDirectionOnShoot = false;
++				ChangePlayerDirectionOnShoot = false;// Added by tML
  				return;
  			case 3612:
  				useStyle = 1;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1240,6 +1240,14 @@
  				useStyle = 5;
  				autoReuse = true;
  				useAnimation = 30;
+@@ -11396,6 +_,7 @@
+ 				knockBack = 6.5f;
+ 				melee = true;
+ 				value = sellPrice(0, 3);
++				ChangePlayerDirectionOnShoot = false;
+ 				break;
+ 			case 724:
+ 				autoReuse = true;
 @@ -12077,6 +_,8 @@
  				scale = 1f;
  				break;
@@ -1276,6 +1284,14 @@
  	public void DefaultToQuestFish()
  	{
  		questItem = true;
+@@ -35265,6 +_,7 @@
+ 				rare = 2;
+ 				UseSound = SoundID.Item64;
+ 				mech = true;
++				ChangePlayerDirectionOnShoot = false;
+ 				return;
+ 			case 3612:
+ 				useStyle = 1;
 @@ -36886,6 +_,8 @@
  				shootSpeed = 17f;
  				return;
@@ -1810,7 +1826,7 @@
  		if (type == 5437)
  			SetDefaults(5358);
  	}
-@@ -47318,14 +_,30 @@
+@@ -47318,14 +_,31 @@
  	{
  		tooltipContext = -1;
  		BestiaryNotes = null;
@@ -1827,6 +1843,7 @@
 +		InterruptChannelOnHurt = false;
 +		StopAnimationOnHurt = false;
 +		DamageType = DamageClass.Default;
++		ChangePlayerDirectionOnShoot = true;
 +
  		sentry = false;
  		hasVanityEffects = false;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5989,6 +5989,16 @@
  		KnockBack = GetWeaponKnockback(sItem, KnockBack);
  		IEntitySource projectileSource_Item_WithPotentialAmmo = GetProjectileSource_Item_WithPotentialAmmo(sItem, usedAmmoItemId);
  		if (projToShoot == 228)
+@@ -36708,7 +_,8 @@
+ 		Vector2 pointPoisition = RotatedRelativePoint(MountedCenter);
+ 		bool flag = true;
+ 		int type = sItem.type;
+-		if (type == 723 || type == 3611)
++		//if (type == 723 || type == 3611)
++		if (!sItem.ChangePlayerDirectionOnShoot)
+ 			flag = false;
+ 
+ 		Vector2 value = Vector2.UnitX.RotatedBy(fullRotation);
 @@ -36824,6 +_,16 @@
  			num3 = vector5.Y;
  		}


### PR DESCRIPTION
https://github.com/tModLoader/tModLoader/issues/3384

### What is the new feature?
Added a field to items that can allow items to prevent shooting a projectile make the player face the projectile
`item.ChangePlayerDirectionOnShoot`

### Why should this be part of tModLoader?
Currently IL editing is required to prevent a shot projectile from making the player turn towards it, since the vanilla implementation that excludes the Beam Sword and Grand Design from this behaviour is hardcoded.

### Are there alternative designs?
Using a set in ItemID.Sets

### Sample usage for the new feature
In ModItem.SetDefaults
```cs
public override void SetDefaults()
{
    item.ChangePlayerDirectionOnShoot = false;
}
```

### ExampleMod updates
I will do one if requested
<!-- If you also updated ExampleMod for your new feature, let us know here -->

