### PR TITLE
Automatically enable depencencies

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -842,7 +842,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Aprilscherz",
 		"ModLoader.Items.StartBag.DisplayName": "Starterpaket",
 		"ModLoader.Items.StartBag.Tooltip": "Einige Starter-Items haben nicht in dein Inventar gepasst",

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Klicken um Konfiguration zu öffnen",
 		"ModOldWarning": "Mod veraltet. Benutzung auf eigene Gefahr!",
 		// "ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Dieser Mod benötigt: {0}\n (Klicken zum aktivieren)",
 		"ModDependencyModsNotFound": "Folgende Mods konnten nicht gefunden werden: {0}",
 		"ModDidNotFullyUnloadWarning": "Dieser Mod wurde beim letzten Entladen nicht vollständig entladen.\n(Dies ist eine Nachricht für den Modentwickler)",
@@ -841,6 +842,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Aprilscherz",
 		"ModLoader.Items.StartBag.DisplayName": "Starterpaket",
 		"ModLoader.Items.StartBag.Tooltip": "Einige Starter-Items haben nicht in dein Inventar gepasst",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -842,6 +842,7 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		"ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		"ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		"ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Click to open config",
 		"ModOldWarning": "Old mod, enable at own risk",
 		"ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		"ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "This mod depends on: {0}\n (click to enable)",
 		"ModDependencyModsNotFound": "The following mods were not found: {0}",
 		"ModDidNotFullyUnloadWarning": "This mod did not fully unload during last unload.\n(This is a message for the mod creator)",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -842,7 +842,6 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		"ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		"ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		"ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -842,7 +842,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Chiste del Día de los Inocentes",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa de partida",
 		"ModLoader.Items.StartBag.Tooltip": "Algunos objetos de partida no cabían en tu inventario",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Haz clic para abrir la configuración",
 		"ModOldWarning": "Mod desactualizado, actívalo bajo tu propia responsabilidad",
 		// "ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Este mod depende de {0}\n(Haz clic para activar)",
 		"ModDependencyModsNotFound": "Los siguientes mods no han sido encontrados: {0}",
 		"ModDidNotFullyUnloadWarning": "Este mod no se desactivó completamente durante la última recarga.\n(Este es un mensaje para el creador del mod)",
@@ -841,6 +842,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Chiste del Día de los Inocentes",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa de partida",
 		"ModLoader.Items.StartBag.Tooltip": "Algunos objetos de partida no cabían en tu inventario",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Cliquez pour ouvrir la configuration",
 		"ModOldWarning": "Mod obsolète, activer à vos risques et périls",
 		// "ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Ce Mod dépend de : {0}\n (Cliquer pour activer)",
 		"ModDependencyModsNotFound": "Ces Mods n'ont pas été trouvés: {0}",
 		"ModDidNotFullyUnloadWarning": "Ce mod ne s'est pas complètement déchargé lors du dernier déchargement.\n(Ceci est un message pour le créateur du mod)",
@@ -841,6 +842,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "La Blague du Poisson D'Avril",
 		"ModLoader.Items.StartBag.DisplayName": "Sac de Départ",
 		"ModLoader.Items.StartBag.Tooltip": "Votre inventaire ne contenait pas assez de place pour certains objets de départ",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -842,7 +842,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "La Blague du Poisson D'Avril",
 		"ModLoader.Items.StartBag.DisplayName": "Sac de Départ",
 		"ModLoader.Items.StartBag.Tooltip": "Votre inventaire ne contenait pas assez de place pour certains objets de départ",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -56,6 +56,7 @@
 		// "ModsOpenConfig": "Click to open config",
 		// "ModOldWarning": "Old mod, enable at own risk",
 		// "ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		// "ModDependencyClickTooltip": "This mod depends on: {0}\n (click to enable)",
 		// "ModDependencyModsNotFound": "The following mods were not found: {0}",
 		// "ModDidNotFullyUnloadWarning": "This mod did not fully unload during last unload.\n(This is a message for the mod creator)",
@@ -843,6 +844,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		// "ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		// "ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		// "ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -844,7 +844,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		// "ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		// "ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		// "ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -842,7 +842,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Prima Aprilis",
 		"ModLoader.Items.StartBag.DisplayName": "Początkowy ekwipunek",
 		"ModLoader.Items.StartBag.Tooltip": "Niektóre początkowe przedmioty nie zmieściły się w twoim ekwipunku.",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Kliknij, aby otworzyć konfigurację",
 		"ModOldWarning": "Stary mod, aktywuj na własną odpowiedzialność",
 		// "ModStableOnPreviewWarning": "No Preview Build. Enable At Own Risk",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Ten mod wymaga moda: {0}\n (kliknij, by włączyć)",
 		"ModDependencyModsNotFound": "Nie znaleziono następujących modów: {0}",
 		"ModDidNotFullyUnloadWarning": "Ten mod nie został w pełni rozładowany podczas ostatniego rozładunku.\n(To jest wiadomość dla twórcy moda)",
@@ -841,6 +842,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Prima Aprilis",
 		"ModLoader.Items.StartBag.DisplayName": "Początkowy ekwipunek",
 		"ModLoader.Items.StartBag.Tooltip": "Niektóre początkowe przedmioty nie zmieściły się w twoim ekwipunku.",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Clique para abrir a configuração",
 		"ModOldWarning": "Mod antigo, ative-o por sua conta e risco",
 		"ModStableOnPreviewWarning": "Sem build para a versão Preview. Ative por sua conta e risco",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Este mod depende de: {0}\n (clique para ativar)",
 		"ModDependencyModsNotFound": "Os mods a seguir não foram encontrados: {0}",
 		"ModDidNotFullyUnloadWarning": "Este mod não descarregou corretamente durante o último descarregamento.\n(Esta é uma mensagem para o criador do mod)",
@@ -841,6 +842,7 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Piada de 1° de Abril",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa Iniciante",
 		"ModLoader.Items.StartBag.Tooltip": "Alguns itens iniciais não cabem em seu inventário",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -842,7 +842,6 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Piada de 1° de Abril",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa Iniciante",
 		"ModLoader.Items.StartBag.Tooltip": "Alguns itens iniciais não cabem em seu inventário",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -54,6 +54,7 @@
 		"ModsOpenConfig": "Нажмите, чтобы открыть конфигурацию мода",
 		"ModOldWarning": "Устаревший мод, включайте на свой страх и риск",
 		"ModStableOnPreviewWarning": "Не подходит для Preview-версии. Включайте на свой страх и риск",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "Запуск этого мода невозможен без:\n{0}\n(нажмите, чтобы включить зависимости)",
 		"ModDependencyModsNotFound": "Следующие моды не найдены: {0}",
 		"ModDidNotFullyUnloadWarning": "Мод не смог полностью выгрузиться\nво время последней выгрузки.\n(Это сообщение для разработчика мода)",
@@ -841,6 +842,7 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Первоапрельская шутка",
 		"ModLoader.Items.StartBag.DisplayName": "Стартовая сумка",
 		"ModLoader.Items.StartBag.Tooltip": "Некоторые стартовые предметы не поместились в ваш инвентарь",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -842,7 +842,6 @@
 		"Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "Первоапрельская шутка",
 		"ModLoader.Items.StartBag.DisplayName": "Стартовая сумка",
 		"ModLoader.Items.StartBag.Tooltip": "Некоторые стартовые предметы не поместились в ваш инвентарь",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -55,6 +55,7 @@
 		"ModsOpenConfig": "点击打开配置",
 		"ModOldWarning": "旧模组，风险自负",
 		"ModStableOnPreviewWarning": "没有对应的测试版，风险自负",
+		// "ModDependencyTooltip": "This mod depends on: {0}\n (These will enable automatically)",
 		"ModDependencyClickTooltip": "该模组依赖于: {0}\n(点击启用)",
 		"ModDependencyModsNotFound": "未找到下列模组: {0}",
 		"ModDidNotFullyUnloadWarning": "该模组在上次卸载时未完全卸载.\n(这是给模组作者的信息)",
@@ -842,6 +843,7 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
+		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "愚人节玩笑",
 		"ModLoader.Items.StartBag.DisplayName": "起始包",
 		"ModLoader.Items.StartBag.Tooltip": "部分起始物品无法正常放入背包",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -843,7 +843,6 @@
 		// "Vector2.Y.Label": "Y"
 	},
 	"Mods": {
-		// "ModLoader.Unloaded": "Unloaded",
 		"ModLoader.Items.AprilFools.DisplayName": "愚人节玩笑",
 		"ModLoader.Items.StartBag.DisplayName": "起始包",
 		"ModLoader.Items.StartBag.Tooltip": "部分起始物品无法正常放入背包",

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -305,12 +305,29 @@ public static class ModLoader
 			return;
 
 		Logging.tML.Info($"{(active ? "Enabling" : "Disabling")} Mod: {modName}");
-		if (active)
+		if (active) {
 			EnabledMods.Add(modName);
-		else
+			EnableModDependencies(modName);
+		}
+		else {
 			EnabledMods.Remove(modName);
+		}
 
 		ModOrganizer.SaveEnabledMods();
+	}
+
+	internal static void EnableModDependencies(string modName)
+	{
+		var availableMods = ModOrganizer.FindMods(logDuplicates: true);
+		var enabledMod = availableMods.FirstOrDefault(m => m.Name == modName);
+		if (enabledMod == null)
+			return;
+
+		var dependencies = enabledMod.properties.RefNames(true);
+		var availableDependencies = availableMods.Where(m => dependencies.Contains(m.Name));
+		foreach (var dependency in availableDependencies) {
+			EnableMod(dependency.Name);
+		}
 	}
 
 	internal static void DisableAllMods()

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -305,29 +305,12 @@ public static class ModLoader
 			return;
 
 		Logging.tML.Info($"{(active ? "Enabling" : "Disabling")} Mod: {modName}");
-		if (active) {
+		if (active)
 			EnabledMods.Add(modName);
-			EnableModDependencies(modName);
-		}
-		else {
+		else 
 			EnabledMods.Remove(modName);
-		}
 
 		ModOrganizer.SaveEnabledMods();
-	}
-
-	internal static void EnableModDependencies(string modName)
-	{
-		var availableMods = ModOrganizer.FindMods(logDuplicates: true);
-		var enabledMod = availableMods.FirstOrDefault(m => m.Name == modName);
-		if (enabledMod == null)
-			return;
-
-		var dependencies = enabledMod.properties.RefNames(true);
-		var availableDependencies = availableMods.Where(m => dependencies.Contains(m.Name));
-		foreach (var dependency in availableDependencies) {
-			EnableMod(dependency.Name);
-		}
 	}
 
 	internal static void DisableAllMods()

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -307,7 +307,7 @@ public static class ModLoader
 		Logging.tML.Info($"{(active ? "Enabling" : "Disabling")} Mod: {modName}");
 		if (active)
 			EnabledMods.Add(modName);
-		else 
+		else
 			EnabledMods.Remove(modName);
 
 		ModOrganizer.SaveEnabledMods();

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -16,6 +16,7 @@ using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.GameContent.UI.States;
 using Terraria.Social.Steam;
 using Terraria.UI;
+using System.Collections.Generic;
 
 namespace Terraria.ModLoader.UI;
 
@@ -408,8 +409,39 @@ internal static class Interface
 				exit = true;
 			}
 			else if (int.TryParse(command, out int value) && value > 0 && value <= mods.Length) {
-				mods[value - 1].Enabled ^= true;
+				var mod = mods[value - 1];
+				mod.Enabled ^= true;
+
+				if (mod.Enabled) {
+					var missingRefs = new List<string>();
+					EnableDepsRecursive(mod, mods, missingRefs);
+
+					if (missingRefs.Any()) {
+						Console.ForegroundColor = ConsoleColor.Red;
+						Console.WriteLine(Language.GetTextValue("tModLoader.ModDependencyModsNotFound", string.Join(", ", missingRefs)) + "\n");
+						Console.ResetColor();
+					}
+				}
 			}
+		}
+	}
+
+	private static void EnableDepsRecursive(LocalMod mod, LocalMod[] mods, List<string> missingRefs)
+	{
+		string[] _modReferences = mod.properties.modReferences.Select(x => x.mod).ToArray();
+		foreach (var name in _modReferences) {
+			var dep = mods.FirstOrDefault(x => x.Name == name);
+			if (dep == null) {
+				missingRefs.Add(name);
+				continue;
+			}
+			EnableDepsRecursive(dep, mods, missingRefs);
+			if (!dep.Enabled) {
+				Console.ForegroundColor = ConsoleColor.Green;
+				Console.WriteLine($"Automatically enabling {dep.DisplayName} required by {mod.DisplayName}");
+				Console.ResetColor();
+			}
+			dep.Enabled ^= true;
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -335,6 +335,15 @@ internal class UIModItem : UIPanel
 	{
 		SoundEngine.PlaySound(SoundID.MenuTick);
 		_mod.Enabled = !_mod.Enabled;
+
+		if (!_mod.Enabled)
+			return;
+
+		foreach (string name in _modReferences) {
+			var dep = Interface.modsMenu.FindUIModItem(name);
+			dep?.Enable();
+			dep?._uiModStateText.SetEnabled();
+		}
 	}
 
 	internal void Enable()

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -134,6 +134,7 @@ internal class UIModItem : UIPanel
 				Left = new StyleDimension(_uiModStateText.Left.Pixels + _uiModStateText.Width.Pixels + PADDING, 0f),
 				Top = { Pixels = 42.5f }
 			};
+			// _modReferenceIcon.OnLeftClick += EnableDependencies;
 
 			Append(_modReferenceIcon);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -130,11 +130,10 @@ internal class UIModItem : UIPanel
 		if (_modReferences.Length > 0 && !_mod.Enabled) {
 			string refs = string.Join(", ", _mod.properties.modReferences);
 			var icon = UICommon.ButtonExclamationTexture;
-			_modReferenceIcon = new UIHoverImage(icon, Language.GetTextValue("tModLoader.ModDependencyClickTooltip", refs)) {
+			_modReferenceIcon = new UIHoverImage(icon, Language.GetTextValue("tModLoader.ModDependencyTooltip", refs)) {
 				Left = new StyleDimension(_uiModStateText.Left.Pixels + _uiModStateText.Width.Pixels + PADDING, 0f),
 				Top = { Pixels = 42.5f }
 			};
-			_modReferenceIcon.OnLeftClick += EnableDependencies;
 
 			Append(_modReferenceIcon);
 		}
@@ -339,11 +338,7 @@ internal class UIModItem : UIPanel
 		if (!_mod.Enabled)
 			return;
 
-		foreach (string name in _modReferences) {
-			var dep = Interface.modsMenu.FindUIModItem(name);
-			dep?.Enable();
-			dep?._uiModStateText.SetEnabled();
-		}
+		EnableDependencies();
 	}
 
 	internal void Enable()
@@ -362,13 +357,13 @@ internal class UIModItem : UIPanel
 		_uiModStateText.SetDisabled();
 	}
 
-	internal void EnableDependencies(UIMouseEvent evt, UIElement listeningElement)
+	internal void EnableDependencies()
 	{
 		var missingRefs = new List<string>();
 		EnableDepsRecursive(missingRefs);
 
 		if (missingRefs.Any()) {
-			Interface.infoMessage.Show(Language.GetTextValue("tModLoader.ModDependencyModsNotFound", string.Join(",", missingRefs)), Interface.modsMenuID);
+			Interface.infoMessage.Show(Language.GetTextValue("tModLoader.ModDependencyModsNotFound", string.Join(", ", missingRefs)), Interface.modsMenuID);
 		}
 	}
 

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 31
-ru-RU 22
-pt-BR 27
-pl-PL 362
-it-IT 807
-fr-FR 419
-es-ES 326
-de-DE 347
+zh-Hans 34
+ru-RU 25
+pt-BR 3
+pl-PL 365
+it-IT 810
+fr-FR 422
+es-ES 329
+de-DE 350


### PR DESCRIPTION
When enabling a mod, automatically enable available dependencies.

### What is the new feature?

When enabling a mod, the mod's dependencies (if installed) will automatically be enabled as well.
When disabling a mod, it will not disable the dependencies. This change only affects disabled -> enabled.

This was requested in issue #3619

### Why should this be part of tModLoader?

It's a small quality of life improvement.

### Are there alternative designs?

Possibly?

I updated `Modloader.cs` to enable the dependencies, and `UIModItem.cs` to make sure the UI updates for the toggled dependencies.

### Sample usage for the new feature

- Install some mods that have (weak) dependencies, and their dependencies.
- Disable all mods.
- Enable a mod that has dependencies, and you should see the dependencies enable as well.

### ExampleMod updates

An easy test is to make `ExampleMod` dependant on something in its `buid.txt`:
```
modReferences = CheatSheet
```

I thought it'd be overkill to actually make `ExampleMod` dependant on something else, as that could complicate development unnecessarily.