### PR TITLE
Hovering Wings

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/WingStats.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/WingStats.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/DataStructures/WingStats.cs
 +++ src/tModLoader/Terraria/DataStructures/WingStats.cs
-@@ -1,15 +_,47 @@
+@@ -1,15 +_,48 @@
  namespace Terraria.DataStructures;
  
 +/// <summary>
@@ -27,18 +27,19 @@
  	public float AccRunAccelerationMult;
 +
 +	/// <summary>
-+	/// If <see langword="true"/>, then players can use these wings to hover.
-+	/// <br/> When hovering, <see cref="DownHoverSpeedOverride"/> and <see cref="DownHoverAccelerationMult"/> apply instead of <see cref="AccRunSpeedOverride"/> and <see cref="AccRunAccelerationMult"/>, respectively.
++	/// If <see langword="true"/>, then players will change speed when trying to hover with these wings (<see cref="Player.TryingToHoverDown"/>).
++	/// <br/> When attempting to hover, <see cref="DownHoverSpeedOverride"/> and <see cref="DownHoverAccelerationMult"/> apply instead of <see cref="AccRunSpeedOverride"/> and <see cref="AccRunAccelerationMult"/>, respectively.
++	/// <br/> <b>This does not allow the player to hover.</b> For that, use <see cref="ID.ArmorIDs.Wing.Sets.CanHover"/>.
 +	/// </summary>
  	public bool HasDownHoverStats;
 +
 +	/// <summary>
-+	/// Overrides the value of <see cref="AccRunSpeedOverride"/> if <see cref="HasDownHoverStats"/> is <see langword="true"/> and the player is hovering.
++	/// Overrides the value of <see cref="AccRunSpeedOverride"/> if <see cref="HasDownHoverStats"/> is <see langword="true"/> and the player is trying to hover (<see cref="Player.TryingToHoverDown"/>).
 +	/// </summary>
  	public float DownHoverSpeedOverride;
 +
 +	/// <summary>
-+	/// Overrides the value of <see cref="AccRunAccelerationMult"/> if <see cref="HasDownHoverStats"/> is <see langword="true"/> and the player is hovering.
++	/// Overrides the value of <see cref="AccRunAccelerationMult"/> if <see cref="HasDownHoverStats"/> is <see langword="true"/> and the player is trying to hover (<see cref="Player.TryingToHoverDown"/>).
 +	/// </summary>
  	public float DownHoverAccelerationMult;
  

--- a/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ArmorIDs.TML.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Terraria.ModLoader;
 
 namespace Terraria.ID;
 
@@ -131,6 +132,57 @@ partial class ArmorIDs
 			/// <br/> Defaults to <see langword="false"/>.
 			/// </summary>
 			public static bool[] OverridesLegs = Factory.CreateBoolSet(15);
+		}
+	}
+
+	partial class Wing
+	{
+		partial class Sets
+		{
+			public static SetFactory Factory = new(EquipLoader.nextEquip[EquipType.Wings]);
+
+			// Below three sets created based on snippets from 'Player.Update'.
+			/// <summary>
+			/// If <see langword="true"/> for a given <see cref="Wing"/>, then the player can hover while that wing is equipped (<see cref="Player.wingsLogic"/>).
+			/// <br/> Defaults to <see langword="false"/>.
+			/// </summary>
+			public static bool[] CanHover = Factory.CreateBoolSet(22, 28, 30, 31, 33, 35, 37, 45);
+
+			/// <summary>
+			/// If <see langword="true"/> for a given <see cref="Wing"/>, then that wing will be considered to be "in use" if the player is attempting to hover with it.
+			/// <br/> If <see langword="false"/>, then that wing will not be considered "in use".
+			/// <br/> If <see langword="null"/>, then that wing will be considered "in use" if it can hover (<see cref="CanHover"/>).
+			/// <br/> Defaults to <see langword="null"/>.
+			/// </summary>
+			public static bool?[] InUseWhenAttemptingHover = Factory.CreateCustomSet<bool?>(null,
+				29, true,
+				31, false,
+				32, true
+				);
+
+			/// <summary>
+			/// The multiplier on the player's Y velocity when entering a hovering state (<see cref="CanHover"/>).
+			/// <br/> Defaults to <c>0.9f</c>.
+			/// </summary>
+			public static float[] HoverSlowdown = Factory.CreateFloatSet(0.9f,
+				45, 0.8f,
+				37, 0.9f * 0.92f // For some reason, Betsy's Wings have their hovering slowdown applied twice.
+				);
+
+			// Created based on 'Player.WingMovement'.
+			/// <summary>
+			/// The <see cref="Player.wingTime"/> usage of a given <see cref="Wing"/> per frame while the player is attempting to hover (<see cref="Player.TryingToHoverDown"/>) and stationary (<c>!<see cref="Player.controlLeft"/> &amp;&amp; !<see cref="Player.controlRight"/></c>).
+			/// <br/> A pair of wings <b>does not need to be able to hover</b> to use this set.
+			/// <br/> Defaults to <c>1f</c>.
+			/// </summary>
+			public static float[] StationaryHoverUsage = Factory.CreateFloatSet(1f,
+				22, 0.5f,
+				28, 0.5f,
+				30, 0.5f,
+				31, 0.5f,
+				37, 0.5f,
+				45, 0.5f
+				);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3303,6 +3303,20 @@
  			velocity.Y -= num * gravDir;
  			if (gravDir == 1f) {
  				if (velocity.Y > 0f)
+@@ -17047,8 +_,13 @@
+ 					velocity.Y = jumpSpeed * num3;
+ 			}
+ 
++			/*
+ 			if ((wingsLogic == 22 || wingsLogic == 28 || wingsLogic == 30 || wingsLogic == 31 || wingsLogic == 37 || wingsLogic == 45) && TryingToHoverDown && !controlLeft && !controlRight)
+ 				wingTime -= 0.5f;
++			*/
++
++			if (wingsLogic > 0 && TryingToHoverDown && !controlLeft && !controlRight)
++				wingTime -= ArmorIDs.Wing.Sets.StationaryHoverUsage[wingsLogic];
+ 			else
+ 				wingTime -= 1f;
+ 		}
 @@ -17335,7 +_,7 @@
  					Position.Y = projectile.position.Y + (float)(projectile.height / 2) - (float)(height / 2);
  					RemoveAllGrapplingHooks();
@@ -3661,6 +3675,20 @@
  			HorizontalMovement();
  			bool flag20 = !mount.Active;
  			if (forcedGravity > 0) {
+@@ -20669,8 +_,13 @@
+ 			if (wingsLogic > 0 && controlJump && wingTime > 0f && jump == 0 && velocity.Y != 0f)
+ 				flag21 = true;
+ 
++			/*
+ 			if ((wingsLogic == 22 || wingsLogic == 28 || wingsLogic == 30 || wingsLogic == 32 || wingsLogic == 29 || wingsLogic == 33 || wingsLogic == 35 || wingsLogic == 37 || wingsLogic == 45) && controlJump && TryingToHoverDown && wingTime > 0f)
+ 				flag21 = true;
++			*/
++
++			if (wingsLogic > 0 && (ArmorIDs.Wing.Sets.InUseWhenAttemptingHover[wingsLogic] ?? ArmorIDs.Wing.Sets.CanHover[wingsLogic]) && controlJump && TryingToHoverDown && wingTime > 0f)
++				flag21 = true;
+ 
+ 			if (frozen || webbed || stoned) {
+ 				if (mount.Active)
 @@ -20684,12 +_,13 @@
  				CancelAllJumpVisualEffects();
  			}
@@ -3692,6 +3720,29 @@
  							if (wings == 4) {
  								rocketDelay2--;
  								if (rocketDelay2 <= 0) {
+@@ -21111,6 +_,8 @@
+ 		if (mount.Active)
+ 			wingFrame = 0;
+ 
++		// Patch context: Hovering wings.
++		/*
+ 		if ((wingsLogic == 22 || wingsLogic == 28 || wingsLogic == 30 || wingsLogic == 31 || wingsLogic == 33 || wingsLogic == 35 || wingsLogic == 37 || wingsLogic == 45) && TryingToHoverDown && controlJump && wingTime > 0f && !merman) {
+ 			float num71 = 0.9f;
+ 			if (wingsLogic == 45)
+@@ -21126,6 +_,13 @@
+ 			if (velocity.Y > -2f && velocity.Y < 1f)
+ 				velocity.Y = 1E-05f;
+ 		}
++		*/
++
++		if (wingsLogic > 0 && ArmorIDs.Wing.Sets.CanHover[wingsLogic] && TryingToHoverDown && controlJump && wingTime > 0f && !merman) {
++			velocity.Y *= ArmorIDs.Wing.Sets.HoverSlowdown[wingsLogic];
++			if (velocity.Y > -2f && velocity.Y < 1f)
++				velocity.Y = 1E-05f;
++		}
+ 
+ 		GrabItems(i);
+ 		LookForTileInteractions();
 @@ -21257,12 +_,16 @@
  
  				for (int num79 = 0; num79 < 200; num79++) {


### PR DESCRIPTION
### What is the new feature?
Resolves #3441.
Allows modders to mark that a certain `wingSlot` should be allowed to hover in place, similarly to vanilla's Hoverboard.
Also allows configuration of this hovering.
All added sets apply to both vanilla and modded wings.

### Why should this be part of tModLoader?
See #3441.

### Are there alternative designs?
See #3441.
This approach adds new sets because no vanilla wing changes its hovering stats at runtime. A hook similar to `VerticalWingSpeeds` could be used to allow changing stats at run time, but it seems excessive for this. Plus, changing `Item.wingSlot` or `Player.wingsLogic` would work just as well.

### Sample usage for the new feature
```cs
// In ModItem.SetStaticDefaults, with [AutoloadEquips(EquipType.Wing)]
// All values set to default value.
ArmorIDs.Wings.Sets.CanHover[Item.wingSlot] = true; // Allows hovering. Default: false
ArmorIDs.Wings.Sets.InUseWhenAttemptingHover[Item.wingSlot] = null; // Used by Solar, Stardust, and Nebula wings, included for compatibility. Default: null (vanilla decision)
ArmorIDs.Wings.Sets.HoverSlowdown[Item.wingSlot] = 0.8f; // How fast the player downs down to a stable hover. Default: 0.9f
ArmorIDs.Wings.Sets.StationaryHoverUsage[Item.wingSlot] = 0.25f; // How much wing time to use per frame when trying to hover. Default: 1f - Hoverboard: 0.5f
```

