### PR TITLE
Fix for #3537

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -86,11 +86,30 @@ else
 	fi
 fi
 
-if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
-	echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
-	[[ -f "$install_dir/dotnet" ]] && chmod a+x "$install_dir/dotnet"
-	exec "$install_dir/dotnet" tModLoader.dll "$customargs" "$@" 2>"$NativeLog"
+if [[ "$_uname" == *"_NT"* ]]; then
+
+	opengl="/gldriver:opengl"
+	args=$(echo "$@" | tr '[:upper:]' '[:lower:]')
+	args=${args//$opengl}
+	customargs=$(echo "$customargs" | tr '[:upper:]' '[:lower:]')
+	customargs=${customargs//$opengl}
+	
+	if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
+		echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
+		[[ -f "$install_dir/dotnet" ]] && chmod a+x "$install_dir/dotnet"
+		echo "$customargs" "$args" 2>&1 | tee -a "$LogFile"
+		exec "$install_dir/dotnet" tModLoader.dll "$customargs" "$args" 2>"$NativeLog"
+	else
+		echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
+		exec dotnet tModLoader.dll "$customargs" "$args" 2>"$NativeLog"
+	fi
 else
-	echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
-	exec dotnet tModLoader.dll "$customargs" "$@" 2>"$NativeLog"
+	if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
+		echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
+		[[ -f "$install_dir/dotnet" ]] && chmod a+x "$install_dir/dotnet"
+		exec "$install_dir/dotnet" tModLoader.dll "$customargs" "$@" 2>"$NativeLog"
+	else
+		echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"
+		exec dotnet tModLoader.dll "$customargs" "$@" 2>"$NativeLog"
+	fi
 fi

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -97,7 +97,6 @@ if [[ "$_uname" == *"_NT"* ]]; then
 	if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
 		echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
 		[[ -f "$install_dir/dotnet" ]] && chmod a+x "$install_dir/dotnet"
-		echo "$customargs" "$args" 2>&1 | tee -a "$LogFile"
 		exec "$install_dir/dotnet" tModLoader.dll "$customargs" "$args" 2>"$NativeLog"
 	else
 		echo "Launched Using System Dotnet"  2>&1 | tee -a "$LogFile"


### PR DESCRIPTION
**What is the bug?**
#3537 - System.InvalidOperationException: No supported FNA3D driver found!
Crash on launch when unsupported CmdLineArg '/gldriver:opengl' is used on windows.

**How did you fix the bug?**
Added a check for '/gldriver:opengl' to ScriptCaller.sh when launched under Windows.
If found, removes the argument from the CommandLineArgs whilst keeping any others.

**Are there alternatives to your fix?**
Current fix in FNAFixes.cs acts on Environment.GetEnvironmentVariable(SDL_VIDEODRIVER) correctly.
But as FNA uses Enviroment.GetCommandLineArgs() Method directly and is called after TModLoaders FNAFixes.Init(), the fix would have to be in FNA's codebase.
