### PR TITLE
Fix #3440, AmmoID.Sets.IsRocket->IsSpecialist

### DIFF
--- a/patches/tModLoader/Terraria/ID/AmmoID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/AmmoID.TML.cs
@@ -22,9 +22,9 @@ partial class AmmoID
 		/// </summary>
 		public static bool[] IsBullet = Factory.CreateBoolSet(false, Bullet, CandyCorn);
 		/// <summary>
-		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then items of that type are counted as arrows for the purposes of <see cref="Player.rocketDamage"/>.
+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then items of that type are counted as specialist ammo for the purposes of <see cref="Player.rocketDamage"/>.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
-		public static bool[] IsRocket = Factory.CreateBoolSet(false, Rocket, StyngerBolt, JackOLantern, NailFriendly);
+		public static bool[] IsSpecialist = Factory.CreateBoolSet(false, Rocket, StyngerBolt, JackOLantern, NailFriendly, Coin, Flare, Dart, Snowball, Sand, FallenStar, Gel);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/AmmoID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/AmmoID.TML.cs
@@ -22,7 +22,7 @@ partial class AmmoID
 		/// </summary>
 		public static bool[] IsBullet = Factory.CreateBoolSet(false, Bullet, CandyCorn);
 		/// <summary>
-		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then items of that type are counted as specialist ammo for the purposes of <see cref="Player.rocketDamage"/>.
+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then items of that type are counted as specialist ammo for the purposes of <see cref="Player.specialistDamage"/>.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] IsSpecialist = Factory.CreateBoolSet(false, Rocket, StyngerBolt, JackOLantern, NailFriendly, Coin, Flare, Dart, Snowball, Sand, FallenStar, Gel);

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -63,9 +63,9 @@ partial class ItemID
 
 		/// <summary>
 		/// If true, the item counts as a specialist weapon.<br/>
-		/// Used for Shroomite Helmet damage buffs.<br/>
+		/// Used for Shroomite Helmet damage buffs (and other effects that will affect <see cref="Player.specialistDamage"/>).<br/>
 		/// </summary>
-		public static bool[] Specialist = Factory.CreateBoolSet(
+		public static bool[] IsRangedSpecialistWeapon = Factory.CreateBoolSet(
 			PiranhaGun, PainterPaintballGun, Toxikarp, Harpoon, AleThrowingGlove
 		);
 

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -62,6 +62,15 @@ partial class ItemID
 		);
 
 		/// <summary>
+		/// If true, the item counts as a specialist weapon.<br/>
+		/// Used for Shroomite Helmet damage buffs.<br/>
+		/// </summary>
+		public static bool[] Specialist = Factory.CreateBoolSet(
+			PiranhaGun, PainterPaintballGun, Toxikarp, Harpoon, AleThrowingGlove
+		);
+
+
+		/// <summary>
 		/// Dictionary for defining what items will drop from a <see cref="ProjectileID.Geode"/> when broken. All items in this dictionary are equally likely to roll, and will drop with a stack size between minStack and maxStack (exclusive).
 		/// <br/>Stack sizes with less than 1 or where minStack is not strictly smaller than maxStack will lead to exceptions being thrown.
 		/// </summary>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -518,7 +518,7 @@
 +	*/
 +	public StatModifier arrowDamage = StatModifier.Default;
 +	public StatModifier bulletDamage = StatModifier.Default;
-+	public StatModifier rocketDamage = StatModifier.Default;
++	public StatModifier rocketDamage = StatModifier.Default; // rename to specialistDamage?
 +	internal ref StatModifier minionDamage => ref GetDamage(DamageClass.Summon);
 +
 +	/*
@@ -6382,7 +6382,7 @@
 +		if (AmmoID.Sets.IsBullet[sItem.useAmmo])
 +			modifier = modifier.CombineWith(bulletDamage);
 +
-+		if (AmmoID.Sets.IsRocket[sItem.useAmmo])
++		if (AmmoID.Sets.IsSpecialist[sItem.useAmmo] || ItemID.Sets.Specialist[sItem.type])
 +			modifier = modifier.CombineWith(rocketDamage);
 +
 +		CombinedHooks.ModifyWeaponDamage(this, sItem, ref modifier);
@@ -6547,7 +6547,7 @@
 +		if (AmmoID.Sets.IsBullet[item.ammo])
 +			ammoDamage = ammoDamage.CombineWith(bulletDamage);
 +
-+		if (AmmoID.Sets.IsRocket[item.ammo])
++		if (AmmoID.Sets.IsSpecialist[item.ammo])
 +			ammoDamage = ammoDamage.CombineWith(rocketDamage);
 +
 +		// TODO: Why do we reset Base to 0 here? Why not use += for Flat?

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6391,7 +6391,7 @@
 +		if (AmmoID.Sets.IsBullet[sItem.useAmmo])
 +			modifier = modifier.CombineWith(bulletDamage);
 +
-+		if (AmmoID.Sets.IsSpecialist[sItem.useAmmo] || ItemID.Sets.Specialist[sItem.type])
++		if (AmmoID.Sets.IsSpecialist[sItem.useAmmo] || ItemID.Sets.IsRangedSpecialistWeapon[sItem.type])
 +			modifier = modifier.CombineWith(specialistDamage);
 +
 +		CombinedHooks.ModifyWeaponDamage(this, sItem, ref modifier);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -518,7 +518,7 @@
 +	*/
 +	public StatModifier arrowDamage = StatModifier.Default;
 +	public StatModifier bulletDamage = StatModifier.Default;
-+	public StatModifier rocketDamage = StatModifier.Default; // rename to specialistDamage?
++	public StatModifier specialistDamage = StatModifier.Default; // previously rocketDamage
 +	internal ref StatModifier minionDamage => ref GetDamage(DamageClass.Summon);
 +
 +	/*
@@ -2255,6 +2255,15 @@
  			moveSpeed += 0.05f;
  		}
  
+@@ -10139,7 +_,7 @@
+ 
+ 		if (armorPiece.type == 1548) {
+ 			rangedCrit += 5;
+-			rocketDamage *= 1.15f;
++			specialistDamage *= 1.15f;
+ 		}
+ 
+ 		if (armorPiece.type == 1549) {
 @@ -10365,14 +_,17 @@
  			minionDamage += 0.11f;
  		}
@@ -2836,7 +2845,7 @@
 +		*/
 +		arrowDamage = StatModifier.Default;
 +		bulletDamage = StatModifier.Default;
-+		rocketDamage = StatModifier.Default;
++		specialistDamage = StatModifier.Default;
 +
  		coolWhipBuff = false;
  		yoraiz0rEye = 0;
@@ -6383,7 +6392,7 @@
 +			modifier = modifier.CombineWith(bulletDamage);
 +
 +		if (AmmoID.Sets.IsSpecialist[sItem.useAmmo] || ItemID.Sets.Specialist[sItem.type])
-+			modifier = modifier.CombineWith(rocketDamage);
++			modifier = modifier.CombineWith(specialistDamage);
 +
 +		CombinedHooks.ModifyWeaponDamage(this, sItem, ref modifier);
 +
@@ -6548,7 +6557,7 @@
 +			ammoDamage = ammoDamage.CombineWith(bulletDamage);
 +
 +		if (AmmoID.Sets.IsSpecialist[item.ammo])
-+			ammoDamage = ammoDamage.CombineWith(rocketDamage);
++			ammoDamage = ammoDamage.CombineWith(specialistDamage);
 +
 +		// TODO: Why do we reset Base to 0 here? Why not use += for Flat?
 +		ammoDamage.Base = 0;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -518,7 +518,7 @@
 +	*/
 +	public StatModifier arrowDamage = StatModifier.Default;
 +	public StatModifier bulletDamage = StatModifier.Default;
-+	public StatModifier specialistDamage = StatModifier.Default; // previously rocketDamage
++	public StatModifier specialistDamage = StatModifier.Default; // previously rocketDamage, Shroomite Helmet changed to use this.
 +	internal ref StatModifier minionDamage => ref GetDamage(DamageClass.Summon);
 +
 +	/*
@@ -2260,7 +2260,7 @@
  		if (armorPiece.type == 1548) {
  			rangedCrit += 5;
 -			rocketDamage *= 1.15f;
-+			specialistDamage *= 1.15f;
++			specialistDamage *= 1.15f; // rocketDamage renamed.
  		}
  
  		if (armorPiece.type == 1549) {

--- a/tModPorter/tModPorter.Tests/TestData/DamageClassPlayerFields.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/DamageClassPlayerFields.Expected.cs
@@ -16,6 +16,7 @@ public class DamageClassPlayerFields : ModPlayer {
 		Player.GetDamage(DamageClass.Magic) += 2;
 		Player.GetDamage(DamageClass.Summon) += 0.1f;
 		Player.GetDamage(DamageClass.Throwing) += 0.1f;
+		Player.specialistDamage += 0.3f;
 
 		Player.GetDamage(DamageClass.Generic) *= 0.08f;
 		Player.GetDamage(DamageClass.Melee) *= 0.08f;

--- a/tModPorter/tModPorter.Tests/TestData/DamageClassPlayerFields.cs
+++ b/tModPorter/tModPorter.Tests/TestData/DamageClassPlayerFields.cs
@@ -16,6 +16,7 @@ public class DamageClassPlayerFields : ModPlayer {
 		player.magicDamage += 2;
 		player.minionDamage += 0.1f;
 		player.thrownDamage += 0.1f;
+		player.rocketDamage += 0.3f;
 
 		player.allDamageMult *= 0.08f;
 		player.meleeDamageMult *= 0.08f;

--- a/tModPorter/tModPorter.Tests/TestData/ModItemTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModItemTest.Expected.cs
@@ -29,6 +29,7 @@ public class ModItemTest : ModItem
 		/* Tooltip.SetDefault(
 			"This tooltip\n" +
 			"Has multiple lines"); */
+		Terraria.ID.AmmoID.Sets.IsSpecialist[Type] = true;
 	}
 
 #if COMPILE_ERROR

--- a/tModPorter/tModPorter.Tests/TestData/ModItemTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModItemTest.cs
@@ -25,6 +25,7 @@ public class ModItemTest : ModItem
 		Tooltip.SetDefault(
 			"This tooltip\n" +
 			"Has multiple lines");
+		Terraria.ID.AmmoID.Sets.IsRocket[Type] = true;
 	}
 
 	public override bool IgnoreDamageModifiers => false;

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -526,5 +526,7 @@ public static partial class Config
 
 		RenameMethod("MonoMod.RuntimeDetour.HookGen.HookEndpointManager", from: "Add", to: "Add", newType: "Terraria.ModLoader.MonoModHooks");
 		RenameMethod("MonoMod.RuntimeDetour.HookGen.HookEndpointManager", from: "Modify", to: "Modify", newType: "Terraria.ModLoader.MonoModHooks");
+
+		RenameStaticField("Terraria.ID.AmmoID.Sets", from: "IsRocket", to: "IsSpecialist");
 	}
 }

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -98,6 +98,7 @@ public static partial class Config
 		RefactorInstanceMember("Terraria.Player",		"allDamage",		DamageModifier("Generic",	"GetDamage"));
 		RefactorInstanceMember("Terraria.Player",		"meleeDamage",		DamageModifier("Melee",		"GetDamage"));
 		RefactorInstanceMember("Terraria.Player",		"rangedDamage",		DamageModifier("Ranged",	"GetDamage"));
+		RenameInstanceField("Terraria.Player",			"rocketDamage",		"specialistDamage");
 		RefactorInstanceMember("Terraria.Player",		"magicDamage",		DamageModifier("Magic",		"GetDamage"));
 		RefactorInstanceMember("Terraria.Player",		"minionDamage",		DamageModifier("Summon",	"GetDamage"));
 		RefactorInstanceMember("Terraria.Player",		"thrownDamage",		DamageModifier("Throwing",	"GetDamage"));


### PR DESCRIPTION
Fixes #3440

Rockets seem to no longer be a sub-class of ranged, it is now called specialist. (See Shroomite Helmet info in https://terraria.wiki.gg/wiki/1.4.4 and https://terraria.wiki.gg/wiki/Shroomite_armor)

This PR adds those new ammo items to the original set and renames the set from `AmmoID.Sets.IsRocket` to `AmmoID.Sets.IsSpecialist`

It also adds `ItemID.Sets.Specialist` for all weapons not using ammo but included in the new specialist damage sub type.

Not sure if `Player.rocketDamage` should be renamed as well.

Tested with dart gun and Shroomite Helmet seems to be working as expected to add to the damage.