### PR TITLE
Auto Enable Dependency Mods on Reload

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -328,7 +328,6 @@ internal static class ModOrganizer
 		var modsToLoad = availableMods.Where(mod => mod.Enabled && LoadSide(mod.properties.side)).ToList();
 		VerifyNames(modsToLoad);
 
-		EnsureDependenciesExist(modsToLoad, false);
 		foreach (var mod in modsToLoad) {
 			EnableWithDeps(mod, availableMods);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -325,17 +325,12 @@ internal static class ModOrganizer
 		//}
 		Interface.loadMods.SetLoadStage("tModLoader.MSFinding");
 
-		var modsToLoad = availableMods.Where(mod => mod.Enabled && LoadSide(mod.properties.side)).ToList();
-		VerifyNames(modsToLoad);
-
-		foreach (var mod in modsToLoad) {
+		foreach (var mod in GetModsToLoad(availableMods)) {
 			EnableWithDeps(mod, availableMods);
 		}
 		SaveEnabledMods();
 
-		modsToLoad = availableMods.Where(mod => mod.Enabled && LoadSide(mod.properties.side)).ToList();
-		VerifyNames(modsToLoad);
-
+		var modsToLoad = GetModsToLoad(availableMods);
 		try {
 			EnsureDependenciesExist(modsToLoad, false);
 			EnsureTargetVersionsMet(modsToLoad);
@@ -346,6 +341,13 @@ internal static class ModOrganizer
 			e.Data["hideStackTrace"] = true;
 			throw;
 		}
+	}
+
+	private static List<LocalMod> GetModsToLoad(IEnumerable<LocalMod> availableMods)
+	{
+		var modsToLoad = availableMods.Where(mod => mod.Enabled && LoadSide(mod.properties.side)).ToList();
+		VerifyNames(modsToLoad);
+		return modsToLoad;
 	}
 
 	private static void CommandLineModPackOverride(IEnumerable<LocalMod> mods)


### PR DESCRIPTION
Adjusts the reload logic to ensure that all dependencies, if on the system, are enabled during mod reload.

Otherwise tosses an error within the try-catch in SelectAndSortMods.

Also some minor refactors of existing dependencies checking code to minimize code duplication.