### PR TITLE
Better Changelogs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,7 +334,7 @@ jobs:
           mkdir -p $ModloaderDir
           
           if [ ${{env.IsRelease}} = 'true' ] ; then
-            ciprep="-ciprep \"Automatic update from GitHub: ${{ github.event.compare }}\" -publishedmodfiles \"$(cygpath -w $publishedfolder)\" -uploadfolder \"/home/runner/work/tModLoader/tModLoader/artifacts/ExampleMod\""
+            ciprep="-ciprep \"Automatic update from GitHub for tModLoader v{tMLVersion}: ${{ github.event.compare }}\" -publishedmodfiles \"$(cygpath -w $publishedfolder)\" -uploadfolder \"/home/runner/work/tModLoader/tModLoader/artifacts/ExampleMod\""
           else
             ciprep=""
           fi

--- a/ExampleMod/changelog.txt
+++ b/ExampleMod/changelog.txt
@@ -1,0 +1,3 @@
+This is an example of a custom changelog.
+Example Mod v{ModVersion} has been published to {tMLBuildPurpose} tML v{tMLVersion}.
+Learn more at the [url={ModHomepage}]homepage[/url]

--- a/ExampleMod/changelog.txt
+++ b/ExampleMod/changelog.txt
@@ -1,2 +1,0 @@
-Example Mod v{ModVersion} has been published to {tMLBuildPurpose} tML v{tMLVersion}.
-Learn more at the [url={ModHomepage}]homepage[/url]

--- a/ExampleMod/changelog.txt
+++ b/ExampleMod/changelog.txt
@@ -1,0 +1,2 @@
+Example Mod v{ModVersion} has been published to {tMLBuildPurpose} tML v{tMLVersion}.
+Learn more at the [url={ModHomepage}]homepage[/url]

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -270,7 +270,7 @@
  				SteamUGC.SetItemContent(uGCUpdateHandle_t, _entryData.ContentFolderPath);
  				SteamUGC.SetItemTags(uGCUpdateHandle_t, _entryData.Tags);
  				if (_entryData.PreviewImagePath != null)
-@@ -262,22 +_,83 @@
+@@ -262,22 +_,91 @@
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
  
@@ -290,16 +290,24 @@
 +					}
 +
 +					patchNotes = _entryData.ChangeNotes;
-+					if (string.IsNullOrEmpty(patchNotes)) {
-+						patchNotes = "Version {0} has been published to {3} tModLoader v{2}";
-+						if (!string.IsNullOrEmpty(_entryData.BuildData["homepage"]))
-+							patchNotes += ", learn more at {1}";
++					// If the modder hasn't supplied any change notes, then we wilil provde some default ones for them
++					if (string.IsNullOrWhiteSpace(patchNotes)) {
++						patchNotes = "Version {ModVersion} has been published to {tMLBuildPurpose} tModLoader v{tMLVersion}";
++						if (!string.IsNullOrWhiteSpace(_entryData.BuildData["homepage"]))
++							patchNotes += ", learn more at the [url={ModHomepage}]homepage[/url]";
 +					}
-+					// {0} to mod version, {1} to mod homepage, {2} to tModLoader version, {3} to tModLoader build purpose
-+					patchNotes = string.Format(patchNotes, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"], BuildInfo.tMLVersion.MajorMinor(), BuildInfo.Purpose);
++
++					// Language.GetText returns the given key if it can't be found, this way we can use LocalizedText.FormatWith
++					// This allows us to use substitution keys such as {ModVersion}
++					patchNotes = Language.GetText(patchNotes).FormatWith(new {
++						ModVersion      = _entryData.BuildData["trueversion"],
++						ModHomepage     = _entryData.BuildData["homepage"],
++						tMLVersion      = BuildInfo.tMLVersion.MajorMinor().ToString(),
++						tMLBuildPurpose = BuildInfo.Purpose.ToString(),
++					});
 +
 +					string refs = _entryData.BuildData["workshopdeps"];
-+					
++
 +					if (!string.IsNullOrWhiteSpace(refs)) {
 +						Logging.tML.Info("Adding dependencies to Workshop Upload");
 +						string[] dependencies = refs.Split(",", StringSplitOptions.TrimEntries);

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -270,7 +270,7 @@
  				SteamUGC.SetItemContent(uGCUpdateHandle_t, _entryData.ContentFolderPath);
  				SteamUGC.SetItemTags(uGCUpdateHandle_t, _entryData.Tags);
  				if (_entryData.PreviewImagePath != null)
-@@ -262,22 +_,79 @@
+@@ -262,22 +_,83 @@
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
  
@@ -289,13 +289,17 @@
 +						SteamUGC.AddItemKeyValueTag(uGCUpdateHandle_t, key, _entryData.BuildData[key]);
 +					}
 +
-+					patchNotes = $"Version {_entryData.BuildData["trueversion"]} has been published to {BuildInfo.Purpose} (v{BuildInfo.tMLVersion.MajorMinor()})";
-+					if(!string.IsNullOrEmpty(_entryData.BuildData["homepage"]))
-+						patchNotes += $" learn more @ { _entryData.BuildData["homepage"]}";
-+					patchNotes += $"\n{_entryData.ChangeNotes}";
++					patchNotes = _entryData.ChangeNotes;
++					if (string.IsNullOrEmpty(patchNotes)) {
++						patchNotes = "Version {0} has been published to {3} tModLoader v{2}";
++						if (!string.IsNullOrEmpty(_entryData.BuildData["homepage"]))
++							patchNotes += ", learn more at {1}";
++					}
++					// {0} to mod version, {1} to mod homepage, {2} to tModLoader version, {3} to tModLoader build purpose
++					patchNotes = string.Format(patchNotes, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"], BuildInfo.tMLVersion.MajorMinor(), BuildInfo.Purpose);
 +
 +					string refs = _entryData.BuildData["workshopdeps"];
-+
++					
 +					if (!string.IsNullOrWhiteSpace(refs)) {
 +						Logging.tML.Info("Adding dependencies to Workshop Upload");
 +						string[] dependencies = refs.Split(",", StringSplitOptions.TrimEntries);


### PR DESCRIPTION
### What is the new feature?
Slightly improved the automatic changelogs text, added substitution for the mod version, mod homepage, tML version, and tML build purpose into the changelogs, and made the automatic changelogs text optional - the automatic changelogs will only be created if there isn't anything in `changelog.txt`, this way people that prefer the automatic changelogs but still want to have customisable changelogs can still use them by pasting the default prompt in.

### Why should this be part of tModLoader?
Currently, changelogs are annoying if you don't like the default one because you have to delete it yourself and if you want to include the version, homepage, and other info it has to be manually copied over.

### Are there alternative designs?
Making the automatic changelogs disabled with a property in build.txt/csproj.

### Sample usage for the new feature
In `changelog.txt`:
```
Example Mod v{ModVersion} for tModLoader v{tMLVersion}
- Example change 1
- Example change 2
```

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
Added an example changelog that I believe doesn't get used when it is published.
Updated the changelog hardcoded in `build.yml`, but I'm not sure if the substitution works there since I don't know the automated uploading works.