### PR TITLE
Allows the fusion of multiple entity sources

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -8,13 +8,13 @@ public class CombinedEntitySource : IEntitySource
     public string Context => "tModLoader_CombinedEntitySource";
     List<IEntitySource> entitySources = new();
 
-    public EntitySourceTest AddEntitySource(IEntitySource second)
+    public CombinedEntitySource AddEntitySource(IEntitySource second)
     {
         entitySources.Add(second);
         return this;
     }
 
-    public EntitySourceTest(IEntitySource first, IEntitySource second)
+    public CombinedEntitySource(IEntitySource first, IEntitySource second)
     {
         entitySources.Add(first);
         entitySources.Add(second);
@@ -26,17 +26,17 @@ public class CombinedEntitySource : IEntitySource
     }
 }
 
-public static class EntitySourceTestExtension
+public static class CombinedEntitySourceExtension
 {
-    public static EntitySourceTest AddEntitySource(this IEntitySource first, IEntitySource second)
+    public static CombinedEntitySource AddEntitySource(this IEntitySource first, IEntitySource second)
     {
-        return new EntitySourceTest(first, second);
+        return new CombinedEntitySource(first, second);
     }
 
     public static T AttemptGet<T>(this IEntitySource collection) where T : class, IEntitySource
     {
-        if(collection is EntitySourceTest)
-            return ((EntitySourceTest)collection).AttemptGet<T>();
+        if(collection is CombinedEntitySource)
+            return ((CombinedEntitySource)collection).AttemptGet<T>();
         return null;
     }
 }

--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -35,7 +35,9 @@ public static class CombinedEntitySourceExtension
 
     public static T AttemptGet<T>(this IEntitySource collection) where T : class, IEntitySource
     {
-        if(collection is CombinedEntitySource)
+        if (collection is T)
+            return (T)collection;
+        if (collection is CombinedEntitySource)
             return ((CombinedEntitySource)collection).AttemptGet<T>();
         return null;
     }

--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -21,11 +21,10 @@ public class CombinedEntitySource : IEntitySource
     }
     public T AttemptGet<T>() where T : class, IEntitySource
     {
-        IEntitySource rv;
         for (LinkedListNode<IEntitySource> node = entitySources.First; node != null; node = node.Next)
         {
-            if(node.Value is T)
-            return node.Value as T;
+            if (node.Value is T)
+                return node.Value as T;
         }
         return null;
     }

--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Terraria.DataStructures;
+
+namespace Terraria.ModLoader;
+
+public class CombinedEntitySource : IEntitySource
+{
+    public string Context => "tModLoader_CombinedEntitySource";
+    List<IEntitySource> entitySources = new();
+
+    public EntitySourceTest AddEntitySource(IEntitySource second)
+    {
+        entitySources.Add(second);
+        return this;
+    }
+
+    public EntitySourceTest(IEntitySource first, IEntitySource second)
+    {
+        entitySources.Add(first);
+        entitySources.Add(second);
+    }
+    public T AttemptGet<T>() where T : class, IEntitySource
+    {
+        IEntitySource rv = entitySources.Find(i => i is T);
+        return rv as T;
+    }
+}
+
+public static class EntitySourceTestExtension
+{
+    public static EntitySourceTest AddEntitySource(this IEntitySource first, IEntitySource second)
+    {
+        return new EntitySourceTest(first, second);
+    }
+
+    public static T AttemptGet<T>(this IEntitySource collection) where T : class, IEntitySource
+    {
+        if(collection is EntitySourceTest)
+            return ((EntitySourceTest)collection).AttemptGet<T>();
+        return null;
+    }
+}

--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -6,23 +6,28 @@ namespace Terraria.ModLoader;
 public class CombinedEntitySource : IEntitySource
 {
     public string Context => "tModLoader_CombinedEntitySource";
-    List<IEntitySource> entitySources = new();
+    LinkedList<IEntitySource> entitySources = new();
 
     public CombinedEntitySource AddEntitySource(IEntitySource second)
     {
-        entitySources.Add(second);
+        entitySources.AddFirst(second);
         return this;
     }
 
     public CombinedEntitySource(IEntitySource first, IEntitySource second)
     {
-        entitySources.Add(first);
-        entitySources.Add(second);
+        entitySources.AddFirst(first);
+        entitySources.AddFirst(second);
     }
     public T AttemptGet<T>() where T : class, IEntitySource
     {
-        IEntitySource rv = entitySources.Find(i => i is T);
-        return rv as T;
+        IEntitySource rv;
+        for (LinkedListNode<IEntitySource> node = entitySources.First; node != null; node = node.Next)
+        {
+            if(node is T)
+            return node as T;
+        }
+        return null;
     }
 }
 

--- a/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedEntitySource.cs
@@ -24,8 +24,8 @@ public class CombinedEntitySource : IEntitySource
         IEntitySource rv;
         for (LinkedListNode<IEntitySource> node = entitySources.First; node != null; node = node.Next)
         {
-            if(node is T)
-            return node as T;
+            if(node.Value is T)
+            return node.Value as T;
         }
         return null;
     }


### PR DESCRIPTION
### What is the new feature?

Allowing mods to combine entity sources into one entity source. This is useful for combining multiple mod-specific entity sources together, which is useful for feeding in spawn-specific data from and to two different mods.

### Why should this be part of tModLoader?

There is no current way to combine two entity sources together, which means there is no way to feed entity source data to two different mods at once. For instance, Summoner's Shine minions are spawned with IEntitySource data read to determine attack speed and crit values, but Calamity's minion respawn minions are spawned with special IEntitySource data which cannot be read by any other mods - hence Calamity's minion respawn feature does not load Summoner's Shine data.

This allows mods who desire better cross-mod support to combine two entity sources together in order for different mods to load them individually in their OnSpawn hooks.

However, existing mods have to adopt this new feature manually if they desire to benefit from it.

### Are there alternative designs?

This is the most streamlined implementation I can think of.

### Sample usage for the new feature

[Your IEntitySource]
.AddEntitySource([Second Entity Source])
.AddEntitySource([Third Entity Source]); //...etc

[Desired IEntitySource] Variable = [Input IEntitySource].AttemptGet<[Desired IEntitySource]>(); //will be null if it failed or isn't a collection. will return the desired IEntitySource if it's already the correct IEntitySource or the correct IEntitySource is in the collection.

### ExampleMod updates
None