### PR TITLE
Made GenPass instances hideable.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -356,8 +356,8 @@ public abstract partial class ModSystem : ModType
 
 	/// <summary>
 	/// A more advanced option to PostWorldGen, this method allows you modify the list of Generation Passes before a new world begins to be generated. <para/>
-	/// For example, removing the "Planting Trees" pass will cause a world to generate without trees. Placing a new Generation Pass before the "Dungeon" pass will prevent the the mod's pass from cutting into the dungeon. <para/>
-	/// To hide generation passes, please use <see cref="GenPass.Disable"/> and defensive coding.
+	/// For example, disabling the "Planting Trees" pass will cause a world to generate without trees. Placing a new Generation Pass before the "Dungeon" pass will prevent the the mod's pass from cutting into the dungeon. <para/>
+	/// To disable or hide generation passes, please use <see cref="GenPass.Disable"/> and defensive coding.
 	/// </summary>
 	public virtual void ModifyWorldGenTasks(List<GenPass> tasks, ref double totalWeight) { }
 
@@ -372,8 +372,8 @@ public abstract partial class ModSystem : ModType
 	public virtual void ResetNearbyTileEffects() { }
 
 	/// <summary>
-	/// Similar to ModifyWorldGenTasks, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. By default the list will only contain 4 items, the vanilla hardmode tasks called "Hardmode Good", "Hardmode Evil", "Hardmode Walls", and "Hardmode Announcement" <para/>
-	/// To hide tasks, please use <see cref="GenPass.Disable"/> and defensive coding.
+	/// Similar to <see cref="ModifyWorldGenTasks(List{GenPass}, ref double)"/>, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. By default the list will only contain 4 items, the vanilla hardmode tasks called "Hardmode Good", "Hardmode Evil", "Hardmode Walls", and "Hardmode Announcement" <para/>
+	/// To disable or hide tasks, please use <see cref="GenPass.Disable"/> and defensive coding.
 	/// </summary>
 	public virtual void ModifyHardmodeTasks(List<GenPass> list) { }
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -356,7 +356,8 @@ public abstract partial class ModSystem : ModType
 
 	/// <summary>
 	/// A more advanced option to PostWorldGen, this method allows you modify the list of Generation Passes before a new world begins to be generated. <para/>
-	/// For example, removing the "Planting Trees" pass will cause a world to generate without trees. Placing a new Generation Pass before the "Dungeon" pass will prevent the the mod's pass from cutting into the dungeon.
+	/// For example, removing the "Planting Trees" pass will cause a world to generate without trees. Placing a new Generation Pass before the "Dungeon" pass will prevent the the mod's pass from cutting into the dungeon. <para/>
+	/// To hide generation passes, please use <see cref="GenPass.Disable"/> and defensive coding.
 	/// </summary>
 	public virtual void ModifyWorldGenTasks(List<GenPass> tasks, ref double totalWeight) { }
 
@@ -371,7 +372,8 @@ public abstract partial class ModSystem : ModType
 	public virtual void ResetNearbyTileEffects() { }
 
 	/// <summary>
-	/// Similar to ModifyWorldGenTasks, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. By default the list will only contain 4 items, the vanilla hardmode tasks called "Hardmode Good", "Hardmode Evil", "Hardmode Walls", and "Hardmode Announcement"
+	/// Similar to ModifyWorldGenTasks, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. By default the list will only contain 4 items, the vanilla hardmode tasks called "Hardmode Good", "Hardmode Evil", "Hardmode Walls", and "Hardmode Announcement" <para/>
+	/// To hide tasks, please use <see cref="GenPass.Disable"/> and defensive coding.
 	/// </summary>
 	public virtual void ModifyHardmodeTasks(List<GenPass> list) { }
 

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -431,6 +431,8 @@ public static partial class SystemLoader
 				throw;
 			}
 		}
+
+		passes.RemoveAll(x => !x.Enabled);
 	}
 
 	public static void PostWorldGen()
@@ -459,6 +461,8 @@ public static partial class SystemLoader
 		foreach (var system in HookModifyHardmodeTasks.Enumerate()) {
 			system.ModifyHardmodeTasks(passes);
 		}
+
+		passes.RemoveAll(x => !x.Enabled);
 	}
 
 	internal static bool HijackGetData(ref byte messageType, ref BinaryReader reader, int playerNumber)

--- a/patches/tModLoader/Terraria/WorldBuilding/GenPass.TML.cs
+++ b/patches/tModLoader/Terraria/WorldBuilding/GenPass.TML.cs
@@ -1,0 +1,8 @@
+﻿namespace Terraria.WorldBuilding;
+
+partial class GenPass
+{
+	public bool Enabled { get; private set; } = true;
+
+	public void Disable() => Enabled = false;
+}

--- a/patches/tModLoader/Terraria/WorldBuilding/GenPass.cs.patch
+++ b/patches/tModLoader/Terraria/WorldBuilding/GenPass.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/WorldBuilding/GenPass.cs
++++ src/tModLoader/Terraria/WorldBuilding/GenPass.cs
+@@ -2,7 +_,7 @@
+ 
+ namespace Terraria.WorldBuilding;
+ 
+-public abstract class GenPass : GenBase
++public abstract partial class GenPass : GenBase
+ {
+ 	public string Name;
+ 	public double Weight;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -566,7 +566,7 @@
  					bool flag2 = TileID.Sets.Dirt[tile2.type];
  					if (notTheBees)
  						flag2 = flag2 || TileID.Sets.Mud[tile2.type];
-@@ -13849,12 +_,35 @@
+@@ -13849,12 +_,33 @@
  			skipFramingDuringGen = false;
  			progress.Message = Lang.gen[87].Value;
  		});
@@ -582,8 +582,6 @@
 +	private static void GenerateWorld_RunTasksAndFinish(int seed, Stopwatch generationStopwatch, GenerationProgress customProgressObject)
 +	{
 +		SystemLoader.ModifyWorldGenTasks(_generator._passes, ref _generator._totalLoadWeight);
-+
-+		_generator._passes.RemoveAll(x => !x.Enabled);
  
  		_generator.GenerateWorld(customProgressObject);
  		ConsumePostGenActions(GenVars.structures);
@@ -797,7 +795,7 @@
  		double num9 = (double)Main.maxTilesX / 4200.0;
  		int num10 = (int)(25.0 * num9);
  		ShapeData shapeData = new ShapeData();
-@@ -19416,13 +_,30 @@
+@@ -19416,13 +_,28 @@
  				shapeData.Clear();
  			}
  		}
@@ -818,8 +816,6 @@
 +	private static void smCallback_End(List<GenPass> hardmodeTasks)
 +	{
 +		SystemLoader.ModifyHardmodeTasks(hardmodeTasks);
-+
-+		hardmodeTasks.RemoveAll(x => !x.Enabled);
 +
 +		foreach (GenPass task in hardmodeTasks) {
 +			task.Apply(null, null);

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -566,7 +566,7 @@
  					bool flag2 = TileID.Sets.Dirt[tile2.type];
  					if (notTheBees)
  						flag2 = flag2 || TileID.Sets.Mud[tile2.type];
-@@ -13849,12 +_,33 @@
+@@ -13849,12 +_,35 @@
  			skipFramingDuringGen = false;
  			progress.Message = Lang.gen[87].Value;
  		});
@@ -582,6 +582,8 @@
 +	private static void GenerateWorld_RunTasksAndFinish(int seed, Stopwatch generationStopwatch, GenerationProgress customProgressObject)
 +	{
 +		SystemLoader.ModifyWorldGenTasks(_generator._passes, ref _generator._totalLoadWeight);
++
++		_generator._passes.RemoveAll(x => !x.Enabled);
  
  		_generator.GenerateWorld(customProgressObject);
  		ConsumePostGenActions(GenVars.structures);
@@ -795,7 +797,7 @@
  		double num9 = (double)Main.maxTilesX / 4200.0;
  		int num10 = (int)(25.0 * num9);
  		ShapeData shapeData = new ShapeData();
-@@ -19416,13 +_,28 @@
+@@ -19416,13 +_,30 @@
  				shapeData.Clear();
  			}
  		}
@@ -816,6 +818,8 @@
 +	private static void smCallback_End(List<GenPass> hardmodeTasks)
 +	{
 +		SystemLoader.ModifyHardmodeTasks(hardmodeTasks);
++
++		hardmodeTasks.RemoveAll(x => !x.Enabled);
 +
 +		foreach (GenPass task in hardmodeTasks) {
 +			task.Apply(null, null);


### PR DESCRIPTION
### What is the new feature?
Makes GenPassses hideable.

### Why should this be part of tModLoader?
Same reason as #3640 

### Are there alternative designs?
None that I'm aware of, no.

### Sample usage for the new feature
```
int index = tasks.FindIndex(genpass => genpass.Name.Equals("Reset"));
// No mod should realistically should remove genpasses.
tasks[index].Disable();
```

### ExampleMod updates
Should be none, I believe.