### PR TITLE
Fix MonoModHooks.DumpILHooks always throwing

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -160,7 +160,7 @@ public static class MonoModHooks
 	{
 		var ilHooksField = typeof(HookEndpointManager).GetField("ILHooks", BindingFlags.NonPublic | BindingFlags.Static);
 		object ilHooksFieldValue = ilHooksField.GetValue(null);
-		if (ilHooksFieldValue is Dictionary<(MethodBase, Delegate), ILHook> ilHooks) {
+		if (ilHooksFieldValue is IDictionary<(MethodBase, Delegate), ILHook> ilHooks) {
 			Logging.tML.Debug("Dump of registered IL Hooks:");
 			foreach (var item in ilHooks) {
 				Logging.tML.Debug(item.Key + ": " + item.Value);

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -160,7 +160,7 @@ public static class MonoModHooks
 	{
 		var ilHooksField = typeof(HookEndpointManager).GetField("ILHooks", BindingFlags.NonPublic | BindingFlags.Static);
 		object ilHooksFieldValue = ilHooksField.GetValue(null);
-		if (ilHooksFieldValue is IDictionary<(MethodBase, Delegate), ILHook> ilHooks) {
+		if (ilHooksFieldValue is IReadOnlyDictionary<(MethodBase, Delegate), ILHook> ilHooks) {
 			Logging.tML.Debug("Dump of registered IL Hooks:");
 			foreach (var item in ilHooks) {
 				Logging.tML.Debug(item.Key + ": " + item.Value);
@@ -179,7 +179,7 @@ public static class MonoModHooks
 	{
 		var hooksField = typeof(HookEndpointManager).GetField("Hooks", BindingFlags.NonPublic | BindingFlags.Static);
 		object hooksFieldValue = hooksField.GetValue(null);
-		if (hooksFieldValue is Dictionary<(MethodBase, Delegate), Hook> detours) {
+		if (hooksFieldValue is IReadOnlyDictionary<(MethodBase, Delegate), Hook> detours) {
 			Logging.tML.Debug("Dump of registered Detours:");
 			foreach (var item in detours) {
 				Logging.tML.Debug(item.Key + ": " + item.Value);


### PR DESCRIPTION
### What is the bug?
`MonoModHooks.DumpILHooks` (and `MonoModHooks.DumpOn`) always throws cause `HookEndpointManager.ILHooks` is `ConcurrentDictionary<(MethodBase, Delegate), ILHook>` and not `Dictionary<(MethodBase, Delegate), ILHook>`

![image](https://github.com/tModLoader/tModLoader/assets/65787578/53381ee0-deaa-4b1f-9ffb-64f2648c2625)

Check docs on `ConcurrentDictionary<TKey, TValue>`: https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2?view=net-6.0

### How did you fix the bug?
Changing check from `Dictionary<...>` to `IReadOnlyDictionary<...>`

### Are there alternatives to your fix?
Change it to `IDictionary<...>` or `ConcurrentDictionary<...>`