### PR TITLE
Fix AnyWeapon mod prefixes not being loaded on items

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
@@ -90,7 +90,7 @@ public static class PrefixLoader
 			if (modPrefix.Category is PrefixCategory.Custom)
 				return true;
 
-			return item.GetPrefixCategory() is PrefixCategory itemCategory && (modPrefix.Category == itemCategory || itemCategory == PrefixCategory.AnyWeapon && IsWeaponSubCategory(modPrefix.Category));
+			return item.GetPrefixCategory() is PrefixCategory itemCategory && (modPrefix.Category == itemCategory || itemCategory == PrefixCategory.AnyWeapon && IsWeaponSubCategory(modPrefix.Category) || modPrefix.Category == PrefixCategory.AnyWeapon && IsWeaponSubCategory(itemCategory));
 		}
 
 		if (item.GetPrefixCategory() is PrefixCategory category) {


### PR DESCRIPTION
### What is the bug?
Modded prefixes that apply to weapons of any type would fail to load (when joining back into a world) onto items that only accept one damage type.

Reproduction: 
1) Obtain an item with a prefix category of `AnyWeapon` (I used ExamplePrefix on a copper shortsword)
2) Leave the world
3) Join back into the world and the prefix will be missing
### How did you fix the bug?
Check for this case in `PrefixLoader.CanRoll`
### Are there alternatives to your fix?
No
