### PR TITLE
Use correct layers for First/LastVanillaLayer

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawLayers.tML.cs
@@ -221,8 +221,8 @@ public partial class PlayerDrawLayers
 
 	internal static IReadOnlyList<PlayerDrawLayer> VanillaLayers = FixedVanillaLayers.Concat(new[] { FrontAccFront, HeldItem }).ToArray();
 
-	public static PlayerDrawLayer FirstVanillaLayer => VanillaLayers[0];
-	public static PlayerDrawLayer LastVanillaLayer => VanillaLayers[^1];
+	public static PlayerDrawLayer FirstVanillaLayer => FixedVanillaLayers[0];
+	public static PlayerDrawLayer LastVanillaLayer => FixedVanillaLayers[^1];
 
 	public static Between BeforeFirstVanillaLayer => new Between(null, FirstVanillaLayer);
 	public static Between AfterLastVanillaLayer => new Between(LastVanillaLayer, null);


### PR DESCRIPTION
### What is the bug?
If any mod uses `PlayerDrawLayers.AfterLastVanillaLayer` in `PlayerDrawLayer.GetDefaultPosition`, the "HeldItem" layer moves infront of the player's front hand.

### How did you fix the bug?
`AfterLastVanillaLayer` was accessing the concatenated "special" layer "HeldItem" which has custom placement rules. Changing it to use the `FixedVanillaLayers` list fixes the issue.

### Are there alternatives to your fix?
No
