### PR TITLE
Fixes #881

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -50,7 +50,7 @@ public partial class WorkshopHelper
 		installLoc ??= "."; // GetAppInstallDir may return null (#2491). Also the default location for dedicated servers and such
 
 		var workshopLoc = Path.Combine(installLoc, "..", "..", "workshop");
-		if (Directory.Exists(workshopLoc) && !Program.LaunchParameters.ContainsKey("-nosteam"))
+		if (Directory.Exists(workshopLoc) && !Program.LaunchParameters.ContainsKey("-nosteam") && !SteamedWraps.FamilyShared)
 			return workshopLoc;
 
 		// Load mods installed by GoG / Manually copied steamapps\workshop directories.


### PR DESCRIPTION
To date, we have made several changes to facilitate #881 

1) Changed steam interactions in to three categories: Family Share, GoG, and Steam Client.
- GoG and Family Share both use the GameServer Steam API to download mods. These mods are downloaded in to the 'Install Folder' under `Install Folder/steamapps/workshop'
- Steam Client uses the standard client Steam API which has full functionality available to it

2) Added a start-tmodloaderFamilyShare script to launch the game with an argument indicating that it should attempt to start the Terraria shim. The Terraria shim is then able to validate if the user has access to Terraria through family share, and thus allows to validate they should be able to play. This workaround avoids the issues with the current SteamAPI Client being unable to validate family share for tmodloader itself, given tmodloader is a free app that depends on a paid external app

This PR resolves an issue with locating mods due to the original logic not accounting for the `../../ workshop` location existing on family share accounts then attempting to use that same location when downloaded mods are showing up in  `Install Folder/steamapps/workshop' like GoG.
The same family share user will not be able to subscribe to mods on workshop itself, and is thus subject to the same limitations as GoG.

This is the last known bug with family share, and thus should finally be able to close that.