### PR TITLE
[ExampleMod] update existing mod integrations to 1.4.4

### DIFF
--- a/ExampleMod/Common/Systems/ModIntegrationsSystem.cs
+++ b/ExampleMod/Common/Systems/ModIntegrationsSystem.cs
@@ -18,10 +18,6 @@ namespace ExampleMod.Common.Systems
 		public override void PostSetupContent() {
 			// Most often, mods require you to use the PostSetupContent hook to call their methods. This guarantees various data is initialized and set up properly
 
-			// Census Mod allows us to add spawn information to the town NPCs UI:
-			// https://forums.terraria.org/index.php?threads/.74786/
-			DoCensusIntegration();
-
 			// Boss Checklist shows comprehensive information about bosses in its own UI. We can customize it:
 			// https://forums.terraria.org/index.php?threads/.50668/
 			DoBossChecklistIntegration();
@@ -29,48 +25,25 @@ namespace ExampleMod.Common.Systems
 			// We can integrate with other mods here by following the same pattern. Some modders may prefer a ModSystem for each mod they integrate with, or some other design.
 		}
 
-		private void DoCensusIntegration() {
-			// We figured out how to add support by looking at it's Call method: https://github.com/JavidPack/Census/blob/1.4/Census.cs
-			// Census also has a wiki, where the Call methods are better explained: https://github.com/JavidPack/Census/wiki/Support-using-Mod-Call
-
-			if (!ModLoader.TryGetMod("Census", out Mod censusMod)) {
-				// TryGetMod returns false if the mod is not currently loaded, so if this is the case, we just return early
-				return;
-			}
-
-			// The "TownNPCCondition" method allows us to write out the spawn condition (which is coded via CanTownNPCSpawn), it requires an NPC type and a message
-			int npcType = ModContent.NPCType<Content.NPCs.ExamplePerson>();
-
-			// The message makes use of chat tags to make the item appear directly, making it more fancy
-			string message = $"Have either an Example Item [i:{ModContent.ItemType<Content.Items.ExampleItem>()}] or an Example Block [i:{ModContent.ItemType<Content.Items.Placeable.ExampleBlock>()}] in your inventory";
-
-			// Finally, call the desired method
-			censusMod.Call("TownNPCCondition", npcType, message);
-
-			// Additional calls can be made here for other Town NPCs in our mod
-		}
-
 		private void DoBossChecklistIntegration() {
-			// The mods homepage links to its own wiki where the calls are explained: https://github.com/JavidPack/BossChecklist/wiki/Support-using-Mod-Call
-			// If we navigate the wiki, we can find the "AddBoss" method, which we want in this case
+			// The mods homepage links to its own wiki where the calls are explained: https://github.com/JavidPack/BossChecklist/wiki/%5B1.4.4%5D-Boss-Log-Entry-Mod-Call
+			// If we navigate the wiki, we can find the "LogBoss" method, which we want in this case
+			// A feature of the call is that it will create an entry in the localization file of the specified NPC type for its spawn info, so make sure to visit the localization file after your mod runs once to edit it
 
 			if (!ModLoader.TryGetMod("BossChecklist", out Mod bossChecklistMod)) {
 				return;
 			}
 
-			// For some messages, mods might not have them at release, so we need to verify when the last iteration of the method variation was first added to the mod, in this case 1.3.1
+			// For some messages, mods might not have them at release, so we need to verify when the last iteration of the method variation was first added to the mod, in this case 1.6
 			// Usually mods either provide that information themselves in some way, or it's found on the github through commit history/blame
-			if (bossChecklistMod.Version < new Version(1, 3, 1)) {
+			if (bossChecklistMod.Version < new Version(1, 6)) {
 				return;
 			}
 
-			// The "AddBoss" method requires many parameters, defined separately below:
+			// The "LogBoss" method requires many parameters, defined separately below:
 
-			// The name used for the title of the page
-			string bossName = "Minion Boss";
-
-			// The NPC type of the boss
-			int bossType = ModContent.NPCType<Content.NPCs.MinionBoss.MinionBossBody>();
+			// Your entry key can be used by other developers to submit mod-collaborative data to your entry. It should not be changed once defined
+			string internalName = "MinionBoss";
 
 			// Value inferred from boss progression, see the wiki for details
 			float weight = 0.7f;
@@ -78,11 +51,14 @@ namespace ExampleMod.Common.Systems
 			// Used for tracking checklist progress
 			Func<bool> downed = () => DownedBossSystem.downedMinionBoss;
 
-			// If the boss should show up on the checklist in the first place and when (here, always)
-			Func<bool> available = () => true;
+			// The NPC type of the boss
+			int bossType = ModContent.NPCType<Content.NPCs.MinionBoss.MinionBossBody>();
+
+			// The item used to summon the boss with (if available)
+			int spawnItem = ModContent.ItemType<Content.Items.Consumables.MinionBossSummonItem>();
 
 			// "collectibles" like relic, trophy, mask, pet
-			List<int> collection = new List<int>()
+			List<int> collectibles = new List<int>()
 			{
 				ModContent.ItemType<Content.Items.Placeable.Furniture.MinionBossRelic>(),
 				ModContent.ItemType<Content.Pets.MinionBossPet.MinionBossPetItem>(),
@@ -90,36 +66,27 @@ namespace ExampleMod.Common.Systems
 				ModContent.ItemType<Content.Items.Armor.Vanity.MinionBossMask>()
 			};
 
-			// The item used to summon the boss with (if available)
-			int summonItem = ModContent.ItemType<Content.Items.Consumables.MinionBossSummonItem>();
-
-			// Information for the player so he knows how to encounter the boss
-			string spawnInfo = $"Use a [i:{summonItem}]";
-
-			// The boss does not have a custom despawn message, so we omit it
-			string despawnInfo = null;
-
 			// By default, it draws the first frame of the boss, omit if you don't need custom drawing
 			// But we want to draw the bestiary texture instead, so we create the code for that to draw centered on the intended location
-			var customBossPortrait = (SpriteBatch sb, Rectangle rect, Color color) => {
+			var customPortrait = (SpriteBatch sb, Rectangle rect, Color color) => {
 				Texture2D texture = ModContent.Request<Texture2D>("ExampleMod/Assets/Textures/Bestiary/MinionBoss_Preview").Value;
 				Vector2 centered = new Vector2(rect.X + (rect.Width / 2) - (texture.Width / 2), rect.Y + (rect.Height / 2) - (texture.Height / 2));
 				sb.Draw(texture, centered, color);
 			};
 
 			bossChecklistMod.Call(
-				"AddBoss",
+				"LogBoss",
 				Mod,
-				bossName,
-				bossType,
+				internalName,
 				weight,
 				downed,
-				available,
-				collection,
-				summonItem,
-				spawnInfo,
-				despawnInfo,
-				customBossPortrait
+				bossType,
+				new Dictionary<string, object>() {
+					["spawnItems"] = spawnItem,
+					["collectibles"] = collectibles,
+					["customPortrait"] = customPortrait
+					// Other optional arguments as needed are inferred from the wiki
+				}
 			);
 
 			// Other bosses or additional Mod.Call can be made here.

--- a/ExampleMod/Common/Systems/ModIntegrationsSystem.cs
+++ b/ExampleMod/Common/Systems/ModIntegrationsSystem.cs
@@ -13,6 +13,9 @@ namespace ExampleMod.Common.Systems
 	// You need to look for resources the mod developers provide regarding how they want you to add mod compatibility
 	// This can be their homepage, workshop page, wiki, github, discord, other contacts etc.
 	// If the mod is open source, you can visit its code distribution platform (usually GitHub) and look for "Call" in its Mod class
+
+	// In addition to the examples shown here, ExampleMod also integrates with the Census Mod (https://steamcommunity.com/sharedfiles/filedetails/?id=2687866031)
+	// That integration is done solely through localization files, look for "Census.SpawnCondition" in the .hjson files. 
 	public class ModIntegrationsSystem : ModSystem
 	{
 		public override void PostSetupContent() {
@@ -35,7 +38,7 @@ namespace ExampleMod.Common.Systems
 			}
 
 			// For some messages, mods might not have them at release, so we need to verify when the last iteration of the method variation was first added to the mod, in this case 1.6
-			// Usually mods either provide that information themselves in some way, or it's found on the github through commit history/blame
+			// Usually mods either provide that information themselves in some way, or it's found on the GitHub through commit history/blame
 			if (bossChecklistMod.Version < new Version(1, 6)) {
 				return;
 			}

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -54,6 +54,9 @@ Mods: {
 					LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
 				}
+
+				# This key is generated and used when the "Census" mod is enabled: It allows the user to see the spawn condition of this town NPC in the Housing UI
+				Census.SpawnCondition: Have either an {$Items.ExampleItem.DisplayName} [i:ExampleMod/ExampleItem] or an {$Items.ExampleBlock.DisplayName} [i:ExampleMod/ExampleBlock] in your inventory
 			}
 
 			ExampleTravelingMerchant.DisplayName: Example Traveling Merchant
@@ -61,7 +64,13 @@ Mods: {
 			ExampleWormHead.DisplayName: Example Worm
 			ExampleWormTail.DisplayName: Example Worm
 			ExampleZombieThief.DisplayName: Example Zombie Thief
-			MinionBossBody.DisplayName: Minion Boss
+
+			MinionBossBody: {
+				DisplayName: Minion Boss
+				# This is part of ModIntegrationsSystem.cs: Information for the player so he knows how to encounter the boss
+				BossChecklistIntegration.SpawnInfo: Use a [i:ExampleMod/MinionBossSummonItem]
+			}
+
 			MinionBossMinion.DisplayName: Minion Boss Minion
 			PartyZombie.DisplayName: Party Zombie
 		}

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -54,6 +54,9 @@ Mods: {
 					// LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					// Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
 				}
+
+				# This key is generated and used when the "Census" mod is enabled: It allows the user to see the spawn condition of this town NPC in the Housing UI
+				// Census.SpawnCondition: Have either an {$Items.ExampleItem.DisplayName} [i:ExampleMod/ExampleItem] or an {$Items.ExampleBlock.DisplayName} [i:ExampleMod/ExampleBlock] in your inventory
 			}
 
 			// ExampleTravelingMerchant.DisplayName: Example Traveling Merchant
@@ -61,7 +64,13 @@ Mods: {
 			// ExampleWormHead.DisplayName: Example Worm
 			// ExampleWormTail.DisplayName: Example Worm
 			// ExampleZombieThief.DisplayName: Example Zombie Thief
-			// MinionBossBody.DisplayName: Minion Boss
+
+			MinionBossBody: {
+				// DisplayName: Minion Boss
+				# This is part of ModIntegrationsSystem.cs: Information for the player so he knows how to encounter the boss
+				// BossChecklistIntegration.SpawnInfo: Use a [i:ExampleMod/MinionBossSummonItem]
+			}
+
 			// MinionBossMinion.DisplayName: Minion Boss Minion
 			// PartyZombie.DisplayName: Party Zombie
 		}

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -54,6 +54,9 @@ Mods: {
 					// LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					// Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
 				}
+
+				# This key is generated and used when the "Census" mod is enabled: It allows the user to see the spawn condition of this town NPC in the Housing UI
+				// Census.SpawnCondition: Have either an {$Items.ExampleItem.DisplayName} [i:ExampleMod/ExampleItem] or an {$Items.ExampleBlock.DisplayName} [i:ExampleMod/ExampleBlock] in your inventory
 			}
 
 			// ExampleTravelingMerchant.DisplayName: Example Traveling Merchant
@@ -61,7 +64,13 @@ Mods: {
 			// ExampleWormHead.DisplayName: Example Worm
 			// ExampleWormTail.DisplayName: Example Worm
 			// ExampleZombieThief.DisplayName: Example Zombie Thief
-			// MinionBossBody.DisplayName: Minion Boss
+
+			MinionBossBody: {
+				// DisplayName: Minion Boss
+				# This is part of ModIntegrationsSystem.cs: Information for the player so he knows how to encounter the boss
+				// BossChecklistIntegration.SpawnInfo: Use a [i:ExampleMod/MinionBossSummonItem]
+			}
+
 			// MinionBossMinion.DisplayName: Minion Boss Minion
 			// PartyZombie.DisplayName: Party Zombie
 		}


### PR DESCRIPTION
### What are the changes to ExampleMod?
Census and Boss Checklist integrations showcased in ExampleMod are updated to reflect their respective 1.4.4 versions.

Census has made the mod call optional, instead the mod's lang file is populated with a key denoting the spawn condition for the town NPC.
Boss Checklist has something similar but still requires a mod call, which has changed its name and parameters.

Since there's now only 1 showcase of Mod.Call, I suggest implementing support for **HERO's Mod**'s God Mode feature to cap "example resource". Journey Mode God Mode is handled in #3525 which can easily be expanded to include other mods' god mode implementations.

### Do these changes need additional documentation?
No
