### PR TITLE
Update language plural rules link.

### DIFF
--- a/patches/tModLoader/Terraria/Localization/LocalizedText.TML.cs
+++ b/patches/tModLoader/Terraria/Localization/LocalizedText.TML.cs
@@ -7,7 +7,7 @@ public partial class LocalizedText
 {
 	private bool? _hasPlurals;
 
-	// https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html
+	// https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html
 	// implementations extracted from build of https://github.com/xyzsd/cldr-plural-rules
 	// English, German, Italian, Spanish, Portugese, French
 	//   one, other


### PR DESCRIPTION
This PR only changes an outdated link to its contemporary counterpart, and doesn't introduce any changes to any code.

Unicode has migrated its CLDR pages to a new URL. Current version is also now version 43 (version 37 isn't available for viewing as a page directly via the browser anymore, though it remains available as a downloadable ZIP archive).
