### PR TITLE
Fix Duplication Search (#3649)

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -8,15 +8,14 @@
  using Terraria.UI;
  
  namespace Terraria.GameContent.Creative;
-@@ -20,17 +_,34 @@
+@@ -20,17 +_,33 @@
  		private int _unusedYoyoLogo;
  		private int _unusedResearchLine;
  		private string _search;
 +		
-+		// Added by TML. [[
++		// Added by TML.
 +		private string[] _toolTipNames = new string[30];
-+		private int _prefixLine = -1;
-+		// ]]
++		//
  
  		public bool FitsFilter(Item entry)
  		{
@@ -32,8 +31,8 @@
  			int numLines = 1;
  			float knockBack = entry.knockBack;
 -			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines);
-+			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _prefixLine);
-+			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedPrefixLine, ref _unusedBadPrefixLines, ref _unusedYoyoLogo, out _, _prefixLine);
++			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _);
++			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedPrefixLine, ref _unusedBadPrefixLines, ref _unusedYoyoLogo, out _, -1);
 +
 +			/*
  			for (int i = 0; i < numLines; i++) {

--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -8,14 +8,13 @@
  using Terraria.UI;
  
  namespace Terraria.GameContent.Creative;
-@@ -20,17 +_,33 @@
+@@ -20,17 +_,32 @@
  		private int _unusedYoyoLogo;
  		private int _unusedResearchLine;
  		private string _search;
 +		
 +		// Added by TML.
 +		private string[] _toolTipNames = new string[30];
-+		//
  
  		public bool FitsFilter(Item entry)
  		{

--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -8,25 +8,42 @@
  using Terraria.UI;
  
  namespace Terraria.GameContent.Creative;
-@@ -20,6 +_,9 @@
+@@ -20,17 +_,34 @@
  		private int _unusedYoyoLogo;
  		private int _unusedResearchLine;
  		private string _search;
 +		
-+		// Added by TML.
++		// Added by TML. [[
 +		private string[] _toolTipNames = new string[30];
++		private int _prefixLine = -1;
++		// ]]
  
  		public bool FitsFilter(Item entry)
  		{
-@@ -28,7 +_,7 @@
+ 			if (_search == null)
+ 				return true;
  
++			// Have to reinitialize because ItemLoader.ModifyTooltips resizes the arrays
++			_toolTipNames = new string[30];
++			_toolTipLines = new string[30];
++			_unusedPrefixLine = new bool[30];
++			_unusedBadPrefixLines = new bool[30];
++
  			int numLines = 1;
  			float knockBack = entry.knockBack;
 -			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines);
-+			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _);
++			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _prefixLine);
++			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedPrefixLine, ref _unusedBadPrefixLines, ref _unusedYoyoLogo, out _, _prefixLine);
++
++			/*
  			for (int i = 0; i < numLines; i++) {
  				if (_toolTipLines[i].ToLower().IndexOf(_search, StringComparison.OrdinalIgnoreCase) != -1)
++			*/
++			foreach (var line in modifiedTooltipLines) {
++				if (line.Text.ToLower().IndexOf(_search, StringComparison.OrdinalIgnoreCase) != -1)
  					return true;
+ 			}
+ 
 @@ -354,7 +_,7 @@
  
  		public MiscFallback(List<IItemEntryFilter> otherFiltersToCheckAgainst)


### PR DESCRIPTION
### What is the bug?
https://github.com/tModLoader/tModLoader/issues/3649

### How did you fix the bug?
By adding an `ItemLoader.ModifyTooltips()` call to `ItemFilters.BySearch.FitsFilter()`

### Are there alternatives to your fix?
Making `Main.MouseText_DrawItemTooltip_GetLinesInfo()` already call `ItemLoader.ModifyTooltips()` and return a `List<TooltipLine>` instead.