### PR TITLE
File Porting changes for 1.4.4 default

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -130,7 +130,7 @@ public static partial class Program
 			return;
 
 		// Backwards compat line for 1.4.3-legacy, intended for use when is not Atomic Lockable
-		string portFilePath = Path.Combine(destination, maxVersionOfSource == "2022.9" ? $"143ported_{cloudName}.txt" : $"{maxVersionOfSource}{destination}ported_{cloudName}.txt");
+		string portFilePath = Path.Combine(superSavePath, destination, maxVersionOfSource == "2022.9" ? $"143ported_{cloudName}.txt" : $"{maxVersionOfSource}{destination}ported_{cloudName}.txt");
 
 		if (isAtomicLockable && Directory.Exists(newFolderPath) || !isAtomicLockable && File.Exists(portFilePath))
 			return;
@@ -150,8 +150,10 @@ public static partial class Program
 			Platform.Get<IPathService>().GetStoragePath($"Terraria");
 
 		string sourceFolderConfig = Path.Combine(defaultSaveFolder, source, "config.json");
-		if (!File.Exists(sourceFolderConfig))
+		if (!File.Exists(sourceFolderConfig)) {
+			Logging.tML.Info($"No config.json found at {sourceFolderConfig}\nAssuming nothing to port");
 			return;
+		}	
 
 		string lastLaunchedTml = null;
 		try {
@@ -199,7 +201,7 @@ public static partial class Program
 				// In case there are no players and worlds, we don't want to keep attempting to port, since eventually that will port future stable files if they appear.
 				// We also need at least 1 file in the directory, otherwise the directory will not exist.
 				if (Social.SocialAPI.Cloud != null) {
-					Social.SocialAPI.Cloud.Write(Path.Combine(destination, portFilePath), new byte[] { });
+					Social.SocialAPI.Cloud.Write(Utilities.FileUtilities.ConvertToRelativePath(superSavePath, portFilePath), new byte[] { });
 				}
 			}
 			else {

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -106,6 +106,7 @@ public static partial class Program
 	/// Source is of variety StableFolder, PreviewFolder... etc
 	/// Destination is of variety StableFolder, PreviewFolder... etc
 	/// maxVersionOfSource is used to determine if we even should port the files. Example: 1.4.3-Legacy has maxVersion of 2022.9
+	/// isAtomicLockable could be expressed as CopyToNewlyCreatedDestinationFolderViaTempFolder if that makes more sense to the reader.
 	/// </summary>
 	private static void PortFilesFromXtoY(string superSavePath, string source, string destination, string maxVersionOfSource, bool isCloud, bool isAtomicLockable)
 	{
@@ -178,7 +179,7 @@ public static partial class Program
 		Logging.tML.Info($"Cloning current {source} files to {destination} save folder. Porting {cloudName}." +
 			$"\nThis may take a few minutes for a large amount of files.");
 		try {
-			Utilities.FileUtilities.CopyFolderEXT(oldFolderPath, isAtomicLockable ? newFolderPath : newFolderPathTemp, isCloud,
+			Utilities.FileUtilities.CopyFolderEXT(oldFolderPath, isAtomicLockable ? newFolderPathTemp : newFolderPath, isCloud,
 				// Exclude the ModSources folder that exists only on Stable, and exclude the temporary 'Workshop' folder created during first time Mod Publishing
 				excludeFilter: new System.Text.RegularExpressions.Regex(@"(Workshop|ModSources)($|/|\\)"),
 				overwriteAlways: false, overwriteOld: true);
@@ -188,16 +189,21 @@ public static partial class Program
 			ErrorReporting.FatalExit($"Migration Failed, please consult the instructions in the \"Migration Failed\" section at \"{e.HelpLink}\" for more information.", e);
 		}
 
-		if (!isAtomicLockable) {
+		if (isAtomicLockable) {
 			// If everything goes well, rename the folder. Only local files use this atomic approach. This will prevent situations where a user ends the porting process from impatience and the port is half complete.
 			Directory.Move(newFolderPathTemp, newFolderPath);
 		}
 		else {
-			// We need a way on the cloud of knowing if the porting has been done, since users might have multiple computers.
-			// In case there are no players and worlds, we don't want to keep attempting to port, since eventually that will port future stable files if they appear.
-			// We also need at least 1 file in the directory, otherwise the directory will not exist.
-			if (Social.SocialAPI.Cloud != null) {
-				Social.SocialAPI.Cloud.Write(Path.Combine(destination, portFilePath), new byte[] { });
+			if (isCloud) {
+				// We need a way on the cloud of knowing if the porting has been done, since users might have multiple computers.
+				// In case there are no players and worlds, we don't want to keep attempting to port, since eventually that will port future stable files if they appear.
+				// We also need at least 1 file in the directory, otherwise the directory will not exist.
+				if (Social.SocialAPI.Cloud != null) {
+					Social.SocialAPI.Cloud.Write(Path.Combine(destination, portFilePath), new byte[] { });
+				}
+			}
+			else {
+				File.Create(portFilePath);
 			}
 		}
 
@@ -212,10 +218,14 @@ public static partial class Program
 
 		// Establishing 1.4.3-Legacy branch
 		PortFilesFromXtoY(savePath, ReleaseFolder, Legacy143Folder, maxVersionOfSource: "2022.9", isCloud, isAtomicLockable: !isCloud);
+		// Local: This is supposed to create a new 1.4.3 folder if it doesn't exist, and ignore it if it does. (already migrated)
+		// Steam: Move files if canary file doesn't exist.
 
 		// Moving files from 1.4.4-preview (beta) to 1.4.4-stable - August 1st 2023 steam release
 		if (BuildInfo.IsStable)
 			PortFilesFromXtoY(savePath, PreviewFolder, ReleaseFolder, maxVersionOfSource: "2023.6", isCloud, isAtomicLockable: false);
+			// Local: Files and destination folder likely exist, copying in new files is expected/desired. Rely on already migrated file (canary file) to determine if migration should happen
+			// Steam: Move files if canary file doesn't exist.
 	}
 
 	private static void SetSavePath()


### PR DESCRIPTION
With the release of 1.4.4 to general Steam,
We will need to somehow get player data from the preview folder in to the Stable folder.

This PR represents that challenge, and addresses it by utilizing the same infrastructure we established for moving 1.4.3-legacy files in Steam Cloud.

Is this the best solution? Likely not for the long term, but it does address immediate needs.
Is safe to overwrite the files in the ReleaseFolder this time around given it's archived in to 1.4.3-legacy.

ALTERNATIVES:
We could make it so you can see all 'versions' of tmodloaders players and attempt to load in to a world with them.
If duplication exists, the player would then be prompted to choose.
I think this would be pushing too much complexity for a typical player and something would break in use, but that's an opinion. It may still be safer than this though.
