### PR TITLE
Forward Port 1.4.3-Legacy Changes for File Migration & UI

### DIFF
--- a/1.4.3_legacy_ForwardPortNotes.txt
+++ b/1.4.3_legacy_ForwardPortNotes.txt
@@ -1,0 +1,5 @@
+Need to Remove "HowToAccessLEgacytModLaoderButton" localization
+Need to review added localizations to determine which ones are even relevant in 1.4.4
+Character/World Select Migration generalization/rework TODO
+
+Cleanup Program.tml.cs changes that aren't desireable

--- a/1.4.3_legacy_ForwardPortNotes.txt
+++ b/1.4.3_legacy_ForwardPortNotes.txt
@@ -1,5 +1,0 @@
-Need to Remove "HowToAccessLEgacytModLaoderButton" localization
-Need to review added localizations to determine which ones are even relevant in 1.4.4
-Character/World Select Migration generalization/rework TODO
-
-Cleanup Program.tml.cs changes that aren't desireable

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
@@ -53,9 +53,10 @@ public partial class UICharacterSelect : UIState
 		var otherPaths = new (string path, string message, int stabilityLevel)[] {
 			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "Players"), "Click to copy \"{0}\" over from Terraria", 0),
 			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", "Players"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
-			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Players"), "Click to copy \"{0}\" over from 1.4-stable", 1),
-			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, "Players"), "Click to copy \"{0}\" over from 1.4-preview", 2),
-			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from 1.4-dev", 3),
+			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Players"), "Click to copy \"{0}\" over from stable", 1),
+			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, "Players"), "Click to copy \"{0}\" over from preview", 2),
+			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from dev", 3),
+			(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Players"), "Click to copy \"{0}\" over from 1.4.3-Legacy", 0),
 		};
 
 		int currentStabilityLevel = BuildInfo.Purpose switch {

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UICharacterSelect.TML.cs
@@ -47,17 +47,8 @@ public partial class UICharacterSelect : UIState
 		migratePlayerList.SetScrollbar(scrollbar);
 		_migrationPanel.VisibleWhenExpanded.Add(scrollbar);
 
-		// TODO: Do we need to do extra work for .plr files that have been renamed? Is that valid?
-		// TODO: We could probably support cloud players as well, if we tried.
-		// Vanilla and 1.3 paths are defaults, 1.4 TML paths are relative to current savepath.
-		var otherPaths = new (string path, string message, int stabilityLevel)[] {
-			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "Players"), "Click to copy \"{0}\" over from Terraria", 0),
-			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", "Players"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
-			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Players"), "Click to copy \"{0}\" over from stable", 1),
-			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, "Players"), "Click to copy \"{0}\" over from preview", 2),
-			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Players"), "Click to copy \"{0}\" over from dev", 3),
-			(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Players"), "Click to copy \"{0}\" over from 1.4.3-Legacy", 0),
-		};
+
+		var otherPaths = FileUtilities.GetAlternateSavePathFiles("Players");
 
 		int currentStabilityLevel = BuildInfo.Purpose switch {
 			BuildInfo.BuildPurpose.Stable => 1,

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.TML.cs
@@ -7,6 +7,7 @@ using Terraria.IO;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI;
+using Terraria.Utilities;
 
 namespace Terraria.GameContent.UI.States;
 
@@ -49,14 +50,7 @@ partial class UIWorldSelect
 
 		// TODO: Do we need to do extra work for .wld files that have been renamed? Is that valid?
 		// Vanilla and 1.3 paths are defaults, 1.4 TML paths are relative to current savepath.
-		var otherPaths = new (string path, string message, int stabilityLevel)[] {
-			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "Worlds"), "Click to copy \"{0}\" over from Terraria", 0),
-			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", "Worlds"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
-			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-stable", 1),
-			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-preview", 2),
-			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-dev", 3),
-			(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Worlds"), "Click to copy \"{0}\" over from 1.4.3-Legacy", 0),
-		};
+		var otherPaths = FileUtilities.GetAlternateSavePathFiles("Worlds");
 
 		int currentStabilityLevel = BuildInfo.Purpose switch {
 			BuildInfo.BuildPurpose.Stable => 1,

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorldSelect.TML.cs
@@ -55,6 +55,7 @@ partial class UIWorldSelect
 			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-stable", 1),
 			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-preview", 2),
 			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, "Worlds"), "Click to copy \"{0}\" over from 1.4-dev", 3),
+			(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, "Worlds"), "Click to copy \"{0}\" over from 1.4.3-Legacy", 0),
 		};
 
 		int currentStabilityLevel = BuildInfo.Purpose switch {

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:Mod;Mods} aktiviert",
 		"MenuModUpdatesAvailable": "({0} {^0:Aktualisierung;Aktualisierungen} verfügbar!)",
 		"AudioNotSupported": "Keine Audio-Hardware gefunden. Ton wird deaktiviert.",
-		"HowToAccessLegacytModLoaderButton": "Wie man auf 1.3 tModLoader zugreift",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader wird bald auf Terraria 1.4.4 aktualisiert, aber viele Mods sind noch nicht umgestiegen.\n\nUm mit Ihren aktuellen Mods auf Terraria 1.4.3 zu bleiben, wechseln Sie über das Steam-Beta Menü zum \"1.4.3-legacy\" Zweig von tModLoader.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "({0} {^0:Aktualisierung;Aktualisierungen} verfügbar!)",
 		"AudioNotSupported": "Keine Audio-Hardware gefunden. Ton wird deaktiviert.",
 		"HowToAccessLegacytModLoaderButton": "Wie man auf 1.3 tModLoader zugreift",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader wird bald auf Terraria 1.4.4 aktualisiert, aber viele Mods sind noch nicht umgestiegen.\n\nUm mit Ihren aktuellen Mods auf Terraria 1.4.3 zu bleiben, wechseln Sie über das Steam-Beta Menü zum \"1.4.3-legacy\" Zweig von tModLoader.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Mod-Liste",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:Mod;Mods} Enabled",
 		"MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		"AudioNotSupported": "No audio hardware found. Disabling all audio.",
-		"HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
 		"SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 		"WaitXSeconds": "Wait {0} seconds...",
 		"ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader will be updating to Terraria 1.4.4 soon, but many mods have not yet been ported.\n\nTo stay on Terraria 1.4.3 with your current mods, use the steam beta menu to switch to the 1.4.3-legacy branch of tModLoader.",
 		"ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		"AudioNotSupported": "No audio hardware found. Disabling all audio.",
 		"HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
+		"SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
+		"WaitXSeconds": "Wait {0} seconds...",
+		"ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader will be updating to Terraria 1.4.4 soon, but many mods have not yet been ported.\n\nTo stay on Terraria 1.4.3 with your current mods, use the steam beta menu to switch to the 1.4.3-legacy branch of tModLoader.",
+		"ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Mods List",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:mod;mods} activados",
 		"MenuModUpdatesAvailable": "(¡{0} {^0:Actualización;Actualizaciones} disponible(s)!)",
 		"AudioNotSupported": "No se han detectado dispositivos de audio. Se desactivará el sonido.",
-		"HowToAccessLegacytModLoaderButton": "Cómo acceder a tModLoader 1.3",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Se ha detectado que estás utilizando una copia de Terraria compartida en familia.\nSteam no admite el préstamo familiar de tModLoader.\nSe ha cargado la solución experimental para ejecutar tModLoader.\nLas siguientes funciones no están disponibles:\n - Superposición de Steam\n - Multijugador de Steam",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader actualizará a Terraria 1.4.4 pronto, pero muchos mods aún no han migrado.\n\nPara quedarte en terraria 1.4.3 con tus mods actuales, usa el menú de betas de steam para cambiar a la rama \"1.4.3-legacy\" de tModLoader.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "(¡{0} {^0:Actualización;Actualizaciones} disponible(s)!)",
 		"AudioNotSupported": "No se han detectado dispositivos de audio. Se desactivará el sonido.",
 		"HowToAccessLegacytModLoaderButton": "Cómo acceder a tModLoader 1.3",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Se ha detectado que estás utilizando una copia de Terraria compartida en familia.\nSteam no admite el préstamo familiar de tModLoader.\nSe ha cargado la solución experimental para ejecutar tModLoader.\nLas siguientes funciones no están disponibles:\n - Superposición de Steam\n - Multijugador de Steam",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader actualizará a Terraria 1.4.4 pronto, pero muchos mods aún no han migrado.\n\nPara quedarte en terraria 1.4.3 con tus mods actuales, usa el menú de betas de steam para cambiar a la rama \"1.4.3-legacy\" de tModLoader.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Lista de mods",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:Mod Activé;Mods Activés}",
 		// "MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		"AudioNotSupported": "Aucun matériel audio trouvé. Désactivation de tout l’audio.",
-		// "HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader sera bientôt mis à jour vers Terraria 1.4.4, mais de nombreux mods ne sont pas encore comptatibles.\n\nPour rester sur Terraria 1.4.3 avec vos mods actuels, utilisez le menu steam bêta et sélectionnez la version \"1.4.3-legacy\" de tModLoader.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -34,7 +34,12 @@
 		// "MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		"AudioNotSupported": "Aucun matériel audio trouvé. Désactivation de tout l’audio.",
 		// "HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader sera bientôt mis à jour vers Terraria 1.4.4, mais de nombreux mods ne sont pas encore comptatibles.\n\nPour rester sur Terraria 1.4.3 avec vos mods actuels, utilisez le menu steam bêta et sélectionnez la version \"1.4.3-legacy\" de tModLoader.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Liste des Mods",
@@ -537,7 +542,7 @@
 		"TagsLanguage_ChineseDescription": "{$TagsLanguage_Description}",
 		"TagsLanguage_PortugueseDescription": "{$TagsLanguage_Description}",
 		"TagsLanguage_GermanDescription": "{$TagsLanguage_Description}",
-		"TagsLanguage_PolishDescription": "{$TagsLanguage_Description}",
+		"TagsLanguage_PolishDescription": "{$TagsLanguage_Description}"
 
 		// Info Display Pages
 		// "NextInfoAccPage": "Next Page",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -35,12 +35,10 @@
 		// "MenuModsEnabled": "{0} {^0:Mod;Mods} Enabled",
 		// "MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		// "AudioNotSupported": "No audio hardware found. Disabling all audio.",
-		// "HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader si aggiornerà presto a Terraria 1.4.4, ma molte mod non sono ancora state trasferite.\n\nPer rimanere su Terraria 1.4.3 con le tue mod attuali, usa il menu beta di Steam per passare al ramo 1.4.3-legacy di tModLoader.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -36,7 +36,12 @@
 		// "MenuModUpdatesAvailable": "({0} {^0:Update;Updates} Available!)",
 		// "AudioNotSupported": "No audio hardware found. Disabling all audio.",
 		// "HowToAccessLegacytModLoaderButton": "How to Access legacy tModLoader versions",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader si aggiornerà presto a Terraria 1.4.4, ma molte mod non sono ancora state trasferite.\n\nPer rimanere su Terraria 1.4.3 con le tue mod attuali, usa il menu beta di Steam per passare al ramo 1.4.3-legacy di tModLoader.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		// "ModsModsList": "Mods List",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "({0} {^0:Aktualizacja Moda dostępna;Aktualizacje Modów dostępne;Aktualizacji Modów dostępnych}!)",
 		"AudioNotSupported": "Nie znaleziono sprzętu audio. Wyłączenie wszystkich urządzeń audio.",
 		"HowToAccessLegacytModLoaderButton": "Jak przywrócić tModLoadera dla wersji gry 1.3",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader będzie wkrótce zaaktualizowany do Terrarii 1.4.4, ale wiele modów nie zostało jeszcze przeniesionych do tej wersji.\n\nAby pozostać na Terrarii 1.4.3 z twoimi bieżącymi modami, użyj steamowego menu wyboru bety aby przełączyć się na wersję \"1.4.3-legacy\" tModLoadera.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Lista modów",
@@ -537,7 +542,7 @@
 		"TagsLanguage_ChineseDescription": "{$TagsLanguage_Description}",
 		"TagsLanguage_PortugueseDescription": "{$TagsLanguage_Description}",
 		"TagsLanguage_GermanDescription": "{$TagsLanguage_Description}",
-		"TagsLanguage_PolishDescription": "{$TagsLanguage_Description}",
+		"TagsLanguage_PolishDescription": "{$TagsLanguage_Description}"
 
 		// Info Display Pages
 		// "NextInfoAccPage": "Next Page",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:Mod Włączony;Mody Włączone;Modów Włączonych}",
 		"MenuModUpdatesAvailable": "({0} {^0:Aktualizacja Moda dostępna;Aktualizacje Modów dostępne;Aktualizacji Modów dostępnych}!)",
 		"AudioNotSupported": "Nie znaleziono sprzętu audio. Wyłączenie wszystkich urządzeń audio.",
-		"HowToAccessLegacytModLoaderButton": "Jak przywrócić tModLoadera dla wersji gry 1.3",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		// "SteamFamilyShareWarning": "It has been detected you are using Family Share copy of Terraria.\nSteam does not support family-shared tModLoader.\nExperimental Family-Shared tModLoader workaround has been loaded.\nThe following features are not available:\n - Steam Overlay\n - Steam Multiplayer",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader będzie wkrótce zaaktualizowany do Terrarii 1.4.4, ale wiele modów nie zostało jeszcze przeniesionych do tej wersji.\n\nAby pozostać na Terrarii 1.4.3 z twoimi bieżącymi modami, użyj steamowego menu wyboru bety aby przełączyć się na wersję \"1.4.3-legacy\" tModLoadera.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "({0} {^0:atualização;atualizações} {^0:disponível;disponíveis}!)",
 		"AudioNotSupported": "Nenhum hardware de áudio encontrado. Desativando todo o áudio.",
 		"HowToAccessLegacytModLoaderButton": "Como acessar as versões antigas do tModLoader",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Foi detectado que você está usando uma cópia do Terraria de uma biblioteca compartilhada.\nO Steam não oferece suporte ao tModLoader em uma biblioteca compartilhada.\nA solução experimental para o tModLoader de bibliotecas compartilhadas foi carregada.\nOs seguintes recursos não estão disponíveis:\n - Overlay do Steam\n - Multijogador do Steam",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader irá atualizar para a versão 1.4.4 em breve, mas vários mods ainda não foram adaptados.\n\nPara ficar na versão 1.4.3 com os seus mods atuais, use o menu de betas da steam e mude para a versão \"1.4.3-legacy\" do tModLoader.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Lista de Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{0} {^0:mod;mods} {^0:ativado;ativados}",
 		"MenuModUpdatesAvailable": "({0} {^0:atualização;atualizações} {^0:disponível;disponíveis}!)",
 		"AudioNotSupported": "Nenhum hardware de áudio encontrado. Desativando todo o áudio.",
-		"HowToAccessLegacytModLoaderButton": "Como acessar as versões antigas do tModLoader",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Foi detectado que você está usando uma cópia do Terraria de uma biblioteca compartilhada.\nO Steam não oferece suporte ao tModLoader em uma biblioteca compartilhada.\nA solução experimental para o tModLoader de bibliotecas compartilhadas foi carregada.\nOs seguintes recursos não estão disponíveis:\n - Overlay do Steam\n - Multijogador do Steam",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader irá atualizar para a versão 1.4.4 em breve, mas vários mods ainda não foram adaptados.\n\nPara ficar na versão 1.4.3 com os seus mods atuais, use o menu de betas da steam e mude para a versão \"1.4.3-legacy\" do tModLoader.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -34,7 +34,12 @@
 		"MenuModUpdatesAvailable": "(Доступно {0} {^0:обновление;обновления;обновлений}!)",
 		"AudioNotSupported": "Звуковое оборудование не найдено. Всё аудио будет отключено.",
 		"HowToAccessLegacytModLoaderButton": "Как установить устаревшие версии tModLoader",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Было обнаружено, что вы используете копию Terraria через Steam Family Share.\nSteam не поддерживает tModLoader из семейной библиотеки.\nПоэтому, был загружён экспериментальный обход Steam Family Share.\nБудут недоступны следующие функции:\n - Оверлей Steam\n - Мультиплеер через Steam",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader скоро обновится до Terraria 1.4.4, но многие моды ещё не перенесены.\n\nЧтобы остаться на версии 1.4.3 с текущими версиями модов, переключитесь на ветку \"1.4.3-legacy\" через меню бета-версий в steam.",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "Список модов",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -33,12 +33,10 @@
 		"MenuModsEnabled": "{^0:Включён;Включено;Включены} {0} {^0:мод;мода;модов}",
 		"MenuModUpdatesAvailable": "(Доступно {0} {^0:обновление;обновления;обновлений}!)",
 		"AudioNotSupported": "Звуковое оборудование не найдено. Всё аудио будет отключено.",
-		"HowToAccessLegacytModLoaderButton": "Как установить устаревшие версии tModLoader",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "Было обнаружено, что вы используете копию Terraria через Steam Family Share.\nSteam не поддерживает tModLoader из семейной библиотеки.\nПоэтому, был загружён экспериментальный обход Steam Family Share.\nБудут недоступны следующие функции:\n - Оверлей Steam\n - Мультиплеер через Steam",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader скоро обновится до Terraria 1.4.4, но многие моды ещё не перенесены.\n\nЧтобы остаться на версии 1.4.3 с текущими версиями модов, переключитесь на ветку \"1.4.3-legacy\" через меню бета-версий в steam.",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -35,7 +35,12 @@
 		"MenuModUpdatesAvailable": "（{0} 个模组可更新！）",
 		"AudioNotSupported": "没有找到音频设备。正在关闭所有音频。",
 		"HowToAccessLegacytModLoaderButton": "使用tModLoader 1.3版本",
+		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "检测到Terraria为Steam家庭共享。\n由于Steam不支持家庭共享tModLoader，因此启用试验性方案。\n以下功能无法使用：\n - 游戏内 Steam 界面\n - Steam 多人",
+		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
+		// "ViewInstructions": "View Instructions",
+		"PleaseMoveTo143LegacyMessage": "tModLoader 很快将会移植至1.4.4，但是许多模组仍未被移植。\n\n请使用 steam beta 菜单切换 tModLoader 至 1.4.3-legacy 分支，以继续保持在 1.4.3 版本游玩您现有的模组",
+		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu
 		"ModsModsList": "模组列表",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -34,12 +34,10 @@
 		"MenuModsEnabled": "{0} 个模组已启用",
 		"MenuModUpdatesAvailable": "（{0} 个模组可更新！）",
 		"AudioNotSupported": "没有找到音频设备。正在关闭所有音频。",
-		"HowToAccessLegacytModLoaderButton": "使用tModLoader 1.3版本",
 		// "SwitchVersionInfoButton": "Switch to a different tModLoader version",
 		"SteamFamilyShareWarning": "检测到Terraria为Steam家庭共享。\n由于Steam不支持家庭共享tModLoader，因此启用试验性方案。\n以下功能无法使用：\n - 游戏内 Steam 界面\n - Steam 多人",
 		// "WaitXSeconds": "Wait {0} {^0:second;seconds}...",
 		// "ViewInstructions": "View Instructions",
-		"PleaseMoveTo143LegacyMessage": "tModLoader 很快将会移植至1.4.4，但是许多模组仍未被移植。\n\n请使用 steam beta 菜单切换 tModLoader 至 1.4.3-legacy 分支，以继续保持在 1.4.3 版本游玩您现有的模组",
 		// "ModReadyFor144": "This mod has been updated to 1.4.4",
 
 		// Mods Menu

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5453,7 +5453,7 @@
 +
 +			// Developer mode button.
 +			if (menuMode == 0 /*&& !ModCompile.DeveloperMode*/) {
-+				string developerModeText = Language.GetTextValue("tModLoader.HowToAccessLegacytModLoaderButton");
++				string developerModeText = Language.GetTextValue("tModLoader.SwitchVersionInfoButton");
 +
 +				// measure and draw text from bottom right
 +				var textSize = FontAssets.MouseText.Value.MeasureString(developerModeText);
@@ -5470,7 +5470,7 @@
 +
 +					if (mouseover && mouseLeftRelease && mouseLeft) {
 +						SoundEngine.PlaySound(SoundID.MenuOpen);
-+						Utils.OpenToURL("https://github.com/tModLoader/tModLoader/wiki/tModLoader-guide-for-players");
++						Utils.OpenToURL("https://github.com/tModLoader/tModLoader/wiki/tModLoader-guide-for-players#beta-branches");
 +					}
 +				}
 +

--- a/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuildInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Terraria.ModLoader;
@@ -50,8 +51,8 @@ public static class BuildInfo
 		// Version name for players
 		versionedName = $"tModLoader v{tMLVersion}";
 
-		if (!string.IsNullOrEmpty(BranchName) && BranchName != "unknown"
-			&& BranchName != "stable" && BranchName != "preview" && BranchName != "1.4")
+		string[] branchNameBlacklist = { "unknown", "stable", "preview", "1.4.3-Legacy" };
+		if (!string.IsNullOrEmpty(BranchName) && !branchNameBlacklist.Contains(BranchName))
 			versionedName += $" {BranchName}";
 
 		if (Purpose != BuildPurpose.Stable)

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -550,36 +550,26 @@ internal static class ModOrganizer
 
 	internal static string GetActiveTmodInRepo(string repo)
 	{
-		Version tmodVersion = new Version(BuildInfo.tMLVersion.Major, BuildInfo.tMLVersion.Minor);
-		string[] tmods = Directory.GetFiles(repo, "*.tmod", SearchOption.AllDirectories);
-		if (tmods.Length == 1)
-			return tmods[0];
-
-		string val = null;
-		Version currVersion = null;
-		foreach (string fileName in tmods) {
-			var match = PublishFolderMetadata.Match(fileName);
-
-			if (match.Success) {
-				Version testVers = new Version(match.Groups[1].Value);
-				if (testVers > tmodVersion) {
-					continue;
-				}
-				else if (testVers == currVersion) {
-					val = fileName;
-					break;
-				}
-				else if (testVers > currVersion) {
-					currVersion = testVers;
-					val = fileName;
-				}
-			}
-			else if (val == null) {
-				val = fileName;
-				currVersion = new Version(0, 12);
-			}
+		var information = AnalyzeWorkshopTmods(repo);
+		if (information == null || information.Count == 0) {
+			Logging.tML.Warn($"Unexpectedly missing .tMods in Workshop Folder {repo}");
+			return null;
 		}
-		return val;
+
+		// This was from the 1.4.3-Legacy transition to 1.4.4. Used to show a mod has a 1.4.4 version based on the tag "1.4.4"
+		/*
+		if (TryReadManifest(repo, out var info))
+			if (info.tags != null && info.tags.Contains("1.4.3"))
+				modsReadyFor144.Add(Path.GetFileNameWithoutExtension(information[0].file));
+		*/
+
+		var recommendedTmod = information.Where(t => t.tModVersion <= BuildInfo.tMLVersion).OrderByDescending(t => t.tModVersion).FirstOrDefault();
+		if (recommendedTmod == default) {
+			Logging.tML.Warn($"No .tMods found for this version in Workshop Folder {repo}. Defaulting to show newest");
+			return information.OrderByDescending(t => t.tModVersion).First().file;
+		}
+
+		return recommendedTmod.file;
 	}
 
 	// Delete in Mod Browser refactor - temp
@@ -597,17 +587,8 @@ internal static class ModOrganizer
 
 	internal static HashSet<string> DetermineSupportedVersionsFromWorkshop(string repo)
 	{
-		string[] tmods = Directory.GetFiles(repo, "*.tmod", SearchOption.AllDirectories);
-		HashSet<string> versions = new HashSet<string>();
-
-		foreach (string fileName in tmods) {
-			var match = PublishFolderMetadata.Match(fileName);
-			if (match.Success) {
-				versions.Add(GetBrowserVersionNumber(new Version(match.Groups[1].Value)));
-			}
-		}
-
-		return versions;
+		var summary = AnalyzeWorkshopTmods(repo);
+		return summary.Select(info => GetBrowserVersionNumber(info.tModVersion)).ToHashSet();
 	}
 
 	/// <summary>
@@ -628,35 +609,50 @@ internal static class ModOrganizer
 		// we need to rollback to the last stable due to a significant bug.
 		// We also keep a 1.4.3 version from version 2022.9 prior
 
-		// Get the list of all tMod files on Workshop
-		List<(string file, Version tModVersion, bool isFolder)> information = new();
-		foreach (var filename in tmods) {
-			var match = PublishFolderMetadata.Match(filename);
-			if (match.Success) {
-				information.Add((Directory.GetParent(filename).ToString(), new Version(match.Groups[1].Value), isFolder: true));
-			}
-			else {
-				// Version 0.12 was the pre-Alpha 1.4 builds where .tMod was placed directly in the Workshop.
-				// Was prior to the preview system introduced, but also just above the 0.11.9.X for 1.3 tML
-				information.Add((filename, new Version(0, 12), isFolder: false));
-			}
-		}
+		var information = AnalyzeWorkshopTmods(repo);
+		if (information == null || information.Count() <= 3)
+			return;
 
 		(string browserVersion, int keepCount)[] keepRequirements =
 			{ ("1.4.3", 1), ("1.4.4", 3) };
 
 		foreach (var requirement in keepRequirements) {
 			// Get an ordered list for the particular version
-			var mods = information.Where(t => GetBrowserVersionNumber(t.tModVersion) == requirement.browserVersion)
-				.OrderByDescending(t => t.tModVersion).Skip(requirement.keepCount);
+			var mods = GetOrderedTmodWorkshopInfoForVersion(information, requirement.browserVersion).Skip(requirement.keepCount);
 
 			foreach (var item in mods) {
-				if (item.isFolder)
-					Directory.Delete(item.file, recursive:true);
+				if (item.isInFolder)
+					Directory.Delete(Path.GetDirectoryName(item.file), recursive: true);
 				else
 					File.Delete(item.file);
 			}
 		}
+	}
+
+	internal static IOrderedEnumerable<(string file, Version tModVersion, bool isInFolder)>
+			GetOrderedTmodWorkshopInfoForVersion(List<(string file, Version tModVersion, bool isInFolder)> information, string tmlVersion)
+	{
+		return information.Where(t => GetBrowserVersionNumber(t.tModVersion) == tmlVersion).OrderByDescending(t => t.tModVersion);
+	}
+
+	internal static List<(string file, Version tModVersion, bool isInFolder)> AnalyzeWorkshopTmods(string repo)
+	{
+		string[] tmods = Directory.GetFiles(repo, "*.tmod", SearchOption.AllDirectories);
+
+		// Get the list of all tMod files on Workshop
+		List<(string file, Version tModVersion, bool isInFolder)> information = new();
+		foreach (var filename in tmods) {
+			var match = PublishFolderMetadata.Match(filename);
+			if (match.Success) {
+				information.Add((filename, new Version(match.Groups[1].Value), isInFolder: true));
+			}
+			else {
+				// Version 0.12 was the pre-Alpha 1.4 builds where .tMod was placed directly in the Workshop.
+				// Was prior to the preview system introduced, but also just above the 0.11.9.X for 1.3 tML
+				information.Add((filename, new Version(0, 12), isInFolder: false));
+			}
+		}
+		return information;
 	}
 
 	// Remove skippable preview builds from extended version (ie 2022.5 if stable is 2022.4 & Preview is 2022.6

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -58,12 +58,24 @@ internal class ErrorReporting
 			tip = Language.GetTextValue("tModLoader.OutOfMemoryHint");
 		else if (e is InvalidOperationException || e is NullReferenceException || e is IndexOutOfRangeException || e is ArgumentNullException)
 			tip = Language.GetTextValue("tModLoader.ModExceptionHint");
-		else if (e is IOException && e.Message.Contains("cloud file provider"))
+		else if (e is IOException && e.Message.Contains("cloud file provider")) {
+			if (string.IsNullOrEmpty(e.HelpLink))
+				e.HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#save-data-file-issues";
 			tip = Language.GetTextValue("tModLoader.OneDriveHint");
+			if (Language.ActiveCulture == null) // This error typically happens before localization is loaded, so fallback to english text.
+				tip = "Tip: Try installing/enabling OneDrive. Right click your Documents folder and enable \"Always save on this device\"";
+		}
 		else if (e is SynchronizationLockException)
 			tip = Language.GetTextValue("tModLoader.AntivirusHint");
 		else if (e is TypeInitializationException)
 			tip = Language.GetTextValue("tModLoader.TypeInitializationHint");
+
+		if (e.HelpLink != null) {
+			try {
+				Utils.OpenToURL(e.HelpLink);
+			}
+			catch { }
+		}
 
 		if (tip != null)
 			message += "\n\n" + tip;

--- a/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
@@ -35,6 +35,8 @@ internal class Steam
 	{
 		RecalculateAvailableSteamCloudStorage();
 		Logging.Terraria.Info($"Steam Cloud Quota: {UIMemoryBar.SizeSuffix((long)lastAvailableSteamCloudStorage)} available");
+		bool OnBetaBranch = SteamApps.GetCurrentBetaName(out string branchName, 1000);
+		Logging.tML.Info($"Steam beta branch: {(OnBetaBranch ? branchName : "None")}");
 	}
 
 	public static string GetSteamTerrariaInstallDir()

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -14,6 +14,7 @@ using Terraria.ModLoader.UI;
 using Terraria.ModLoader.UI.DownloadManager;
 using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.GameContent.UI.States;
+using Terraria.Social;
 using Terraria.Social.Steam;
 using Terraria.UI;
 
@@ -35,6 +36,7 @@ internal static class Interface
 	//internal const int managePublishedID = 10011;
 	internal const int updateMessageID = 10012;
 	internal const int infoMessageID = 10013;
+	internal const int infoMessageDelayedID = 10014;
 	//internal const int enterPassphraseMenuID = 10015;
 	internal const int modPacksMenuID = 10016;
 	internal const int tModLoaderSettingsID = 10017;
@@ -52,6 +54,7 @@ internal static class Interface
 	internal static UIErrorMessage errorMessage = new UIErrorMessage();
 	internal static UIModBrowser modBrowser = new UIModBrowser();
 	internal static UIModInfo modInfo = new UIModInfo();
+	internal static UIForcedDelayInfoMessage infoMessageDelayed = new UIForcedDelayInfoMessage();
 	//internal static UIManagePublished managePublished = new UIManagePublished();
 	internal static UIUpdateMessage updateMessage = new UIUpdateMessage();
 	internal static UIInfoMessage infoMessage = new UIInfoMessage();

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIForcedDelayInfoMessage.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIForcedDelayInfoMessage.cs
@@ -1,0 +1,58 @@
+using Microsoft.Xna.Framework;
+using Terraria.GameContent.UI.Elements;
+using Terraria.Localization;
+
+namespace Terraria.ModLoader.UI;
+
+internal class UIForcedDelayInfoMessage : UIInfoMessage
+{
+	int timeLeft = -1;
+	private UITextPanel<string> waitPanel;
+
+	internal void Delay(int seconds)
+	{
+		Main.menuMode = Interface.infoMessageDelayedID;
+		if (timeLeft == -1)
+			timeLeft = seconds * 60;
+	}
+
+	public override void OnInitialize()
+	{
+		base.OnInitialize();
+
+		waitPanel = new UITextPanel<string>(Language.GetTextValue("tModLoader.WaitXSeconds", timeLeft / 60), 0.7f, true) {
+			Width = { Pixels = -10, Percent = 0.5f },
+			Height = { Pixels = 50 },
+			Left = { Percent = 0 },
+			VAlign = 1f,
+			Top = { Pixels = -30 },
+			BackgroundColor = Color.Orange
+		};
+	}
+
+	public override void OnActivate()
+	{
+		base.OnActivate();
+
+		_area.AddOrRemoveChild(_button, false);
+		_area.Append(waitPanel);
+	}
+
+	public override void Update(GameTime gameTime)
+	{
+		base.Update(gameTime);
+
+		if (timeLeft > 0) {
+			timeLeft--;
+			waitPanel.SetText(Language.GetTextValue("tModLoader.WaitXSeconds", timeLeft / 60 + 1));
+
+			if (timeLeft == 0) {
+				// Leftover from 1.4.3-Legacy to 1.4.4 transition
+				//ModLoader.SeenMigrateTo143BranchMessage = true; // altbutton will trigger the state refresh, unfortunately.
+
+				_area.AddOrRemoveChild(waitPanel, false);
+				_area.AddOrRemoveChild(_button, true);
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIInfoMessage.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIInfoMessage.cs
@@ -10,9 +10,9 @@ namespace Terraria.ModLoader.UI;
 
 internal class UIInfoMessage : UIState, IHaveBackButtonCommand
 {
-	private UIElement _area;
+	protected UIElement _area;
 	private UIMessageBox _messageBox;
-	private UITextPanel<string> _button;
+	protected UITextPanel<string> _button;
 	private UITextPanel<string> _buttonAlt;
 	private UIState _gotoState;
 	private string _message;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -31,6 +31,7 @@ internal class UIModItem : UIPanel
 	private UIImage _configButton;
 	private UIText _modName;
 	private UIModStateText _uiModStateText;
+	private UIAutoScaleTextTextPanel<string> tMLUpdateRequired;
 	private UIHoverImage _modReferenceIcon;
 	private UIImage _deleteModButton;
 	private UIAutoScaleTextTextPanel<string> _dialogYesButton;
@@ -100,22 +101,45 @@ internal class UIModItem : UIPanel
 			Left = { Pixels = _modIconAdjust }
 		};
 		_uiModStateText.OnLeftClick += ToggleEnabled;
-		Append(_uiModStateText);
 
+		// Don't show the Enable/Disable button if there is no loadable version
+		if (BuildInfo.tMLVersion.MajorMinorBuild() < _mod.tModLoaderVersion.MajorMinorBuild()) {
+			string updateVersion = $"v{_mod.tModLoaderVersion}";
+			string updateURL = "https://github.com/tModLoader/tModLoader/releases/latest";
+
+			if (_mod.tModLoaderVersion.MajorMinor() > BuildInfo.stableVersion)
+				updateVersion = $"Preview {updateVersion}";
+
+			tMLUpdateRequired = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MBRequiresTMLUpdate", updateVersion)).WithFadedMouseOver(Color.Orange, Color.Orange * 0.7f);
+			tMLUpdateRequired.BackgroundColor = Color.Orange * 0.7f;
+			tMLUpdateRequired.Top.Pixels = 40;
+			tMLUpdateRequired.Width.Pixels = 280;
+			tMLUpdateRequired.Height.Pixels = 36;
+			tMLUpdateRequired.Left.Pixels += _uiModStateText.Width.Pixels + _uiModStateText.Left.Pixels + PADDING;
+			tMLUpdateRequired.OnLeftClick += (a, b) => {
+				Utils.OpenToURL(updateURL);
+			};
+			Append(tMLUpdateRequired);
+		}
+		else
+			Append(_uiModStateText);
+
+		int bottomRightRowOffset = -36;
 		_moreInfoButton = new UIImage(UICommon.ButtonModInfoTexture) {
 			Width = { Pixels = 36 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = -36, Precent = 1 },
+			Left = { Pixels = bottomRightRowOffset, Precent = 1 },
 			Top = { Pixels = 40 }
 		};
 		_moreInfoButton.OnLeftClick += ShowMoreInfo;
 		Append(_moreInfoButton);
 
 		if (ModLoader.TryGetMod(ModName, out var loadedMod) && ConfigManager.Configs.ContainsKey(loadedMod)) {
+			bottomRightRowOffset -= 36;
 			_configButton = new UIImage(UICommon.ButtonModConfigTexture) {
 				Width = { Pixels = 36 },
 				Height = { Pixels = 36f },
-				Left = { Pixels = _moreInfoButton.Left.Pixels - 36 - PADDING, Precent = 1f },
+				Left = { Pixels = bottomRightRowOffset - PADDING, Precent = 1f },
 				Top = { Pixels = 40f }
 			};
 			_configButton.OnLeftClick += OpenConfig;
@@ -209,10 +233,11 @@ internal class UIModItem : UIPanel
 		};
 
 		if (!_loaded) {
+			bottomRightRowOffset -= 36;
 			_deleteModButton = new UIImage(TextureAssets.Trash) {
 				Width = { Pixels = 36 },
 				Height = { Pixels = 36 },
-				Left = { Pixels = _moreInfoButton.Left.Pixels - 36 - PADDING, Precent = 1 },
+				Left = { Pixels = bottomRightRowOffset - PADDING, Precent = 1 },
 				Top = { Pixels = 42.5f }
 			};
 			_deleteModButton.OnLeftClick += QuickModDelete;
@@ -310,6 +335,9 @@ internal class UIModItem : UIPanel
 				_tooltip = Language.GetTextValue("tModLoader.ModAddedSinceLastLaunchMessage");
 			else
 				_tooltip = Language.GetTextValue("tModLoader.ModUpdatedSinceLastLaunchMessage", previousVersionHint);
+		}
+		else if (tMLUpdateRequired?.IsMouseHovering == true) {
+			_tooltip = Language.GetTextValue("tModLoader.MBClickToUpdate");
 		}
 	}
 

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using ReLogic.OS;
 using System;
 using System.Collections.Generic;
@@ -41,20 +42,26 @@ public static partial class Program
 		}
 	}
 
-	private static void PortOldSaveDirectories()
+	public const string PreviewFolder = "tModLoader-preview";
+	public const string ReleaseFolder = "tModLoader";
+	public const string DevFolder = "tModLoader-dev";
+	public const string Legacy143Folder = "tModLoader-1.4.3";
+	public static string SaveFolderName => BuildInfo.IsStable ? ReleaseFolder : BuildInfo.IsPreview ? PreviewFolder : DevFolder;
+
+	private static void PortOldSaveDirectories(string savePath)
 	{
 		// PortOldSaveDirectories should only run once no matter which branch is run first.
 
 		// Port old file format users
-		var oldBetas = Path.Combine(SavePath, "ModLoader", "Beta");
+		var oldBetas = Path.Combine(savePath, "ModLoader", "Beta");
 
 		if (!Directory.Exists(oldBetas))
 			return;
 
 		Logging.tML.Info($"Old tModLoader alpha folder \"{oldBetas}\" found, attempting folder migration");
 
-		var newPath = Path.Combine(SavePath, ReleaseFolder);
-		if (Directory.Exists(newPath)){
+		var newPath = Path.Combine(savePath, ReleaseFolder);
+		if (Directory.Exists(newPath)) {
 			Logging.tML.Warn($"Both \"{oldBetas}\" and \"{newPath}\" exist, assuming user launched old tModLoader alpha, aborting migration");
 			return;
 		}
@@ -67,6 +74,7 @@ public static partial class Program
 			string newSaveOriginalSubDirPath = Path.Combine(newPath, subDir);
 			if (Directory.Exists(newSaveOriginalSubDirPath)) {
 				string newSaveNewSubDirPath = Path.Combine(newPath, subDir.Replace(" ", ""));
+
 				Logging.tML.Info($"Renaming from \"{newSaveOriginalSubDirPath}\" to \"{newSaveNewSubDirPath}\"");
 				Directory.Move(newSaveOriginalSubDirPath, newSaveNewSubDirPath);
 			}
@@ -74,21 +82,126 @@ public static partial class Program
 		Logging.tML.Info($"Folder Renames Success");
 	}
 
-	private static void PortCommonFiles()
+	private static void PortCommonFilesToStagingBranches(string savePath)
 	{
 		// Only create and port config files from stable if needed.
 		if (BuildInfo.IsStable)
 			return;
 		
-		var releasePath = Path.Combine(SavePath, ReleaseFolder);
-		var newPath = Path.Combine(SavePath, SaveFolderName);
+		var releasePath = Path.Combine(savePath, ReleaseFolder);
+		var newPath = Path.Combine(savePath, SaveFolderName);
 		if (Directory.Exists(releasePath) && !Directory.Exists(newPath)) {
 			Directory.CreateDirectory(newPath);
+			Logging.tML.Info("Cloning common files from Stable to preview and dev.");
+
 			if (File.Exists(Path.Combine(releasePath, "config.json")))
 				File.Copy(Path.Combine(releasePath, "config.json"), Path.Combine(newPath, "config.json"));
 			if (File.Exists(Path.Combine(releasePath, "input profiles.json")))
 				File.Copy(Path.Combine(releasePath, "input profiles.json"), Path.Combine(newPath, "input profiles.json"));
 		}
+	}
+
+	/// <summary>
+	/// Super Save Path is the parent directory containing both folders. Usually Program.SavePath or Steam Cloud
+	/// Source is of variety StableFolder, PreviewFolder... etc
+	/// Destination is of variety StableFolder, PreviewFolder... etc
+	/// maxVersionOfSource is used to determine if we even should port the files. Example: 1.4.3-Legacy has maxVersion of 2022.9
+	/// </summary>
+	private static void PortFilesFromXtoY(string superSavePath, string source, string destination, string maxVersionOfSource, bool isCloud)
+	{
+		string newFolderPath = Path.Combine(superSavePath, destination);
+		string newFolderPathTemp = Path.Combine(superSavePath, destination + "-temp");
+		string oldFolderPath = Path.Combine(superSavePath, source);
+		string cloudName = isCloud ? "Steam Cloud" : "Local Files";
+		// Previous code relied on "143portedLocal Files.txt" and "143portedSteam Cloud.txt" in oldFolderPath,
+		// this could potentially cause issues if a user clears out their stable folder in the future.
+		// Now we rely on the folder existing as the sole indicator.
+
+		// We need to port if:
+		// 1. We haven't already ported -> Check if destination folder exists.
+		// and
+		// 2. We have something to port -> Check if source folder exists and we that have no indication that the files in it are for a future version.
+
+		if (Directory.Exists(newFolderPath) || !Directory.Exists(oldFolderPath))
+			return;
+
+		// We need onedrive running if it is on Path
+		if (newFolderPath.Contains("OneDrive")) {
+			Logging.tML.Info("Ensuring OneDrive is running before starting to Migrate Files");
+			try {
+				System.Diagnostics.Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft OneDrive\\OneDrive.exe"));
+				Thread.Sleep(3000);
+			}
+			catch { }
+		}
+
+		// Verify that we are moving maxVersionOfSource player data to destination folder. Do so by checking for version <= maxVersionOfSource
+		string defaultSaveFolder = LaunchParameters.ContainsKey("-savedirectory") ? LaunchParameters["-savedirectory"] :
+			Platform.Get<IPathService>().GetStoragePath($"Terraria");
+
+		string sourceFolderConfig = Path.Combine(defaultSaveFolder, source, "config.json");
+		if (!File.Exists(sourceFolderConfig))
+			return;
+
+		string lastLaunchedTml = null;
+		try {
+			var configCollection = JsonConvert.DeserializeObject<Dictionary<string, object>>(File.ReadAllText(sourceFolderConfig));
+			if (configCollection.TryGetValue("LastLaunchedTModLoaderVersion", out object lastLaunchedTmlObject))
+				lastLaunchedTml = (string)lastLaunchedTmlObject;
+		}
+		catch (Exception e) {
+			e.HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#configjson-corrupted";
+			ErrorReporting.FatalExit($"Attempt to Port from \"{oldFolderPath}\" to \"{newFolderPath}\" aborted, the \"{sourceFolderConfig}\" file is corrupted.", e);
+		}
+
+		if (string.IsNullOrEmpty(lastLaunchedTml)) {
+			// It's unclear what we should do in this situation. Leave it up to the user.
+			// It is possible the user copied in their Terraria config.json.
+			ErrorReporting.FatalExit($"Attempt to Port from \"{oldFolderPath}\" to \"{newFolderPath}\" aborted, the \"{sourceFolderConfig}\" file is missing the \"LastLaunchedTModLoaderVersion\" entry. If porting is desired, follow the instructions at \"https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#manually-port\"");
+			return;
+		}
+		if (new Version(lastLaunchedTml).MajorMinor() > new Version(maxVersionOfSource)) {
+			Logging.tML.Info($"Attempt to Port from \"{oldFolderPath}\" to \"{newFolderPath}\" aborted, \"{lastLaunchedTml}\" is a newer version.");
+			return;
+		}
+
+		// Copy all current stable player files to 1.4.3-legacy during transition period. Skip ModSources & Workshop shared folders
+		Logging.tML.Info($"Cloning current {source} files to {destination} save folder. Porting {cloudName}." +
+			$"\nThis may take a few minutes for a large amount of files.");
+		try {
+			Utilities.FileUtilities.CopyFolderEXT(oldFolderPath, isCloud ? newFolderPath : newFolderPathTemp, isCloud,
+				// Exclude the ModSources folder that exists only on Stable, and exclude the temporary 'Workshop' folder created during first time Mod Publishing
+				excludeFilter: new System.Text.RegularExpressions.Regex(@"(Workshop|ModSources)($|/|\\)"),
+				overwriteAlways: false, overwriteOld: true);
+		}
+		catch (Exception e) {
+			e.HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#migration-failed";
+			ErrorReporting.FatalExit($"Migration Failed, please consult the instructions in the \"Migration Failed\" section at \"{e.HelpLink}\" for more information.", e);
+		}
+
+		if (!isCloud) {
+			// If everything goes well, rename the folder. Only local files use this atomic approach. This will prevent situations where a user ends the porting process from impatience and the port is half complete.
+			Directory.Move(newFolderPathTemp, newFolderPath);
+		}
+		else {
+			// We need a way on the cloud of knowing if the porting has been done, since users might have multiple computers.
+			// In case there are no players and worlds, we don't want to keep attempting to port, since eventually that will port future stable files if they appear.
+			// We also need at least 1 file in the directory, otherwise the directory will not exist.
+			if (Social.SocialAPI.Cloud != null) {
+				// Backwards compat line for 1.4.3-legacy
+				string portFileName = maxVersionOfSource == "2022.9" ? $"143ported_{cloudName}.txt" : $"{maxVersionOfSource}{destination}ported_{cloudName}.txt";
+				Social.SocialAPI.Cloud.Write(Path.Combine(destination, portFileName), new byte[] { });
+			}
+		}
+
+		Logging.tML.Info($"Porting {cloudName} finished");
+	}
+
+	internal static void PortFilesMaster(string savePath, bool isCloud)
+	{
+		PortOldSaveDirectories(savePath);
+		PortCommonFilesToStagingBranches(savePath);
+		PortFilesFromXtoY(savePath, ReleaseFolder, Legacy143Folder, maxVersionOfSource: "2022.9", isCloud);
 	}
 
 	private static void SetSavePath()
@@ -106,8 +219,7 @@ public static partial class Program
 		else {
 			// File migration is only attempted for the default save folder
 			try {
-				PortOldSaveDirectories();
-				PortCommonFiles();
+				PortFilesMaster(SavePath, isCloud: false);
 			}
 			catch (Exception e) {
 				ErrorReporting.FatalExit("An error occured migrating files and folders to the new structure", e);

--- a/patches/tModLoader/Terraria/Program.cs.patch
+++ b/patches/tModLoader/Terraria/Program.cs.patch
@@ -92,15 +92,10 @@
  		try {
  			Console.OutputEncoding = Encoding.UTF8;
  			if (Platform.IsWindows)
-@@ -147,23 +_,56 @@
+@@ -147,23 +_,51 @@
  		}
  	}
  
-+	public const string PreviewFolder = "tModLoader-preview";
-+	public const string ReleaseFolder = "tModLoader";
-+	public const string DevFolder = "tModLoader-dev";
-+	public static string SaveFolderName => BuildInfo.IsStable ? ReleaseFolder : BuildInfo.IsPreview ? PreviewFolder : DevFolder;
-+
 +	//IMPORTANT: We really want arg parsing, logging, and monomod initialized before static Main()
 +	// Moving all calls to Main to LaunchGame_() mitigates this risk
  	public static void LaunchGame(string[] args, bool monoArgs = false)

--- a/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.TML.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace Terraria.Social.Steam;
+
+public partial class CoreSocialModule : ISocialModule
+{
+	private static void PortFilesToCurrentStructure()
+	{
+		// Note that if we want Steam to actually acknowledge the changes, we have to use the API calls for IREmoteStorage (the isCloud flag)
+		Program.PortFilesMaster(GetCloudSaveLocation(), isCloud: true);
+	}
+
+	internal static string GetCloudSaveLocation()
+	{
+		// 512 is Windows Path max length
+		Steamworks.SteamUser.GetUserDataFolder(out string steamCloudFolder, 512);
+
+		// current steamCloudFolder looks like: C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\1281930\\local
+		// So we have to do some path manipulation to get to C:\\Program Files (x86)\\Steam\\userdata\\SteamID OLD\\\\105600\\local
+		return Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(steamCloudFolder)), "105600", "remote");
+	}
+}

--- a/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/CoreSocialModule.cs.patch
@@ -12,7 +12,8 @@
  
  namespace Terraria.Social.Steam;
  
- public class CoreSocialModule : ISocialModule
+-public class CoreSocialModule : ISocialModule
++public partial class CoreSocialModule : ISocialModule
  {
  	private static CoreSocialModule _instance;
 +
@@ -23,7 +24,7 @@
  	private bool IsSteamValid;
  	private object _steamTickLock = new object();
  	private object _steamCallbackLock = new object();
-@@ -26,14 +_,16 @@
+@@ -26,15 +_,18 @@
  	public void Initialize()
  	{
  		_instance = this;
@@ -40,5 +41,7 @@
 -			Environment.Exit(1);
 +			ErrorReporting.FatalExit(Language.GetTextValue("Error.LaunchFromSteam"));
  		}
++		PortFilesToCurrentStructure();
  
  		IsSteamValid = true;
+ 		Thread thread = new Thread(SteamCallbackLoop);

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
@@ -1,0 +1,103 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Terraria.Social;
+
+namespace Terraria.Utilities;
+
+public static partial class FileUtilities
+{
+	public static void CopyExtended(string source, string destination, bool cloud, bool overwriteAlways, bool overwriteOld = true)
+	{
+		bool overwrite = DetermineIfShouldOverwrite(overwriteAlways, overwriteOld, source, destination);
+		if (!overwrite && File.Exists(destination))
+			return;
+
+		if (!cloud) {
+			try {
+				File.Copy(source, destination, overwrite);
+			}
+			catch (IOException ex) {
+				if (ex.GetType() != typeof(IOException))
+					throw;
+
+				// TER-827 - fallback for random File.Copy failures on Win11
+				using (var inputstream = File.OpenRead(source))
+				using (var outputstream = File.Create(destination))
+					inputstream.CopyTo(outputstream);
+			}
+			return;
+		}
+
+		// Sanitize the paths for Steam calls
+		string cloudPath = Social.Steam.CoreSocialModule.GetCloudSaveLocation();
+		destination = ConvertToRelativePath(cloudPath, destination);
+		source = ConvertToRelativePath(cloudPath, source);
+
+		if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination))) {
+			var bytes = SocialAPI.Cloud.Read(source);
+			SocialAPI.Cloud.Write(destination, bytes);
+		}
+	}
+
+	public static void CopyFolderEXT(string sourcePath, string destinationPath, bool isCloud = false, Regex excludeFilter = null, bool overwriteAlways = false, bool overwriteOld = false)
+	{
+		Directory.CreateDirectory(destinationPath);
+		string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
+		for (int i = 0; i < directories.Length; i++) {
+			string relativePath = ConvertToRelativePath(sourcePath, directories[i]);
+			if (excludeFilter != null && excludeFilter.IsMatch(relativePath))
+				continue;
+
+			Directory.CreateDirectory(directories[i].Replace(sourcePath, destinationPath));
+		}
+
+		directories = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
+		// Assumes each file is on average 0.5 MB and is moved at 15 MB/s.  - Solxan.
+		ModLoader.Logging.tML.Info($"Number of files to Copy: {directories.Length}. Estimated time for HDD @15 MB/s: {directories.Length / 30} seconds");
+		foreach (string obj in directories) {
+			string relativePath = ConvertToRelativePath(sourcePath, obj);
+			if (excludeFilter != null && excludeFilter.IsMatch(relativePath))
+				continue;
+
+			CopyExtended(obj, obj.Replace(sourcePath, destinationPath), isCloud, overwriteAlways, overwriteOld);
+		}
+	}
+
+	/// <summary>
+	/// Converts the full 'path' to remove the base path component.
+	/// Example: C://My Documents//Help Me I'm Hungry.txt is full 'path'
+	///		basePath is C://My Documents
+	///		Thus returns 'Help Me I'm Hungry.txt'
+	/// </summary>
+	public static string ConvertToRelativePath(string basePath, string fullPath)
+	{
+		if (!fullPath.StartsWith(basePath)) {
+			ModLoader.Logging.tML.Debug($"string {fullPath} does not contain string {basePath}. Is this correct?");
+			return fullPath;
+		}
+
+		return fullPath.Substring(basePath.Length + 1);
+	}
+
+	/// <summary>
+	/// DEtermines if should overwrite the file at Destination with the file at Source
+	/// </summary>
+	private static bool DetermineIfShouldOverwrite(bool overwriteAlways, bool overwriteOld, string source, string destination)
+	{
+		if (overwriteAlways)
+			return true;
+
+		// doesn't really matter
+		if (!File.Exists(destination))
+			return overwriteAlways;
+
+		// If file exists, and we aren't going to overwrite old versions
+		if (!overwriteOld)
+			return false;
+
+		var srcFile = File.GetLastWriteTimeUtc(source);
+		var dstFile = File.GetLastWriteTimeUtc(destination);
+
+		return dstFile < srcFile;
+	}
+}

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
@@ -100,4 +100,19 @@ public static partial class FileUtilities
 
 		return dstFile < srcFile;
 	}
+
+	// TODO: Do we need to do extra work for .plr files that have been renamed? Is that valid?
+	// TODO: We could probably support cloud players as well, if we tried.
+	// Vanilla and 1.3 paths are defaults, 1.4 TML paths are relative to current savepath.
+	public static (string path, string message, int stabilityLevel)[] GetAlternateSavePathFiles(string folderName)
+	{
+		return new (string path, string message, int stabilityLevel)[] {
+			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), $"{folderName}"), "Click to copy \"{0}\" over from Terraria", 0),
+			(path: Path.Combine(ReLogic.OS.Platform.Get<ReLogic.OS.IPathService>().GetStoragePath("Terraria"), "ModLoader", $"{folderName}"), "Click to copy \"{0}\" over from 1.3 tModLoader", 0),
+			(path: Path.Combine(Main.SavePath, "..", Program.ReleaseFolder, $"{folderName}"), "Click to copy \"{0}\" over from stable", 1),
+			(path: Path.Combine(Main.SavePath, "..", Program.PreviewFolder, $"{folderName}"), "Click to copy \"{0}\" over from preview", 2),
+			(path: Path.Combine(Main.SavePath, "..", Program.DevFolder, $"{folderName}"), "Click to copy \"{0}\" over from dev", 3),
+			(path: Path.Combine(Main.SavePath, "..", Program.Legacy143Folder, $"{folderName}"), "Click to copy \"{0}\" over from 1.4.3-Legacy", 0),
+		};
+	}
 }

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.cs.patch
@@ -1,0 +1,45 @@
+--- src/TerrariaNetCore/Terraria/Utilities/FileUtilities.cs
++++ src/tModLoader/Terraria/Utilities/FileUtilities.cs
+@@ -7,7 +_,7 @@
+ 
+ namespace Terraria.Utilities;
+ 
+-public static class FileUtilities
++public static partial class FileUtilities
+ {
+ 	private static Regex FileNameRegex = new Regex("^(?<path>.*[\\\\\\/])?(?:$|(?<fileName>.+?)(?:(?<extension>\\.[^.]*$)|$))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+ 
+@@ -39,6 +_,7 @@
+ 
+ 	public static void Copy(string source, string destination, bool cloud, bool overwrite = true)
+ 	{
++		/*
+ 		if (!cloud) {
+ 			try {
+ 				File.Copy(source, destination, overwrite);
+@@ -57,6 +_,8 @@
+ 
+ 		if (SocialAPI.Cloud != null && (overwrite || !SocialAPI.Cloud.HasFile(destination)))
+ 			SocialAPI.Cloud.Write(destination, SocialAPI.Cloud.Read(source));
++		*/
++		CopyExtended(source, destination, cloud, overwriteAlways: overwrite);
+ 	}
+ 
+ 	public static void Move(string source, string destination, bool cloud, bool overwrite = true, bool forceDeleteSourceFile = false)
+@@ -181,6 +_,7 @@
+ 
+ 	public static void CopyFolder(string sourcePath, string destinationPath)
+ 	{
++		/*
+ 		Directory.CreateDirectory(destinationPath);
+ 		string[] directories = Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories);
+ 		for (int i = 0; i < directories.Length; i++) {
+@@ -191,6 +_,8 @@
+ 		foreach (string obj in directories) {
+ 			File.Copy(obj, obj.Replace(sourcePath, destinationPath), overwrite: true);
+ 		}
++		*/
++		CopyFolderEXT(sourcePath, destinationPath, isCloud: false, overwriteAlways: true);
+ 	}
+ 
+ 	public static void ProtectedInvoke(Action action)


### PR DESCRIPTION
This is a draft for forwarding porting of changes deployed in 1.4.3-Legacy to cover off migrating save data and related UI.

The aim of the port is to be as close as is reasonable to https://github.com/tModLoader/tModLoader/compare/stable...1.4.3-legacy

However, it is noticed that there are a few items that will have to be cleaned up before merging.