### PR TITLE
Add ProjectileID.Sets.PlayerHurtDamageIgnoresDifficultyScaling for explosives

### DIFF
--- a/patches/tModLoader/Terraria/ID/ProjectileID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.cs.patch
@@ -256,7 +256,7 @@
  		public static float[] ExtendedCanHitCheckRange = Factory.CreateFloatSet(0f, 833f, 48f, 834f, 48f, 835f, 48f);
  		public static bool[] NeedsUUID = Factory.CreateBoolSet(625, 626, 627, 628);
  		public static bool[] StardustDragon = Factory.CreateBoolSet(625, 626, 627, 628);
-@@ -269,12 +_,50 @@
+@@ -269,13 +_,57 @@
  			834,
  			835
  		};
@@ -305,5 +305,12 @@
 +		/// <br/> Defaults to <see langword="false"/>.
 +		/// </summary>
  		public static bool[] CanHitPastShimmer = Factory.CreateBoolSet(605, 270, 719, 961, 962, 926, 922, 100, 84, 83, 96, 101, 102, 275, 276, 277, 258, 259, 384, 385, 386, 874, 872, 873, 871, 683, 676, 670, 675, 686, 687, 467, 468, 464, 465, 466, 526, 456, 462, 455, 452, 454, 949);
++
++		/// <summary>
++		/// If <see langword="true"/> for a given projectile type (<see cref="Projectile.type"/>), then that projectile will do the same damage to players regardless of difficulty (expert/master etc). <br/>
++		/// This set includes all the friendly vanilla explosives which can hurt players from vanilla
++		/// </summary>
++		public static bool[] PlayerHurtDamageIgnoresDifficultyScaling = Factory.CreateBoolSet(28, 29, 30, 37, 108, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 164, 397, 470, 516, 517, 519, 588, 637, 773, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 903, 904, 905, 906, 910, 911, 1002);
  
  		public static SettingsForCharacterPreview SimpleLoop(int startFrame, int frameCount, int delayPerFrame = 4, bool bounceLoop = false)
+ 		{

--- a/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CombinedHooks.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using System;
 using Terraria.DataStructures;
 using Terraria.GameContent.Creative;
+using Terraria.ID;
 
 namespace Terraria.ModLoader;
 
@@ -167,7 +168,7 @@ public static class CombinedHooks
 		if (player.resistCold && projectile.coldDamage)
 			modifiers.IncomingDamageMultiplier *= 0.7f;
 
-		if (!projectile.reflected) {
+		if (!projectile.reflected && !ProjectileID.Sets.PlayerHurtDamageIgnoresDifficultyScaling[projectile.type]) {
 			float damageMult = Main.GameModeInfo.EnemyDamageMultiplier;
 			if (Main.GameModeInfo.IsJourneyMode) {
 				var power = CreativePowerManager.Instance.GetPower<CreativePowers.DifficultySliderPower>();


### PR DESCRIPTION
### What is the bug?
- #3666

### How did you fix the bug?
Added a new `ProjectileID.Sets.PlayerHurtDamageIgnoresDifficultyScaling` set, and included all `friendly` vanilla explosives which can damage players in it.

### Porting Notes & Example Mod
Modders need to add their friendly explosive projectiles to the set to get the same behavior.

### Are there alternatives to your fix?
tML could check `aiStyle == 16 && friendly` to prevent the scaling. This alternative was not chosen because:
- The effect would be buried in the code, and need to be documented somewhere
- It would making reasoning about the damage system harder.
- Modders would not be able to achieve the same effect for their own custom projectile ai