### PR TITLE
Add `IsTileBiomeSightable` hook to `ModTile`

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -31,7 +31,9 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		// Example of how to enable the Biome Sight buff to highlight this tile
-		public override bool IsTileBiomeSightable(int i, int j) => true;
+		public override bool IsTileBiomeSightable(int i, int j) {
+			return true;
+		}
 	}
 
 	public class ExampleOreSystem : ModSystem

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -30,7 +30,7 @@ namespace ExampleMod.Content.Tiles
 			// MinPick = 200;
 		}
 
-		// Example of how to enable the Biome Sight buff to highlight this tile
+		// Example of how to enable the Biome Sight buff to highlight this tile. Biome Sight is technically intended to show "infected" tiles, so this example is purely for demonstration purposes.
 		public override bool IsTileBiomeSightable(int i, int j, ref Color sightColor) {
 			sightColor = Color.Blue;
 			return true;

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -30,6 +30,7 @@ namespace ExampleMod.Content.Tiles
 			// MinPick = 200;
 		}
 
+		// Example of how to enable the Biome Sight buff to highlight this tile
 		public override bool IsTileBiomeSightable(int i, int j) => true;
 	}
 

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -29,6 +29,8 @@ namespace ExampleMod.Content.Tiles
 			// MineResist = 4f;
 			// MinPick = 200;
 		}
+
+		public override bool IsTileBiomeSightable(int i, int j) => true;
 	}
 
 	public class ExampleOreSystem : ModSystem

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -31,7 +31,8 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		// Example of how to enable the Biome Sight buff to highlight this tile
-		public override bool IsTileBiomeSightable(int i, int j) {
+		public override bool IsTileBiomeSightable(int i, int j, ref Color sightColor) {
+			sightColor = Color.Blue;
 			return true;
 		}
 	}

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -121,6 +121,15 @@
  			if (drawData.tileLight.R < 200)
  				drawData.tileLight.R = 200;
  
+@@ -665,7 +_,7 @@
+ 
+ 		if (_localPlayer.biomeSight) {
+ 			Color sightColor = Color.White;
+-			if (Main.IsTileBiomeSightable(drawData.typeCache, drawData.tileFrameX, drawData.tileFrameY, ref sightColor)) {
++			if (Main.IsTileBiomeSightable(tileX, tileY, drawData.typeCache, drawData.tileFrameX, drawData.tileFrameY, ref sightColor)) {
+ 				if (drawData.tileLight.R < sightColor.R)
+ 					drawData.tileLight.R = sightColor.R;
+ 
 @@ -715,6 +_,7 @@
  
  		Rectangle rectangle = new Rectangle(drawData.tileFrameX + drawData.addFrX, drawData.tileFrameY + drawData.addFrY, drawData.tileWidth, drawData.tileHeight - drawData.halfBrickHeight);
@@ -529,6 +538,15 @@
  			if (tileLight.R < 200)
  				tileLight.R = 200;
  
+@@ -6432,7 +_,7 @@
+ 			return;
+ 
+ 		Color sightColor = Color.White;
+-		if (Main.IsTileBiomeSightable(typeCache, tileFrameX, tileFrameY, ref sightColor)) {
++		if (Main.IsTileBiomeSightable(i, j, typeCache, tileFrameX, tileFrameY, ref sightColor)) {
+ 			if (tileLight.R < sightColor.R)
+ 				tileLight.R = sightColor.R;
+ 
 @@ -6453,7 +_,17 @@
  		}
  	}
@@ -568,3 +586,12 @@
  	{
  		_windGrid.GetWindTime(i, j, pushAnimationTimeTotal, out var windTimeLeft, out var directionX, out var _);
  		float num = (float)windTimeLeft / (float)pushAnimationTimeTotal;
+@@ -6903,7 +_,7 @@
+ 			float num6 = (float)num2 * num3 * windCycle + num4;
+ 			if (_localPlayer.biomeSight) {
+ 				Color sightColor = Color.White;
+-				if (Main.IsTileBiomeSightable(type, tileFrameX, tileFrameY, ref sightColor)) {
++				if (Main.IsTileBiomeSightable(x, i, type, tileFrameX, tileFrameY, ref sightColor)) {
+ 					if (color.R < sightColor.R)
+ 						color.R = sightColor.R;
+ 

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -71,6 +71,15 @@ public partial class Main
 		return IsTileSpelunkable(tileX, tileY, tile.type, tile.frameX, tile.frameY);
 	}
 
+	/// <summary>
+	/// Checks if a tile at the given coordinates counts towards tile coloring from the Biome Sight buff.
+	/// </summary>
+	public static bool IsTileBiomeSightable(int tileX, int tileY, ref Color sightColor)
+	{
+		Tile tile = Main.tile[tileX, tileY];
+		return IsTileBiomeSightable(tileX, tileY, tile.type, tile.frameX, tile.frameY, ref sightColor);
+	}
+
 	public static void InfoDisplayPageHandler(int startX, ref string mouseText, out int startingDisplay, out int endingDisplay)
 	{
 		startingDisplay = 0;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3169,6 +3169,38 @@
  		if (tileSpelunker[typeCache])
  			return true;
  
+@@ -17293,19 +_,27 @@
+ 		return false;
+ 	}
+ 
+-	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
++	//TML: Added x/y to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
++	internal static bool IsTileBiomeSightable(int tileX, int tileY, Tile t, ref Microsoft.Xna.Framework.Color sightColor) =>
++		IsTileBiomeSightable(tileX, tileY, t.type, t.frameX, t.frameY, ref sightColor);
++
++	internal static bool IsTileBiomeSightable(int tileX, int tileY, ushort typeCache, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
+ 	{
++		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, typeCache);
++		if (modded.HasValue)
++			return modded.Value;
++
+-		if (TileID.Sets.CorruptBiomeSight[type] || (remixWorld && type == 474)) {
++		if (TileID.Sets.CorruptBiomeSight[typeCache] || (remixWorld && typeCache == 474)) {
+ 			sightColor = new Microsoft.Xna.Framework.Color(200, 100, 240);
+ 			return true;
+ 		}
+ 
+-		if (TileID.Sets.CrimsonBiomeSight[type] || (remixWorld && type == 195)) {
++		if (TileID.Sets.CrimsonBiomeSight[typeCache] || (remixWorld && typeCache == 195)) {
+ 			sightColor = new Microsoft.Xna.Framework.Color(255, 100, 100);
+ 			return true;
+ 		}
+ 
+-		if (TileID.Sets.HallowBiomeSight[type]) {
++		if (TileID.Sets.HallowBiomeSight[typeCache]) {
+ 			sightColor = new Microsoft.Xna.Framework.Color(255, 160, 240);
+ 			return true;
+ 		}
 @@ -17325,19 +_,25 @@
  				continue;
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3169,38 +3169,24 @@
  		if (tileSpelunker[typeCache])
  			return true;
  
-@@ -17293,19 +_,27 @@
+@@ -17293,8 +_,16 @@
  		return false;
  	}
  
--	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
 +	// TML: Added x/y to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
 +	internal static bool IsTileBiomeSightable(int tileX, int tileY, Tile t, ref Microsoft.Xna.Framework.Color sightColor) =>
 +		IsTileBiomeSightable(tileX, tileY, t.type, t.frameX, t.frameY, ref sightColor);
 +
-+	internal static bool IsTileBiomeSightable(int tileX, int tileY, ushort typeCache, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
+-	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
++	internal static bool IsTileBiomeSightable(int tileX, int tileY, ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
  	{
-+		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, typeCache);
++		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, type);
 +		if (modded.HasValue)
 +			return modded.Value;
 +
--		if (TileID.Sets.CorruptBiomeSight[type] || (remixWorld && type == 474)) {
-+		if (TileID.Sets.CorruptBiomeSight[typeCache] || (remixWorld && typeCache == 474)) {
+ 		if (TileID.Sets.CorruptBiomeSight[type] || (remixWorld && type == 474)) {
  			sightColor = new Microsoft.Xna.Framework.Color(200, 100, 240);
  			return true;
- 		}
- 
--		if (TileID.Sets.CrimsonBiomeSight[type] || (remixWorld && type == 195)) {
-+		if (TileID.Sets.CrimsonBiomeSight[typeCache] || (remixWorld && typeCache == 195)) {
- 			sightColor = new Microsoft.Xna.Framework.Color(255, 100, 100);
- 			return true;
- 		}
- 
--		if (TileID.Sets.HallowBiomeSight[type]) {
-+		if (TileID.Sets.HallowBiomeSight[typeCache]) {
- 			sightColor = new Microsoft.Xna.Framework.Color(255, 160, 240);
- 			return true;
- 		}
 @@ -17325,19 +_,25 @@
  				continue;
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3180,7 +3180,7 @@
 -	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
 +	internal static bool IsTileBiomeSightable(int tileX, int tileY, ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
  	{
-+		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, type);
++		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, type, ref sightColor);
 +		if (modded.HasValue)
 +			return modded.Value;
 +

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3174,7 +3174,7 @@
  	}
  
 -	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
-+	//TML: Added x/y to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
++	// TML: Added x/y to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
 +	internal static bool IsTileBiomeSightable(int tileX, int tileY, Tile t, ref Microsoft.Xna.Framework.Color sightColor) =>
 +		IsTileBiomeSightable(tileX, tileY, t.type, t.frameX, t.frameY, ref sightColor);
 +

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -112,6 +112,18 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
+	/// Allows you to customize whether this tile can glow white while having the Biome Sight buff.
+	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions. Returns null by default.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	/// <param name="type">The tile type</param>
+	public virtual bool? IsTileBiomeSightable(int i, int j, int type)
+	{
+		return null;
+	}
+
+	/// <summary>
 	/// Allows you to customize whether this tile can glow yellow while having the Spelunker buff, and is also detected by various pets.
 	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions. Returns null by default.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -118,7 +118,7 @@ public abstract class GlobalTile : GlobalBlockType
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
-	/// <param name="sightColor">The color this tile should glow with.</param>
+	/// <param name="sightColor">The color this tile should glow with, which defaults to <see cref="Color.White"/>.</param>
 	public virtual bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
 	{
 		return null;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -118,6 +118,7 @@ public abstract class GlobalTile : GlobalBlockType
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
+	/// <param name="sightColor">The color this tile should glow with.</param>
 	public virtual bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
 	{
 		return null;

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -112,8 +112,9 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// Allows you to customize whether this tile can glow white while having the Biome Sight buff.
-	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions. Returns null by default.
+	/// Allows you to customize whether this tile glows <paramref name="sightColor"/> while the local player has the Biome Sight buff (https://terraria.wiki.gg/wiki/Biome_Sight_Potion).
+	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions and colors. Returns null by default. 
+	/// <br/>This is only called on the local client.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -112,7 +112,7 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// Allows you to customize whether this tile glows <paramref name="sightColor"/> while the local player has the Biome Sight buff (https://terraria.wiki.gg/wiki/Biome_Sight_Potion).
+	/// Allows you to customize whether this tile glows <paramref name="sightColor"/> while the local player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
 	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions and colors. Returns null by default. 
 	/// <br/>This is only called on the local client.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -118,7 +118,7 @@ public abstract class GlobalTile : GlobalBlockType
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
-	public virtual bool? IsTileBiomeSightable(int i, int j, int type)
+	public virtual bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
 	{
 		return null;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -307,7 +307,7 @@ public abstract class ModTile : ModBlockType
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
-	/// <param name="sightColor">The color this tile should glow with.</param>
+	/// <param name="sightColor">The color this tile should glow with, which defaults to <see cref="Color.White"/>.</param>
 	public virtual bool IsTileBiomeSightable(int i, int j, ref Color sightColor)
 	{
 		return false;

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -302,7 +302,7 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Allows you to determine whether this tile glows <paramref name="sightColor"/> while the local player has the Biome Sight buff (https://terraria.wiki.gg/wiki/Biome_Sight_Potion).
+	/// Allows you to determine whether this tile glows <paramref name="sightColor"/> while the local player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
 	/// <br/>Return true and assign to <paramref name="sightColor"/> to allow this tile to glow.
 	/// <br/>This is only called on the local client.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -302,6 +302,17 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Allows you to determine whether this tile glows white when the given player has the Biome Sight buff.
+	/// <br/>This is only called on the local client.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	public virtual bool IsTileBiomeSightable(int i, int j)
+	{
+		return false;
+	}
+
+	/// <summary>
 	/// Allows you to customize whether this tile can glow yellow while having the Spelunker buff, and is also detected by various pets.
 	/// <br/>This is only called if Main.tileSpelunker[type] is false.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -302,7 +302,8 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Allows you to determine whether this tile glows "sightColor" when the given player has the Biome Sight buff.
+	/// Allows you to determine whether this tile glows <paramref name="sightColor"/> while the local player has the Biome Sight buff (https://terraria.wiki.gg/wiki/Biome_Sight_Potion).
+	/// <br/>Return true and assign to <paramref name="sightColor"/> to allow this tile to glow.
 	/// <br/>This is only called on the local client.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -302,12 +302,13 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Allows you to determine whether this tile glows white when the given player has the Biome Sight buff.
+	/// Allows you to determine whether this tile glows "sightColor" when the given player has the Biome Sight buff.
 	/// <br/>This is only called on the local client.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
-	public virtual bool IsTileBiomeSightable(int i, int j)
+	/// <param name="sightColor">The color this tile should glow with.</param>
+	public virtual bool IsTileBiomeSightable(int i, int j, ref Color sightColor)
 	{
 		return false;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -67,7 +67,8 @@ public static class TileLoader
 	private delegate void DelegateModifyLight(int i, int j, int type, ref float r, ref float g, ref float b);
 	private static DelegateModifyLight[] HookModifyLight;
 	private static Func<int, int, int, Player, bool?>[] HookIsTileDangerous;
-	private static Func<int, int, int, bool?>[] HookIsTileBiomeSightable;
+	private delegate bool? DelegateIsTileBiomeSightable(int i, int j, int type, ref Color sightColor);
+	private static DelegateIsTileBiomeSightable[] HookIsTileBiomeSightable;
 	private static Func<int, int, int, bool?>[] HookIsTileSpelunkable;
 	private delegate void DelegateSetSpriteEffects(int i, int j, int type, ref SpriteEffects spriteEffects);
 	private static DelegateSetSpriteEffects[] HookSetSpriteEffects;
@@ -705,18 +706,18 @@ public static class TileLoader
 		return retVal;
 	}
 
-	public static bool? IsTileBiomeSightable(int i, int j, int type)
+	public static bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
 	{
 		bool? retVal = null;
 
 		ModTile modTile = GetTile(type);
 
-		if (modTile != null && modTile.IsTileBiomeSightable(i, j)) {
+		if (modTile != null && modTile.IsTileBiomeSightable(i, j, ref sightColor)) {
 			retVal = true;
 		}
 
 		foreach (var hook in HookIsTileBiomeSightable) {
-			bool? globalRetVal = hook(i, j, type);
+			bool? globalRetVal = hook(i, j, type, ref sightColor);
 			if (globalRetVal.HasValue) {
 				if (globalRetVal.Value) {
 					retVal = true;

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -67,6 +67,7 @@ public static class TileLoader
 	private delegate void DelegateModifyLight(int i, int j, int type, ref float r, ref float g, ref float b);
 	private static DelegateModifyLight[] HookModifyLight;
 	private static Func<int, int, int, Player, bool?>[] HookIsTileDangerous;
+	private static Func<int, int, int, bool?>[] HookIsTileBiomeSightable;
 	private static Func<int, int, int, bool?>[] HookIsTileSpelunkable;
 	private delegate void DelegateSetSpriteEffects(int i, int j, int type, ref SpriteEffects spriteEffects);
 	private static DelegateSetSpriteEffects[] HookSetSpriteEffects;
@@ -219,6 +220,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook(ref HookNearbyEffects, globalTiles, g => g.NearbyEffects);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateModifyLight>(ref HookModifyLight, globalTiles, g => g.ModifyLight);
 		ModLoader.BuildGlobalHook(ref HookIsTileDangerous, globalTiles, g => g.IsTileDangerous);
+		ModLoader.BuildGlobalHook(ref HookIsTileBiomeSightable, globalTiles, g => g.IsTileBiomeSightable);
 		ModLoader.BuildGlobalHook(ref HookIsTileSpelunkable, globalTiles, g => g.IsTileSpelunkable);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateSetSpriteEffects>(ref HookSetSpriteEffects, globalTiles, g => g.SetSpriteEffects);
 		ModLoader.BuildGlobalHook(ref HookAnimateTile, globalTiles, g => g.AnimateTile);
@@ -690,6 +692,31 @@ public static class TileLoader
 
 		foreach (var hook in HookIsTileDangerous) {
 			bool? globalRetVal = hook(i, j, type, player);
+			if (globalRetVal.HasValue) {
+				if (globalRetVal.Value) {
+					retVal = true;
+				}
+				else {
+					return false;
+				}
+			}
+		}
+
+		return retVal;
+	}
+
+	public static bool? IsTileBiomeSightable(int i, int j, int type)
+	{
+		bool? retVal = null;
+
+		ModTile modTile = GetTile(type);
+
+		if (modTile != null && modTile.IsTileBiomeSightable(i, j)) {
+			retVal = true;
+		}
+
+		foreach (var hook in HookIsTileBiomeSightable) {
+			bool? globalRetVal = hook(i, j, type);
 			if (globalRetVal.HasValue) {
 				if (globalRetVal.Value) {
 					retVal = true;


### PR DESCRIPTION
### What is the new feature?
A new hook for mod tiles called `IsTileBiomeSightable` that allows for the tile to be picked up by the biome sight potion and its buff.

Reported here: #3507

The PR got larger than I expected, as these hooks seem to touch quite a few files.
I looked at `IsTileSpelunkable` and `IsTileDangerous` for examples.

### Why should this be part of tModLoader?
This adds mod support so modded tiles can be highlighted from the biome sight potion.

### Are there alternative designs?
Another proposed suggestion was to use a `TileID.Sets` property, but a hook seemed preferable (more flexible in use)

### Sample usage for the new feature

In a `ModTile`, override the `IsTileBiomeSightable` hook:

```csharp
public override bool IsTileBiomeSightable(int i, int j) => true;
```

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->

I made the `ExampleOre` in `ExampleMod` biome sightable
