### PR TITLE
Modded toilet poo support

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleToilet.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleToilet.cs
@@ -81,6 +81,9 @@ namespace ExampleMod.Content.Tiles.Furniture
 				info.AnchorTilePosition.Y++; // Here, since our chair is only 2 tiles high, we can just check if the tile is the top-most one, then move it 1 down
 			}
 
+			// Finally, since this is a toilet, it should generate Poo while any tier of Well Fed is active
+			info.ExtraInfo.IsAToilet = true;
+
 			// Here we add a custom fun effect to this tile that vanilla toilets do not have. This shows how you can type cast the restingEntity to Player and use visualOffset as well.
 			if (info.RestingEntity is Player player && player.HasBuff(BuffID.Stinky)) {
 				info.VisualOffset = Main.rand.NextVector2Circular(2, 2);

--- a/patches/tModLoader/Terraria/DataStructures/TileRestingInfo.cs
+++ b/patches/tModLoader/Terraria/DataStructures/TileRestingInfo.cs
@@ -43,7 +43,7 @@ public struct TileRestingInfo
 	/// </summary>
 	public ExtraSeatInfo ExtraInfo;
 
-	public TileRestingInfo(Entity restingEntity, Point anchorTilePosition, Vector2 visualOffset, int targetDirection, int directionOffset, Vector2 finalOffset, ExtraSeatInfo extraInfo)
+	public TileRestingInfo(Entity restingEntity, Point anchorTilePosition, Vector2 visualOffset, int targetDirection, int directionOffset = 0, Vector2 finalOffset = default, ExtraSeatInfo extraInfo = default)
 	{
 		RestingEntity = restingEntity;
 		AnchorTilePosition = anchorTilePosition;
@@ -52,17 +52,6 @@ public struct TileRestingInfo
 		DirectionOffset = directionOffset;
 		FinalOffset = finalOffset;
 		ExtraInfo = extraInfo;
-	}
-
-	public TileRestingInfo(Entity restingEntity, Point anchorTilePosition, Vector2 visualOffset, int targetDirection, int directionOffset = 0, Vector2 finalOffset = default)
-	{
-		RestingEntity = restingEntity;
-		AnchorTilePosition = anchorTilePosition;
-		VisualOffset = visualOffset;
-		TargetDirection = targetDirection;
-		DirectionOffset = directionOffset;
-		FinalOffset = finalOffset;
-		ExtraInfo = default;
 	}
 
 	public void Deconstruct(out Entity restingEntity, out Point anchorTilePosition, out Vector2 visualOffset, out int targetDirection, out int directionOffset, out Vector2 finalOffset, out ExtraSeatInfo extraInfo)
@@ -74,15 +63,5 @@ public struct TileRestingInfo
 		directionOffset = DirectionOffset;
 		finalOffset = FinalOffset;
 		extraInfo = ExtraInfo;
-	}
-
-	public void Deconstruct(out Entity restingEntity, out Point anchorTilePosition, out Vector2 visualOffset, out int targetDirection, out int directionOffset, out Vector2 finalOffset)
-	{
-		restingEntity = RestingEntity;
-		anchorTilePosition = AnchorTilePosition;
-		visualOffset = VisualOffset;
-		targetDirection = TargetDirection;
-		directionOffset = DirectionOffset;
-		finalOffset = FinalOffset;
 	}
 }

--- a/patches/tModLoader/Terraria/DataStructures/TileRestingInfo.cs
+++ b/patches/tModLoader/Terraria/DataStructures/TileRestingInfo.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using Terraria.GameContent;
 
 namespace Terraria.DataStructures;
 
@@ -23,7 +24,7 @@ public struct TileRestingInfo
 	public Vector2 VisualOffset;
 
 	/// <summary>
-	/// Direction the entity is facing while resting.
+	/// Direction the entity is facing while resting. Is 0 by default for beds.
 	/// </summary>
 	public int TargetDirection;
 
@@ -37,6 +38,22 @@ public struct TileRestingInfo
 	/// </summary>
 	public Vector2 FinalOffset;
 
+	/// <summary>
+	/// Contains additional information, such as <see cref="ExtraSeatInfo.IsAToilet"/>.
+	/// </summary>
+	public ExtraSeatInfo ExtraInfo;
+
+	public TileRestingInfo(Entity restingEntity, Point anchorTilePosition, Vector2 visualOffset, int targetDirection, int directionOffset, Vector2 finalOffset, ExtraSeatInfo extraInfo)
+	{
+		RestingEntity = restingEntity;
+		AnchorTilePosition = anchorTilePosition;
+		VisualOffset = visualOffset;
+		TargetDirection = targetDirection;
+		DirectionOffset = directionOffset;
+		FinalOffset = finalOffset;
+		ExtraInfo = extraInfo;
+	}
+
 	public TileRestingInfo(Entity restingEntity, Point anchorTilePosition, Vector2 visualOffset, int targetDirection, int directionOffset = 0, Vector2 finalOffset = default)
 	{
 		RestingEntity = restingEntity;
@@ -45,6 +62,18 @@ public struct TileRestingInfo
 		TargetDirection = targetDirection;
 		DirectionOffset = directionOffset;
 		FinalOffset = finalOffset;
+		ExtraInfo = default;
+	}
+
+	public void Deconstruct(out Entity restingEntity, out Point anchorTilePosition, out Vector2 visualOffset, out int targetDirection, out int directionOffset, out Vector2 finalOffset, out ExtraSeatInfo extraInfo)
+	{
+		restingEntity = RestingEntity;
+		anchorTilePosition = AnchorTilePosition;
+		visualOffset = VisualOffset;
+		targetDirection = TargetDirection;
+		directionOffset = DirectionOffset;
+		finalOffset = FinalOffset;
+		extraInfo = ExtraInfo;
 	}
 
 	public void Deconstruct(out Entity restingEntity, out Point anchorTilePosition, out Vector2 visualOffset, out int targetDirection, out int directionOffset, out Vector2 finalOffset)

--- a/patches/tModLoader/Terraria/GameContent/ExtraSeatInfo.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ExtraSeatInfo.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/GameContent/ExtraSeatInfo.cs
++++ src/tModLoader/Terraria/GameContent/ExtraSeatInfo.cs
+@@ -2,5 +_,8 @@
+ 
+ public struct ExtraSeatInfo
+ {
++	/// <summary>
++	/// If true, player will generate <see cref="ID.ItemID.PoopBlock"/> after a short period of time while any tier of <see cref="ID.BuffID.WellFed"/> is active
++	/// </summary>
+ 	public bool IsAToilet;
+ }

--- a/patches/tModLoader/Terraria/GameContent/PlayerSittingHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/PlayerSittingHelper.cs.patch
@@ -18,13 +18,13 @@
  		if (!isSitting)
  			return false;
  
-@@ -263,7 +_,19 @@
+@@ -263,7 +_,20 @@
  			}
  		}
  
 +		// At this point, vanilla tile num/num2 represent the bottom-most tile coordinate of the tile (no vanilla tile for sitting is higher than 2),
 +		// Modded ones are arbitrary, modder responsibility to find the bottom-post tile
-+		TileRestingInfo info = new TileRestingInfo(player, new Point(num, num2), seatDownOffset, targetDirection, num3, zero);
++		TileRestingInfo info = new TileRestingInfo(player, new Point(num, num2), seatDownOffset, targetDirection, num3, zero, extraInfo);
 +		TileLoader.ModifySittingTargetInfo(x, y, tileSafely.type, ref info);
 +		num = info.AnchorTilePosition.X;
 +		num2 = info.AnchorTilePosition.Y;
@@ -32,6 +32,7 @@
 +		targetDirection = info.TargetDirection;
 +		seatDownOffset = info.VisualOffset;
 +		zero = info.FinalOffset;
++		extraInfo = info.ExtraInfo;
 +
 +		//TML: 'num2 + 1' hardcode moved into ModifySittingTargetInfo
 -		playerSittingPosition = new Point(num, num2 + 1).ToWorldCoordinates(8f, 16f);


### PR DESCRIPTION
### What is the new feature?
Modders can now flag their toilets to generate [Poo](https://terraria.wiki.gg/wiki/Poo).

### Why should this be part of tModLoader?
1.4.4 feature

### Are there alternative designs?
The existing constructor and `Deconstruct` helper for `TileRestingInfo` could be kept intact to avoid any breakage (as was the point when initially adding them in the sit/sleep PR). But Chicken-Bones on discord said that the next 1.4.4 release on preview will have breaking changes already, so it was decided to just expand the existing code.

### Sample usage for the new feature
info.ExtraInfo.IsAToilet = true;

### ExampleMod updates
`ExampleToilet` was updated

## Porting Notes
* Recompile if you used `TileRestingInfo` constructor/deconstructor
* Add `info.ExtraInfo.IsAToilet = true;` to your toilet tile's `ModifySittingTargetInfo` hook
