### PR TITLE
Initial Code for Steam Cloud Save Migrations

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.cs.patch
@@ -83,7 +83,7 @@
 +
 +					autoMigrateButton.Append(migrateText);
 +					_playerList.Add(autoMigrateButton);
-+					var noPlayersMessage = new UIText(Language.GetTextValue("tModLoader.MigratePlayersMessage", Program.ReleaseFolder));
++					var noPlayersMessage = new UIText(Language.GetTextValue("tModLoader.MigratePlayersMessage", Program.Legacy143Folder));
 +					noPlayersMessage.Width.Set(0, 1);
 +					noPlayersMessage.Height.Set(300, 0);
 +					noPlayersMessage.MarginTop = 20f;
@@ -128,9 +128,9 @@
 +			var otherPaths = new (string path, string message, int stabilityLevel)[] {
 +				(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "Players"), "Click to copy \"{0}\" over from Terraria", 0),
 +				(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", "Players"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
-+				(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Players"), "Click to copy \"{0}\" over from 1.4.3-legacy", 1),
++				(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Players"), "Click to copy \"{0}\" over from 1.4.3-legacy", 1),
 +				(path: Path.Combine(Main.SavePath, "..", Program.StableFolder, "Players"), "Click to copy \"{0}\" over from Default (stable)", 2),
-+				//(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from 1.4-dev", 3),
++				(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from dev", 3),
 +			};
 +
 +			int currentStabilityLevel = BuildInfo.Purpose switch {

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.cs.patch
@@ -65,7 +65,7 @@
 +
 +					autoMigrateButton.Append(migrateText);
 +					_worldList.Add(autoMigrateButton);
-+					var noWorldsMessage = new UIText(Language.GetTextValue("tModLoader.MigrateWorldsMessage", Program.ReleaseFolder));
++					var noWorldsMessage = new UIText(Language.GetTextValue("tModLoader.MigrateWorldsMessage", Program.Legacy143Folder));
 +					noWorldsMessage.Width.Set(0, 1);
 +					noWorldsMessage.Height.Set(300, 0);
 +					noWorldsMessage.MarginTop = 20f;
@@ -110,9 +110,9 @@
 +			var otherPaths = new (string path, string message, int stabilityLevel)[] {
 +				(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "Worlds"), "Click to copy \"{0}\" over from Terraria", 0),
 +				(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", "Worlds"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
-+				(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4.3-legacy", 1),
++				(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Worlds"), "Click to copy \"{0}\" over from 1.4.3-legacy", 1),
 +				(path: Path.Combine(Main.SavePath, "..", Program.StableFolder, "Worlds"), "Click to copy \"{0}\" over from Default (stable)", 2),
-+				//(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from 1.4-dev", 3),
++				(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from dev", 3),
 +			};
 +
 +			int currentStabilityLevel = BuildInfo.Purpose switch {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -304,10 +304,10 @@
  		public static WorldFileData ActiveWorldFileData = new WorldFileData();
  		public static string WorldPath = Path.Combine(SavePath, "Worlds");
 -		public static string CloudWorldPath = "worlds";
-+		public static string CloudWorldPath = (Program.ReleaseFolder) + "/worlds";
++		public static string CloudWorldPath = (Program.Legacy143Folder) + "/worlds";
  		public static string PlayerPath = Path.Combine(SavePath, "Players");
 -		public static string CloudPlayerPath = "players";
-+		public static string CloudPlayerPath = (Program.ReleaseFolder) + "/players";
++		public static string CloudPlayerPath = (Program.Legacy143Folder) + "/players";
  		public static Preferences Configuration = new Preferences(SavePath + Path.DirectorySeparatorChar + "config.json");
  		public static Preferences InputProfiles = new Preferences(SavePath + Path.DirectorySeparatorChar + "input profiles.json");
  		public static KeyboardState inputText;

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -89,12 +89,13 @@ namespace Terraria
 		private static void Port143FilesFromStable(string savePath, bool isCloud) {
 			// Copy all current stable player files to 1.4.3-legacy during transition period. Skip ModSources & Workshop shared folders
 
-			string newFolderPath = Path.Combine(savePath, ReleaseFolder);
+			string newFolderPath = Path.Combine(savePath, Legacy143Folder);
 			string oldFolderPath = Path.Combine(savePath, StableFolder);
 
 			if (!Directory.Exists(newFolderPath) && Directory.Exists(oldFolderPath)) {
 				Utilities.FileUtilities.CopyFolder(oldFolderPath, newFolderPath, isCloud,
-					excludeFilter: new System.Text.RegularExpressions.Regex("(Workshop)|(ModSources)"));
+					// Exclude the ModSources folder that exists only on Stable, and exclude the temporary 'Workshop' folder created during first time Mod Publishing
+					excludeFilter: new System.Text.RegularExpressions.Regex("((/|\\)Workshop(/|\\))|((/|\\)ModSources(/|\\))"));
 			}
 		}
 
@@ -104,7 +105,7 @@ namespace Terraria
 			Port143FilesFromStable(savePath, isCloud);
 		}
 
-		public const string ReleaseFolder = "tModLoader-1.4.3";
+		public const string Legacy143Folder = "tModLoader-1.4.3";
 		public const string StableFolder = "tModLoader";
 		public const string DevFolder = "tModLoader-dev";
 		public const string PreviewFolder = "tModLoader-preview";
@@ -123,7 +124,7 @@ namespace Terraria
 			}
 
 			// 1.4.3 legacy custom statement - the legacy 143 folder
-			var fileFolder = ReleaseFolder;
+			var fileFolder = Legacy143Folder;
 
 			SavePath = Path.Combine(SavePath, fileFolder);
 

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -95,7 +95,7 @@ namespace Terraria
 			if (!Directory.Exists(newFolderPath) && Directory.Exists(oldFolderPath)) {
 				Utilities.FileUtilities.CopyFolder(oldFolderPath, newFolderPath, isCloud,
 					// Exclude the ModSources folder that exists only on Stable, and exclude the temporary 'Workshop' folder created during first time Mod Publishing
-					excludeFilter: new System.Text.RegularExpressions.Regex("((/|\\)Workshop(/|\\))|((/|\\)ModSources(/|\\))"));
+					excludeFilter: new System.Text.RegularExpressions.Regex("(Workshop|ModSources)($|/|\\))"));
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -87,24 +87,14 @@ namespace Terraria
 		}
 
 		private static void Port143FilesFromStable(string savePath, bool isCloud) {
-			// Copy all current stable player files to 1.4.3-legacy during transition period
+			// Copy all current stable player files to 1.4.3-legacy during transition period. Skip ModSources & Workshop shared folders
 
 			string newFolderPath = Path.Combine(savePath, ReleaseFolder);
 			string oldFolderPath = Path.Combine(savePath, StableFolder);
 
 			if (!Directory.Exists(newFolderPath) && Directory.Exists(oldFolderPath)) {
-				
-				Utilities.FileUtilities.CopyFolder(oldFolderPath, newFolderPath, isCloud);
-
-				// Windows doesn't like deleting things right after a copy call. It tends to lag behind.
-				// Especially if OneDrive is involved. This is not a good solution and will fail as is
-				string modSources = Path.Combine(newFolderPath, "ModSources");
-				if (Directory.Exists(modSources))
-					Directory.Delete(modSources, true);
-
-				string workshopTemp = Path.Combine(newFolderPath, "Workshop");
-				if (Directory.Exists(workshopTemp))
-					Directory.Delete(workshopTemp, true);
+				Utilities.FileUtilities.CopyFolder(oldFolderPath, newFolderPath, isCloud,
+					excludeFilter: new System.Text.RegularExpressions.Regex("(Workshop)|(ModSources)"));
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
@@ -4,10 +4,6 @@ namespace Terraria.Social.Steam
 {
 	public partial class CoreSocialModule : ISocialModule
 	{
-		public const string WindowsSteamCloudPath = "C:\\Program Files (x86)\\Steam\\userdata";
-		public const string LinuxSteamCloudPath = "~/.local/share/Steam/userdata";
-		public const string MacSteamCloudPath = "~/Library/Application Support/Steam/userdata";
-
 		private static void PortFilesToCurrentStructure() {
 			// Note that if we want Steam to actually acknowledge the changes, we have to use the API calls for IREmoteStorage (the isCloud flag)
 			Program.PortFilesMaster(GetCloudSaveLocation(), isCloud: true);
@@ -19,7 +15,7 @@ namespace Terraria.Social.Steam
 
 			// current steamCloudFolder looks like: C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\1281930\\local
 			// So we have to do some path manipulation to get to C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\\\105600\\local
-			return Path.Combine(Directory.GetParent(Directory.GetParent(steamCloudFolder).ToString()).ToString(), "105600", "remote");
+			return Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(steamCloudFolder)), "105600", "remote");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
@@ -1,0 +1,25 @@
+using System.IO;
+
+namespace Terraria.Social.Steam
+{
+	public partial class CoreSocialModule : ISocialModule
+	{
+		public const string WindowsSteamCloudPath = "C:\\Program Files (x86)\\Steam\\userdata";
+		public const string LinuxSteamCloudPath = "~/.local/share/Steam/userdata";
+		public const string MacSteamCloudPath = "~/Library/Application Support/Steam/userdata";
+
+		private static void PortFilesToCurrentStructure() {
+			// Note that if we want Steam to actually acknowledge the changes, we have to use the API calls for IREmoteStorage (the isCloud flag)
+			Program.PortFilesMaster(GetCloudSaveLocation(), isCloud: true);
+		}
+
+		internal static string GetCloudSaveLocation() {
+			// 512 is Windows Path max length
+			Steamworks.SteamUser.GetUserDataFolder(out string steamCloudFolder, 512);
+
+			// current steamCloudFolder looks like: C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\1281930\\local
+			// So we have to do some path manipulation to get to C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\\\105600\\local
+			return Path.Combine(Directory.GetParent(Directory.GetParent(steamCloudFolder).ToString()).ToString(), "105600", "remote");
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.cs.patch
@@ -12,7 +12,8 @@
  
  namespace Terraria.Social.Steam
  {
- 	public class CoreSocialModule : ISocialModule
+-	public class CoreSocialModule : ISocialModule
++	public partial class CoreSocialModule : ISocialModule
  	{
  		private static CoreSocialModule _instance;
 -		public const int SteamAppId = 105600;
@@ -20,7 +21,7 @@
  		private bool IsSteamValid;
  		private object _steamTickLock = new object();
  		private object _steamCallbackLock = new object();
-@@ -24,14 +_,16 @@
+@@ -24,15 +_,18 @@
  
  		public void Initialize() {
  			_instance = this;
@@ -37,5 +38,7 @@
 -				Environment.Exit(1);
 +				ErrorReporting.FatalExit(Language.GetTextValue("Error.LaunchFromSteam"));
  			}
++			PortFilesToCurrentStructure();
  
  			IsSteamValid = true;
+ 			Thread thread = new Thread(SteamCallbackLoop);

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -17,3 +17,46 @@
  		}
  
  		public static string GetFullPath(string path, bool cloud) {
+@@ -38,10 +_,21 @@
+ 		}
+ 
+ 		public static void Copy(string source, string destination, bool cloud, bool overwrite = true) {
+-			if (!cloud)
++			if (!cloud) {
+ 				File.Copy(source, destination, overwrite);
+-			else if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination)))
+-				SocialAPI.Cloud.Write(destination, SocialAPI.Cloud.Read(source));
++				return;
++			}
++
++			// Sanitize the paths for Steam calls
++			string cloudPath = Social.Steam.CoreSocialModule.GetCloudSaveLocation();
++			destination = destination.Replace(cloudPath, "");
++			source = source.Replace(cloudPath, "");
++
++			if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination))) {
++				var bytes = SocialAPI.Cloud.Read(source);
++				SocialAPI.Cloud.Write(destination, bytes);
++			}
++				
+ 		}
+ 
+ 		public static void Move(string source, string destination, bool cloud, bool overwrite = true, bool forceDeleteSourceFile = false) {
+@@ -154,7 +_,7 @@
+ 			return match.Groups["path"].Value;
+ 		}
+ 
+-		public static void CopyFolder(string sourcePath, string destinationPath) {
++		public static void CopyFolder(string sourcePath, string destinationPath, bool isCloud = false) {
+ 			Directory.CreateDirectory(destinationPath);
+ 			string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
+ 			for (int i = 0; i < directories.Length; i++) {
+@@ -163,7 +_,7 @@
+ 
+ 			directories = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
+ 			foreach (string obj in directories) {
+-				File.Copy(obj, obj.Replace(sourcePath, destinationPath), overwrite: true);
++				Copy(obj, obj.Replace(sourcePath, destinationPath), isCloud, overwrite: true);
+ 			}
+ 		}
+ 

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -32,7 +32,7 @@
 +			// Sanitize the paths for Steam calls
 +			string cloudPath = Social.Steam.CoreSocialModule.GetCloudSaveLocation();
 +			destination = ConvertToRelativePath(cloudPath, destination);
-+			destination = ConvertToRelativePath(cloudPath, source);
++			source = ConvertToRelativePath(cloudPath, source);
 +
 +			if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination))) {
 +				var bytes = SocialAPI.Cloud.Read(source);
@@ -51,8 +51,8 @@
  			Directory.CreateDirectory(destinationPath);
  			string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
  			for (int i = 0; i < directories.Length; i++) {
-+				string testStr = ConvertToRelativePath(sourcePath, directories[i]);
-+				if (excludeFilter != null && excludeFilter.IsMatch(testStr))
++				string relativePath = ConvertToRelativePath(sourcePath, directories[i]);
++				if (excludeFilter != null && excludeFilter.IsMatch(relativePath))
 +					continue;
 +
  				Directory.CreateDirectory(directories[i].Replace(sourcePath, destinationPath));
@@ -60,8 +60,8 @@
  
  			directories = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
  			foreach (string obj in directories) {
-+				string testStr = ConvertToRelativePath(sourcePath, obj);
-+				if (excludeFilter != null && excludeFilter.IsMatch(testStr))
++				string relativePath = ConvertToRelativePath(sourcePath, obj);
++				if (excludeFilter != null && excludeFilter.IsMatch(relativePath))
 +					continue;
 +
 -				File.Copy(obj, obj.Replace(sourcePath, destinationPath), overwrite: true);

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -42,19 +42,26 @@
  		}
  
  		public static void Move(string source, string destination, bool cloud, bool overwrite = true, bool forceDeleteSourceFile = false) {
-@@ -154,7 +_,7 @@
+@@ -154,16 +_,22 @@
  			return match.Groups["path"].Value;
  		}
  
 -		public static void CopyFolder(string sourcePath, string destinationPath) {
-+		public static void CopyFolder(string sourcePath, string destinationPath, bool isCloud = false) {
++		public static void CopyFolder(string sourcePath, string destinationPath, bool isCloud = false, Regex excludeFilter = null) {
  			Directory.CreateDirectory(destinationPath);
  			string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
  			for (int i = 0; i < directories.Length; i++) {
-@@ -163,7 +_,7 @@
++				if (excludeFilter != null && excludeFilter.IsMatch(directories[i]))
++					continue;
++
+ 				Directory.CreateDirectory(directories[i].Replace(sourcePath, destinationPath));
+ 			}
  
  			directories = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
  			foreach (string obj in directories) {
++				if (excludeFilter != null && excludeFilter.IsMatch(obj))
++					continue;
++
 -				File.Copy(obj, obj.Replace(sourcePath, destinationPath), overwrite: true);
 +				Copy(obj, obj.Replace(sourcePath, destinationPath), isCloud, overwrite: true);
  			}

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -69,7 +69,7 @@
  			}
  		}
  
-@@ -176,6 +_,16 @@
+@@ -176,6 +_,21 @@
  			finally {
  				Thread.CurrentThread.IsBackground = isBackground;
  			}
@@ -82,7 +82,12 @@
 +		///		Thus returns 'Help Me I'm Hungry.txt'
 +		/// </summary>
 +		public static string ConvertToRelativePath(string basePath, string fullPath) {
-+			return fullPath.Replace(basePath + Path.DirectorySeparatorChar, "");
++			if (!fullPath.StartsWith(basePath)) {
++				ModLoader.Logging.tML.Debug($"string {fullPath} does not contain string {basePath}. Is this correct?");
++				return fullPath;
++			}
++
++			return fullPath.Substring(basePath.Length + 1);
  		}
  	}
  }

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -31,8 +31,8 @@
 +
 +			// Sanitize the paths for Steam calls
 +			string cloudPath = Social.Steam.CoreSocialModule.GetCloudSaveLocation();
-+			destination = destination.Replace(cloudPath, "");
-+			source = source.Replace(cloudPath, "");
++			destination = ConvertToRelativePath(cloudPath, destination);
++			destination = ConvertToRelativePath(cloudPath, source);
 +
 +			if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination))) {
 +				var bytes = SocialAPI.Cloud.Read(source);
@@ -42,7 +42,7 @@
  		}
  
  		public static void Move(string source, string destination, bool cloud, bool overwrite = true, bool forceDeleteSourceFile = false) {
-@@ -154,16 +_,22 @@
+@@ -154,16 +_,24 @@
  			return match.Groups["path"].Value;
  		}
  
@@ -51,7 +51,8 @@
  			Directory.CreateDirectory(destinationPath);
  			string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
  			for (int i = 0; i < directories.Length; i++) {
-+				if (excludeFilter != null && excludeFilter.IsMatch(directories[i]))
++				string testStr = ConvertToRelativePath(sourcePath, directories[i]);
++				if (excludeFilter != null && excludeFilter.IsMatch(testStr))
 +					continue;
 +
  				Directory.CreateDirectory(directories[i].Replace(sourcePath, destinationPath));
@@ -59,7 +60,8 @@
  
  			directories = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
  			foreach (string obj in directories) {
-+				if (excludeFilter != null && excludeFilter.IsMatch(obj))
++				string testStr = ConvertToRelativePath(sourcePath, obj);
++				if (excludeFilter != null && excludeFilter.IsMatch(testStr))
 +					continue;
 +
 -				File.Copy(obj, obj.Replace(sourcePath, destinationPath), overwrite: true);
@@ -67,3 +69,20 @@
  			}
  		}
  
+@@ -176,6 +_,16 @@
+ 			finally {
+ 				Thread.CurrentThread.IsBackground = isBackground;
+ 			}
++		}
++
++		/// <summary>
++		/// Converts the full 'path' to remove the base path component.
++		/// Example: C://My Documents//Help Me I'm Hungry.txt is full 'path'
++		///		basePath is C://My Documents
++		///		Thus returns 'Help Me I'm Hungry.txt'
++		/// </summary>
++		public static string ConvertToRelativePath(string basePath, string fullPath) {
++			return fullPath.Replace(basePath + Path.DirectorySeparatorChar, "");
+ 		}
+ 	}
+ }


### PR DESCRIPTION
In order to support the transition to 1.4.3-legacy branch and having both 1.4.4 and 1.3 and 1.4.3 available, we have to implement some changes in save data structures.

This takes the changes made previously to have a 1.4.3-legacy folder created, and adds the equivalent code for Steam Cloud.

Outstanding:

- [x] Cleanup Port143FilesFromStable to not crash due to file inaccessibility by changing it's design.
- [x] DEtermine if better to just write all new code specifically for steam cloud saves instead of trying to reuse code haphazardly