### PR TITLE
Add modded world header data

### DIFF
--- a/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
@@ -1,0 +1,36 @@
+﻿using ExampleMod.Content;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria;
+using Terraria.GameContent.UI.Elements;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+
+namespace ExampleMod.Common.Systems
+{
+	public class ExampleWorldHeaderSystem : ModSystem
+	{
+		public override void SaveWorldHeader(TagCompound tag) {
+			tag["ExampleModExists"] = true;
+		}
+
+		public override void Load() {
+			On_UIWorldListItem.DrawSelf += (orig, self, spriteBatch) => {
+				orig(self, spriteBatch);
+				DrawWorldSelectItemOverlay(self, spriteBatch);
+			};
+		}
+
+		private void DrawWorldSelectItemOverlay(UIWorldListItem uiItem, SpriteBatch spriteBatch) {
+			if (MenuLoader.CurrentMenu is not ExampleModMenu)
+				return;
+
+			if (!uiItem.Data.TryGetHeaderData(this, out var data) || !data.GetBool("ExampleModExists"))
+				return;
+
+			var dims = uiItem.GetInnerDimensions();
+			var pos = new Vector2(dims.X + 400, dims.Y);
+			Utils.DrawBorderString(spriteBatch, "EM played before", pos, Color.BlueViolet);
+		}
+	}
+}

--- a/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
@@ -1,8 +1,11 @@
 ﻿using ExampleMod.Content;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Linq;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
+using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -31,6 +34,19 @@ namespace ExampleMod.Common.Systems
 			var dims = uiItem.GetInnerDimensions();
 			var pos = new Vector2(dims.X + 400, dims.Y);
 			Utils.DrawBorderString(spriteBatch, "EM played before", pos, Color.BlueViolet);
+		}
+	}
+
+	public class ExampleWorldHeaderPlayer : ModPlayer {
+		public override void OnEnterWorld() {
+			// modsGeneratedWith can only be checked in Single Player
+			if (Main.netMode == NetmodeID.SinglePlayer ) {
+				// Check if this world was generated with at least a specific version of a mod.
+				// Tracking mods used to generate a world was added in v2023.8, so if modsGeneratedWith is null we don't know for sure if ExampleMod was enabled when this world was generated.
+				if (Main.ActiveWorldFileData.modsGeneratedWith?.Any(x => x.modName == "ExampleMod" && x.modVersion >= new System.Version(1, 0)) == false) {
+					Main.NewText(Language.GetTextValue(Mod.GetLocalizationKey("NotPresentDuringWorldGenMessage")), Color.Orange);
+				}
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
+++ b/ExampleMod/Common/Systems/ExampleWorldHeaderSystem.cs
@@ -1,7 +1,7 @@
 ﻿using ExampleMod.Content;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System.Linq;
+using System;
 using Terraria;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
@@ -37,15 +37,27 @@ namespace ExampleMod.Common.Systems
 		}
 	}
 
-	public class ExampleWorldHeaderPlayer : ModPlayer {
+	public class ExampleWorldHeaderPlayer : ModPlayer
+	{
 		public override void OnEnterWorld() {
-			// modsGeneratedWith can only be checked in Single Player
-			if (Main.netMode == NetmodeID.SinglePlayer ) {
-				// Check if this world was generated with at least a specific version of a mod.
-				// Tracking mods used to generate a world was added in v2023.8, so if modsGeneratedWith is null we don't know for sure if ExampleMod was enabled when this world was generated.
-				if (Main.ActiveWorldFileData.modsGeneratedWith?.Any(x => x.modName == "ExampleMod" && x.modVersion >= new System.Version(1, 0)) == false) {
-					Main.NewText(Language.GetTextValue(Mod.GetLocalizationKey("NotPresentDuringWorldGenMessage")), Color.Orange);
+			// This data can only be checked in Single Player
+			if (Main.netMode != NetmodeID.SinglePlayer) {
+				return;
+			}
+
+			// Check if this world was generated with at least a specific version of a mod.
+			// Tracking mods used to generate a world was added in v2023.8, so if WorldGenModsRecorded is false we don't know for sure if ExampleMod was enabled when this world was generated.
+			if (!Main.ActiveWorldFileData.WorldGenModsRecorded) {
+				return;
+			}
+
+			if (Main.ActiveWorldFileData.TryGetModVersionGeneratedWith("ExampleMod", out Version modVersion)) {
+				if (modVersion < new Version(1, 0)) {
+					// Here we could have a message about the world missing a new biome added in v1.0 of this mod that won't be present in the world because it was generated before then.
 				}
+			}
+			else {
+				Main.NewText(Language.GetTextValue(Mod.GetLocalizationKey("NotPresentDuringWorldGenMessage")), Color.Orange);
 			}
 		}
 	}

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 513/513, 100%, missing 0
-ru-RU, 6/513, 1%, missing 507
-zh-Hans, 1/513, 0%, missing 512
+en-US, 514/514, 100%, missing 0
+ru-RU, 6/514, 1%, missing 508
+zh-Hans, 1/514, 0%, missing 513

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -1105,6 +1105,8 @@ Mods: {
 			ExampleTravellingMerchantEmote.Command: extravelingmerchant
 			MinionBossEmote.Command: exminionboss
 		}
+
+		NotPresentDuringWorldGenMessage: ExampleMod was not used to generate this world, your experience with the content of ExampleMod will be degraded
 	}
 }
 

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -1105,6 +1105,8 @@ Mods: {
 			// ExampleTravellingMerchantEmote.Command: extravelingmerchant
 			// MinionBossEmote.Command: exminionboss
 		}
+
+		// NotPresentDuringWorldGenMessage: ExampleMod was not used to generate this world, your experience with the content of ExampleMod will be degraded
 	}
 }
 

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -1105,6 +1105,8 @@ Mods: {
 			// ExampleTravellingMerchantEmote.Command: extravelingmerchant
 			// MinionBossEmote.Command: exminionboss
 		}
+
+		// NotPresentDuringWorldGenMessage: ExampleMod was not used to generate this world, your experience with the content of ExampleMod will be degraded
 	}
 }
 

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/AWorldListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/AWorldListItem.cs.patch
@@ -1,0 +1,12 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/AWorldListItem.cs
++++ src/tModLoader/Terraria/GameContent/UI/Elements/AWorldListItem.cs
+@@ -9,6 +_,9 @@
+ 
+ public abstract class AWorldListItem : UIPanel
+ {
++	// Added by TML
++	public WorldFileData Data => _data;
++
+ 	protected WorldFileData _data;
+ 	protected int _glitchFrameCounter;
+ 	protected int _glitchFrame;

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs.patch
@@ -1,21 +1,18 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UICharacterListItem.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.cs
-@@ -9,10 +_,14 @@
- using Terraria.Localization;
- using Terraria.Social;
- using Terraria.UI;
-+using Terraria.Utilities;
-+using Terraria.ModLoader;
-+using System.Linq;
-+using Terraria.ModLoader.UI;
+@@ -12,8 +_,11 @@
  
  namespace Terraria.GameContent.UI.Elements;
  
 -public class UICharacterListItem : UIPanel
 +public partial class UICharacterListItem : UIPanel
  {
++	// Added by TML
++	public PlayerFileData Data => _data;
++
  	private PlayerFileData _data;
  	private Asset<Texture2D> _dividerTexture;
+ 	private Asset<Texture2D> _innerPanelTexture;
 @@ -43,6 +_,9 @@
  		_buttonPlayTexture = Main.Assets.Request<Texture2D>("Images/UI/ButtonPlay");
  		_buttonRenameTexture = Main.Assets.Request<Texture2D>("Images/UI/ButtonRename");

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
@@ -1,7 +1,10 @@
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using System;
+using System.Linq;
 using Terraria.IO;
+using Terraria.Localization;
+using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.Utilities;
 
@@ -36,6 +39,74 @@ public partial class UIWorldListItem : AWorldListItem
 			offset += 24f;
 		}
 		*/
+
+		// TODO: Mostly duplicate code with UICharacterListItem, need to find good place for shared method
+		// TODO: Should we also show a separate button for mods that were present during worldgen but aren't enabled?
+		if (data.usedMods != null) {
+			string[] currentModNames = ModLoader.ModLoader.Mods.Select(m => m.Name).ToArray();
+			var missingMods = data.usedMods.Except(currentModNames).ToList();
+			var newMods = currentModNames.Except(new[] { "ModLoader" }).Except(data.usedMods).ToList();
+			bool checkModPack = System.IO.Path.GetFileNameWithoutExtension(ModLoader.Core.ModOrganizer.ModPackActive) != data.modPack;
+
+			if (checkModPack || missingMods.Count > 0 || newMods.Count > 0) {
+				UIText warningLabel = new UIText("", 1f, false) {
+					VAlign = 0f,
+					HAlign = 1f
+				};
+
+				warningLabel.Left.Set(-30f, 0f);
+				warningLabel.Top.Set(3f, 0f);
+
+				Append(warningLabel);
+
+				UIImageButton modListWarning = new UIImageButton(UICommon.ButtonErrorTexture) {
+					VAlign = 0f,
+					HAlign = 1f
+				};
+
+				modListWarning.Top.Set(-2f, 0f);
+
+				System.Text.StringBuilder fullSB = new System.Text.StringBuilder(Language.GetTextValue("tModLoader.ModsDifferentSinceLastPlay"));
+				System.Text.StringBuilder shortSB = new System.Text.StringBuilder();
+
+				string Separator()
+					=> shortSB.Length != 0 ? "; " : null;
+
+				if (checkModPack) {
+					string pack = data.modPack;
+					if (string.IsNullOrEmpty(pack))
+						pack = "None";
+
+					shortSB.Append(Separator() + Language.GetTextValue("tModLoader.ModPackMismatch", pack));
+					fullSB.Append("\n" + Language.GetTextValue("tModLoader.ModPackMismatch", pack));
+				}
+
+				if (missingMods.Count > 0) {
+					shortSB.Append(Separator() + (missingMods.Count > 1 ? Language.GetTextValue("tModLoader.MissingXMods", missingMods.Count) : Language.GetTextValue("tModLoader.Missing1Mod")));
+					fullSB.Append("\n" + Language.GetTextValue("tModLoader.MissingModsListing", string.Join("\n", missingMods.Select(x => "- " + x))));
+				}
+
+				if (newMods.Count > 0) {
+					shortSB.Append(Separator() + (newMods.Count > 1 ? Language.GetTextValue("tModLoader.NewXMods", newMods.Count) : Language.GetTextValue("tModLoader.New1Mod")));
+					fullSB.Append("\n" + Language.GetTextValue("tModLoader.NewModsListing", string.Join("\n", newMods.Select(x => "- " + x))));
+				}
+
+				if (shortSB.Length != 0) {
+					shortSB.Append('.');
+				}
+
+				string warning = shortSB.ToString();
+				string fullWarning = fullSB.ToString();
+
+				modListWarning.OnMouseOver += (a, b) => warningLabel.SetText(warning);
+				modListWarning.OnMouseOut += (a, b) => warningLabel.SetText("");
+				modListWarning.OnLeftClick += (a, b) => {
+					Interface.infoMessage.Show(fullWarning, 888, Main._worldSelectMenu);
+				};
+
+				Append(modListWarning);
+			}
+		}
 	}
 
 	internal static Action PlayReload()

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -43,7 +43,12 @@
  		_cachedSandstormSeverity = Sandstorm.Severity;
  		_cachedSandstormIntendedSeverity = Sandstorm.IntendedSeverity;
  		_cachedLanternNightCooldown = LanternNight.LanternNightsOnCooldown;
-@@ -387,7 +_,8 @@
+@@ -384,10 +_,13 @@
+ 				binaryReader.ReadBoolean();
+ 				binaryReader.ReadBoolean();
+ 				worldFileData.DefeatedMoonlord = binaryReader.ReadBoolean();
++
++				WorldIO.ReadWorldHeader(worldFileData);
  				return worldFileData;
  			}
  		}

--- a/patches/tModLoader/Terraria/IO/WorldFileData.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFileData.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/IO/WorldFileData.cs
 +++ src/tModLoader/Terraria/IO/WorldFileData.cs
-@@ -5,6 +_,7 @@
+@@ -5,11 +_,12 @@
  using Terraria.Audio;
  using Terraria.GameContent;
  using Terraria.Localization;
@@ -8,6 +8,12 @@
  using Terraria.Utilities;
  
  namespace Terraria.IO;
+ 
+-public class WorldFileData : FileData
++public partial class WorldFileData : FileData
+ {
+ 	private const ulong GUID_IN_WORLD_FILE_VERSION = 777389080577uL;
+ 	public DateTime CreationTime;
 @@ -177,6 +_,8 @@
  		if (!base.IsCloudSave) {
  			string worldPathFromName = Main.GetWorldPathFromName(Name, cloudSave: true);

--- a/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
+++ b/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -6,6 +7,13 @@ namespace Terraria.IO;
 
 public partial class WorldFileData
 {
+	internal IList<string> usedMods; // log this?
+	internal string modPack;
+	/// <summary>
+	/// Contains the mods (and their version) that were enabled when this world was generated.<para/>
+	/// The feature tracking which mods were used to generate a world was added in v2023.8, so if <see cref="modsGeneratedWith"/> is <see langword="null"/>, this world was generated before then and can't be used to determine if a specific mod was enabled when the world was generated.
+	/// </summary>
+	public IList<(string modName, Version modVersion)> modsGeneratedWith; // TODO: Log this when loading world.
 	internal Dictionary<string, TagCompound> ModHeaders { get; set; } = new Dictionary<string, TagCompound>();
 
 	public bool TryGetHeaderData<T>(out TagCompound data) where T : ModSystem => TryGetHeaderData(ModContent.GetInstance<T>(), out data);

--- a/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
+++ b/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Terraria.GameContent.UI;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -7,13 +8,20 @@ namespace Terraria.IO;
 
 public partial class WorldFileData
 {
-	internal IList<string> usedMods; // log this?
+	internal IList<string> usedMods;
 	internal string modPack;
+	internal Dictionary<string, Version> modVersionsDuringWorldGen; // Note: "ModLoader" entry also present, can be used to know tML version
 	/// <summary>
-	/// Contains the mods (and their version) that were enabled when this world was generated.<para/>
-	/// The feature tracking which mods were used to generate a world was added in v2023.8, so if <see cref="modsGeneratedWith"/> is <see langword="null"/>, this world was generated before then and can't be used to determine if a specific mod was enabled when the world was generated.
+	/// Retrieves the version that the specified mod was at when the world was generated. <see langword="false"/> will be returned for mods that were not enabled when the world was generated.<para/>
+	/// The feature tracking which mods were used to generate a world was added in v2023.8, so modders should first check <see cref="WorldGenModsRecorded"/> to see if the mods used to generate the world were recorded at all.
 	/// </summary>
-	public IList<(string modName, Version modVersion)> modsGeneratedWith; // TODO: Log this when loading world.
+	public bool TryGetModVersionGeneratedWith(string mod, out Version modVersion) => modVersionsDuringWorldGen.TryGetValue(mod, out modVersion);
+	/// <summary>
+	/// If <see langword="true"/>, the mods used to genereate this world have been saved and their version can be retrieved using <see cref="TryGetModVersionGeneratedWith(string, out Version)"/>.<para/>
+	/// If <see langword="false"/>, this world was generated before the feature tracking mods used to generate a world was added (v2023.8) and modders can't determine if a specific mod was enabled when the world was generated.
+	/// </summary>
+	public bool WorldGenModsRecorded => modVersionsDuringWorldGen != null;
+
 	internal Dictionary<string, TagCompound> ModHeaders { get; set; } = new Dictionary<string, TagCompound>();
 
 	public bool TryGetHeaderData<T>(out TagCompound data) where T : ModSystem => TryGetHeaderData(ModContent.GetInstance<T>(), out data);

--- a/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
+++ b/patches/tModLoader/Terraria/IO/WorldFileData.tML.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Terraria.ModLoader;
+using Terraria.ModLoader.IO;
+
+namespace Terraria.IO;
+
+public partial class WorldFileData
+{
+	internal Dictionary<string, TagCompound> ModHeaders { get; set; } = new Dictionary<string, TagCompound>();
+
+	public bool TryGetHeaderData<T>(out TagCompound data) where T : ModSystem => TryGetHeaderData(ModContent.GetInstance<T>(), out data);
+	public bool TryGetHeaderData(ModSystem system, out TagCompound data) => ModHeaders.TryGetValue(system.FullName, out data);
+}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -237,7 +237,7 @@
  	public static int maxTilesY = (int)bottomWorld / 16 + 1;
  	public const int sectionWidth = 200;
  	public const int sectionHeight = 150;
-@@ -683,11 +_,11 @@
+@@ -683,12 +_,12 @@
  	public const int maxItemText = 20;
  	public const int maxPlayers = 255;
  	public static int maxNetPlayers = 255;
@@ -251,9 +251,11 @@
 +	public static readonly int maxNPCs = 200;
 -	private static UICharacterSelect _characterSelectMenu = new UICharacterSelect();
 +	internal static UICharacterSelect _characterSelectMenu = new UICharacterSelect();
- 	private static UIWorldSelect _worldSelectMenu = new UIWorldSelect();
+-	private static UIWorldSelect _worldSelectMenu = new UIWorldSelect();
++	internal static UIWorldSelect _worldSelectMenu = new UIWorldSelect();
  	public static UIManageControls ManageControlsMenu = new UIManageControls();
  	public static UIAchievementsMenu AchievementsMenu = new UIAchievementsMenu();
+ 	public static int maxRain = 750;
 @@ -743,19 +_,48 @@
  	public static int LogoA = 255;
  	public static int LogoB;

--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -388,7 +388,7 @@ internal static class PlayerIO
 
 	internal static void LoadUsedModPack(Player player, string modpack)
 	{
-		player.modPack = modpack;
+		player.modPack = string.IsNullOrEmpty(modpack) ? null : modpack; // tag.GetString returns "" even though null 
 	}
 
 	internal static string SaveUsedModPack(Player player)

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagIO.cs
@@ -312,8 +312,10 @@ public static class TagIO
 		}
 
 		name = StringHandler.reader(r);
-		return PayloadHandlers[id].Read(r);
+		return ReadTagImpl(id, r);
 	}
+
+	public static object? ReadTagImpl(int id, BinaryReader r) => PayloadHandlers[id].Read(r);
 
 	public static void WriteTag(string name, object tag, BinaryWriter w)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TagSerializer.cs
@@ -194,3 +194,10 @@ public class RectangleSerializer : TagSerializer<Rectangle, TagCompound>
 
 	public override Rectangle Deserialize(TagCompound tag) => new Rectangle(tag.GetInt("x"), tag.GetInt("y"), tag.GetInt("width"), tag.GetInt("height"));
 }
+
+public class VersionSerializer : TagSerializer<Version, string>
+{
+	public override string Serialize(Version value) => value.ToString(); // Since 1.0 and 1.0.0 are different, it's simpler to just use ToString than implement all the branching logic.
+
+	public override Version Deserialize(string tag) => new Version(tag);
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/WorldIO.cs
@@ -3,9 +3,10 @@ using ReLogic.OS;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using Terraria.GameContent.Events;
 using Terraria.ID;
-using Terraria.ModLoader.Core;
+using Terraria.IO;
 using Terraria.ModLoader.Default;
 using Terraria.ModLoader.Exceptions;
 using Terraria.Social;
@@ -25,6 +26,7 @@ internal static class WorldIO
 			FileUtilities.Copy(path, path + ".bak", isCloudSave);
 
 		var tag = new TagCompound {
+			["0header"] = SaveHeader(),
 			["chests"] = SaveChestInventory(),
 			["tiles"] = TileIO.SaveBasics(),
 			["containers"] = TileIO.SaveContainers(),
@@ -42,6 +44,7 @@ internal static class WorldIO
 
 		FileUtilities.WriteTagCompound(path, isCloudSave, tag);
 	}
+
 	//add near end of Terraria.IO.WorldFile.loadWorld before setting failure and success
 	internal static void Load(string path, bool isCloudSave)
 	{
@@ -629,6 +632,82 @@ internal static class WorldIO
 		}
 		else if (SocialAPI.Cloud != null) {
 			SocialAPI.Cloud.Delete(path);
+		}
+	}
+
+	private static TagCompound SaveHeader()
+	{
+		return new TagCompound {
+			["modHeaders"] = SaveModHeaders(),
+		};			
+	}
+
+	private static TagCompound SaveModHeaders()
+	{
+		var modHeaders = new TagCompound();
+
+		var saveData = new TagCompound();
+		foreach (var system in SystemLoader.Systems) {
+			system.SaveWorldHeader(saveData);
+			if (saveData.Count == 0)
+				continue;
+
+			modHeaders[system.FullName] = saveData;
+			saveData = new TagCompound();
+		}
+
+		// preserve data for unloaded systems
+		foreach (var entry in Main.ActiveWorldFileData.ModHeaders) {
+			if (!ModContent.TryFind<ModSystem>(entry.Key, out _))
+				modHeaders[entry.Key] = entry.Value;
+		}
+
+		return modHeaders;
+	}
+
+	internal static void ReadWorldHeader(WorldFileData data)
+	{
+		string path = Path.ChangeExtension(data.Path, ".twld");
+		bool isCloudSave = data.IsCloudSave;
+
+		if (!FileUtilities.Exists(path, isCloudSave))
+			return;
+
+		try {
+			// this code hard-traverses the NBT format to read the just the first nested tag, if preset.
+			// It relies on deterministic tag saving order for the header to be first.
+			// Because the NBT format is not seekable, there is no way to skip reading the entire tag tree in order to find a specific sub-tag at an arbitrary path.
+
+			using Stream stream = isCloudSave ? new MemoryStream(SocialAPI.Cloud.Read(path)) : new FileStream(path, FileMode.Open);
+			using BinaryReader reader = new BigEndianReader(new GZipStream(stream, CompressionMode.Decompress));
+			if (reader.ReadByte() != 10)
+				throw new IOException("Root tag not a TagCompound");
+
+			// ignore root tag name
+			_ = TagIO.ReadTagImpl(8, reader);
+			if (reader.ReadByte() != 10)
+				return; // no header tag
+
+			if ((string)TagIO.ReadTagImpl(8, reader) != "0header")
+				return;
+
+			LoadWorldHeader(data, (TagCompound)TagIO.ReadTagImpl(10, reader));
+		}
+		catch (Exception ex) {
+			Logging.tML.Warn($"Error reading .twld header from: {path} (IsCloudSave={isCloudSave})", ex);
+		}
+	}
+
+	private static void LoadWorldHeader(WorldFileData data, TagCompound tag)
+	{
+		data.ModHeaders = new Dictionary<string, TagCompound>();
+		foreach (var entry in tag.GetCompound("modHeaders")) {
+			string fullname = entry.Key;
+
+			if (ModContent.TryFind<ModSystem>(fullname, out var system)) // handle legacy renames
+				fullname = system.FullName;
+
+			data.ModHeaders[fullname] = (TagCompound)entry.Value;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -304,6 +304,17 @@ public abstract partial class ModSystem : ModType
 	public virtual void LoadWorldData(TagCompound tag) { }
 
 	/// <summary>
+	/// <br/>Allows you to save custom data for this system in the current world, and have that data accessible in the world select UI and during vanilla world loading.
+	/// <br/><b>WARNING:</b> Saving too much data here will cause lag when opening the world select menu for users with many worlds.
+	/// <br/>Can be retrieved via <see cref="WorldFileData.TryGetHeaderData(ModSystem, out TagCompound)"/> and <see cref="Main.ActiveWorldFileData"/>
+	/// <br/>
+	/// <br/><b>NOTE:</b> The provided tag is always empty by default, and is provided as an argument only for the sake of convenience and optimization.
+	/// <br/><b>NOTE:</b> Try to only save data that isn't default values.
+	/// </summary>
+	/// <param name="tag"> The TagCompound to save data into. Note that this is always empty by default, and is provided as an argument only for the sake of convenience and optimization. </param>
+	public virtual void SaveWorldHeader(TagCompound tag) { }
+
+	/// <summary>
 	/// Allows you to prevent the world and player from being loaded/selected as a valid combination, similar to Journey Mode pairing.
 	/// </summary>
 	public virtual bool CanWorldBePlayed(PlayerFileData playerData, WorldFileData worldFileData)

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -597,7 +597,7 @@
 +		SystemLoader.PostWorldGen();
 +
  		Main.WorldFileMetadata = FileMetadata.FromCurrentSettings(FileType.World);
-+		Main.ActiveWorldFileData.modsGeneratedWith = ModLoader.ModLoader.Mods.Where(x => x.Name != "ModLoader").Select(x => (x.Name, x.Version)).ToList();
++		Main.ActiveWorldFileData.modVersionsDuringWorldGen = ModLoader.ModLoader.Mods.ToDictionary(x => x.Name, x => x.Version);
  		Main.NotifyOfEvent(GameNotificationType.WorldGen);
  		drunkWorldGenText = false;
 +

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1,5 +1,13 @@
 --- src/TerrariaNetCore/Terraria/WorldGen.cs
 +++ src/tModLoader/Terraria/WorldGen.cs
+@@ -1,6 +_,7 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Diagnostics;
++using System.Linq;
+ using System.Threading;
+ using System.Threading.Tasks;
+ using Microsoft.Xna.Framework;
 @@ -22,13 +_,15 @@
  using Terraria.IO;
  using Terraria.Localization;
@@ -566,7 +574,7 @@
  					bool flag2 = TileID.Sets.Dirt[tile2.type];
  					if (notTheBees)
  						flag2 = flag2 || TileID.Sets.Mud[tile2.type];
-@@ -13849,12 +_,33 @@
+@@ -13849,12 +_,34 @@
  			skipFramingDuringGen = false;
  			progress.Message = Lang.gen[87].Value;
  		});
@@ -589,6 +597,7 @@
 +		SystemLoader.PostWorldGen();
 +
  		Main.WorldFileMetadata = FileMetadata.FromCurrentSettings(FileType.World);
++		Main.ActiveWorldFileData.modsGeneratedWith = ModLoader.ModLoader.Mods.Where(x => x.Name != "ModLoader").Select(x => (x.Name, x.Version)).ToList();
  		Main.NotifyOfEvent(GameNotificationType.WorldGen);
  		drunkWorldGenText = false;
 +


### PR DESCRIPTION
### What is the new feature?

Modded world data can be now be saved into a 'header' in the .twld file. The header can be read without deserializing the entire .twld file, and the modded data is accessible in the world select menu and during vanilla world loading.

- Use `ModSystem.SaveWorldHeader` to add data to the header.
- Use `WorldFileData.TryGetHeaderData<ModSystem>(out TagCompound data)` to access the data.
- Data for the current world is in `Main.ActiveWorldFileData`
-  `UIWorldListItem.Data` and `UICharacterListItem.Data` getters have been added for mods wishing to modify the selection menus.
- Use `WorldFileData.WorldGenModsRecorded` and `TryGetModVersionGeneratedWith(string mod, out Version modVersion)` to detect when the world was generated without your mod, or with an old version.

#### Implementation details
Unfortunately the NBT file format is not seekable so it is not possible to skip the reading of some tags in order to find a specific path. However, by relying on the implementation of `TagCompound` saving tags in insertion order, we are able to ensure the header tag is always the first one in the file, and initialize a reader at the correct position to only read the header.

### Why should this be part of tModLoader?

Enables:
- #3697
- #1704
- #1416

### Are there alternative designs?

A separate `.twldheader` file would reduce the reliance on potentially fragile insertion order saving (which in turn depends on the implementation of `Dictionary`), but at the cost of significant additional file maintenance and desync risk.

### Sample usage for the new feature

To save some custom data:
```cs
		public override void SaveWorldHeader(TagCompound tag) {
			tag["isSpecialModdedWorld"] = ...
		}
```

To read some custom data:
```cs
UIWorldListItem uiItem = ...
if (uiItem.Data.TryGetHeaderData<MyModSystem>(out TagCompound data) && data.GetBool("isSpecialModdedWorld"))
    ...
```
or 
```cs
if (Main.ActiveWorldFileData.TryGetHeaderData<ExampleModSystem>(out TagCompound data) && data.GetBool("isSpecialModdedWorld"))
    ...
```

To check which version of your mod was enabled during world-gen on entering a world
```cs
public override void OnEnterWorld() {
	if (Main.netMode == NetmodeID.SinglePlayer && Main.ActiveWorldFileData.WorldGenModsRecorded 
			&& Main.ActiveWorldFileData.TryGetModVersionGeneratedWith("ExampleMod", out Version modVersion)) {
		// check version or display a message about a biome missing from the world
		// consider saving a marker in the world file or header indicating that the message has been displayed
	}
}
```
### ExampleMod updates

Added `ExampleWorldHeaderSystem`

