### PR TITLE
Mod Icon Bug Fixes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -84,6 +84,18 @@
  		uiList.Add(CreatePreviewImageSelectionPanel("image"));
  		uiList.Add(CreatePublicSettingsRow(0f, 44f, "public"));
  		uiList.Add(CreateTagOptionsPanel(0f, 44, "tags"));
+@@ -124,7 +_,10 @@
+ 		uIElement.SetPadding(0f);
+ 		obj.Append(uIElement);
+ 		float num = 86f;
++		if (!_isMod)
+-		_defaultPreviewImageTexture = Main.Assets.Request<Texture2D>("Images/UI/Workshop/DefaultPreviewImage");
++			_defaultPreviewImageTexture = Main.Assets.Request<Texture2D>("Images/UI/Workshop/DefaultPreviewImage");
++		else
++			_defaultPreviewImageTexture = Main.Assets.Request<Texture2D>("Images/UI/DefaultResourcePackIcon");
+ 		UIImage uIImage = new UIImage(_defaultPreviewImageTexture) {
+ 			Width = new StyleDimension(-4f, 1f),
+ 			Height = new StyleDimension(-4f, 1f),
 @@ -140,7 +_,8 @@
  		};
  

--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -84,6 +84,16 @@
  		uiList.Add(CreatePreviewImageSelectionPanel("image"));
  		uiList.Add(CreatePublicSettingsRow(0f, 44f, "public"));
  		uiList.Add(CreateTagOptionsPanel(0f, 44, "tags"));
+@@ -140,7 +_,8 @@
+ 		};
+ 
+ 		uIElement.Append(uIImage);
++		if (!_isMod)
+-		uIElement.Append(element);
++			uIElement.Append(element);
+ 		_previewImageUIElement = uIImage;
+ 		UICharacterNameButton uICharacterNameButton = new UICharacterNameButton(Language.GetText("Workshop.PreviewImagePathTitle"), Language.GetText("Workshop.PreviewImagePathEmpty"), Language.GetText("Workshop.PreviewImagePathDescription")) {
+ 			Width = StyleDimension.FromPixelsAndPercent(0f - num, 1f),
 @@ -169,10 +_,14 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -76,7 +76,11 @@ internal class UIModItem : UIPanel
 			try {
 				using (_mod.modFile.Open())
 				using (var s = _mod.modFile.GetStream("icon.png")) {
-					modIcon = Main.Assets.CreateUntracked<Texture2D>(s, ".png");
+					var iconTexture = Main.Assets.CreateUntracked<Texture2D>(s, ".png");
+
+					if (iconTexture.Width() == 80 && iconTexture.Height() == 80) {
+						modIcon = iconTexture;
+					}
 				}
 			}
 			catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -69,26 +69,29 @@ internal class UIModItem : UIPanel
 		base.OnInitialize();
 
 		string text = _mod.DisplayName + " v" + _mod.modFile.Version;
+		var modIcon = Main.Assets.Request<Texture2D>("Images/UI/DefaultResourcePackIcon", AssetRequestMode.ImmediateLoad);
+		_modIconAdjust += 85;
+
 		if (_mod.modFile.HasFile("icon.png")) {
 			try {
 				using (_mod.modFile.Open())
 				using (var s = _mod.modFile.GetStream("icon.png")) {
-					var iconTexture = Main.Assets.CreateUntracked<Texture2D>(s, ".png").Value;
-
-					if (iconTexture.Width == 80 && iconTexture.Height == 80) {
-						_modIcon = new UIImage(iconTexture) {
-							Left = { Percent = 0f },
-							Top = { Percent = 0f }
-						};
-						Append(_modIcon);
-						_modIconAdjust += 85;
-					}
+					modIcon = Main.Assets.CreateUntracked<Texture2D>(s, ".png");
 				}
 			}
 			catch (Exception e) {
 				Logging.tML.Error("Unknown error", e);
 			}
 		}
+
+		_modIcon = new UIImage(modIcon) {
+			Left = { Percent = 0f },
+			Top = { Percent = 0f },
+			Width = { Pixels = 80 },
+			Height = { Pixels = 80 },
+			ScaleToFit = true,
+		};
+		Append(_modIcon);
 
 		_modName = new UIText(text) {
 			Left = new StyleDimension(_modIconAdjust, 0f),


### PR DESCRIPTION
### What is the bug?
- When publishing a mod, there is a weird border around the mod icon
- Mod icons can sometimes disappear in the manage mods menu because they aren't 80x80 pixels in size

### How did you fix the bug?
- Removed the weird border if a mod is being published
- Added a fallback texture in case a mod icon can't be found, and otherwise forcibly scales all mod icons to 80x80

Unless there is code that forces a mod to have an 80x80 icon (I haven't checked), then mods can now have non 80x80 icons. This could have many implications, and I don't know if there is a reason there was a forced 80x80 size apart from displaying in the mods menu if `ScaleToFit` didn't exist. Additionally, the mod browser scales the icons since it uses the steam workshop icons. This means that `icon_workshop.png` will most likely become redundant with `icon.png` becoming larger and used for workshop and in-game.

### Are there alternatives to your fix?
For the mod icon, it could be forced for mods to have an 80x80 icon in the mod building instead.
