### PR TITLE
[ExampleMod] Tweaks & fixes for example resource

### DIFF
--- a/ExampleMod/Common/Players/ExampleResourcePlayer.cs
+++ b/ExampleMod/Common/Players/ExampleResourcePlayer.cs
@@ -20,7 +20,7 @@ namespace ExampleMod.Common.Players
 		// Here are additional things you might need to implement if you intend to make a custom resource:
 		// - Multiplayer Syncing: The current example doesn't require MP code, but pretty much any additional functionality will require this. ModPlayer.SendClientChanges and CopyClientState will be necessary, as well as SyncPlayer if you allow the user to increase exampleResourceMax.
 		// - Save/Load permanent changes to max resource: You'll need to implement Save/Load to remember increases to your exampleResourceMax cap.
-		// - Resouce replenishment item: Use GlobalNPC.NPCLoot to drop the item. ModItem.OnPickup and ModItem.ItemSpace will allow it to behave like Mana Star or Heart. Use code similar to Player.HealEffect to spawn (and sync) a colored number suitable to your resource.
+		// - Resouce replenishment item: Use GlobalNPC.OnKill to drop the item. ModItem.OnPickup and ModItem.ItemSpace will allow it to behave like Mana Star or Heart. Use code similar to Player.HealEffect to spawn (and sync) a colored number suitable to your resource.
 
 		public override void Initialize() {
 			exampleResourceMax = DefaultExampleResourceMax;
@@ -44,19 +44,29 @@ namespace ExampleMod.Common.Players
 			UpdateResource();
 		}
 
+		public override void PostUpdate() {
+			CapResourceGodMode();
+		}
+
 		// Lets do all our logic for the custom resource here, such as limiting it, increasing it and so on.
 		private void UpdateResource() {
 			// For our resource lets make it regen slowly over time to keep it simple, let's use exampleResourceRegenTimer to count up to whatever value we want, then increase currentResource.
 			exampleResourceRegenTimer++; // Increase it by 60 per second, or 1 per tick.
 
-			// A simple timer that goes up to 3 seconds, increases the exampleResourceCurrent by 1 and then resets back to 0.
-			if (exampleResourceRegenTimer > 180 / exampleResourceRegenRate) {
+			// A simple timer that goes up to 1 second, increases the exampleResourceCurrent by 1 and then resets back to 0.
+			if (exampleResourceRegenTimer > 60 / exampleResourceRegenRate) {
 				exampleResourceCurrent += 1;
 				exampleResourceRegenTimer = 0;
 			}
 
 			// Limit exampleResourceCurrent from going over the limit imposed by exampleResourceMax.
 			exampleResourceCurrent = Utils.Clamp(exampleResourceCurrent, 0, exampleResourceMax2);
+		}
+
+		public void CapResourceGodMode() {
+			if (Main.myPlayer == Player.whoAmI && Player.creativeGodMode) {
+				exampleResourceCurrent = exampleResourceMax2;
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/Players/ExampleResourcePlayer.cs
+++ b/ExampleMod/Common/Players/ExampleResourcePlayer.cs
@@ -63,7 +63,7 @@ namespace ExampleMod.Common.Players
 			exampleResourceCurrent = Utils.Clamp(exampleResourceCurrent, 0, exampleResourceMax2);
 		}
 
-		public void CapResourceGodMode() {
+		private void CapResourceGodMode() {
 			if (Main.myPlayer == Player.whoAmI && Player.creativeGodMode) {
 				exampleResourceCurrent = exampleResourceMax2;
 			}

--- a/ExampleMod/Common/UI/ExampleResourceUI/ExampleResourceBar.cs
+++ b/ExampleMod/Common/UI/ExampleResourceUI/ExampleResourceBar.cs
@@ -8,6 +8,7 @@ using ExampleMod.Common.Players;
 using ExampleMod.Content.Items.Weapons;
 using Terraria.GameContent;
 using System.Collections.Generic;
+using Terraria.Localization;
 
 namespace ExampleMod.Common.UI.ExampleResourceUI
 {
@@ -92,24 +93,28 @@ namespace ExampleMod.Common.UI.ExampleResourceUI
 
 			var modPlayer = Main.LocalPlayer.GetModPlayer<ExampleResourcePlayer>();
 			// Setting the text per tick to update and show our resource values.
-			text.SetText($"Example Resource: {modPlayer.exampleResourceCurrent} / {modPlayer.exampleResourceMax2}");
+			text.SetText(ExampleResourceUISystem.ExampleResourceText.Format(modPlayer.exampleResourceCurrent, modPlayer.exampleResourceMax2));
 			base.Update(gameTime);
 		}
 	}
 
-	class ExampleResourseUISystem : ModSystem
+	// This class will only be autoloaded/registered if we're not loading on a server
+	[Autoload(Side = ModSide.Client)]
+	internal class ExampleResourceUISystem : ModSystem
 	{
 		private UserInterface ExampleResourceBarUserInterface;
 
 		internal ExampleResourceBar ExampleResourceBar;
 
+		public static LocalizedText ExampleResourceText { get; private set; }
+
 		public override void Load() {
-			// All code below runs only if we're not loading on a server
-			if (!Main.dedServ) {
-				ExampleResourceBar = new();
-				ExampleResourceBarUserInterface = new();
-				ExampleResourceBarUserInterface.SetState(ExampleResourceBar);
-			}
+			ExampleResourceBar = new();
+			ExampleResourceBarUserInterface = new();
+			ExampleResourceBarUserInterface.SetState(ExampleResourceBar);
+
+			string category = "UI";
+			ExampleResourceText ??= Language.GetOrRegister(Mod.GetLocalizationKey($"{category}.ExampleResource"));
 		}
 
 		public override void UpdateUI(GameTime gameTime) {

--- a/ExampleMod/Content/Items/Weapons/ExampleCustomResourceWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleCustomResourceWeapon.cs
@@ -3,6 +3,7 @@ using ExampleMod.Common.Players;
 using ExampleMod.Content.Tiles.Furniture;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items.Weapons
@@ -11,6 +12,12 @@ namespace ExampleMod.Content.Items.Weapons
 	public class ExampleCustomResourceWeapon : ModItem
 	{
 		private int exampleResourceCost; // Add our custom resource cost
+
+		public static LocalizedText UsesXExampleResourceText { get; private set; }
+
+		public override void SetStaticDefaults() {
+			UsesXExampleResourceText = this.GetLocalization("UsesXExampleResource");
+		}
 
 		public override void SetDefaults() {
 			Item.damage = 130;
@@ -33,19 +40,23 @@ namespace ExampleMod.Content.Items.Weapons
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			tooltips.Add(new TooltipLine(Mod, "Example Resource Cost", $"Uses {exampleResourceCost} example resource"));
+			tooltips.Add(new TooltipLine(Mod, "ExampleResourceCost", UsesXExampleResourceText.Format(exampleResourceCost)));
 		}
 
 		// Make sure you can't use the item if you don't have enough resource
 		public override bool CanUseItem(Player player) {
 			var exampleResourcePlayer = player.GetModPlayer<ExampleResourcePlayer>();
 
-			if (exampleResourcePlayer.exampleResourceCurrent >= exampleResourceCost) {
-				exampleResourcePlayer.exampleResourceCurrent -= exampleResourceCost;
-				return true;
-			}
+			return exampleResourcePlayer.exampleResourceCurrent >= exampleResourceCost;
+		}
 
-			return false;
+		// Reduce resource on use
+		public override bool? UseItem(Player player) {
+			var exampleResourcePlayer = player.GetModPlayer<ExampleResourcePlayer>();
+
+			exampleResourcePlayer.exampleResourceCurrent -= exampleResourceCost;
+
+			return true;
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -595,6 +595,7 @@ Mods: {
 			ExampleCustomResourceWeapon: {
 				DisplayName: Example Custom Resource Weapon
 				Tooltip: ""
+				UsesXExampleResource: Uses {0} example resource
 			}
 
 			ExampleFlail: {
@@ -1018,6 +1019,8 @@ Mods: {
 			JourneyMode: Drops in Journey Mode
 			Example: Drops during daytime
 		}
+
+		UI.ExampleResource: Example Resource: {0} / {1}
 	}
 }
 

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -595,6 +595,7 @@ Mods: {
 			ExampleCustomResourceWeapon: {
 				// DisplayName: Example Custom Resource Weapon
 				// Tooltip: ""
+				// UsesXExampleResource: Uses {0} example resource
 			}
 
 			ExampleFlail: {
@@ -1018,6 +1019,8 @@ Mods: {
 			// JourneyMode: Drops in Journey Mode
 			// Example: Drops during daytime
 		}
+
+		// UI.ExampleResource: Example Resource: {0} / {1}
 	}
 }
 

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -595,6 +595,7 @@ Mods: {
 			ExampleCustomResourceWeapon: {
 				// DisplayName: Example Custom Resource Weapon
 				// Tooltip: ""
+				// UsesXExampleResource: Uses {0} example resource
 			}
 
 			ExampleFlail: {
@@ -1018,6 +1019,8 @@ Mods: {
 			// JourneyMode: Drops in Journey Mode
 			// Example: Drops during daytime
 		}
+
+		// UI.ExampleResource: Example Resource: {0} / {1}
 	}
 }
 


### PR DESCRIPTION
### What are the changes to ExampleMod?
* The weapon was decrementing the resource within `CanUseItem`, which is bad. Moved it to `UseItem`
* Localized the weapon tooltip and UI text
* Tripled the resource regen time, since it's too slow currently for an _example_
* ExampleResourseUISystem typo fix, made to autoload on client instead of `dedServ` check
* Implemented god mode check to cap resource

### Do these changes need additional documentation?
No

