### PR TITLE
[1.4.4] unhide

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -33,13 +33,6 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	public sealed override void SetupContent() => SetStaticDefaults();
 
 	/// <summary>
-	/// Allows you to set the properties of any and every NPC that gets created.
-	/// </summary>
-	public virtual void SetDefaults(NPC npc)
-	{
-	}
-
-	/// <summary>
 	/// Gets called when any NPC spawns in world
 	/// </summary>
 	public virtual void OnSpawn(NPC npc, IEntitySource source)

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -28,14 +28,6 @@ public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile
 	public sealed override void SetupContent() => SetStaticDefaults();
 
 	/// <summary>
-	/// Allows you to set the properties of any and every projectile that gets created.
-	/// </summary>
-	/// <param name="projectile"></param>
-	public virtual void SetDefaults(Projectile projectile)
-	{
-	}
-
-	/// <summary>
 	/// Gets called when any projectiles spawns in world
 	/// </summary>
 	public virtual void OnSpawn(Projectile projectile, IEntitySource source)


### PR DESCRIPTION
### What is the bug?

GlobalProjectile.SetDefaults are not called

### How did you fix the bug?

Removing the function as it hides GlobalType.SetDefaults

### Are there alternatives to your fix?

Nay
