### PR TITLE
Implement selective TownNPCMood key registration.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -159,9 +159,13 @@ public static class NPCLoader
 			keys.Add("Princess_LovesNPC");
 
 			foreach (var key in keys) {
+				string oldKey = npc.Mod.GetLocalizationKey($"TownNPCMood.{npc.Name}.{key}");
+				if (key == "Princess_LovesNPC")
+					oldKey = $"TownNPCMood_Princess.LoveNPC_{npc.FullName}";
 				string fullKey = $"{prefix}.{key}";
 				string defaultValueKey = "TownNPCMood." + key;
-				Language.GetOrRegister(fullKey, () => Language.GetTextValue(defaultValueKey)); // Register current language translation rather than vanilla text substitution so modder can see the {BiomeName} and {NPCName} usages. Might result in non-English values, but modder is expected to change the translation value anyway.
+				// Register current language translation rather than vanilla text substitution so modder can see the {BiomeName} and {NPCName} usages. Might result in non-English values, but modder is expected to change the translation value anyway.
+				Language.GetOrRegister(fullKey, () => Language.Exists(oldKey) ? $"{{${oldKey}}}" : Language.GetTextValue(defaultValueKey));
 			}
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -16,9 +16,7 @@ using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Utilities;
 using HookList = Terraria.ModLoader.Core.GlobalHookList<Terraria.ModLoader.GlobalNPC>;
 using Terraria.ModLoader.IO;
-using static Terraria.GameContent.Bestiary.BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions;
 using Terraria.GameContent.Personalities;
-using Terraria.IO;
 
 namespace Terraria.ModLoader;
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -16,6 +16,9 @@ using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Utilities;
 using HookList = Terraria.ModLoader.Core.GlobalHookList<Terraria.ModLoader.GlobalNPC>;
 using Terraria.ModLoader.IO;
+using static Terraria.GameContent.Bestiary.BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions;
+using Terraria.GameContent.Personalities;
+using Terraria.IO;
 
 namespace Terraria.ModLoader;
 
@@ -125,9 +128,38 @@ public static class NPCLoader
 	{
 		if (npc.NPC.townNPC && !NPCID.Sets.IsTownPet[npc.NPC.type] && !NPCID.Sets.NoTownNPCHappiness[npc.NPC.type]) {
 			string prefix = npc.GetLocalizationKey("TownNPCMood");
-			string[] keys = new string[] {
-				"Content", "NoHome", "FarFromHome", "LoveSpace", "DislikeCrowded", "HateCrowded", "LoveBiome", "LikeBiome", "DislikeBiome", "HateBiome", "LoveNPC", "LikeNPC", "DislikeNPC", "HateNPC", "LikeNPC_Princess", "Princess_LovesNPC"
+			List<string> keys = new List<string> {
+				"Content", "NoHome", "FarFromHome", "LoveSpace", "DislikeCrowded", "HateCrowded"
 			};
+
+			if (Main.ShopHelper._database.TryGetProfileByNPCID(npc.NPC.type, out var personalityProfile)) {
+				var shopModifiers = personalityProfile.ShopModifiers;
+
+				var biomePreferenceList = (BiomePreferenceListTrait)shopModifiers.SingleOrDefault(t => t is BiomePreferenceListTrait);
+				if (biomePreferenceList != null) {
+					if(biomePreferenceList.Preferences.Any(x => x.Affection == AffectionLevel.Love))
+						keys.Add("LoveBiome");
+					if(biomePreferenceList.Preferences.Any(x => x.Affection == AffectionLevel.Like))
+						keys.Add("LikeBiome");
+					if(biomePreferenceList.Preferences.Any(x => x.Affection == AffectionLevel.Dislike))
+						keys.Add("DislikeBiome");
+					if(biomePreferenceList.Preferences.Any(x => x.Affection == AffectionLevel.Hate))
+						keys.Add("HateBiome");
+				}
+
+				if(shopModifiers.Any(t => t is NPCPreferenceTrait { Level: AffectionLevel.Love }))
+					keys.Add("LoveNPC");
+				if (shopModifiers.Any(t => t is NPCPreferenceTrait { Level: AffectionLevel.Like }))
+					keys.Add("LikeNPC");
+				if (shopModifiers.Any(t => t is NPCPreferenceTrait { Level: AffectionLevel.Dislike }))
+					keys.Add("DislikeNPC");
+				if (shopModifiers.Any(t => t is NPCPreferenceTrait { Level: AffectionLevel.Hate }))
+					keys.Add("HateNPC");
+			}
+
+			keys.Add("LikeNPC_Princess"); // Added here because it makes sense to order this at end.
+			keys.Add("Princess_LovesNPC");
+
 			foreach (var key in keys) {
 				string fullKey = $"{prefix}.{key}";
 				string defaultValueKey = "TownNPCMood." + key;


### PR DESCRIPTION
As requested, only register TownNPCMood keys that will be used.

Also, auto migrates legacy TownNPCMood keys to new key pattern. Resulting entry will be a substitution pointing to original key. Modders will still want to eventually move the text, but they don't need to immediately to get the mod working. (Can't put actual translation text because that would only affect the current language.)