### PR TITLE
Change SplitStack() favorited behavior to match OnStack()

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1566,7 +1566,10 @@ public static class ItemLoader
 	public static void SplitStack(Item destination, Item source, int numToTransfer)
 	{
 		destination.stack = 0;
-		destination.favorited = false;
+		if (source.favorited) {
+			destination.favorited = true;
+			source.favorited = false;
+		}
 
 		foreach (var g in HookSplitStack.Enumerate(destination)) {
 			g.SplitStack(destination, source, numToTransfer);


### PR DESCRIPTION
### What is the bug?
OnStack() causes the favorited status to follow the item to the destination item, where SplitStack() removes favorited status from the destination item.   
Example:
Stack of 4 throwing knives in your inventory that is favorited. Right click the stack once, now 1 in the mouse, 3 in your inventory.  The stack in your inventory is favorited and the on in the mouse is not.  Right click a 2nd time, and the inventory stack looses favorited and the mouse stack gains favorited.

### How did you fix the bug?
Replacing "destination.favorited = false;" in SplitStack() with the same code from OnStack() for swapping favorited.

### Are there alternatives to your fix?
Create a separate function for SwapFavorited() called by SplitStack() and OnStack() to prevent duplicated code.  Let me know if you would like me to switch it to that.