### PR TITLE
Fix `ModTree.Shake` hook not working

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
@@ -200,7 +200,8 @@ public abstract class ModTree : ITree
 	}
 
 	/// <summary>
-	/// Executed on tree shake, return false to skip vanilla tree shake drops
+	/// Executed on tree shake, return false to skip vanilla tree shake drops.<br/>
+	/// The x and y coordinates correspond to the top of the tree, where items usually spawn.
 	/// </summary>
 	/// <returns></returns>
 	public virtual bool Shake(int x, int y, ref bool createLeaves)

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2146,7 +2146,7 @@
  
 +		bool flag = false;
 +
-+		if (!PlantLoader.ShakeTree(x, y, Main.tile[x, y].type, ref flag)) { } else
++		if (!PlantLoader.ShakeTree(x, y, Main.tile[x, num].type, ref flag)) { } else
  		if (Main.getGoodWorld && genRand.Next(17) == 0) {
  			Projectile.NewProjectile(GetProjectileSource_ShakeTree(x, y), x * 16, y * 16, (float)Main.rand.Next(-100, 101) * 0.002f, 0f, 28, 0, 0f, Main.myPlayer, 16f, 16f);
  		}


### PR DESCRIPTION
### What is the bug?
`ModTree.Shake` wouldn't work at all.

### How did you fix the bug?
Call it with the correct y coordinate:
* At the time of the Shake invocation, `y` is the top-most tree tile, which means its type is `TileID.Trees`, which will return `null` in `PlantLoader.GetTree`. Using `num`, which is a cached `y` before vanilla "scans up" to the tree gives the correct floor tile which will retreive the correct `ModTree`.

### Are there alternatives to your fix?
No
