### PR TITLE
ItemUseStyleID.RaiseLamp Front Arm Animation Fix

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4280,10 +4280,13 @@
  		if (!isDisplayDollOrInanimate) {
  			if (((body == 68 && legs == 57 && head == 106) || (body == 74 && legs == 63 && head == 106)) && Main.rand.Next(10) == 0) {
  				int num3 = Dust.NewDust(new Vector2(position.X - velocity.X * 2f, position.Y - 2f - velocity.Y * 2f), width, height, 43, 0f, 0f, 100, new Color(255, 0, 255), 0.3f);
-@@ -28029,6 +_,9 @@
+@@ -28028,7 +_,11 @@
+ 
  		Item.GetDrawHitbox(HeldItem.type, this);
  		bool flag3 = CanVisuallyHoldItem(HeldItem);
- 		bool flag4 = HeldItem.type != 4952;
+-		bool flag4 = HeldItem.type != 4952;
++		// bool flag4 = HeldItem.type != 4952;
++		bool flag4 = HeldItem.useStyle != ItemUseStyleID.RaiseLamp; // TML: #RaiseLampAnimationFix
 +
 +		ItemLoader.UpdateVanitySet(this);
 +


### PR DESCRIPTION
### What is the bug?

Any item that uses `ItemUseStyleID.RaiseLamp` (ID 14) will cause the front arm to not animation correctly while using the item. In vanilla, the only item that uses this useStyle is the Nightglow. The Nightglow does not suffer from this issue because there is an explicit check for the Nightglow. Nightglow is item ID 4952.
```cs
bool flag4 = HeldItem.type != 4952;
// later:
else if (itemAnimation > 0 && inventory[selectedItem].useStyle != 10 && flag4) {
	// bodyFrame.Y animation
```

Any other item that uses `ItemUseStyleID.RaiseLamp` will cause the front arm to freeze in the frame it was before the item animation started. Here is a clip of the bug in action:

![RaiseLampBug](https://github.com/tModLoader/tModLoader/assets/11262234/68693411-edb5-41f0-bb44-00550676a34a)

`ItemHoldStyleID.HoldLamp` is not affected by this bug, in case you were wondering.

### How did you fix the bug?

I changed the explicit check for the Nightglow to a check for the useStyle.
```diff
- bool flag4 = HeldItem.type != 4952;
+ bool flag4 = HeldItem.useStyle != ItemUseStyleID.RaiseLamp;
```
This fixes the animation for any item that uses that useStyle and does not break the Nightglow, either. Here is a clip of the fix including the Nightglow.

![RaiseLampFix](https://github.com/tModLoader/tModLoader/assets/11262234/e72ce387-5970-4423-b561-bdc9084d05ed)

### Are there alternatives to your fix?

Commenting style. Let me know/feel free to change the comments that I made.

Instead of changing the `flag4` bool, the `else if` statement checking for `flag4` could be changed to check for the useStyle. That statement already checks for not useStyle 10, so it wouldn't be weird to check for not useStyle 14 either.

Perhaps this change could be made in vanilla for 1.4.5. A quick search on GitHub shows that there are only about 29 items that have this useStyle, 1 of which are Example Mod, 1 of which is a Chinese translation of Example Mod, and 22 of which are items from my own mod (where I fixed this issue with an IL Edit). My point is that so few people use this useStyle that waiting for a fix to be made in vanilla 1.4.5 is not a big deal.