### PR TITLE
Add Additional World Save & Load Protections

### DIFF
--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -54,10 +54,11 @@
  			if (!FileUtilities.Exists(Main.worldPathName, flag) && Main.autoGen) {
  				if (!flag) {
  					for (int num = Main.worldPathName.Length - 1; num >= 0; num--) {
-@@ -356,6 +_,8 @@
+@@ -356,6 +_,9 @@
  							CheckSavedOreTiers();
  							binaryReader.Close();
  							memoryStream.Close();
++							// tML Added
 +							SystemLoader.OnWorldLoad();
 +							WorldIO.Load(Main.worldPathName, flag);
  							if (num3 != 0)
@@ -73,17 +74,12 @@
  			new Stopwatch().Start();
  			int num;
  			byte[] array;
-@@ -551,6 +_,13 @@
+@@ -551,6 +_,8 @@
  
  			if (text != null && array2 != null)
  				FileUtilities.WriteAllBytes(text, array2, useCloudSaving);
-+			try {
-+				WorldIO.Save(Main.worldPathName, useCloudSaving);
-+			}
-+			catch (Exception e) {
-+				Utils.ShowFancyErrorMessage(e.Message, 0);
-+			}
-+			
++
++			WorldIO.Save(Main.worldPathName, useCloudSaving);
  		}
  
  		private static void DoRollingBackups(string backupWorldWritePath) {

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -73,11 +73,17 @@
  			new Stopwatch().Start();
  			int num;
  			byte[] array;
-@@ -551,6 +_,7 @@
+@@ -551,6 +_,13 @@
  
  			if (text != null && array2 != null)
  				FileUtilities.WriteAllBytes(text, array2, useCloudSaving);
-+			WorldIO.Save(Main.worldPathName, useCloudSaving);
++			try {
++				WorldIO.Save(Main.worldPathName, useCloudSaving);
++			}
++			catch (Exception e) {
++				Utils.ShowFancyErrorMessage(e.Message, 0);
++			}
++			
  		}
  
  		private static void DoRollingBackups(string backupWorldWritePath) {

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -7,7 +7,6 @@ using Terraria.ID;
 using Terraria.ModLoader.Default;
 using Terraria.ModLoader.Engine;
 using Terraria.ModLoader.Exceptions;
-using Terraria.Social;
 using Terraria.Utilities;
 
 namespace Terraria.ModLoader.IO
@@ -25,11 +24,7 @@ namespace Terraria.ModLoader.IO
 			if (FileUtilities.Exists(path, isCloudSave))
 				FileUtilities.Copy(path, path + ".bak", isCloudSave);
 
-			using (Stream stream = isCloudSave ? (Stream)new MemoryStream() : (Stream)new FileStream(path, FileMode.Create)) {
-				TagIO.ToStream(tag, stream);
-				if (isCloudSave && SocialAPI.Cloud != null)
-					SocialAPI.Cloud.Write(path, ((MemoryStream)stream).ToArray());
-			}
+			FileUtilities.WriteTagCompound(path, isCloudSave, tag);
 		}
 
 		internal static TagCompound SaveData(Player player) {
@@ -89,8 +84,7 @@ namespace Terraria.ModLoader.IO
 			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
 
 			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				//LoadLegacy(player, buf);
-				return false;
+				throw new IOException($"{path} File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
 			}
 
 			tag = TagIO.FromStream(new MemoryStream(buf));

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -84,7 +84,7 @@ namespace Terraria.ModLoader.IO
 			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
 
 			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				throw new IOException($"{path} File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
+				throw new IOException($"{Path.GetFileName(path)}:: File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
 			}
 
 			tag = TagIO.FromStream(new MemoryStream(buf));

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
@@ -304,7 +304,6 @@ namespace Terraria.ModLoader.IO
 		public static void WriteTag(string name, object tag, BinaryWriter w) {
 			int id = GetPayloadId(tag.GetType());
 			w.Write((byte)id);
-
 			StringHandler.writer(w, name);
 			PayloadHandlers[id].Write(w, tag);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
@@ -304,6 +304,7 @@ namespace Terraria.ModLoader.IO
 		public static void WriteTag(string name, object tag, BinaryWriter w) {
 			int id = GetPayloadId(tag.GetType());
 			w.Write((byte)id);
+
 			StringHandler.writer(w, name);
 			PayloadHandlers[id].Write(w, tag);
 		}
@@ -342,9 +343,12 @@ namespace Terraria.ModLoader.IO
 		}
 
 		public static void ToStream(TagCompound root, Stream stream, bool compress = true) {
-			if (compress) stream = new GZipStream(stream, CompressionMode.Compress, true);
+			if (compress)
+				stream = new GZipStream(stream, CompressionMode.Compress, true);
+
 			Write(root, new BigEndianWriter(stream));
-			if (compress) stream.Close();
+			if (compress)
+				stream.Close();
 		}
 
 		public static void Write(TagCompound root, BinaryWriter writer) => WriteTag("", root, writer);

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -38,16 +38,7 @@ namespace Terraria.ModLoader.IO
 				["alteredVanillaFields"] = SaveAlteredVanillaFields()
 			};
 
-			var stream = new MemoryStream();
-			TagIO.ToStream(tag, stream);
-
-			var data = stream.ToArray();
-			if (data[0] != 0x1F || data[1] != 0x8B) {
-				FileUtilities.Write(path + ".corr", data, data.Length, isCloudSave);
-				throw new IOException("Detected Corrupted Save Attempt. Aborting to avoid world corruption.\nYour last successful save will be kept. ERROR: Missing NBT Header.");
-			}
-
-			FileUtilities.Write(path, data, data.Length, isCloudSave);
+			FileUtilities.WriteTagCompound(path, isCloudSave, tag);
 		}
 
 		//add near end of Terraria.IO.WorldFile.loadWorld before setting failure and success
@@ -61,10 +52,7 @@ namespace Terraria.ModLoader.IO
 			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
 
 			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				throw new CustomModDataException(null, ".twld File Corrupted during Last Save Step. Aborting...", new Exception("Missing NBT Header"));
-
-				//LegacyLoad()
-				return;
+				throw new IOException($"{path} File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
 			}
 
 			var tag = TagIO.FromStream(new MemoryStream(buf));

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -52,7 +52,7 @@ namespace Terraria.ModLoader.IO
 			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
 
 			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				throw new IOException($"{path} File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
+				throw new IOException($"{Path.GetFileName(path)}:: File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
 			}
 
 			var tag = TagIO.FromStream(new MemoryStream(buf));

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -40,9 +40,16 @@ namespace Terraria.ModLoader.IO
 
 			var stream = new MemoryStream();
 			TagIO.ToStream(tag, stream);
+
 			var data = stream.ToArray();
+			if (data[0] != 0x1F || data[1] != 0x8B) {
+				FileUtilities.Write(path + ".corr", data, data.Length, isCloudSave);
+				throw new IOException("Detected Corrupted Save Attempt. Aborting to avoid world corruption.\nYour last successful save will be kept. ERROR: Missing NBT Header.");
+			}
+
 			FileUtilities.Write(path, data, data.Length, isCloudSave);
 		}
+
 		//add near end of Terraria.IO.WorldFile.loadWorld before setting failure and success
 		internal static void Load(string path, bool isCloudSave) {
 			customDataFail = null;
@@ -54,7 +61,9 @@ namespace Terraria.ModLoader.IO
 			byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
 
 			if (buf[0] != 0x1F || buf[1] != 0x8B) {
-				//LoadLegacy(buf);
+				throw new CustomModDataException(null, ".twld File Corrupted during Last Save Step. Aborting...", new Exception("Missing NBT Header"));
+
+				//LegacyLoad()
 				return;
 			}
 

--- a/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
+++ b/patches/tModLoader/Terraria/Utilities/FileUtilities.TML.cs
@@ -104,10 +104,11 @@ namespace Terraria.Utilities
 			TagIO.ToStream(tag, stream);
 
 			var data = stream.ToArray();
+			var fileName = Path.GetFileName(path);
 
 			if (data[0] != 0x1F || data[1] != 0x8B) {
 				Write(path + ".corr", data, data.Length, isCloud);
-				throw new IOException($"Detected Corrupted Save Stream attempt.\nAborting to avoid {path} corruption.\nYour last successful save will be kept. ERROR: Stream Missing NBT Header.");
+				throw new IOException($"Detected Corrupted Save Stream attempt.\nAborting to avoid {fileName} corruption.\nYour last successful save will be kept. ERROR: Stream Missing NBT Header.");
 			}
 
 			// Attempt 1: Write
@@ -116,12 +117,12 @@ namespace Terraria.Utilities
 				return true;
 
 			// Attempt 2: Write
-			ModLoader.Logging.tML.Warn($"Detected failed save for {path}. Re-attempting after 2 seconds");
+			ModLoader.Logging.tML.Warn($"Detected failed save for {fileName}. Re-attempting after 2 seconds");
 			System.Threading.Thread.Sleep(2000);
 
 			Write(path, data, data.Length, isCloud);
 			if (!Enumerable.SequenceEqual(ReadAllBytes(path, isCloud), data))
-				throw new IOException($"Unable to save current progress.\nAborting to avoid {path} corruption.\nYour last successful save will be kept. ERROR: Stream Missing NBT Header.");
+				throw new IOException($"Unable to save current progress.\nAborting to avoid {fileName} corruption.\nYour last successful save will be kept. ERROR: Stream Missing NBT Header.");
 
 			return true;
 		}


### PR DESCRIPTION
1.4.3 - Legacy seems to have had a few issues with Saving .twld files.

It is proposed to add additional Save&Load logic to mitigate this issue and ideally catch it happening at save-time to increase likelihood of getting meaningful reproduction information.

https://discord.com/channels/103110554649894912/1133952295474831411