### PR TITLE
Mod/GlobalNPC.CanBeHitByNPC hooks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -169,9 +169,9 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	}
 
 	/// <summary>
-	/// Allows you to make things happen whenever an NPC is hit, such as creating dust or gores. <br/> 
-	/// Called on local, server and remote clients. <br/> 
-	/// Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for <c>if (npc.life &lt;= 0)</c> to do client-side death effects, such as spawning dust, gore, or death sounds. <br/> 
+	/// Allows you to make things happen whenever an NPC is hit, such as creating dust or gores. <br/>
+	/// Called on local, server and remote clients. <br/>
+	/// Usually when something happens when an npc dies such as item spawning, you use NPCLoot, but you can use HitEffect paired with a check for <c>if (npc.life &lt;= 0)</c> to do client-side death effects, such as spawning dust, gore, or death sounds. <br/>
 	/// </summary>
 	public virtual void HitEffect(NPC npc, NPC.HitInfo hit)
 	{
@@ -335,12 +335,12 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	}
 
 	/// <summary>
-	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the aggressor from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
+	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the attacker from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
 	/// </summary>
 	/// <param name="npc"></param>
-	/// <param name="aggressor"></param>
+	/// <param name="attacker"></param>
 	/// <returns></returns>
-	public virtual bool CanBeHitByNPC(NPC npc, NPC aggressor)
+	public virtual bool CanBeHitByNPC(NPC npc, NPC attacker)
 	{
 		return true;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -335,6 +335,17 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	}
 
 	/// <summary>
+	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the aggressor from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
+	/// </summary>
+	/// <param name="npc"></param>
+	/// <param name="aggressor"></param>
+	/// <returns></returns>
+	public virtual bool CanBeHitByNPC(NPC npc, NPC aggressor)
+	{
+		return true;
+	}
+
+	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC does to a friendly NPC.
 	/// </summary>
 	/// <param name="npc"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -407,6 +407,16 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
+	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the aggressor from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
+	/// </summary>
+	/// <param name="aggressor"></param>
+	/// <returns></returns>
+	public virtual bool CanBeHitByNPC(NPC aggressor)
+	{
+		return true;
+	}
+
+	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that this NPC does to a friendly NPC. <br/>
 	/// Runs in single player or on the server. <br/>
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -407,11 +407,11 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the aggressor from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
+	/// Allows you to determine whether a friendly NPC can be hit by an NPC. Return false to block the attacker from hitting the NPC, and return true to use the vanilla code for whether the target can be hit. Returns true by default.
 	/// </summary>
-	/// <param name="aggressor"></param>
+	/// <param name="attacker"></param>
 	/// <returns></returns>
-	public virtual bool CanBeHitByNPC(NPC aggressor)
+	public virtual bool CanBeHitByNPC(NPC attacker)
 	{
 		return true;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -600,7 +600,7 @@ public static class NPCLoader
 				return false;
 		}
 
-		if (npc.ModNPC?.CanHitNPC(target) == false)
+		if (npc.ModNPC?.CanHitNPC(target) is false)
 			return false;
 
 		return target.ModNPC?.CanBeHitByNPC(npc) ?? true;

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -595,7 +595,7 @@ public static class NPCLoader
 				return false;
 		}
 
-		foreach (var g in HookCanBeHitByNPC.Enumerate(npc)) {
+		foreach (var g in HookCanBeHitByNPC.Enumerate(target)) {
 			if (!g.CanBeHitByNPC(target, npc))
 				return false;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -586,6 +586,7 @@ public static class NPCLoader
 	}
 
 	private static HookList HookCanHitNPC = AddHook<Func<NPC, NPC, bool>>(g => g.CanHitNPC);
+	private static HookList HookCanBeHitByNPC = AddHook<Func<NPC, NPC, bool>>(g => g.CanBeHitByNPC);
 
 	public static bool CanHitNPC(NPC npc, NPC target)
 	{
@@ -594,7 +595,15 @@ public static class NPCLoader
 				return false;
 		}
 
-		return npc.ModNPC?.CanHitNPC(target) ?? true;
+		foreach (var g in HookCanBeHitByNPC.Enumerate(npc)) {
+			if (!g.CanBeHitByNPC(target, npc))
+				return false;
+		}
+
+		if (npc.ModNPC?.CanHitNPC(target) == false)
+			return false;
+
+		return target.ModNPC?.CanBeHitByNPC(npc) ?? true;
 	}
 
 	private delegate void DelegateModifyHitNPC(NPC npc, NPC target, ref NPC.HitModifiers modifiers);


### PR DESCRIPTION
### What is the new feature?
New hooks, mirroring CanHitNPCs but called on the victim's =`ModNPC` and `GlobalNPC`

### Why should this be part of tModLoader?
Currently, if you want to prevent an NPC being attacked by another NPC, you need a universal `GlobalNPC` which checks for your `ModNPC` or `GlobalNPC` flag in `CanHitNPC`

### Are there alternative designs?
Not which solve the problem

