### PR TITLE
add DamageClassLoader.GetDamageClass

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Terraria.ModLoader;
@@ -68,4 +67,11 @@ public static class DamageClassLoader
 			ModTypeLookup<DamageClass>.Register(damageClass);
 		}
 	}
+
+	/// <summary>
+	/// Gets the DamageClass instance corresponding to the specified type
+	/// </summary>
+	/// <param name="type">The <see cref="DamageClass.Type"/> of the damage class</param>
+	/// <returns>The DamageClass instance, null if not found.</returns>
+	public static DamageClass GetDamageClass(int type) => type < DamageClasses.Count ? DamageClasses[type] : null;
 }


### PR DESCRIPTION
### What is the new feature?
new `DamageClassLoader.GetDamageClass` method for retrieving a `DamageClass` instance from its type.

### Why should this be part of tModLoader?
Modders have currently no way to actually use `DamageClass.Type` as a lookup for the `DamageClass` instance. TML itself does it in i.e. netcode, modders might need it too.

### Are there alternative designs?
No. This mirrors existing `XLoader.GetX` methods.

### Sample usage for the new feature
```cs
binaryWriter.Write7BitEncodedInt(damageClass.Type);
//
DamageClass damageClass = DamageClassLoader.GetDamageClass(binaryReader.Read7BitEncodedInt());
```

### ExampleMod updates
None

