### PR TITLE
ItemID.Sets.IsSpaceGun

### DIFF
--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -120,5 +120,7 @@ partial class ItemID
 			{ GoldOre, (3, 13) },
 			{ PlatinumOre, (3, 13) },
 		};
+
+		public static bool[] IsSpaceGun = Factory.CreateBoolSet(false, SpaceGun, ZapinatorGray, ZapinatorOrange);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -121,6 +121,9 @@ partial class ItemID
 			{ PlatinumOre, (3, 13) },
 		};
 
+		/// <summary>
+		/// Set to <see langword="true"/> to make this Item set its mana cost to 0 whenever <see cref="Player.spaceGun"/> is set to <see langword="true"/>.
+		/// </summary>
 		public static bool[] IsSpaceGun = Factory.CreateBoolSet(false, SpaceGun, ZapinatorGray, ZapinatorOrange);
 	}
 }

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -506,8 +506,8 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	{
 		float reduce = manaCost;
 		float mult = 1;
-		// TODO: Make a space gun set
-		if (spaceGun && (item.type == ItemID.SpaceGun || item.type == ItemID.ZapinatorGray || item.type == ItemID.ZapinatorOrange))
+
+		if (spaceGun && ItemID.Sets.IsSpaceGun[item.type])
 			mult = 0;
 
 		if(item.type == ItemID.BookStaff && altFunctionUse == 2)


### PR DESCRIPTION
### What is the new feature?
Adds `ItemID.Sets.IsSpaceGun`

### Why should this be part of tModLoader?
Allows removing space guns or adding custom guns to the set slightly easier.

### Sample usage for the new feature
```
ItemID.Sets.IsSpaceGun[ItemID.SpaceGun] = false;
ItemID.Sets.IsSpaceGun[ItemType<ExampleGun>()] = true;
```

### ExampleMod updates
None, but could make one of guns be in that set.