### PR TITLE
Fix gravity being assigned instead of fall speed in maxFallSpeed private set.

### DIFF
--- a/patches/tModLoader/Terraria/NPC.TML.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.cs
@@ -238,7 +238,7 @@ public partial class NPC : IEntityWithGlobals<GlobalNPC>
 		get => vanillaMaxFallSpeed * MaxFallSpeedMultiplier.Value;
 		private set {
 			MaxFallSpeedMultiplier = MultipliableFloat.One;
-			vanillaGravity = value;
+			vanillaMaxFallSpeed = value;
 		}
 	}
 


### PR DESCRIPTION
### What is the bug?
Gravity is very high for entities in liquid #3528, due to #3415 

### How did you fix the bug?
Whenever maxFallSpeed is set, that value is assigned to gravity instead of fall speed, silly mistake, silly fix