### PR TITLE
WIP: Add loading UI for Host & Play

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -221,6 +221,16 @@
  	public static int renderCount = 99;
  	private const int MF_BYPOSITION = 1024;
  	public static GraphicsDeviceManager graphics;
+@@ -606,7 +_,8 @@
+ 	public static BasicDebugDrawer DebugDrawer;
+ 	public static SamplerState SamplerStateForCursor = SamplerState.LinearClamp;
+ 	public static GenerationProgress AutogenProgress = new GenerationProgress();
++	// TML: #HostPlayProgress: Turned to public for use with UIStartServer
+-	private static Process tServer;
++	public static Process tServer;
+ 	private static Stopwatch saveTime = new Stopwatch();
+ 	public static KeyboardState keyState;
+ 	public static KeyboardState oldKeyState;
 @@ -671,7 +_,15 @@
  	public static float rightWorld = 134400f;
  	public static float topWorld = 0f;
@@ -995,7 +1005,7 @@
  			string lpWindowName = (Console.Title = "terraria" + rand.Next(int.MaxValue));
  			if (Platform.IsWindows) {
  				IntPtr intPtr = FindWindow(null, lpWindowName);
-@@ -4157,17 +_,32 @@
+@@ -4157,17 +_,39 @@
  			}
  		}
  		else {
@@ -1006,6 +1016,13 @@
  		dedServ = true;
  		showSplash = false;
  		Initialize();
++
++		if (Program.LaunchParameters.ContainsKey("-serverclientipc")) {
++			var client = ServerClientIPC.InitClient();
++			Logging.tML.Debug("IPC Client Connecting...");
++			client.Connect();
++			Logging.tML.Debug("IPC Client Connected.");
++		}
 +
 +		bool reloadMods;
 +
@@ -5402,7 +5419,7 @@
  		if (menuMode == num)
  			GamepadMainMenuHandler.LastDrew = num;
  	}
-@@ -42624,7 +_,15 @@
+@@ -42624,7 +_,18 @@
  
  		text = ((!ActiveWorldFileData.IsCloudSave) ? (text + SanitizePathArgument("world", worldPathName)) : (text + SanitizePathArgument("cloudworld", worldPathName)));
  		text = text + " -worldrollbackstokeep " + WorldRollingBackupsCountToKeep;
@@ -5412,13 +5429,16 @@
 +		if (showServerConsole)
 +			text += " -showserverconsole";
 +
++		ServerClientIPC.InitServer();
++		text += " -serverclientipc";
++
  		tServer = new Process();
 +
 +		/*
  		if (Platform.IsLinux)
  			tServer.StartInfo.FileName = "TerrariaServer";
  		else if (Platform.IsOSX)
-@@ -42633,13 +_,22 @@
+@@ -42633,23 +_,37 @@
  			tServer.StartInfo.FileName = "TerrariaServer.exe";
  
  		tServer.StartInfo.Arguments = text;
@@ -5441,6 +5461,21 @@
  		if (SocialAPI.Network != null)
  			SocialAPI.Network.LaunchLocalServer(tServer, MenuServerMode);
  		else
+ 			tServer.Start();
+ 
++		/*
+ 		Netplay.SetRemoteIP("127.0.0.1");
+ 		autoPass = true;
+ 		statusText = Lang.menu[8].Value;
+ 		Netplay.StartTcpClient();
+ 		menuMode = 10;
++		*/
++
++		menuMode = 888;
++		MenuUI.SetState(Interface.startServer);
+ 	}
+ 
+ 	private static void ExitServerPasswordMenu()
 @@ -42703,7 +_,22 @@
  
  	private static void DrawVersionNumber(Microsoft.Xna.Framework.Color menuColor, float upBump)

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ServerClientIPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ServerClientIPC.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using log4net;
+using Terraria.ModLoader.UI;
+
+namespace Terraria.ModLoader.Engine;
+internal class ServerClientIPC
+{
+	private enum IsWaiting
+	{
+		None,
+		DisplayName,
+		Version
+	}
+
+	private static ILog Logger { get; } = LogManager.GetLogger("ServerClientIPC");
+
+	public static NamedPipeServerStream ServerPipe;
+	public static NamedPipeClientStream ClientPipe;
+
+	public const string MsgLoadStage = "load:";
+	public const string MsgCurrentCount = "count:";
+	public const string MsgSendDisplayName = "send_display_name";
+	public const string MsgSendVersion = "send_version";
+	public const string MsgCommitMod = "commit_mod";
+	public const string MsgDone = "done_load";
+
+	public static NamedPipeClientStream InitClient()
+	{
+		if (ClientPipe == null) {
+			ClientPipe = new NamedPipeClientStream(".", "TML.ServerClientIPC", PipeDirection.Out);
+		}
+		return ClientPipe;
+	}
+
+	public static NamedPipeServerStream InitServer()
+	{
+		if (ServerPipe == null) {
+			ServerPipe = new NamedPipeServerStream("TML.ServerClientIPC", PipeDirection.In);
+		}
+		return ServerPipe;
+	}
+
+	public static void ShutdownClient()
+	{
+		if (ClientPipe != null) {
+			SendCmd(MsgDone);
+			ClientPipe.Dispose();
+			ClientPipe = null;
+		}
+	}
+
+	public static void ShutdownServer()
+	{
+		if (ServerPipe != null) {
+			ServerPipe.Dispose();
+			ServerPipe = null;
+		}
+	}
+
+	public static void SendCmd(string cmd)
+	{
+		if (ClientPipe == null)
+			return;
+
+		using var sw = new StreamWriter(ClientPipe, leaveOpen: true);
+		sw.WriteLine(cmd);
+	}
+
+	public static void SendCurrentStage(string stageText, int modCount = -1)
+	{
+		SendCmd($"{MsgLoadStage}{stageText}:{modCount}");
+	}
+
+	public static void SendCurrentMod(int i, string displayName, Version version)
+	{
+		SendCmd($"{MsgCurrentCount}{i}");
+		SendCmd(MsgSendDisplayName);
+		SendCmd(displayName);
+		SendCmd(MsgSendVersion);
+		SendCmd(version.ToString());
+		SendCmd(MsgCommitMod);
+	}
+
+	public static void Run(CancellationToken token)
+	{
+		Task.Run(() => {
+			if (ServerPipe == null)
+				return;
+
+			try {
+				using (StreamReader sr = new StreamReader(ServerPipe, leaveOpen: true)) {
+					var Recv = () => {
+						var s = sr.ReadLine().Trim();
+						if (s == null) {
+							throw new EndOfStreamException();
+						}
+
+						Logger.Debug($"Recieved \"{s}\"");
+
+						return s;
+					};
+
+					ServerPipe.WaitForConnection();
+
+					IsWaiting waiting = IsWaiting.None;
+					string displayName = string.Empty;
+					string version = string.Empty;
+					int currentCount = 0;
+
+					while (true) {
+						var cmd = Recv();
+
+						if (cmd == MsgDone)
+							break;
+
+						switch (waiting) {
+							case IsWaiting.DisplayName:
+								displayName = cmd;
+								waiting = IsWaiting.None;
+								break;
+							case IsWaiting.Version:
+								version = cmd;
+								waiting = IsWaiting.None;
+								break;
+						}
+
+						if (cmd.StartsWith(MsgLoadStage)) {
+							string[] data = cmd.Substring(MsgLoadStage.Length).Split(':');
+							if (data.Length != 2)
+								throw new InvalidOperationException($"The command \"{cmd}\" is not valid");
+
+							string stage = data[0];
+							int modCount = int.Parse(data[1]);
+
+							Interface.startServer.SetLoadStage(stage, modCount);
+						}
+						else if (cmd.StartsWith(MsgCurrentCount)) {
+							currentCount = int.Parse(cmd.Substring(MsgCurrentCount.Length));
+						}
+						else if (cmd == MsgSendDisplayName) {
+							waiting = IsWaiting.DisplayName;
+							continue;
+						}
+						else if (cmd == MsgSendVersion) {
+							waiting = IsWaiting.Version;
+							continue;
+						}
+						else if (cmd == MsgCommitMod) {
+							Interface.startServer.SetCurrentMod(currentCount, displayName, version);
+							currentCount = 0;
+							displayName = string.Empty;
+							version = string.Empty;
+						}
+					}
+
+					Netplay.SetRemoteIP("127.0.0.1");
+					Main.autoPass = true;
+					Netplay.StartTcpClient();
+					Main.statusText = Lang.menu[8].Value;
+				}
+			}
+			catch when (token.IsCancellationRequested) {
+				// Silently catch any errors because the server pipe being closed by UIStartServer should be the cause of it
+			}
+		}, token);
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -193,10 +193,16 @@ public static class ModLoader
 
 	internal static void Reload()
 	{
-		if (Main.dedServ)
+		if (Main.dedServ) {
 			Load();
-		else
+			if (ServerClientIPC.ClientPipe != null) {
+				ServerClientIPC.ShutdownClient();
+			}
+		}
+		else {
 			Main.menuMode = Interface.loadModsID;
+		}
+			
 	}
 
 	internal static bool Unload()

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -68,6 +68,7 @@ internal static class Interface
 	internal static UICreateMod createMod = new UICreateMod();
 	internal static UIProgress progress = new UIProgress();
 	internal static UIDownloadProgress downloadProgress = new UIDownloadProgress();
+	internal static UIStartServer startServer = new UIStartServer();
 
 	// adds to Terraria.Main.DrawMenu in Main.menuMode == 0, after achievements
 	//Interface.AddMenuButtons(this, this.selectedMenu, array9, array7, ref num, ref num3, ref num10, ref num5);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -40,6 +40,10 @@ internal class UILoadMods : UIProgress
 		if (modCount < 0) SetProgressText(Language.GetTextValue(stageText));
 		Progress = 0;
 		SubProgressText = "";
+
+		if (Main.dedServ && ServerClientIPC.ClientPipe != null) {
+			ServerClientIPC.SendCurrentStage(stageText, modCount);
+		}
 	}
 
 	private void SetProgressText(string text, string logText = null)
@@ -55,6 +59,10 @@ internal class UILoadMods : UIProgress
 		var log = $"{modName} ({displayName}) v{version}";
 		SetProgressText(Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
 		Progress = i / (float)modCount;
+
+		if (Main.dedServ && ServerClientIPC.ClientPipe != null) {
+			ServerClientIPC.SendCurrentMod(i, displayName, version);
+		}
 	}
 
 	public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.Version);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIStartServer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIStartServer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Terraria.Audio;
+using Terraria.Localization;
+using Terraria.ModLoader.Engine;
+
+namespace Terraria.ModLoader.UI;
+internal class UIStartServer : UIProgress
+{
+	private int modCount;
+
+	private string stageText;
+
+	private CancellationTokenSource _cts;
+
+	public override void OnActivate()
+	{
+		base.OnActivate();
+
+		_cts = new CancellationTokenSource();
+
+		OnCancel += () => {
+			if (Main.tServer != null) {
+				try {
+					Main.tServer.Kill();
+					Main.tServer = null;
+				}
+				catch {
+				}
+			}
+			ServerClientIPC.ShutdownServer();
+		};
+
+		ServerClientIPC.Run(_cts.Token);
+		DisplayText = "Starting server...";
+		SubProgressText = "Waiting for server";
+	}
+
+	public override void OnDeactivate()
+	{
+		base.OnDeactivate();
+		ServerClientIPC.ShutdownServer();
+		_cts?.Dispose();
+		_cts = null;
+	}
+
+	public void SetLoadStage(string stageText, int modCount = -1)
+	{
+		this.stageText = stageText;
+		this.modCount = modCount;
+		if (modCount < 0)
+			SubProgressText = Language.GetTextValue(stageText);
+		Progress = 0;
+		SubProgressText = "";
+	}
+
+	public void SetCurrentMod(int i, string displayName, string version)
+	{
+		var display = $"{displayName} v{version}";
+		SubProgressText = Language.GetTextValue(stageText, display);
+		Progress = i / (float)modCount;
+	}
+}


### PR DESCRIPTION
### What is the new feature?
Adds a progress bar UI to the Host & Play menu, allowing players to see the progress of the server starting without needing to see the server console. Closes #3317 
The feature uses Named Pipes, allowing the server to send the client what mod and what stage the server is loading on.

### Why should this be part of tModLoader?
Without the progress bar UI, the player will just be left with "Starting server..." in the menu. The player would have no indication whether or not the server is actually loading in mods or if the server just hung/crashed. With the progress bar UI, the player can be sure if the server is loading in mods or has hung.

### Are there alternative designs?
Currently, the server only communicates to the client on loading mods. Once all the mods have been loaded, the server sends a message to the client that all the mods have been loaded, then the client will try to connect to the server, even though the server still needs time to load the world. It might be better to also make the client wait for the server to finish loading the world, but that would make the patch bigger.

### Sample usage for the new feature
See video: https://streamable.com/e3saqp

### Notes
Still a draft as I have not fully tested the code and will do that soon, currently confused on how I would manually crash/hang the server. But, I would still appreciate any feedback regarding the PR, especially for the `ServerClientIPC` class!

