### PR TITLE
Correct LogStartup order & Int.MaxValue UnloadedItem

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -22,7 +22,7 @@ public sealed class UnloadedItem : ModLoaderModItem
 
 		// Needs to be  > 1 for vanilla maxStack changes in 1.4.4,
 		// but also conflicts with inability to know if two unloaded items are the same - Solxan
-		Item.maxStack = 9999;
+		Item.maxStack = int.MaxValue;
 	}
 
 	internal void Setup(TagCompound tag)

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeLibraries.cs
@@ -8,6 +8,7 @@ internal class NativeLibraries
 {
 	const string WindowsVersionNDesc = "Windows Versions N and KN are missing some media features.\n\nFollow the instructions in the Microsoft website\n\nSearch \"Media Feature Pack list for Windows N editions\" if the page doesn't open automatically.";
 	const string WindowsVersionNUrl = "https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a";
+	const string FailedDependency = "Unexpected failure in verifying dependency. Please reach out in the tModLoader Discord for support";
 
 	internal static void CheckNativeFAudioDependencies()
 	{
@@ -21,6 +22,9 @@ internal class NativeLibraries
 			e.HelpLink = "https://www.microsoft.com/en-us/download/details.aspx?id=53587";
 			ErrorReporting.FatalExit("Microsoft Visual C++ 2015 Redistributable Update 3 is missing. You will need to download and install it from the Microsoft website.", e);
 		}
+		catch (Exception e) {
+			ErrorReporting.FatalExit("vcruntime140.dll: " + FailedDependency, e);
+		}
 
 		try {
 			NativeLibrary.Load("mfplat.dll", Assembly.GetExecutingAssembly(), DllImportSearchPath.System32);
@@ -32,6 +36,9 @@ internal class NativeLibraries
 		catch (BadImageFormatException e) {
 			e.HelpLink = WindowsVersionNUrl;
 			ErrorReporting.FatalExit(WindowsVersionNUrl + "\n\nIf this doesn't work try Search \"MFPlat.DLL is either not designed to run on Windows\" and follow those instructions");
+		}
+		catch (Exception e) {
+			ErrorReporting.FatalExit("mfplat.dll: "+ FailedDependency, e);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -78,9 +78,6 @@ public static partial class Logging
 		if (!string.IsNullOrEmpty(stackLimit))
 			tML.InfoFormat("Override Default Thread Stack Size Limit: {0}", stackLimit);
 
-		if (ModCompile.DeveloperMode)
-			tML.Info("Developer mode enabled");
-
 		foreach (string line in initWarnings)
 			tML.Warn(line);
 
@@ -89,9 +86,6 @@ public static partial class Logging
 		AssemblyResolving.Init();
 		LoggingHooks.Init();
 		LogArchiver.ArchiveLogs();
-		
-		if (!dedServ)
-			FNALogging.RedirectLogs();
 	}
 
 	private static void ConfigureAppenders(LogFile logFile)

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -52,7 +52,12 @@ public static partial class Logging
 
 		// This is the first file we attempt to use.
 		Utils.TryCreatingDirectory(LogDir);
-		ConfigureAppenders(logFile);
+		try {
+			ConfigureAppenders(logFile);
+		}
+		catch (Exception e) {
+			ErrorReporting.FatalExit("Failed to init logging", e);
+		}
 	}
 
 	internal static void LogStartup(bool dedServ)

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -127,7 +127,7 @@ public static partial class Program
 			Logging.Init(isServer ? Logging.LogFile.Server : Logging.LogFile.Client);
 
 			if (Platform.Current.Type == PlatformType.Windows && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture != System.Runtime.InteropServices.Architecture.X64)
-				throw new Exception("The current Windows Architecture of your System is CURRENTLY unsupported. Aborting...");
+				ErrorReporting.FatalExit("The current Windows Architecture of your System is CURRENTLY unsupported. Aborting...");
 		}
 		catch (Exception e) {
 			ErrorReporting.FatalExit("Failed to init logging", e);
@@ -142,25 +142,15 @@ public static partial class Program
 			ErrorReporting.FatalExit("Failed to establish a save location", e);
 		}
 				
-		if (ModLoader.Core.ModCompile.DeveloperMode) // Needs to run after SetSavePath
+		if (ModLoader.Core.ModCompile.DeveloperMode) // Needs to run after SetSavePath, as the static ctor depends on SavePath
 			Logging.tML.Info("Developer mode enabled");
 
 		AttemptSupportHighDPI(isServer); // Can run anytime
 
-		try {
-			CheckDependencies(); // Should run after LogStartup
-		}
-		catch (Exception e) {
-			ErrorReporting.FatalExit("Unexpected failure in verifying dependencies. Please reach out in the tModLoader Discord for support", e);
-		}
-
-		if (!isServer)
+		if (!isServer) {
+			NativeLibraries.CheckNativeFAudioDependencies();
 			FNALogging.RedirectLogs(); // Needs to run after CheckDependencies
-	}
-
-	private static void CheckDependencies()
-	{
-		NativeLibraries.CheckNativeFAudioDependencies();
+		}
 	}
 
 	private const int HighDpiThreshold = 96; // Rando internet value that Solxan couldn't refind the sauce for.

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -92,7 +92,7 @@
  		try {
  			Console.OutputEncoding = Encoding.UTF8;
  			if (Platform.IsWindows)
-@@ -147,23 +_,81 @@
+@@ -147,23 +_,82 @@
  		}
  	}
  
@@ -154,6 +154,8 @@
 +			ErrorReporting.FatalExit("Failed to establish a save location", e);
 +		}
 +
++		Logging.LogStartup(isServer); // Should run as early as is possible. Want as complete a log file as possible
++
 +		try {
 +			CheckDependencies();
 +		}
@@ -162,7 +164,6 @@
 +		}
 +		
 +		AttemptSupportHighDPI(isServer);
-+		Logging.LogStartup(isServer);
 +		LaunchGame_(isServer);
 +	}
 +

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -92,7 +92,7 @@
  		try {
  			Console.OutputEncoding = Encoding.UTF8;
  			if (Platform.IsWindows)
-@@ -147,23 +_,82 @@
+@@ -147,23 +_,56 @@
  		}
  	}
  
@@ -136,34 +136,8 @@
 -#endif
 +		bool isServer = LaunchParameters.ContainsKey("-server");
 +
-+		try {
-+			ControlledFolderAccessSupport.CheckFileSystemAccess();
-+			Logging.Init(isServer ? Logging.LogFile.Server : Logging.LogFile.Client);
-+
-+			if (Platform.Current.Type == PlatformType.Windows && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture != System.Runtime.InteropServices.Architecture.X64)
-+				throw new Exception("The current Windows Architecture of your System is CURRENTLY unsupported. Aborting...");
-+		}
-+		catch (Exception e) {
-+			ErrorReporting.FatalExit("Failed to init logging", e);
-+		}
-+
-+		try {
-+			SetSavePath(); // Needs to run before Logging.LogStartup due to DeveloperMode check in ModCompile
-+		}
-+		catch (Exception e) {
-+			ErrorReporting.FatalExit("Failed to establish a save location", e);
-+		}
-+
-+		Logging.LogStartup(isServer); // Should run as early as is possible. Want as complete a log file as possible
-+
-+		try {
-+			CheckDependencies();
-+		}
-+		catch (Exception e) {
-+			ErrorReporting.FatalExit("Unexpected failure in verifying dependencies. Please reach out in the tModLoader Discord for support", e);
-+		}
++		StartupSequenceTml(isServer);
 +		
-+		AttemptSupportHighDPI(isServer);
 +		LaunchGame_(isServer);
 +	}
 +


### PR DESCRIPTION
Correct LogStartup order & Int.MaxValue UnloadedItem
From #3414 & ea0150d5e5609b7413d119c6c56ab9412964c453

Notes:
Probably should refactor all these custom calls and try/catch in to a Program.StartupTmlSequence method and reduce patch size. 
Could also move the DeveloperMode check as well then so that Startup logging is earliest in chain 