### PR TITLE
Update Log Archiver For Terraria Steam Client And Environment.Log

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
@@ -53,7 +53,7 @@ internal static class LogArchiver
 		}
 		catch (Exception e) {
 			Logging.tML.Error(e);
-                return Enumerable.Empty<string>();
+			return Enumerable.Empty<string>();
 		}
 	}
 
@@ -89,13 +89,14 @@ internal static class LogArchiver
 
 	private static void Archive()
 	{
-		var logFiles = GetOldLogs();
-		var referenceLogFile = logFiles.First();
+		var logFiles = GetOldLogs().ToList();
+		if (!logFiles.Any())
+			return;
 
 		// Get the Creation Time to use for the Zip.
 		DateTime time;
 		try {
-			time = File.GetCreationTime(referenceLogFile);
+			time = logFiles.Select(File.GetCreationTime).Min();
 		}
 		catch (Exception e) {
 			Logging.tML.Error(e);
@@ -127,7 +128,7 @@ internal static class LogArchiver
 					using (var stream = File.OpenRead(logFile)) {
 						if (stream.Length > 10_000_000) {
 							// Some users have enormous log files for unknown reasons. Techinically 4GB is the limit for regular zip files, but 10MB seems reasonable.
-							Logging.tML.Error($"The log file {logFile} exceeds 10MB, it will be truncated for the logs archive.");
+							Logging.tML.Warn($"{logFile} exceeds 10MB, it will be truncated for the logs archive.");
 							zip.AddEntry(entryName, stream.ReadBytes(10_000_000));
 						}
 						else {

--- a/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
@@ -30,8 +30,8 @@ internal static class LogArchiver
 	internal static void ArchiveLogs()
 	{
 		SetupLogDirs();
-            MoveZipsToArchiveDir();
-		MoveOldLogs();
+		MoveZipsToArchiveDir();
+		Archive();
 		DeleteOldArchives();
 	}
 
@@ -87,15 +87,11 @@ internal static class LogArchiver
 		}
 	}
 
-	private static void MoveOldLogs()
+	private static void Archive()
 	{
-		foreach (string log in GetOldLogs()) {
-			Archive(log, Path.GetFileNameWithoutExtension(log));
-		}
-	}
-
-	private static void Archive(string logFile, string entryName)
-	{
+		var logFiles = GetOldLogs();
+		var logFile = logFiles.First();
+		var entryName = Path.GetFileName(logFile);
 
 		DateTime time;
 		try {

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -37,7 +37,6 @@ public static partial class Logging
 	private static readonly Regex statusRegex = new(@"(.+?)[: \d]*%$");
 
 	public static string LogPath { get; private set; }
-	private static string MainLogName { get; set; }
 
 	/// <summary> Available for logging when Mod.Logging is not available, such as field initialization </summary>
 	public static ILog PublicLogger { get; } = LogManager.GetLogger("PublicLogger");
@@ -118,7 +117,7 @@ public static partial class Logging
 
 		var fileAppender = new FileAppender {
 			Name = "FileAppender",
-			File = LogPath = Path.Combine(LogDir, GetNewLogFileAndMarkOld(logFile.ToString().ToLowerInvariant())),
+			File = LogPath,
 			AppendToFile = false,
 			Encoding = encoding,
 			Layout = layout
@@ -140,7 +139,7 @@ public static partial class Logging
 			return;
 
 		string mainLogFile = logFile.ToString().ToLowerInvariant();
-		MainLogName = GetNewLogFileAndMarkOld(mainLogFile).Replace(".log", "");
+		LogPath = Path.Combine(LogDir, GetNewLogFileAndMarkOld(mainLogFile));
 
 		GetNewLogFileAndMarkOld(GetEnvironmentLogName());
 		if (logFile == LogFile.Client) {
@@ -251,5 +250,5 @@ public static partial class Logging
 		}
 	}
 
-	private static string GetEnvironmentLogName() => $"environment-{MainLogName}";
+	private static string GetEnvironmentLogName() => $"environment-{Path.GetFileNameWithoutExtension(LogPath)}";
 }

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -53,7 +53,7 @@ public static partial class Logging
 		// This is the first file we attempt to use.
 		Utils.TryCreatingDirectory(LogDir);
 		try {
-			MarkCommonLogFilesAsOld(logFile);
+			InitLogPaths(logFile);
 			ConfigureAppenders(logFile);
 		}
 		catch (Exception e) {
@@ -129,27 +129,33 @@ public static partial class Logging
 		BasicConfigurator.Configure(appenders.ToArray());
 	}
 
-	private static void MarkCommonLogFilesAsOld(LogFile logFile)
+	private static void InitLogPaths(LogFile logFile)
 	{
 		// Launch.log is for the current run, so don't mark as old. Only needed for startup issues
-		// Environment.log is old, will be replaced with new one during Logging.LogStartup
-		// TerrariaSteamClient.Log is a log for the client that will be replaced with a new one during later tML Startup.
+		// environment-client.log and environment-sever.log are old, will be replaced with new one during Logging.LogStartup
+		// terrariasteamclient.log is a log for the client that will be replaced with a new one during later tML Startup.
 
-		if (logFile == LogFile.TerrariaSteamClient)
-			return;
+		// the environment log file name is derived from the free log name we get below, so if this process logs to client2.log, env vars will dump to environment-client2.log
+		// We could pasa a log file name launch arg to TerrariaSteamClient, but in practice collisions should rarely if ever happen, due to steam not allowing parallel launches.
 
-		string mainLogFile = logFile.ToString().ToLowerInvariant();
-		LogPath = Path.Combine(LogDir, GetNewLogFileAndMarkOld(mainLogFile));
+		var mainLogName = logFile.ToString().ToLowerInvariant();
+		var baseLogNames = new List<string> { mainLogName };
 
-		GetNewLogFileAndMarkOld(GetEnvironmentLogName());
-		if (logFile == LogFile.Client) {
-			GetNewLogFileAndMarkOld(LogFile.TerrariaSteamClient.ToString().ToLowerInvariant());
-		}
+		if (logFile != LogFile.TerrariaSteamClient)
+			baseLogNames.Add("environment-" + mainLogName);
+		if (logFile == LogFile.Client)
+			baseLogNames.Add(LogFile.TerrariaSteamClient.ToString().ToLowerInvariant());
+
+		var logFileName = GetFreeLogFileName(baseLogNames, roll: logFile != LogFile.TerrariaSteamClient);
+		LogPath = Path.Combine(LogDir, logFileName);
+
+		// potential race condition, unless we Touch the file we're about to use. Unlikely to be an issue in practice.
 	}
 
-	private static string GetNewLogFileAndMarkOld(string baseName)
+	private static string GetFreeLogFileName(List<string> baseLogNames, bool roll)
 	{
-		var pattern = new Regex($"{baseName}(\\d*)\\.log$");
+		var baseLogName = baseLogNames[0];
+		var pattern = new Regex($"(?:{string.Join('|', baseLogNames)})(\\d*)\\.log$");
 		var existingLogs = Directory.GetFiles(LogDir).Where(s => pattern.IsMatch(Path.GetFileName(s))).ToList();
 
 		if (!existingLogs.All(CanOpen)) {
@@ -159,9 +165,21 @@ public static partial class Logging
 				return tok.Length == 0 ? 1 : int.Parse(tok);
 			}).Max();
 
-			return $"{baseName}{n + 1}.log";
+			return $"{baseLogName}{n + 1}.log";
 		}
 
+		if (roll) {
+			RenameToOld(existingLogs);
+		}
+		else if (existingLogs.Any()) {
+			var logNames = existingLogs.Select(s => Path.GetFileName(s));
+			initWarnings.Add($"Old log files found which should have already been archived. The {baseLogName}.log will be overwritten. [{string.Join(", ", logNames)}]");
+		}
+
+		return $"{baseLogName}.log";
+	}
+
+	private static void RenameToOld(List<string> existingLogs) {
 		foreach (string existingLog in existingLogs.OrderBy(File.GetCreationTime)) {
 			string oldExt = ".old";
 			int n = 0;
@@ -177,8 +195,6 @@ public static partial class Logging
 				initWarnings.Add($"Move failed during log initialization: {existingLog} -> {Path.GetFileName(existingLog)}{oldExt}\n{e}");
 			}
 		}
-
-		return $"{baseName}.log";
 	}
 
 	private static bool CanOpen(string fileName)
@@ -239,7 +255,8 @@ public static partial class Logging
 	private static void DumpEnvVars()
 	{
 		try {
-			using var f = File.OpenWrite(Path.Combine(LogDir, GetEnvironmentLogName() + ".log"));
+			string fileName = $"environment-{Path.GetFileName(LogPath)}";
+			using var f = File.OpenWrite(Path.Combine(LogDir, fileName));
 			using var w = new StreamWriter(f);
 			foreach (var key in Environment.GetEnvironmentVariables().Keys) {
 				w.WriteLine($"{key}={Environment.GetEnvironmentVariable((string)key)}");
@@ -249,6 +266,4 @@ public static partial class Logging
 			tML.Error("Failed to dump env vars", e);
 		}
 	}
-
-	private static string GetEnvironmentLogName() => $"environment-{Path.GetFileNameWithoutExtension(LogPath)}";
 }

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -37,6 +37,7 @@ public static partial class Logging
 	private static readonly Regex statusRegex = new(@"(.+?)[: \d]*%$");
 
 	public static string LogPath { get; private set; }
+	private static string MainLogName { get; set; }
 
 	/// <summary> Available for logging when Mod.Logging is not available, such as field initialization </summary>
 	public static ILog PublicLogger { get; } = LogManager.GetLogger("PublicLogger");
@@ -138,9 +139,10 @@ public static partial class Logging
 		if (logFile == LogFile.TerrariaSteamClient)
 			return;
 
-		GetNewLogFileAndMarkOld("environment");
-		GetNewLogFileAndMarkOld(logFile.ToString().ToLowerInvariant());
+		string mainLogFile = logFile.ToString().ToLowerInvariant();
+		MainLogName = GetNewLogFileAndMarkOld(mainLogFile).Replace(".log", "");
 
+		GetNewLogFileAndMarkOld(GetEnvironmentLogName());
 		if (logFile == LogFile.Client) {
 			GetNewLogFileAndMarkOld(LogFile.TerrariaSteamClient.ToString().ToLowerInvariant());
 		}
@@ -238,7 +240,7 @@ public static partial class Logging
 	private static void DumpEnvVars()
 	{
 		try {
-			using var f = File.OpenWrite(Path.Combine(LogDir, "environment.log"));
+			using var f = File.OpenWrite(Path.Combine(LogDir, GetEnvironmentLogName() + ".log"));
 			using var w = new StreamWriter(f);
 			foreach (var key in Environment.GetEnvironmentVariables().Keys) {
 				w.WriteLine($"{key}={Environment.GetEnvironmentVariable((string)key)}");
@@ -248,4 +250,6 @@ public static partial class Logging
 			tML.Error("Failed to dump env vars", e);
 		}
 	}
+
+	private static string GetEnvironmentLogName() => $"environment-{MainLogName}";
 }

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -128,6 +128,14 @@ public static partial class Logging
 		BasicConfigurator.Configure(appenders.ToArray());
 	}
 
+	private static void MarkLogFilesAsOld(LogFile logFile)
+	{
+		if (logFile == LogFile.TerrariaSteamClient)
+			return;
+
+
+	}
+
 	private static string GetNewLogFile(string baseName)
 	{
 		var pattern = new Regex($"{baseName}(\\d*)\\.log$");


### PR DESCRIPTION
When TerrariaSteamClient was added, the log archives then became a mix of a single server.log, single client.log, and single TerrariaSteamClient.log.

Given TerrariaSteamClient.Log is a part of the client instance, this PR updates it to be grouped as such.

Further, this PR also adds archiving of environment.log for each.