### PR TITLE
Fix "UseMana" tooltip

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleMagicWeapon.cs
@@ -1,3 +1,4 @@
+using Terraria;
 using Terraria.Enums;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -28,6 +29,14 @@ namespace ExampleMod.Content.Items.Weapons
 				.AddIngredient<ExampleItem>()
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
+		}
+
+		public override void ModifyManaCost(Player player, ref float reduce, ref float mult) {
+			// We can use ModifyManaCost to dynamically adjust the mana cost of this item, similar to how Space Gun works with the Meteor armor set.
+			// See ExampleHood to see how accessories give the reduce mana cost effect.
+			if (player.statLife < player.statLifeMax2 / 2) {
+				mult *= 0.5f; // Half the mana cost when at low health. Make sure to use multiplication with the mult parameter.
+			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2822,7 +2822,7 @@
  				numLines++;
  			}
  
-@@ -16536,36 +_,43 @@
+@@ -16536,36 +_,51 @@
  					toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.RestoresLife", item.healLife);
  				}
  
@@ -2836,8 +2836,16 @@
  				numLines++;
  			}
  
++			/* TML: Show mana cost based on Player.GetManaCost method and show UseMana tooltip on Space Gun with Meteor Armor
  			if (item.mana > 0 && (item.type != 127 || !player[myPlayer].spaceGun)) {
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.UsesMana", (int)((float)item.mana * player[myPlayer].manaCost));
++				toolTipNames[numLines] = "UseMana";
++				numLines++;
++			}
++			*/
++
++			if (item.mana > 0) {
++				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.UsesMana", player[myPlayer].GetManaCost(item));
 +				toolTipNames[numLines] = "UseMana";
  				numLines++;
  			}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2836,7 +2836,7 @@
  				numLines++;
  			}
  
-+			/* TML: Show mana cost based on Player.GetManaCost method and show UseMana tooltip on Space Gun with Meteor Armor
++			/* TML: Show mana cost based on Player.GetManaCost method and show UseMana tooltip on Space Gun with Meteor Armor. There has been suggestions to show "Uses X mana (Y% reduction)", but that seems more suited for a mod. This change brings ModifyManaCost behavior in line with Player.manaCost behavior.
  			if (item.mana > 0 && (item.type != 127 || !player[myPlayer].spaceGun)) {
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.UsesMana", (int)((float)item.mana * player[myPlayer].manaCost));
 +				toolTipNames[numLines] = "UseMana";


### PR DESCRIPTION
Implements #3739 

### What is the new feature?

Fixes vanilla "UseMana" tooltips not taking into account the various `ModifyManaCost` hooks.

This also changes Space Gun to say "Uses 0 mana" instead of lacking a tooltip.

### Why should this be part of tModLoader?

See issue

### Are there alternative designs?

There is more to discuss, we didn't really arrive at a consensus. 