### PR TITLE
ModPrefix.GetTooltipLines, examples, plus inheritable localization example

### DIFF
--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -1,4 +1,7 @@
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
 using Terraria;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Prefixes
@@ -41,5 +44,40 @@ namespace ExampleMod.Content.Prefixes
 		public override void Apply(Item item) {
 			//
 		}
+
+		// This prefix doesn't affect any non-standard stats, but if it did, these are some examples of how TooltipLines could be added:
+		/*
+		public override IEnumerable<TooltipLine> GetTooltipLines(Item item) {
+			// This uses the vanilla translation for defense, resulting in "-5 defense"
+			yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {
+				IsModifier = true,
+				IsModifierBad = true,
+			};
+			// The localization key for Mods.ExampleMod.Prefixes.PowerTooltip uses a special format that will automatically prefix + or - to the value.
+			// This shared localization is formatted with the Power value, resulting in different text for ExamplePrefix and ExampleDerivedPrefix.
+			// This results in "+1 Power" for ExamplePrefix and "+2 Power" for ExampleDerivedPrefix.
+			// Power isn't an actual stat, the effects of Power are already shown in the "+X% damage" tooltip, so this example is purely educational.
+			yield return new TooltipLine(Mod, "PrefixWeaponAwesome", PowerTooltip.Format(Power)) {
+				IsModifier = true,
+			};
+			// This localization is not shared with the inherited classes. ExamplePrefix and ExampleDerivedPrefix have their own translations for this line.
+			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
+				IsModifier = true,
+			};
+		}
+
+		// PowerTooltip is shared between ExamplePrefix and ExampleDerivedPrefix. 
+		public static LocalizedText PowerTooltip { get; private set; }
+
+		// AdditionalTooltip shows off how to do the inheritable localized properties approach. This is necessary this this example uses inheritance and we want different translations for each inheriting class. https://github.com/tModLoader/tModLoader/wiki/Localization#inheritable-localized-properties
+		public LocalizedText AdditionalTooltip => this.GetLocalization(nameof(AdditionalTooltip));
+
+		public override void SetStaticDefaults() {
+			// this.GetLocalization is not used here because we want to use a shared key
+			PowerTooltip = Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.{nameof(PowerTooltip)}"));
+			// This seemingly useless code is required to properly register the key for AdditionalTooltip
+			_ = AdditionalTooltip;
+		}
+		*/
 	}
 }

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -45,25 +45,26 @@ namespace ExampleMod.Content.Prefixes
 			//
 		}
 
-		// This prefix doesn't affect any non-standard stats, but if it did, these are some examples of how TooltipLines could be added:
-		/*
+		// This prefix doesn't affect any non-standard stats, so these additional tooltiplines aren't actually necessary, but this pattern can be followed for a prefix that does affect other stats.
 		public override IEnumerable<TooltipLine> GetTooltipLines(Item item) {
-			// This uses the vanilla translation for defense, resulting in "-5 defense"
-			yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {
-				IsModifier = true,
-				IsModifierBad = true,
-			};
+			// Due to inheritance, this code runs for ExamplePrefix and ExampleDerivedPrefix. We add 2 tooltip lines, the first is the typical prefix tooltip line showing the stats boost, while the other is just some additional flavor text.
+
 			// The localization key for Mods.ExampleMod.Prefixes.PowerTooltip uses a special format that will automatically prefix + or - to the value.
 			// This shared localization is formatted with the Power value, resulting in different text for ExamplePrefix and ExampleDerivedPrefix.
 			// This results in "+1 Power" for ExamplePrefix and "+2 Power" for ExampleDerivedPrefix.
 			// Power isn't an actual stat, the effects of Power are already shown in the "+X% damage" tooltip, so this example is purely educational.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesome", PowerTooltip.Format(Power)) {
-				IsModifier = true,
+				IsModifier = true, // Sets the color to the positive modifier color.
 			};
 			// This localization is not shared with the inherited classes. ExamplePrefix and ExampleDerivedPrefix have their own translations for this line.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
 				IsModifier = true,
 			};
+			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense". Note that IsModifierBad is used for this bad modifier.
+			/*yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {
+				IsModifier = true,
+				IsModifierBad = true,
+			};*/
 		}
 
 		// PowerTooltip is shared between ExamplePrefix and ExampleDerivedPrefix. 
@@ -78,6 +79,5 @@ namespace ExampleMod.Content.Prefixes
 			// This seemingly useless code is required to properly register the key for AdditionalTooltip
 			_ = AdditionalTooltip;
 		}
-		*/
 	}
 }

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -932,8 +932,18 @@ Mods: {
 		}
 
 		Prefixes: {
-			ExamplePrefix.DisplayName: Example Prefix
-			ExampleDerivedPrefix.DisplayName: Example Derived Prefix
+			ExamplePrefix: {
+				DisplayName: Example Prefix
+				AdditionalTooltip: More Power
+			}
+
+			ExampleDerivedPrefix: {
+				DisplayName: Example Derived Prefix
+				AdditionalTooltip: Even More Power
+			}
+
+			# This special format will force a + or - sign to display depending on the value: -3, +0, +3. (https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings?redirectedfrom=MSDN#SectionSeparator)
+			PowerTooltip: "{0:+0;-#} Power"
 		}
 
 		#This is what displays during all of an NPC's happiness levels. Note that the localization key for these should always be "TownNPCMood.*NPCName*.*Mood*" or else it won't display properly.

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -932,8 +932,18 @@ Mods: {
 		}
 
 		Prefixes: {
-			ExamplePrefix.DisplayName: Пример префикса
-			ExampleDerivedPrefix.DisplayName: Пример префикса с наследованием
+			ExamplePrefix: {
+				DisplayName: Пример префикса
+				// AdditionalTooltip: More Power
+			}
+
+			ExampleDerivedPrefix: {
+				DisplayName: Пример префикса с наследованием
+				// AdditionalTooltip: Even More Power
+			}
+
+			# This special format will force a + or - sign to display depending on the value: -3, +0, +3. (https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings?redirectedfrom=MSDN#SectionSeparator)
+			// PowerTooltip: "{0:+0;-#} Power"
 		}
 
 		#This is what displays during all of an NPC's happiness levels. Note that the localization key for these should always be "TownNPCMood.*NPCName*.*Mood*" or else it won't display properly.

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -932,8 +932,18 @@ Mods: {
 		}
 
 		Prefixes: {
-			// ExamplePrefix.DisplayName: Example Prefix
-			// ExampleDerivedPrefix.DisplayName: Example Derived Prefix
+			ExamplePrefix: {
+				// DisplayName: Example Prefix
+				// AdditionalTooltip: More Power
+			}
+
+			ExampleDerivedPrefix: {
+				// DisplayName: Example Derived Prefix
+				// AdditionalTooltip: Even More Power
+			}
+
+			# This special format will force a + or - sign to display depending on the value: -3, +0, +3. (https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings?redirectedfrom=MSDN#SectionSeparator)
+			// PowerTooltip: "{0:+0;-#} Power"
 		}
 
 		#This is what displays during all of an NPC's happiness levels. Note that the localization key for these should always be "TownNPCMood.*NPCName*.*Mood*" or else it won't display properly.

--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -23,7 +23,7 @@
  			int numLines = 1;
  			float knockBack = entry.knockBack;
 -			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines);
-+			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames);
++			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _);
  			for (int i = 0; i < numLines; i++) {
  				if (_toolTipLines[i].ToLower().IndexOf(_search, StringComparison.OrdinalIgnoreCase) != -1)
  					return true;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2309,7 +2309,7 @@
 +		string[] tooltipNames = new string[num2];
 +
 -		MouseText_DrawItemTooltip_GetLinesInfo(hoverItem, ref yoyoLogo, ref researchLine, knockBack, ref numLines, array, array2, array3);
-+		MouseText_DrawItemTooltip_GetLinesInfo(hoverItem, ref yoyoLogo, ref researchLine, knockBack, ref numLines, array, array2, array3, tooltipNames);
++		MouseText_DrawItemTooltip_GetLinesInfo(hoverItem, ref yoyoLogo, ref researchLine, knockBack, ref numLines, array, array2, array3, tooltipNames, out int prefixlineIndex);
  		float num3 = (float)(int)mouseTextColor / 255f;
  		float num4 = num3;
  		int a = mouseTextColor;
@@ -2342,7 +2342,7 @@
  		Vector2 zero = Vector2.Zero;
 +
 +		// TML's abstractions over tooltip arrays.
-+		List<TooltipLine> lines = ItemLoader.ModifyTooltips(HoverItem, ref numLines, tooltipNames, ref array, ref array2, ref array3, ref yoyoLogo, out Color?[] overrideColor);
++		List<TooltipLine> lines = ItemLoader.ModifyTooltips(HoverItem, ref numLines, tooltipNames, ref array, ref array2, ref array3, ref yoyoLogo, out Color?[] overrideColor, prefixlineIndex);
 +		List<DrawableTooltipLine> drawableLines = lines.Select((TooltipLine x, int i) => new DrawableTooltipLine(x, i, 0, 0, Color.White)).ToList();
 +
  		int num12 = 0;
@@ -2422,7 +2422,7 @@
  					if (diff == 1)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num4), (byte)((float)(int)mcColor.G * num4), (byte)((float)(int)mcColor.B * num4), a);
  
-@@ -16311,47 +_,91 @@
+@@ -16311,47 +_,92 @@
  
  					if (hoverItem.expert || rare == -12)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)DiscoR * num4), (byte)((float)DiscoG * num4), (byte)((float)DiscoB * num4), a);
@@ -2475,8 +2475,9 @@
  	}
  
 -	public static void MouseText_DrawItemTooltip_GetLinesInfo(Item item, ref int yoyoLogo, ref int researchLine, float oldKB, ref int numLines, string[] toolTipLine, bool[] preFixLine, bool[] badPreFixLine)
-+	public static void MouseText_DrawItemTooltip_GetLinesInfo(Item item, ref int yoyoLogo, ref int researchLine, float oldKB, ref int numLines, string[] toolTipLine, bool[] preFixLine, bool[] badPreFixLine, string[] toolTipNames)
++	public static void MouseText_DrawItemTooltip_GetLinesInfo(Item item, ref int yoyoLogo, ref int researchLine, float oldKB, ref int numLines, string[] toolTipLine, bool[] preFixLine, bool[] badPreFixLine, string[] toolTipNames, out int prefixlineIndex)
  	{
++		prefixlineIndex = -1;
  		toolTipLine[0] = item.HoverName;
 +		toolTipNames[0] = "ItemName";
  		if (item.favorited) {
@@ -2814,7 +2815,7 @@
  					numLines++;
  				}
  
-@@ -16739,137 +_,163 @@
+@@ -16739,137 +_,165 @@
  						badPreFixLine[numLines] = true;
  
  					preFixLine[numLines] = true;
@@ -2954,6 +2955,8 @@
 +					toolTipNames[numLines] = "PrefixAccMeleeSpeed";
  					numLines++;
  				}
++
++				prefixlineIndex = numLines;
  			}
  
  			if (item.wornArmor && player[myPlayer].setBonus != "") {

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2156,7 +2156,7 @@ public static class ItemLoader
 
 	private static HookList HookModifyTooltips = AddHook<Action<Item, List<TooltipLine>>>(g => g.ModifyTooltips);
 
-	public static List<TooltipLine> ModifyTooltips(Item item, ref int numTooltips, string[] names, ref string[] text, ref bool[] modifier, ref bool[] badModifier, ref int oneDropLogo, out Color?[] overrideColor)
+	public static List<TooltipLine> ModifyTooltips(Item item, ref int numTooltips, string[] names, ref string[] text, ref bool[] modifier, ref bool[] badModifier, ref int oneDropLogo, out Color?[] overrideColor, int prefixlineIndex)
 	{
 		var tooltips = new List<TooltipLine>();
 
@@ -2170,6 +2170,16 @@ public static class ItemLoader
 			}
 
 			tooltips.Add(tooltip);
+		}
+
+		if (item.prefix >= PrefixID.Count && prefixlineIndex != -1) {
+			var tooltipLines = PrefixLoader.GetPrefix(item.prefix)?.GetTooltipLines(item);
+			if (tooltipLines != null) {
+				foreach (var line in tooltipLines) {
+					tooltips.Insert(prefixlineIndex, line);
+					prefixlineIndex++;
+				}
+			}
 		}
 
 		item.ModItem?.ModifyTooltips(tooltips);

--- a/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPrefix.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Terraria.Localization;
 
@@ -86,4 +87,12 @@ public abstract class ModPrefix : ModType, ILocalizedModType
 	/// </summary>
 	/// <param name="player"> The player gaining the benefits of this accessory. </param>
 	public virtual void ApplyAccessoryEffects(Player player) { }
+
+	/// <summary>
+	/// Use this to add tooltips to any item with this prefix applied. Note that the stat bonuses applied via <see cref="SetStats"/> will automatically generate tooltips. (such as damage, use speed, crit chance, mana cost, scale, shoot speed, and knockback)<br/>
+	/// </summary>
+	public virtual IEnumerable<TooltipLine> GetTooltipLines(Item item)
+	{
+		return null;
+	}
 }


### PR DESCRIPTION
Prefixes typically affect stats, many of those stats are automatically handled, but custom stats are not. Modders currently need to use ModifyTooltipLines in GlobalItem to add tooltip lines for every prefix added in the mod. 

This approach can get messy, it would be nicer to have a way to declare the tooltip lines in the modprefix class itself, this PR does that.

This PR also shows an example of https://github.com/tModLoader/tModLoader/wiki/Localization#inheritable-localized-properties and an example of sharing the same key between inherited classes. These examples are lacking from ExampleMod since only ExamplePrefix uses inheritance for content.