### PR TITLE
Rewrite CheckIfPublishedForThisBrowserVersion Logic

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -571,34 +571,31 @@ internal static class ModOrganizer
 		return recommendedTmod.file;
 	}
 
+	/// <summary>
+	/// Case 1:
+	///		tmlVersion = 1.4.4
+	///		modVersion = 2023.1 => 1.4.4 transition versions prior to major breaking changes completion
+	///	Returns false as 2023.1 isn't considered 1.4.4 ready. Supplies modBrowserVersion as 1.4.3 as achievable version
+	///	Case 2:
+	///		tmlVersion = 1.4.3
+	///		modVersion = 2022.9 => 1.4.3
+	///	Returns true as tmlVersion = modVersion. Supplies modBrowserVersion as 1.4.3
+	///	Case 3:
+	///		tmlVersion = 1.4.4
+	///		modVersion = 2023.6 => 1.4.4
+	///	Returns true as tmlVersion = modVersion. Supplies modBrowserVersion as 1.4.4
+	///	 1.4.4 tag is 2023.03.85.0 onwards
+	/// </summary>
 	public static bool CheckIfPublishedForThisBrowserVersion(LocalMod mod, out string modBrowserVersion)
 	{
-		string thisVersion = SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
-		modBrowserVersion = thisVersion;
-		// If Can't Read Manifest, assume local build and thus must be compatible
-		if (!TryReadManifest(GetParentDir(mod.modFile.path), out var info))
-			return true;
-
-		// If Tags is null, it would be a pre-1.4 release mod. IE "1.4-alpha". 
-		if (info.tags == null) {
-			modBrowserVersion = "1.4.3";
-			return modBrowserVersion == thisVersion;
-		}
-
-		// Attempt checking if it's supported on this version, if so, then it's for this duh.
-		if (info.tags.Contains(thisVersion))
-			return true;
-
-		// Attempt checking if the version it is for matches the tags it has, to ensure we recommend correct version
+		string tmlVersion = SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
 		modBrowserVersion = SocialBrowserModule.GetBrowserVersionNumber(mod.tModLoaderVersion);
-		if (info.tags.Contains(modBrowserVersion))
-			return false;
 
-		// Version unknown. Assume 1.4.3
-		modBrowserVersion = "1.4.3";
-		return false;
+		if (modBrowserVersion == SocialBrowserModule.GetBrowserVersionNumber(new Version(2023, 01)))
+			modBrowserVersion = "1.4.3";
+
+		return modBrowserVersion == tmlVersion;
 	}
-
 
 	internal static HashSet<string> DetermineSupportedVersionsFromWorkshop(string repo)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -16,6 +16,7 @@ using Terraria.GameContent;
 using ReLogic.Content;
 using System.IO;
 using ReLogic.Utilities;
+using Terraria.Social.Base;
 
 namespace Terraria.ModLoader.UI;
 
@@ -125,7 +126,7 @@ internal class UIModItem : UIPanel
 		}
 
 		// Detect if it's for a different browser version entirely
-		if (!ModOrganizer.CheckIfPublishedForThisBrowserVersion(_mod, out var modBrowserVersion)) {
+		if (!CheckIfPublishedForThisBrowserVersion(out var modBrowserVersion)) {
 			updateVersion = $"{modBrowserVersion} v{_mod.tModLoaderVersion}";
 			updateColor = Color.Yellow;
 		}
@@ -585,5 +586,11 @@ internal class UIModItem : UIPanel
 
 		CloseDialog(evt, listeningElement);
 		Interface.modsMenu.Activate();
+	}
+
+	private bool CheckIfPublishedForThisBrowserVersion(out string recommendedModBrowserVersion)
+	{
+		recommendedModBrowserVersion = SocialBrowserModule.GetBrowserVersionNumber(_mod.tModLoaderVersion);
+		return recommendedModBrowserVersion == SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
 	}
 }

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -129,6 +129,9 @@ public interface SocialBrowserModule
 		if (tmlVersion < new Version(2022, 10)) // Versions 0.12 to 2022.9
 			return "1.4";
 
+		if (tmlVersion < new Version(2023, 3, 85)) // Introduction of 1.4.4 tag and end of major 1.4.4 breaking changes
+			return "1.4.4-Transitive";
+
 		return "1.4.4";
 	}
 }

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -124,15 +124,20 @@ public interface SocialBrowserModule
 	public static string GetBrowserVersionNumber(Version tmlVersion)
 	{
 		if (tmlVersion < new Version(0, 12)) // Versions 0 to 0.11.8.9
-			return "1.3";
+			return "1.3"; // Long Term Service Version 1.3
 
 		if (tmlVersion < new Version(2022, 10)) // Versions 0.12 to 2022.9
-			return "1.4";
+			return "1.4.3"; // Long Term Service version 1.4.3
 
+		// We treat tModLoader versions between 2022.10.0.0 and 2023.3.85.0 as 'dead' versions.
+		// Any mods built against these are not expected to actually work with tModLoader, and should be excluded in any ModBrowser or Mods Menu usage
+		// The core reasonsing is due to systemic changes that broke nearly all mods during the 1.4.4 port (Localization rework)
+		// It is recommended, given the timing of it, to ignore all tMods in publish folder with this.
+		// NOTE: This does cause this tag to be added on Steam in the 'unsorted tags' category, for better or worse - Solxan
 		if (tmlVersion < new Version(2023, 3, 85)) // Introduction of 1.4.4 tag and end of major 1.4.4 breaking changes
 			return "1.4.4-Transitive";
 
-		return "1.4.4";
+		return "1.4.4"; // Long Term Service Version 1.4.4 (Current)
 	}
 }
 

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -134,7 +134,7 @@ public partial class WorkshopSocialModule
 			ModOrganizer.CleanupOldPublish(workshopFolderPath);
 
 			// Should be called after folder created & cleaned up
-			tagsList.AddRange(ModOrganizer.DetermineSupportedVersionsFromWorkshop(workshopFolderPath));
+			tagsList.AddRange(DetermineSupportedVersionsFromWorkshop(workshopFolderPath));
 
 			var modPublisherInstance = new WorkshopHelper.ModPublisherInstance();
 
@@ -164,6 +164,12 @@ public partial class WorkshopSocialModule
 		}
 
 		return true;
+	}
+
+	internal static HashSet<string> DetermineSupportedVersionsFromWorkshop(string repo)
+	{
+		var summary = ModOrganizer.AnalyzeWorkshopTmods(repo);
+		return summary.Select(info => SocialBrowserModule.GetBrowserVersionNumber(info.tModVersion)).ToHashSet();
 	}
 
 	internal static LocalMod OpenModFile(string path)


### PR DESCRIPTION
Followup to cleanup logic gaps and simplify code surrounding Checking if the the mod was published for this browser version.

Added commentary on the three cases to consider.
Added non-visible tag 1.4.4-transitive to be used for internal logic
Simplified logic

SHould be backported to 1.4.3-Legacy when approved