### PR TITLE
UseImageX method overloads

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Shaders/ArmorShaderData.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Shaders/ArmorShaderData.cs.patch
@@ -1,0 +1,15 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Shaders/ArmorShaderData.cs
++++ src/tModLoader/Terraria/Graphics/Shaders/ArmorShaderData.cs
+@@ -77,6 +_,12 @@
+ 		return this;
+ 	}
+ 
++	public ArmorShaderData UseImage(Asset<Texture2D> asset)
++	{
++		_uImage = asset;
++		return this;
++	}
++
+ 	public ArmorShaderData UseOpacity(float alpha)
+ 	{
+ 		_uOpacity = alpha;

--- a/patches/tModLoader/Terraria/Graphics/Shaders/HairShaderData.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Shaders/HairShaderData.cs.patch
@@ -1,0 +1,15 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Shaders/HairShaderData.cs
++++ src/tModLoader/Terraria/Graphics/Shaders/HairShaderData.cs
+@@ -70,6 +_,12 @@
+ 		return this;
+ 	}
+ 
++	public HairShaderData UseImage(Asset<Texture2D> asset)
++	{
++		_uImage = asset;
++		return this;
++	}
++
+ 	public HairShaderData UseOpacity(float alpha)
+ 	{
+ 		_uOpacity = alpha;

--- a/patches/tModLoader/Terraria/Graphics/Shaders/MiscShaderData.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Shaders/MiscShaderData.cs.patch
@@ -1,0 +1,27 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Shaders/MiscShaderData.cs
++++ src/tModLoader/Terraria/Graphics/Shaders/MiscShaderData.cs
+@@ -105,6 +_,24 @@
+ 		return this;
+ 	}
+ 
++	public MiscShaderData UseImage0(Asset<Texture2D> asset)
++	{
++		_uImage0 = asset;
++		return this;
++	}
++
++	public MiscShaderData UseImage1(Asset<Texture2D> asset)
++	{
++		_uImage1 = asset;
++		return this;
++	}
++
++	public MiscShaderData UseImage2(Asset<Texture2D> asset)
++	{
++		_uImage2 = asset;
++		return this;
++	}
++
+ 	private static bool IsPowerOfTwo(int n) => (int)Math.Ceiling(Math.Log(n) / Math.Log(2.0)) == (int)Math.Floor(Math.Log(n) / Math.Log(2.0));
+ 
+ 	public MiscShaderData UseOpacity(float alpha)

--- a/patches/tModLoader/Terraria/Graphics/Shaders/ScreenShaderData.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Shaders/ScreenShaderData.cs.patch
@@ -1,0 +1,17 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Shaders/ScreenShaderData.cs
++++ src/tModLoader/Terraria/Graphics/Shaders/ScreenShaderData.cs
+@@ -103,6 +_,14 @@
+ 		return this;
+ 	}
+ 
++	public ScreenShaderData UseImage(Asset<Texture2D> image, int index = 0, SamplerState samplerState = null)
++	{
++		_samplerStates[index] = samplerState;
++		_uAssetImages[index] = image;
++		_uCustomImages[index] = null;
++		return this;
++	}
++
+ 	public ScreenShaderData UseImage(Texture2D image, int index = 0, SamplerState samplerState = null)
+ 	{
+ 		_samplerStates[index] = samplerState;


### PR DESCRIPTION
#3196 

### What is the new feature?
Adds overloads for `ScreenShaderData`, `MiscShaderData`, `HairShaderData` and `AmorShaderData` `UseImage` methods.

### Why should this be part of tModLoader?
New overloads for `UseImage` methods accept `Asset<Texture2D>` instead of `string`, allowing modders to use their own textures rather than limited by vanilla ones.

### Are there alternative designs?
No.

### Sample usage for the new feature
```
GameShader.Misc["MyMod:MyShader"] = new MiscShaderData(...);
GameShader.Misc["MyMod:MyShader"].UseImage0(ModContent.Request<Texture2D>("MyMod/SomeAsset"));
```