### PR TITLE
ModPlayer OnPickup hook

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -307,4 +307,9 @@ public static class CombinedHooks
 		PlayerLoader.FrameEffects(player);
 		EquipLoader.EquipFrameEffects(player);
 	}
+
+	public static bool OnPickup(Item item, Player player)
+	{
+		return ItemLoader.OnPickup(item, player) && PlayerLoader.OnPickup(player, item);
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1253,7 +1253,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
-	/// Allows you to make special things happen when the player picks up this item. Return false to stop the item from being added to the player's inventory; returns true by default.
+	/// Allows you to make special things happen when this player picks up an item. Return false to stop the item from being added to the player's inventory; returns true by default.
 	/// </summary>
 	/// <param name="item">The item being picked up</param>
 	/// <returns></returns>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1251,4 +1251,14 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 		itemConsumedCallback = null;
 		return null;
 	}
+
+	/// <summary>
+	/// Allows you to make special things happen when the player picks up this item. Return false to stop the item from being added to the player's inventory; returns true by default.
+	/// </summary>
+	/// <param name="item">The item being picked up</param>
+	/// <returns></returns>
+	public virtual bool OnPickup(Item item)
+	{
+		return true;
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1436,4 +1436,17 @@ public static class PlayerLoader
 				yield return (items, onUsedForCrafting);
 		}
 	}
+
+	private static HookList HookOnPickup = AddHook<Func<Item, bool>>(p => p.OnPickup);
+
+	public static bool OnPickup(Player player, Item item)
+	{
+		foreach (var modPlayer in HookOnPickup.Enumerate(player)) {
+			if (!modPlayer.OnPickup(item)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4379,7 +4379,7 @@
  			if (base.Hitbox.Intersects(hitbox)) {
 -				if (i == Main.myPlayer && (inventory[selectedItem].type != 0 || itemAnimation <= 0))
 +				if (i == Main.myPlayer && (inventory[selectedItem].type != 0 || itemAnimation <= 0)) {
-+					if (!ItemLoader.OnPickup(Main.item[j], this)) {
++					if (!CombinedHooks.OnPickup(Main.item[j], this)) {
 +						Main.item[j] = new Item();
 +						if (Main.netMode == 1)
 +							NetMessage.SendData(21, -1, -1, null, j);


### PR DESCRIPTION
Implements #3754 

### What is the new feature?
`ModPlayer` `OnPickup` hook, 

### Why should this be part of tModLoader?
See issue

### Are there alternative designs?
Could be renamed, as mentioned in the issue, but it's documented and method parameters make it obvious

### Sample usage for the new feature
```cs
	public class SomePlayer : ModPlayer
	{
		public override bool OnPickup(Item item) {
			if (item.type == ItemID.Zenith) {
				Main.NewText("Lol no zenith for you :p");
				return false;
			}

			return base.OnPickup(item);
		}
	}
```