### PR TITLE
Fix docs on Item.cs.patch

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1668,7 +1668,7 @@
 +	/// useStyle = useGulpSound ? <see cref="ItemUseStyleID.DrinkLiquid"/> : <see cref="ItemUseStyleID.EatFood"/>;
 +	/// useTurn = true;
 +	/// useAnimation = useTime = animationTime;
-+	/// maxStack = 30;
++	/// maxStack = Item.CommonMaxStack;
 +	/// consumable = true;
 +	/// buffType = <paramref name="foodbuff"/>;
 +	/// buffTime = <paramref name="foodbuffduration"/>;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1354,7 +1354,7 @@
 +	///	height = 12;
 +	/// value = buyPrice(0, 0, 15);
 +	/// rare = 3;
-+	///	maxStack = CommonMaxStack;
++	///	maxStack = <see cref="CommonMaxStack"/>;
 +	///	consumable = true;
 +	/// </code>
 +	/// </summary>
@@ -1668,7 +1668,7 @@
 +	/// useStyle = useGulpSound ? <see cref="ItemUseStyleID.DrinkLiquid"/> : <see cref="ItemUseStyleID.EatFood"/>;
 +	/// useTurn = true;
 +	/// useAnimation = useTime = animationTime;
-+	/// maxStack = Item.CommonMaxStack;
++	/// maxStack = <see cref="CommonMaxStack"/>;
 +	/// consumable = true;
 +	/// buffType = <paramref name="foodbuff"/>;
 +	/// buffTime = <paramref name="foodbuffduration"/>;


### PR DESCRIPTION
### What is the bug?
The XML docs for `DefaultToFood` indicate that the item stack is set to 30 instead of 9999

### How did you fix the bug?
Changed `30` to `Item.CommonMaxStack`

### Are there alternatives to your fix?
Pretty sure not.
