### PR TITLE
Added AddBackgroundTexture overload

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -38,6 +38,22 @@ public sealed class BackgroundTextureLoader : Loader
 	/// <summary> Safely attempts to output the slot/ID of the background texture with the given mod and path. </summary>
 	public static bool TryGetBackgroundSlot(Mod mod, string texture, out int slot) => TryGetBackgroundSlot($"{mod.Name}/{texture}", out slot);
 
+	/// <inheritdoc cref="AddBackgroundTexture(Mod, string)"/>
+	public static void AddBackgroundTexture(string texture)
+	{
+		if (texture == null)
+			throw new ArgumentNullException(nameof(texture));
+
+		ModContent.SplitName(texture, out string modName, out _);
+		if (!ModLoader.TryGetMod(modName, out Mod mod) || !mod.loading) {
+			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
+		}
+
+		mod.Assets.Request<Texture2D>(texture);
+
+		backgrounds[texture] = Instance.Reserve();
+	}
+
 	/// <summary>
 	/// Adds a texture to the list of background textures and assigns it a background texture slot.
 	/// </summary>
@@ -48,15 +64,10 @@ public sealed class BackgroundTextureLoader : Loader
 		if (mod == null)
 			throw new ArgumentNullException(nameof(mod));
 
-		if (texture == null)
-			throw new ArgumentNullException(nameof(texture));
-
 		if (!mod.loading)
 			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
 
-		ModContent.Request<Texture2D>(texture);
-
-		backgrounds[texture] = Instance.Reserve();
+		AddBackgroundTexture($"{mod.Name}/{texture}");
 	}
 
 	internal override void ResizeArrays()

--- a/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BackgroundLoaders.cs
@@ -64,9 +64,6 @@ public sealed class BackgroundTextureLoader : Loader
 		if (mod == null)
 			throw new ArgumentNullException(nameof(mod));
 
-		if (!mod.loading)
-			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorNotLoading"));
-
 		AddBackgroundTexture($"{mod.Name}/{texture}");
 	}
 


### PR DESCRIPTION
### What is the bug?
Currently, `BackgroundTextureLoader.AddBackgroundTexture(Mod, string)` takes _full_ texture path.

For example, `BackgroundTextureLoader.AddBackgroundTexture(Mod, "Assets/Textures/Backgrounds/ExampleBiomeSurfaceClose")` would throw but if you add mod name to texture path then it will be just fine.

### How did you fix the bug?
Added `BackgroundTextureLoader.AddBackgroundTexture(string)` overload that takes full texture path and adjusted `BackgroundTextureLoader.AddBackgroundTexture(Mod, string)` to call it instead.

### Are there alternatives to your fix?
No.