### PR TITLE
BuyItem and PreReforge split into more granular methods, Fixed savings in void bag not being considered when reforging

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/CustomCurrencyManager.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/CustomCurrencyManager.cs.patch
@@ -8,6 +8,33 @@
  		CustomCurrencyID.DefenderMedals = RegisterCurrency(new CustomCurrencySingleCoin(3817, 999L));
  	}
  
+@@ -63,6 +_,13 @@
+ 
+ 	public static bool BuyItem(Player player, long price, int currencyIndex)
+ 	{
++		if (CanAfford(player, price, currencyIndex))
++			return PayCurrency(player, price, currencyIndex);
++		return false;
++	}
++
++	public static bool CanAfford(Player player, long price, int currencyIndex = -1)
++	{
+ 		CustomCurrencySystem customCurrencySystem = _currencies[currencyIndex];
+ 		bool overFlowing;
+ 		long num = customCurrencySystem.CountCurrency(out overFlowing, player.inventory, 58, 57, 56, 55, 54);
+@@ -72,7 +_,12 @@
+ 		long num5 = customCurrencySystem.CountCurrency(out overFlowing, player.bank4.item);
+ 		if (customCurrencySystem.CombineStacks(out overFlowing, num, num2, num3, num4, num5) < price)
+ 			return false;
++		return true;
++	}
+ 
++	public static bool PayCurrency(Player player, long price, int currencyIndex = -1)
++	{
++		CustomCurrencySystem customCurrencySystem = _currencies[currencyIndex];
+ 		List<Item[]> list = new List<Item[]>();
+ 		Dictionary<int, List<int>> dictionary = new Dictionary<int, List<int>>();
+ 		List<Point> list2 = new List<Point>();
 @@ -138,4 +_,12 @@
  	{
  		_currencies[item.shopSpecialCurrency].GetItemExpectedPrice(item, out calcForSelling, out calcForBuying);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4111,7 +4111,7 @@
 +						/*
  						if (mouseLeftRelease && mouseLeft && player[myPlayer].BuyItem(num58)) {
 +						*/
-+						if (mouseLeftRelease && mouseLeft && player[myPlayer].CanBuyItem(num58) && ItemLoader.PreReforge(reforgeItem)) {
++						if (mouseLeftRelease && mouseLeft && player[myPlayer].CanAfford(num58) && ItemLoader.PreReforge(reforgeItem)) {
 +							player[myPlayer].BuyItem(num58);
 +
  							reforgeItem.ResetPrefix();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4103,7 +4103,7 @@
  					string text2 = "";
  					int num59 = 0;
  					int num60 = 0;
-@@ -33431,11 +_,20 @@
+@@ -33431,11 +_,21 @@
  
  						mouseReforge = true;
  						player[myPlayer].mouseInterface = true;
@@ -4111,8 +4111,9 @@
 +						/*
  						if (mouseLeftRelease && mouseLeft && player[myPlayer].BuyItem(num58)) {
 +						*/
-+						if (mouseLeftRelease && mouseLeft && player[myPlayer].CanAfford(num58) && ItemLoader.PreReforge(reforgeItem)) {
++						if (mouseLeftRelease && mouseLeft && player[myPlayer].CanAfford(num58) && ItemLoader.CanReforge(reforgeItem)) {
 +							player[myPlayer].BuyItem(num58);
++							ItemLoader.PreReforge(reforgeItem); // After BuyItem just in case
 +
  							reforgeItem.ResetPrefix();
  							reforgeItem.Prefix(-2);

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -810,12 +810,19 @@ public abstract class GlobalItem : GlobalType<Item, GlobalItem>
 
 	/// <summary>
 	/// This hook gets called when the player clicks on the reforge button and can afford the reforge.
-	/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
+	/// Returns whether the reforge will take place. If false is returned by the ModItem or any GlobalItem, the item will not be reforged, the cost to reforge will not be paid, and PreRefoge and PostReforge hooks will not be called.
 	/// Reforging preserves modded data on the item.
 	/// </summary>
-	public virtual bool PreReforge(Item item)
+	public virtual bool CanReforge(Item item)
 	{
 		return true;
+	}
+
+	/// <summary>
+	/// This hook gets called immediately before an item gets reforged by the Goblin Tinkerer.
+	/// </summary>
+	public virtual void PreReforge(Item item)
+	{
 	}
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1595,21 +1595,34 @@ public static class ItemLoader
 		return b;
 	}
 
-	// TODO: PreReforge marked obsolete until v0.11
-	private static HookList HookPreReforge = AddHook<Func<Item, bool>>(g => g.PreReforge);
+	private static HookList HookCanReforge = AddHook<Func<Item, bool>>(g => g.CanReforge);
+
+	/// <summary>
+	/// Calls ModItem.CanReforge, then all GlobalItem.CanReforge hooks. If any return false then false is returned.
+	/// </summary>
+	public static bool CanReforge(Item item)
+	{
+		bool b = item.ModItem?.CanReforge() ?? true;
+
+		foreach (var g in HookCanReforge.Enumerate(item)) {
+			b &= g.CanReforge(item);
+		}
+
+		return b;
+	}
+
+	private static HookList HookPreReforge = AddHook<Action<Item>>(g => g.PreReforge);
 
 	/// <summary>
 	/// Calls ModItem.PreReforge, then all GlobalItem.PreReforge hooks.
 	/// </summary>
-	public static bool PreReforge(Item item)
+	public static void PreReforge(Item item)
 	{
-		bool b = item.ModItem?.PreReforge() ?? true;
+		item.ModItem?.PreReforge();
 
 		foreach (var g in HookPreReforge.Enumerate(item)) {
-			b &= g.PreReforge(item);
+			g.PreReforge(item);
 		}
-
-		return b;
 	}
 
 	private static HookList HookPostReforge = AddHook<Action<Item>>(g => g.PostReforge);

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -914,12 +914,19 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 
 	/// <summary>
 	/// This hook gets called when the player clicks on the reforge button and can afford the reforge.
-	/// Returns whether the reforge will take place. If false is returned, the PostReforge hook is never called.
+	/// Returns whether the reforge will take place. If false is returned by this or any GlobalItem, the item will not be reforged, the cost to reforge will not be paid, and PreRefoge and PostReforge hooks will not be called.
 	/// Reforging preserves modded data on the item.
 	/// </summary>
-	public virtual bool PreReforge()
+	public virtual bool CanReforge()
 	{
 		return true;
+	}
+
+	/// <summary>
+	/// This hook gets called immediately before an item gets reforged by the Goblin Tinkerer.
+	/// </summary>
+	public virtual void PreReforge()
+	{
 	}
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -497,22 +497,6 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 		return healValue > 0 ? healValue : 0;
 	}
 
-	public bool CanBuyItem(int price, int customCurrency = -1)
-	{
-		if (customCurrency != -1)
-			return CustomCurrencyManager.BuyItem(this, price, customCurrency);
-
-		long num = Utils.CoinsCount(out _, inventory, new[] { 58, 57, 56, 55, 54 });
-		long num2 = Utils.CoinsCount(out _, bank.item, Array.Empty<int>());
-		long num3 = Utils.CoinsCount(out _, bank2.item, Array.Empty<int>());
-		long num4 = Utils.CoinsCount(out _, bank3.item, Array.Empty<int>());
-		long voidBag = Utils.CoinsCount(out _, bank4.item, Array.Empty<int>());
-
-		long num5 = Utils.CoinsCombineStacks(out _, new[] { num, num2, num3, num4, voidBag});
-
-		return num5 >= price;
-	}
-
 	/// <summary>
 	/// Calculates the mana needed to use the given item.
 	/// </summary>

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -506,8 +506,9 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 		long num2 = Utils.CoinsCount(out _, bank.item, Array.Empty<int>());
 		long num3 = Utils.CoinsCount(out _, bank2.item, Array.Empty<int>());
 		long num4 = Utils.CoinsCount(out _, bank3.item, Array.Empty<int>());
+		long voidBag = Utils.CoinsCount(out _, bank4.item, Array.Empty<int>());
 
-		long num5 = Utils.CoinsCombineStacks(out _, new[] { num, num2, num3, num4 });
+		long num5 = Utils.CoinsCombineStacks(out _, new[] { num, num2, num3, num4, voidBag});
 
 		return num5 >= price;
 	}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4024,6 +4024,49 @@
  		return num;
  	}
  
+@@ -27344,11 +_,26 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Attempts to "purchase" something that costs the given <paramref name="price"/>.<br/>
++	/// Items will be taken from all of the player inventories and banks combined.<br/>
++	/// If <paramref name="customCurrency"/> is provided, the price will be in terms of the custom currency instead of coins.<br/>
++	/// If the player has enough currency, the currency will be taken from the inventories.<br/>
++	/// </summary>
++	/// <param name="price"></param>
++	/// <param name="customCurrency"></param>
++	/// <returns>true if the player had enough currency to pay the price.</returns>
+ 	public bool BuyItem(long price, int customCurrency = -1)
+ 	{
+-		if (customCurrency != -1)
+-			return CustomCurrencyManager.BuyItem(this, price, customCurrency);
++		if (CanAfford(price, customCurrency))
++			return PayCurrency(price, customCurrency);
++		return false;
++	}
+ 
++	public bool CanAfford(long price, int customCurrency = -1)
++	{
++		if (customCurrency != -1)
++			return CustomCurrencyManager.CanAfford(this, price, customCurrency);
+ 		bool overFlowing;
+ 		long num = Utils.CoinsCount(out overFlowing, inventory, 58, 57, 56, 55, 54);
+ 		long num2 = Utils.CoinsCount(out overFlowing, bank.item);
+@@ -27357,7 +_,13 @@
+ 		long num5 = Utils.CoinsCount(out overFlowing, bank4.item);
+ 		if (Utils.CoinsCombineStacks(out overFlowing, num, num2, num3, num4, num5) < price)
+ 			return false;
++		return true;
++	}
+ 
++	public bool PayCurrency(long price, int customCurrency = -1)
++	{
++		if (customCurrency != -1)
++			return CustomCurrencyManager.PayCurrency(this, price, customCurrency);
+ 		List<Item[]> list = new List<Item[]>();
+ 		Dictionary<int, List<int>> dictionary = new Dictionary<int, List<int>>();
+ 		List<Point> list2 = new List<Point>();
 @@ -27569,7 +_,7 @@
  			num2 += 4;
  		}

--- a/tModPorter/tModPorter.Tests/TestData/GlobalItemTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalItemTest.Expected.cs
@@ -10,7 +10,9 @@ public class GlobalItemTest : GlobalItem
 
 	public override bool? UseItem(Item item, Player player)/* tModPorter Suggestion: Return null instead of false */ => false;
 
-	public override bool PreReforge(Item item) { return false; /* comment */ }
+#if COMPILE_ERROR
+	public override void PreReforge(Item item)/* tModPorter Note: Use CanReforge instead for logic determining if a reforge can happen. */ { return false; /* comment */ }
+#endif
 
 	public override void HoldStyle(Item item, Player player, Rectangle heldItemFrame) { /* comment */ }
 

--- a/tModPorter/tModPorter.Tests/TestData/ModItemTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModItemTest.Expected.cs
@@ -41,7 +41,9 @@ public class ModItemTest : ModItem
 
 	public override ModItem Clone(Item newEntity) { return null; }
 
-	public override bool PreReforge() { return false; /* comment */ }
+#if COMPILE_ERROR
+	public override void PreReforge()/* tModPorter Note: Use CanReforge instead for logic determining if a reforge can happen. */ { return false; /* comment */ }
+#endif
 
 	public override bool? UseItem(Player player)/* tModPorter Suggestion: Return null instead of false */ { return true; /* comment */ }
 

--- a/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.Expected.cs
@@ -123,6 +123,7 @@ public class SimpleRenamedVanillaMembersTest
 #if COMPILE_ERROR
 		player.VanillaUpdateEquip(null)/* tModPorter Note: Removed. Use either GrantPrefixBenefits (if Item.accessory) or GrantArmorBenefits (for armor slots) */;
 #endif
+		player.CanAfford(100000);
 
 		// not-yet-implemented
 		Main.PlayerRenderer.DrawPlayer(Main.Camera, player, Vector2.Zero, 0f, Vector2.Zero, 1f);

--- a/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/SimpleRenamedVanillaMembersTest.cs
@@ -102,6 +102,7 @@ public class SimpleRenamedVanillaMembersTest
 		var discount = player.discount;
 		player.IsAValidEquipmentSlotForIteration(0);
 		player.VanillaUpdateEquip(null);
+		player.CanBuyItem(100000);
 
 		Main.DrawPlayer(player, Vector2.Zero, 0f, Vector2.Zero, 1f);
 

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -83,6 +83,8 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "NetRecieve",			to: "NetReceive");
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "NewPreReforge",		to: "PreReforge");
 		RenameMethod("Terraria.ModLoader.GlobalItem",	from: "NewPreReforge",		to: "PreReforge");
+		ChangeHookSignature("Terraria.ModLoader.ModItem", "PreReforge", comment: "Note: Use CanReforge instead for logic determining if a reforge can happen.");
+		ChangeHookSignature("Terraria.ModLoader.GlobalItem", "PreReforge", comment: "Note: Use CanReforge instead for logic determining if a reforge can happen.");
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "GetWeaponCrit",		to: "ModifyWeaponCrit");
 		RenameMethod("Terraria.ModLoader.GlobalItem",	from: "GetWeaponCrit",		to: "ModifyWeaponCrit");
 		RenameMethod("Terraria.ModLoader.ModPlayer",	from: "GetWeaponCrit",		to: "ModifyWeaponCrit");

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -117,6 +117,7 @@ public static partial class Config
 		RefactorInstanceMember("Terraria.Player",		"whipUseTimeMultiplier",	DamageModifier("SummonMeleeSpeed",	"GetAttackSpeed"));
 
 		RefactorInstanceMethodCall("Terraria.Player", "VanillaUpdateEquip",	Removed("Use either GrantPrefixBenefits (if Item.accessory) or GrantArmorBenefits (for armor slots)"));
+		RenameMethod("Terraria.Player", "CanBuyItem", "CanAfford");
 
 		RefactorInstanceMember("Terraria.Main", "fastForwardTime", Removed("Suggestion: IsFastForwardingTime(), fastForwardTimeToDawn or fastForwardTimeToDusk"));
 


### PR DESCRIPTION
### What is the bug?
Coins in the void bag would not be considered when reforging
### How did you fix the bug?
Count the void bag coins in `Player.CanBuyItem`
### Are there alternatives to your fix?
It might be advantageous to make the method internal or remove the `customCurrency` parameter because it calls 
`CustomCurrencyManager.BuyItem` for custom currencies which consumes items