### PR TITLE
Fix melee speed affecting tool use speed

### DIFF
--- a/ExampleMod/Content/Items/Tools/ExampleDrill.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleDrill.cs
@@ -17,7 +17,7 @@ namespace ExampleMod.Content.Items.Tools
 
 		public override void SetDefaults() {
 			Item.damage = 27;
-			Item.DamageType = DamageClass.Melee;
+			Item.DamageType = DamageClass.MeleeNoSpeed; // ignores melee speed bonuses. There's no need for drill animations to play faster, nor drills to dig faster with melee speed.
 			Item.width = 20;
 			Item.height = 12;
 			// IsDrill/IsChainsaw effects must be applied manually, so 60% or 0.6 times the time of the corresponding pickaxe. In this case, 60% of 7 is 4 and 60% of 25 is 15.

--- a/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleHamaxe.cs
@@ -24,6 +24,7 @@ namespace ExampleMod.Content.Items.Tools
 
 			Item.axe = 30; // How much axe power the weapon has, note that the axe power displayed in-game is this value multiplied by 5
 			Item.hammer = 100; // How much hammer power the weapon has
+			Item.attackSpeedOnlyAffectsWeaponAnimation = true; // Melee speed affects how fast the tool swings for damage purposes, but not how fast it can dig
 		}
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {

--- a/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
+++ b/ExampleMod/Content/Items/Tools/ExamplePickaxe.cs
@@ -25,6 +25,7 @@ namespace ExampleMod.Content.Items.Tools
 			Item.autoReuse = true;
 
 			Item.pick = 220; // How strong the pickaxe is, see https://terraria.wiki.gg/wiki/Pickaxe_power for a list of common values
+			Item.attackSpeedOnlyAffectsWeaponAnimation = true; // Melee speed affects how fast the tool swings for damage purposes, but not how fast it can dig
 		}
 
 		public override void MeleeEffects(Player player, Rectangle hitbox) {

--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -267,7 +267,8 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 
 	private void RestoreMeleeSpeedBehaviorOnVanillaItems()
 	{
-		if (type < ItemID.Count && melee && shoot > 0 && !ItemID.Sets.Spears[type] && !shootsEveryUse) {
+		bool isTool = pick > 0 || axe > 0 || hammer > 0 || type == ItemID.GravediggerShovel;
+		if (type < ItemID.Count && melee && (shoot > 0 && !ItemID.Sets.Spears[type] && !shootsEveryUse || isTool)) {
 			if (noMelee)
 				DamageType = DamageClass.MeleeNoSpeed;
 			else

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6146,6 +6146,15 @@
  		ItemCheck_UseWiringTools(sItem);
  		ItemCheck_UseLawnMower(sItem);
  		ItemCheck_PlayInstruments(sItem);
+@@ -33858,7 +_,7 @@
+ 		else {
+ 			toolTime--;
+ 			if (toolTime < 0)
+-				toolTime = sItem.useTime;
++				toolTime = CombinedHooks.TotalUseTime(sItem.useTime, this, sItem); //sItem.useTime;
+ 		}
+ 
+ 		ItemCheck_TryDestroyingDrones(sItem);
 @@ -33898,7 +_,10 @@
  			Projectile.NewProjectile(GetProjectileSource_Accessory(boneGloveItem), center.X, center.Y, vector.X, vector.Y, 532, 25, 5f, whoAmI);
  		}


### PR DESCRIPTION
### What is the bug?
- #3667

### How did you fix the bug?

- Set `Item.DamageType = DamageClass.MeleeNoSpeed` for drills.
- Set `Item.attackSpeedOnlyAffectsWeaponAnimation = true` for all other vanilla tools

This is the same adjustment made to all other vanilla melee weapons to handle the fact that vanilla melee speed doesn't affect projectile fire rate (except for spears).

### Porting Notes & Example Mod
Modders need to apply the same changes to their own tools, setting one of the above properties depending on whether melee speed should still affect the tool animation or not.

### Are there alternatives to your fix?
tML could check `Item.pick/axe/hammer` alongside `attackSpeedOnlyAffectsWeaponAnimation` internally, removing the need for modders to set it manually. This alternative was not chosen because:
- The effect would be buried in the code, and need to be documented somewhere
- It would making reasoning about the use and animation system harder.
- Modders would not be able to achieve the same effect for their own custom tool types.
- Modders would not be able to override the change