### PR TITLE
Re-enable Auto-Reload and Enable Mods Leaving ModBrowser

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
@@ -375,10 +375,8 @@ internal partial class UIModBrowser : UIState, IHaveBackButtonCommand
 			onNewModInstalled: mod => {
 				newModInstalled = true;
 				if (ModLoader.autoReloadAndEnableModsLeavingModBrowser) {
-					/* TODO: Do we want this re-added?
 					ModLoader.EnableMod(mod.ModName);
 					reloadOnExit = true;
-					*/
 				}
 			});
 	}


### PR DESCRIPTION
In 1.3 tModLoader, we had a feature that would auto-enable newly downloaded mods from the Mod Browser, and reload on exit.

This behavior was opt-out via an in-game tModLoader Settings option.

This PR enables the last bit of code to bring that back; question is should we.

ALTERNATIVE:
We modify the "New Mods Detected" on Launch UI to be generalized to be usable with Mod Browser, ensure dependencies are downloaded regardless of choice, and make it a choice on that UI whether they want to auto-enable the mods or "I will Enable My Mods"