### PR TITLE
Now TooltipLine instances can be hidden.

### DIFF
--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -53,7 +53,7 @@ namespace ExampleMod.Content.Items
 			}
 
 			// Another method of hiding can be done if you want to hide just one line.
-			// tooltips.FirstOrDefault(x => x.Mod == "ExampleMod" && x.Name == "Vertbose:RemoveMe")?.Hide();
+			// tooltips.FirstOrDefault(x => x.Mod == "ExampleMod" && x.Name == "Verbose:RemoveMe")?.Hide();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -52,11 +52,8 @@ namespace ExampleMod.Content.Items
 				}
 			}
 
-			// Another method of hiding can be done if you know the index of the tooltip:
-			// tooltips[index].Hide();
-
-			// You can also hide a specific line, if you have access to that object:
-			// tooltipLine.Hide();
+			// Another method of hiding can be done if you want to hide just one line.
+			// tooltips.FirstOrDefault(x => x.Mod == "ExampleMod" && x.Name == "Vertbose:RemoveMe")?.Hide();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -44,15 +44,19 @@ namespace ExampleMod.Content.Items
 				}
 			}
 
-			// Here we will remove all tooltips whose title end with ':RemoveMe'
+			// Here we will hide all tooltips whose title end with ':RemoveMe'
 			// One like that is added at the start of this method
-			tooltips.RemoveAll(l => l.Name.EndsWith(":RemoveMe"));
+			foreach (var l in tooltips) {
+				if (l.Name.EndsWith(":RemoveMe")) {
+					l.Hide();
+				}
+			}
 
-			// Another method of removal can be done if you know the index of the tooltip:
-			// tooltips.RemoveAt(index);
+			// Another method of hiding can be done if you know the index of the tooltip:
+			// tooltips[index].Hide();
 
-			// You can also remove a specific line, if you have access to that object:
-			// tooltips.Remove(tooltipLine);
+			// You can also hide a specific line, if you have access to that object:
+			// tooltipLine.Hide();
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -1102,7 +1102,7 @@ ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float const
 	}
 
 	/// <summary>
-	/// Allows you to modify all the tooltips that display for the given item. See here for information about TooltipLine.
+	/// Allows you to modify all the tooltips that display for the given item. See here for information about TooltipLine. To hide tooltips, please use <see cref="TooltipLine.Hide"/> and defensive coding.
 	/// </summary>
 	public virtual void ModifyTooltips(Item item, List<TooltipLine> tooltips)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2191,6 +2191,8 @@ public static class ItemLoader
 			}
 		}
 
+		tooltips.RemoveAll(x => !x.Visible);
+
 		numTooltips = tooltips.Count;
 		text = new string[numTooltips];
 		modifier = new bool[numTooltips];

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -1314,7 +1314,7 @@ ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float const
 	}
 
 	/// <summary>
-	/// Allows you to modify all the tooltips that display for this item. See here for information about TooltipLine.
+	/// Allows you to modify all the tooltips that display for this item. See here for information about TooltipLine. To hide tooltips, please use <see cref="TooltipLine.Hide"/> and defensive coding.
 	/// </summary>
 	/// <param name="tooltips">The tooltips.</param>
 	public virtual void ModifyTooltips(List<TooltipLine> tooltips)

--- a/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
@@ -118,4 +118,8 @@ public class TooltipLine
 		Name = name;
 		Text = text;
 	}
+
+	public bool Visible { get; private set; } = true;
+
+	public void Hide() => Visible = false;
 }

--- a/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
@@ -18,6 +18,11 @@ public class TooltipLine
 	public readonly string Name;
 
 	/// <summary>
+	/// => $"{Mod}/{Name}"
+	/// </summary>
+	public string FullName => $"{Mod}/{Name}";
+
+	/// <summary>
 	/// The actual text that this tooltip displays.
 	/// </summary>
 	public string Text;


### PR DESCRIPTION
### What is the new feature?
#3640 

### Why should this be part of tModLoader?
#3640 

### Are there alternative designs?
None that I'm aware of, no.

### Sample usage for the new feature
```
int index = tooltips.FindIndex(x => x.Mod == "Terraria" && x.Name == "ItemName");
// Hide Item's Name tooltip line. This realistically should be always safe to do since every item has a name
tooltips[index].Hide();
```

### ExampleMod updates
`ExampleTooltipsItem` was changed to encourage modders use `Hide` instead of `Remove` methods.