### PR TITLE
BelongsToInvasion NPC sets

### DIFF
--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -59,7 +59,7 @@ public partial class NPCID
 		// All BelongsToInvasion set IDs taken from NPC.GetNPCInvasionGroup
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Goblin Army invasion.
-		/// <br/> During the Goblin Army invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> During the Goblin Army invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified in <see cref="InvasionSlotCount"/> when killed.
 		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Goblin Army music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
@@ -67,7 +67,7 @@ public partial class NPCID
 
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Frost Legion invasion.
-		/// <br/> During the Frost Legion invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> During the Frost Legion invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified in <see cref="InvasionSlotCount"/> when killed.
 		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Boss 3 music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
@@ -75,7 +75,7 @@ public partial class NPCID
 
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Pirate invasion.
-		/// <br/> During the Pirate invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> During the Pirate invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified in <see cref="InvasionSlotCount"/> when killed.
 		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Pirate Invasion music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
@@ -83,7 +83,7 @@ public partial class NPCID
 
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Martian Madness invasion.
-		/// <br/> During the Martian Madness invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> During the Martian Madness invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified in <see cref="InvasionSlotCount"/> when killed.
 		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Martian Madness music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
@@ -103,7 +103,7 @@ public partial class NPCID
 		/// <br/> If this NPC's entry is 0, it won't play its associated invasion's music when alive.
 		/// </summary>
 		/// <remarks>
-		///	Note: Even though this defaults to 1, this set should only be checked if <see cref="NPC.GetNPCInvasionGroup(int)"/> is above 0 or any BelongsToInvasion sets are <see langword="false"/>.
+		///	Note: Even though this defaults to 1, this set should only be checked if <see cref="NPC.GetNPCInvasionGroup(int)"/> is above 0 or if any BelongsToInvasion sets are <see langword="true"/>.
 		/// </remarks>
 		public static int[] InvasionSlotCount = Factory.CreateIntSet(1, 216, 5, 395, 10, 491, 10, 471, 10, 472, 0, 387, 0);
 	}

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -55,5 +55,56 @@ public partial class NPCID
 		/// Note: This set DOES NOT DO ANYTHING if your NPC doesn't use the Vanilla TownNPC aiStyle (aiStyle == 7).
 		/// </remarks>
 		public static bool[] AllowDoorInteraction = Factory.CreateBoolSet();
+
+		// All BelongsToInvasion set IDs taken from NPC.GetNPCInvasionGroup
+		/// <summary>
+		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Goblin Army invasion.
+		/// <br/> During the Goblin Army invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> If any NPC in this set is alive, the Goblin Army music will play.
+		/// <br/> Defaults to <see langword="false"/>.
+		/// </summary>
+		public static bool[] BelongsToInvasionGoblinArmy = Factory.CreateBoolSet(26, 27, 28, 29, 111, 471, 472);
+
+		/// <summary>
+		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Frost Legion invasion.
+		/// <br/> During the Frost Legion invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> If any NPC in this set is alive, the Boss 3 music will play.
+		/// <br/> Defaults to <see langword="false"/>.
+		/// </summary>
+		public static bool[] BelongsToInvasionFrostLegion = Factory.CreateBoolSet(143, 144, 145);
+
+		/// <summary>
+		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Pirate invasion.
+		/// <br/> During the Pirate invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> If any NPC in this set is alive, the Pirate Invasion music will play.
+		/// <br/> Defaults to <see langword="false"/>.
+		/// </summary>
+		public static bool[] BelongsToInvasionPirate = Factory.CreateBoolSet(212, 213, 214, 215, 216, 491);
+
+		/// <summary>
+		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Martian Madness invasion.
+		/// <br/> During the Martian Madness invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
+		/// <br/> If any NPC in this set is alive, the Martian Madness music will play.
+		/// <br/> Defaults to <see langword="false"/>.
+		/// </summary>
+		public static bool[] BelongsToInvasionMartianMadness = Factory.CreateBoolSet(381, 382, 383, 385, 386, 387, 388, 389, 390, 391, 395);
+
+		// IDs taken from Main.UpdateAudio_DecideOnNewMusic, only if it doesn't appear in any BelongsToInvasion set
+		/// <summary>
+		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC will not play its associated invasion music.
+		/// <br/> By default, alive NPCs in any BelongsToInvasion set will automatically play the associated invasion music.
+		/// <br/> Defaults to <see langword="false"/>.
+		/// </summary>
+		public static bool[] NoInvasionMusic = Factory.CreateBoolSet(387);
+
+		// IDs taken from NPC.checkDead
+		/// <summary>
+		/// If above 0 for a given NPC type (<see cref="NPC.type"/>), and its associated invasion is NOT a wave-based one, then that NPC will decrement <see cref="Main.invasionSize"/> by that amount when killed.
+		/// <br/> If this NPC's entry is 0, it won't play its associated invasion's music when alive.
+		/// </summary>
+		/// <remarks>
+		///	Note: Even though this defaults to 1, this set should only be checked if <see cref="NPC.GetNPCInvasionGroup(int)"/> is above 0 or any BelongsToInvasion sets are <see langword="false"/>.
+		/// </remarks>
+		public static int[] InvasionSlotCount = Factory.CreateIntSet(1, 216, 5, 395, 10, 491, 10, 471, 10, 472, 0, 387, 0);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -87,7 +87,7 @@ public partial class NPCID
 		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Martian Madness music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
-		public static bool[] BelongsToInvasionMartianMadness = Factory.CreateBoolSet(381, 382, 383, 385, 386, 387, 388, 389, 390, 391, 395);
+		public static bool[] BelongsToInvasionMartianMadness = Factory.CreateBoolSet(381, 382, 383, 385, 386, 387, 388, 389, 390, 391, 395, 520);
 
 		// IDs taken from Main.UpdateAudio_DecideOnNewMusic, only if it doesn't appear in any BelongsToInvasion set
 		/// <summary>

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -60,7 +60,7 @@ public partial class NPCID
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Goblin Army invasion.
 		/// <br/> During the Goblin Army invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
-		/// <br/> If any NPC in this set is alive, the Goblin Army music will play.
+		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Goblin Army music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] BelongsToInvasionGoblinArmy = Factory.CreateBoolSet(26, 27, 28, 29, 111, 471, 472);
@@ -68,7 +68,7 @@ public partial class NPCID
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Frost Legion invasion.
 		/// <br/> During the Frost Legion invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
-		/// <br/> If any NPC in this set is alive, the Boss 3 music will play.
+		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Boss 3 music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] BelongsToInvasionFrostLegion = Factory.CreateBoolSet(143, 144, 145);
@@ -76,7 +76,7 @@ public partial class NPCID
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Pirate invasion.
 		/// <br/> During the Pirate invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
-		/// <br/> If any NPC in this set is alive, the Pirate Invasion music will play.
+		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Pirate Invasion music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] BelongsToInvasionPirate = Factory.CreateBoolSet(212, 213, 214, 215, 216, 491);
@@ -84,7 +84,7 @@ public partial class NPCID
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC belongs to the Martian Madness invasion.
 		/// <br/> During the Martian Madness invasion, NPCs in this set will decrement <see cref="Main.invasionSize"/> by the amount specified (<see cref="InvasionSlotCount"/>) when killed.
-		/// <br/> If any NPC in this set is alive, the Martian Madness music will play.
+		/// <br/> If any NPC in this set is alive and <see cref="InvasionSlotCount"/> is above 0, the Martian Madness music will play.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] BelongsToInvasionMartianMadness = Factory.CreateBoolSet(381, 382, 383, 385, 386, 387, 388, 389, 390, 391, 395);
@@ -92,7 +92,7 @@ public partial class NPCID
 		// IDs taken from Main.UpdateAudio_DecideOnNewMusic, only if it doesn't appear in any BelongsToInvasion set
 		/// <summary>
 		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC will not play its associated invasion music.
-		/// <br/> By default, alive NPCs in any BelongsToInvasion set will automatically play the associated invasion music.
+		/// <br/> By default, alive NPCs in any BelongsToInvasion set will automatically play the associated invasion music if <see cref="InvasionSlotCount"/> is above 0.
 		/// <br/> Defaults to <see langword="false"/>.
 		/// </summary>
 		public static bool[] NoInvasionMusic = Factory.CreateBoolSet(387);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1666,6 +1666,77 @@
  			Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle((int)screenPosition.X, (int)screenPosition.Y, screenWidth, screenHeight);
  			int num2 = 5000;
  			for (int j = 0; j < 200; j++) {
+@@ -10219,12 +_,15 @@
+ 					case 131:
+ 						num3 = 1;
+ 						break;
++					/*
+ 					case 26:
+ 					case 27:
+ 					case 28:
+ 					case 29:
+ 					case 111:
+ 					case 471:
++					*/
++					case int _ when NPCID.Sets.BelongsToInvasionGoblinArmy[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
+ 						num3 = 11;
+ 						break;
+ 					case 113:
+@@ -10236,18 +_,24 @@
+ 					case 134:
+ 					case 135:
+ 					case 136:
++					/*
+ 					case 143:
+ 					case 144:
+ 					case 145:
++					*/
++					case int _ when NPCID.Sets.BelongsToInvasionFrostLegion[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
+ 					case 266:
+ 						num3 = 3;
+ 						break;
++					/*
+ 					case 212:
+ 					case 213:
+ 					case 214:
+ 					case 215:
+ 					case 216:
+ 					case 491:
++					*/
++					case int _ when NPCID.Sets.BelongsToInvasionPirate[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
+ 						num3 = 8;
+ 						break;
+ 					case 245:
+@@ -10261,6 +_,7 @@
+ 					case 264:
+ 						num3 = 6;
+ 						break;
++					/*
+ 					case 381:
+ 					case 382:
+ 					case 383:
+@@ -10271,7 +_,10 @@
+ 					case 390:
+ 					case 391:
+ 					case 395:
+-					case 520:
++					*/
++					// No 387 tesla turret, handled via NoInvasionMusic below 
++					case int _ when npc[j].type != 387 && NPCID.Sets.BelongsToInvasionMartianMadness[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
++					case 520: // martian walker, currently not in NPC.GetInvasionGroup and by extension not in NPCID.Sets.BelongsToInvasionMartianMadness
+ 						num3 = 9;
+ 						break;
+ 					case 398:
+@@ -10309,6 +_,9 @@
+ 				if (NPCID.Sets.BelongsToInvasionOldOnesArmy[npc[j].type])
+ 					num3 = 12;
+ 
++				if (NPCID.Sets.NoInvasionMusic[npc[j].type])
++					num3 = 0;
++
+ 				if (num3 == 0 && npc[j].boss)
+ 					num3 = 1;
+ 
 @@ -10320,6 +_,12 @@
  
  				Microsoft.Xna.Framework.Rectangle value = new Microsoft.Xna.Framework.Rectangle((int)(npc[j].position.X + (float)(npc[j].width / 2)) - num2, (int)(npc[j].position.Y + (float)(npc[j].height / 2)) - num2, num2 * 2, num2 * 2);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1731,7 +1731,7 @@
  				if (NPCID.Sets.BelongsToInvasionOldOnesArmy[npc[j].type])
  					num3 = 12;
  
-+				if (NPCID.Sets.NoInvasionMusic[npc[j].type])
++				if (NPCID.Sets.NoInvasionMusic[npc[j].type] && NPC.GetNPCInvasionGroup(npc[j].type) != 0)
 +					num3 = 0;
 +
  				if (num3 == 0 && npc[j].boss)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1715,15 +1715,15 @@
  					case 381:
  					case 382:
  					case 383:
-@@ -10271,7 +_,10 @@
+@@ -10271,7 +_,11 @@
  					case 390:
  					case 391:
  					case 395:
--					case 520:
 +					*/
++					// 520 martian walker, currently not in NPC.GetNPCInvasionGroup and by extension not in NPCID.Sets.BelongsToInvasionMartianMadness
+ 					case 520:
 +					// No 387 tesla turret, handled via NoInvasionMusic below 
 +					case int _ when NPCID.Sets.BelongsToInvasionMartianMadness[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
-+					case 520: // martian walker, currently not in NPC.GetInvasionGroup and by extension not in NPCID.Sets.BelongsToInvasionMartianMadness
  						num3 = 9;
  						break;
  					case 398:

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1722,7 +1722,7 @@
 -					case 520:
 +					*/
 +					// No 387 tesla turret, handled via NoInvasionMusic below 
-+					case int _ when npc[j].type != 387 && NPCID.Sets.BelongsToInvasionMartianMadness[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
++					case int _ when NPCID.Sets.BelongsToInvasionMartianMadness[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
 +					case 520: // martian walker, currently not in NPC.GetInvasionGroup and by extension not in NPCID.Sets.BelongsToInvasionMartianMadness
  						num3 = 9;
  						break;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1715,13 +1715,11 @@
  					case 381:
  					case 382:
  					case 383:
-@@ -10271,7 +_,11 @@
- 					case 390:
+@@ -10272,6 +_,9 @@
  					case 391:
  					case 395:
-+					*/
-+					// 520 martian walker, currently not in NPC.GetNPCInvasionGroup and by extension not in NPCID.Sets.BelongsToInvasionMartianMadness
  					case 520:
++					*/
 +					// No 387 tesla turret, handled via NoInvasionMusic below 
 +					case int _ when NPCID.Sets.BelongsToInvasionMartianMadness[npc[j].type] && NPCID.Sets.InvasionSlotCount[npc[j].type] > 0:
  						num3 = 9;

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -52,7 +52,12 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	/// </summary>
 	public int AnimationType { get; set; }
 
-	/// <summary> The ID of the music that plays when this NPC is on or near the screen. Defaults to -1, which means music plays normally. </summary>
+	/// <summary>
+	/// The ID of the music that plays when this NPC is on or near the screen. Defaults to -1, which means music plays normally.
+	/// </summary>
+	/// <remarks>
+	/// Note: This properly gets ignored if the game would not play music for this NPC by default (i.e. it's not a boss, or it doesn't belong to an invasion)
+	/// </remarks>
 	/// Will be superseded by ModSceneEffect. Kept for legacy.
 	public int Music { get; set; } = -1;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -56,7 +56,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	/// The ID of the music that plays when this NPC is on or near the screen. Defaults to -1, which means music plays normally.
 	/// </summary>
 	/// <remarks>
-	/// Note: This properly gets ignored if the game would not play music for this NPC by default (i.e. it's not a boss, or it doesn't belong to an invasion)
+	/// Note: This property gets ignored if the game would not play music for this NPC by default (i.e. it's not a boss, or it doesn't belong to an invasion)
 	/// </remarks>
 	/// Will be superseded by ModSceneEffect. Kept for legacy.
 	public int Music { get; set; } = -1;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1514,12 +1514,11 @@
  			case 381:
  			case 382:
  			case 383:
-@@ -58836,6 +_,9 @@
+@@ -58836,6 +_,8 @@
  			case 390:
  			case 391:
  			case 395:
 +			*/
-+			// 520 martian walker missing, vanilla bug?
 +			case int _ when NPCID.Sets.BelongsToInvasionMartianMadness[npcID]:
  				result = 4;
  				break;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -1454,7 +1454,15 @@
  		if (type == 13 || type == 14 || type == 15) {
  			DropEoWLoot();
  		}
-@@ -58799,6 +_,15 @@
+@@ -58761,6 +_,7 @@
+ 				break;
+ 		}
+ 
++		num10 = NPCID.Sets.InvasionSlotCount[type];
+ 		if (num10 > 0) {
+ 			Main.invasionSize -= num10;
+ 			if (Main.invasionSize < 0)
+@@ -58799,10 +_,20 @@
  		}
  	}
  
@@ -1470,6 +1478,52 @@
  	public static int GetNPCInvasionGroup(int npcID)
  	{
  		int result = 0;
+ 		switch (npcID) {
++			/*
+ 			case 26:
+ 			case 27:
+ 			case 28:
+@@ -58810,21 +_,30 @@
+ 			case 111:
+ 			case 471:
+ 			case 472:
++			*/
++			case int _ when NPCID.Sets.BelongsToInvasionGoblinArmy[npcID]:
+ 				result = 1;
+ 				break;
++			/*
+ 			case 143:
+ 			case 144:
+ 			case 145:
++			*/
++			case int _ when NPCID.Sets.BelongsToInvasionFrostLegion[npcID]:
+ 				result = 2;
+ 				break;
++			/*
+ 			case 212:
+ 			case 213:
+ 			case 214:
+ 			case 215:
+ 			case 216:
+ 			case 491:
++			*/
++			case int _ when NPCID.Sets.BelongsToInvasionPirate[npcID]:
+ 				result = 3;
+ 				break;
++			/*
+ 			case 381:
+ 			case 382:
+ 			case 383:
+@@ -58836,6 +_,9 @@
+ 			case 390:
+ 			case 391:
+ 			case 395:
++			*/
++			// 520 martian walker missing, vanilla bug?
++			case int _ when NPCID.Sets.BelongsToInvasionMartianMadness[npcID]:
+ 				result = 4;
+ 				break;
+ 			case 338:
 @@ -59211,7 +_,7 @@
  
  	public static void ResetKillCount()


### PR DESCRIPTION
### What is the new feature?
New sets for non wave-based invasions (goblin army, pirate, frost legion, martian madness), which take care of handling the invasion progress and music playback.
Added complementary sets for how much progress individual NPCs contribute and if an NPC should _not_ play music despite being an event NPC.

The naming is based on the existing set `BelongsToInvasionOldOnesArmy`.

### Why should this be part of tModLoader?
Currently, modders have to write alot of boilerplate to make enemies work with invasions properly.

For playing music, since `ModNPC.Music` does not work on things that don't already have music by default (i.e. bosses), a `ModSceneEffect` is required which checks for alive NPCs.

For handling invasion progress, code that handles that and the multiplayer side of it is required to be added to `ModNPC.OnKill/checkDead` hooks.

If any mods need to identify which invasion an NPC belongs to (vanilla or modded), these sets become valuable.

### Are there alternative designs?
1. Regarding patches, you could make the `NPC.GetNPCInvasionGroup` patches in a way where you don't touch the switch cases at all and instead re-assign the values, just need to use the magic numbers for `InvasionID`.

2. To minimize the patch associated with `InvasionSlotCount` I just kept the vanilla code the same and let tml overwrite the value.

3. The patches that handle music are kept the same as the `NPC.GetNPCInvasionGroup` patches currently, you can make use of copied vanilla magic numbers for `MusicID` otherwise.

4. `520 (Martian Walker)` doesn't get checked in `NPC.GetNPCInvasionGroup` for the martian madness, this is probably a vanilla bug. I didn't include it in the set, so I had to leave the manual check for it in the music code.
**EDIT:** This has been confirmed as a bug by CB, fixed on 1.4.5. This PR "backports" the fix for less maintenance when that update arrives.

5. The only use for `NoInvasionMusic` is for `387 (Tesla Turret)`, I made it a set anyway because mods may add similar things that are temporary but contribute to progress.
**EDIT after investigating 1.4.5 changes:** This was a redundant entry to the set and a wrong explanation: Tesla Turret has 0 invasion slots so it automatically doesn't count towards music, and **doesn't** contribute to progress.

6. I named the set responsible for frost legion `BelongsToInvasionFrostLegion` instead of matching `InvasionID.SnowLegion`. Could be changed to match, but then you also would need to change `BelongsToInvasionPirate` to `BelongsToInvasionPirateInvasion` to match `InvasionID.PirateInvasion`, which does look awkward, hence why I didn't match it either.

7. `InvasionSlotCount` has a default of `1` which technically makes things that aren't in any invasions act as if they would decrease the count. If it were `0`, you'd require alot more assignments in the set to match vanilla behavior. Since the set is only accessed if the NPC matches an invasion, it makes sense to keep it that way.

**Disclaimer:** I have purposefully not touched anything related to wave-based invasions (frost moon, OOA), their code is handled differently. I suggest it should be a separate PR if the need arises.

### Sample usage for the new feature
```cs
NPCID.Sets.BelongsToInvasionGoblinArmy[NPC.type] = true; // Make it count towards goblin army for music playback and invasion progress
NPCID.Sets.InvasionSlotCount[NPC.type] = 5; // Make it count as 5 enemies defeated for the invasion progress
NPCID.Sets.NoInvasionMusic[NPC.type] = true; // Rarely used, for example a temporary enemy that is alive after the invasion ends but does not have InvasionSlotCount 0
```

### ExampleMod updates
Ideally an invasion enemy could be added but I personally don't have the time (or sprites) for this. It would need to include the set usage here, aswell as spawning only if an invasion is ongoing, and code (either ModNPC.AIType or custom) to make it "flee" if the invasion is over.

### Porting Notes
* Use the `NPCID.Sets.BelongsToInvasionX` sets for non wave-based invasion enemies. You can remove custom music code (i.e. from a `ModSceneEffect`) that sets the invasion music, and any code that handles wave progress through `Main.invasionSize`. To customize by how much `Main.invasionSize` would be previously decremented by, use `NPCID.Sets.InvasionSlotCount`