### PR TITLE
Fixing one (1) comment in Example Mod

### DIFF
--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -41,7 +41,7 @@ namespace ExampleMod.Content
 			////////////////////////////////////////////////////////////////////////////////////
 
 			Recipe recipe = Recipe.Create(ModContent.ItemType<Items.ExampleItem>(), 999);
-			// This adds a requirement of 1 dirt block to the recipe.
+			// This adds a requirement of 1 stone block to the recipe.
 			recipe.AddIngredient(ItemID.StoneBlock);
 			// When you're done, call this to register the recipe.
 			recipe.Register();


### PR DESCRIPTION
### What are the changes to Example Mod
added #3122 (changed line 44 of ExampleRecipes.cs from "...dirt..." to "...stone...", reflecting the recipe it refers to)

### Do these changes need additional documentation
absolutely not, the change both affects documentation, and probably doesn't even affect any one individual