### PR TITLE
Fix #3668

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1215,7 +1215,7 @@ public static class TileLoader
 	{
 		for (int k = 0; k < ItemLoader.ItemCount; k++) {
 			Item item = ContentSamples.ItemsByType[k];
-			if (item.ModItem != null && !ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
+			if (!ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
 				if (item.createTile > -1) {
 					// TryAdd won't override existing value if present. Existing ModTile.RegisterItemDrop entries take precedence
 					tileTypeAndTileStyleToItemType.TryAdd((item.createTile, item.placeStyle), item.type);

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1215,7 +1215,7 @@ public static class TileLoader
 	{
 		for (int k = 0; k < ItemLoader.ItemCount; k++) {
 			Item item = ContentSamples.ItemsByType[k];
-			if (!ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
+			if (item.ModItem != null && !ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
 				if (item.createTile > -1) {
 					// TryAdd won't override existing value if present. Existing ModTile.RegisterItemDrop entries take precedence
 					tileTypeAndTileStyleToItemType.TryAdd((item.createTile, item.placeStyle), item.type);

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -329,7 +329,7 @@ public static class WallLoader
 	{
 		for (int k = 0; k < ItemLoader.ItemCount; k++) {
 			Item item = ContentSamples.ItemsByType[k];
-			if (!ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
+			if (item.ModItem != null && !ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
 				if (item.createWall > -1) {
 					// TryAdd won't override existing value if present. Existing ModWall.RegisterItemDrop entries take precedence
 					WallLoader.wallTypeToItemType.TryAdd(item.createWall, item.type);

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -199,11 +199,14 @@ public static class WallLoader
 				return false;
 			}
 		}
-		if (wallTypeToItemType.TryGetValue(type, out int value)) {
-			dropType = value;
-		}
 		ModWall modWall = GetWall(type);
-		return modWall?.Drop(i, j, ref dropType) ?? true;
+		if (modWall != null) {
+			if (wallTypeToItemType.TryGetValue(type, out int value)) {
+				dropType = value;
+			}
+			return modWall.Drop(i, j, ref dropType);
+		}
+		return true;
 	}
 	//in Terraria.WorldGen.KillWall after if statements setting fail to true call
 	//  WallLoader.KillWall(i, j, tile.wall, ref fail);
@@ -329,7 +332,7 @@ public static class WallLoader
 	{
 		for (int k = 0; k < ItemLoader.ItemCount; k++) {
 			Item item = ContentSamples.ItemsByType[k];
-			if (item.ModItem != null && !ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
+			if (!ItemID.Sets.DisableAutomaticPlaceableDrop[k]) {
 				if (item.createWall > -1) {
 					// TryAdd won't override existing value if present. Existing ModWall.RegisterItemDrop entries take precedence
 					WallLoader.wallTypeToItemType.TryAdd(item.createWall, item.type);


### PR DESCRIPTION
### What is the bug?
https://github.com/tModLoader/tModLoader/issues/3668

### How did you fix the bug?
By adding a check so only modded tiles and walls are added to `tileTypeAndTileStyleToItemType` and `wallTypeToItemType`.

### Are there alternatives to your fix?
Not that I know of
