### PR TITLE
Re-order Program startup so error messages are relevant

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
@@ -87,7 +87,6 @@ internal static class FNALogging
 		uint fna3d_version = FNA3D.FNA3D_LinkedVersion();
 		Logging.FNA.Debug($"FNA3D v{fna3d_version / 10000}.{fna3d_version / 100 % 100}.{fna3d_version % 100}");
 
-		NativeLibraries.CheckNativeFAudioDependencies();
 		uint faudio_version = FAudio.FAudioLinkedVersion();
 		Logging.FNA.Debug($"FAudio v{faudio_version / 10000}.{faudio_version / 100 % 100}.{faudio_version % 100}");
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
@@ -21,10 +21,15 @@ internal class NativeLibraries
 
 		try {
 			NativeLibrary.Load("mfplat.dll", Assembly.GetExecutingAssembly(), DllImportSearchPath.System32);
+			throw new BadImageFormatException();
 		}
 		catch (DllNotFoundException e) {
 			e.HelpLink = "https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a";
 			ErrorReporting.FatalExit("Windows Versions N and KN are missing some media features.\n\nFollow the instructions in the Microsoft website\n\nSearch \"Media Feature Pack list for Windows N editions\" if the page doesn't open automatically.", e);
+		}
+		catch (BadImageFormatException e) {
+			e.HelpLink = "https://answers.microsoft.com/en-us/windows/forum/all/mfplatdll-is-either-not-designed-to-run-on-windows/4c59e05b-ee5e-404f-8356-32f88cee6c0c";
+			ErrorReporting.FatalExit("MFPlat.DLL is either not designed to run on Windows or it contains an error.\n\nFollow the instructions in the Microsoft website\n\nSearch \"MFPlat.DLL is either not designed to run on Windows\" if the page doesn't open automatically.");
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
@@ -6,6 +6,9 @@ namespace Terraria.ModLoader.Engine;
 
 internal class NativeLibraries
 {
+	const string WindowsVersionNDesc = "Windows Versions N and KN are missing some media features.\n\nFollow the instructions in the Microsoft website\n\nSearch \"Media Feature Pack list for Windows N editions\" if the page doesn't open automatically.";
+	const string WindowsVersionNUrl = "https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a";
+
 	internal static void CheckNativeFAudioDependencies()
 	{
 		if (!OperatingSystem.IsWindows())
@@ -24,12 +27,12 @@ internal class NativeLibraries
 			throw new BadImageFormatException();
 		}
 		catch (DllNotFoundException e) {
-			e.HelpLink = "https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a";
-			ErrorReporting.FatalExit("Windows Versions N and KN are missing some media features.\n\nFollow the instructions in the Microsoft website\n\nSearch \"Media Feature Pack list for Windows N editions\" if the page doesn't open automatically.", e);
+			e.HelpLink = WindowsVersionNUrl;
+			ErrorReporting.FatalExit(WindowsVersionNDesc, e);
 		}
 		catch (BadImageFormatException e) {
-			e.HelpLink = "https://answers.microsoft.com/en-us/windows/forum/all/mfplatdll-is-either-not-designed-to-run-on-windows/4c59e05b-ee5e-404f-8356-32f88cee6c0c";
-			ErrorReporting.FatalExit("MFPlat.DLL is either not designed to run on Windows or it contains an error.\n\nFollow the instructions in the Microsoft website\n\nSearch \"MFPlat.DLL is either not designed to run on Windows\" if the page doesn't open automatically.");
+			e.HelpLink = WindowsVersionNUrl;
+			ErrorReporting.FatalExit(WindowsVersionNUrl + "\n\nIf this doesn't work try Search \"MFPlat.DLL is either not designed to run on Windows\" and follow those instructions");
 		}
 	}
 

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -120,6 +120,11 @@ public static partial class Program
 			Logging.tML.Info($"Controlled Folder Access feature detected. If game fails to launch make sure to add \"{Environment.ProcessPath}\" to the \"Allow an app through Controlled folder access\" menu found in the \"Ransomware protection\" menu."); // Before language is loaded, no need to localize
 	}
 
+	private static void CheckDependencies()
+	{
+		NativeLibraries.CheckNativeFAudioDependencies();
+	}
+
 	private const int HighDpiThreshold = 96; // Rando internet value that Solxan couldn't refind the sauce for.
 
 	// Add Support for High DPI displays, such as Mac M1 laptops. Must run before Game constructor.

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -92,7 +92,7 @@
  		try {
  			Console.OutputEncoding = Encoding.UTF8;
  			if (Platform.IsWindows)
-@@ -147,23 +_,74 @@
+@@ -147,23 +_,81 @@
  		}
  	}
  
@@ -149,13 +149,20 @@
 +
 +		try {
 +			SetSavePath(); // Needs to run before Logging.LogStartup due to DeveloperMode check in ModCompile
-+			Logging.LogStartup(isServer);
 +		}
 +		catch (Exception e) {
-+			ErrorReporting.FatalExit("Failed to handle save data", e);
++			ErrorReporting.FatalExit("Failed to establish a save location", e);
 +		}
 +
++		try {
++			CheckDependencies();
++		}
++		catch (Exception e) {
++			ErrorReporting.FatalExit("Unexpected failure in verifying dependencies. Please reach out in the tModLoader Discord for support", e);
++		}
++		
 +		AttemptSupportHighDPI(isServer);
++		Logging.LogStartup(isServer);
 +		LaunchGame_(isServer);
 +	}
 +


### PR DESCRIPTION
Currently, errors in logging startup are shown as "Failed to Handle Save Data", which is really misleading.
As well, FNALogging also included a dependency check buried inside it, which would make the problem worse.

This PR moves the FAUDIO dep check in to a separately wrapped method, handles the BadFormat error with another Catch, and moves Logging.Startup to occur after HighDPI environment changes, 
