### PR TITLE
Fix Character Creation Window Hair Draw Ordering Bug

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIHairStyleButton.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIHairStyleButton.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UIHairStyleButton.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/UIHairStyleButton.cs
+@@ -25,6 +_,8 @@
+ 		Height = StyleDimension.FromPixels(44f);
+ 		_selectedBorderTexture = Main.Assets.Request<Texture2D>("Images/UI/CharCreation/CategoryPanelHighlight");
+ 		_hoveredBorderTexture = Main.Assets.Request<Texture2D>("Images/UI/CharCreation/CategoryPanelBorder");
++		// TML: Fix player dummies drawing under everything else.
++		UseImmediateMode = true;
+ 	}
+ 
+ 	public void SkipRenderingContent(int timeInFrames)


### PR DESCRIPTION
### What is the bug?
Fixes #3550.

### How did you fix the bug?
Enabled `UIElement.UseImmediateMode` in `UIHairStyleButton`. This follows usage from other UI elements that draw entities (`UICharacter`, `UIBestiaryEntryIcon`), as well as discussion in #collaborators about how players always draw using `SpriteSortMode.Immediate` (https://discord.com/channels/103110554649894912/445276626352209920/1092236989383839805).

### Are there alternatives to your fix?
This bug only happens on the `tModLoader` solution: The `Terraria` and `TerrariaNetCore` solutions do not have this bug, nor does vanilla *Terraria*. Thus, this bug was most likely caused by a tModLoader change.

It might be better to track down and fix the underlying issue, but I'm nowhere near well-versed enough in tModLoader's player drawing changes (or XNA/FNA graphics) to feel comfortable doing so.
The bug first appears after this commit: d85ea870730eb3178469e139a683236d18dec96b