### PR TITLE
Enable hotbar key item swap and smart select while auto-reusing items

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3761,6 +3761,17 @@
  					}
  				}
  				else {
+@@ -19467,8 +_,10 @@
+ 				}
+ 			}
+ 
++			/* Moved into ItemCheck
+ 			if (selectedItem != 58)
+ 				SmartSelectLookup();
++			*/
+ 
+ 			if (stoned != lastStoned) {
+ 				if (whoAmI == Main.myPlayer && stoned) {
 @@ -19566,11 +_,14 @@
  					}
  				}
@@ -5867,7 +5878,7 @@
  					cursorItemIconPush = 6;
  				}
  			}
-@@ -33268,6 +_,54 @@
+@@ -33268,6 +_,59 @@
  			}
  		}
  
@@ -5919,6 +5930,11 @@
 +		goto DecrementItemAnimation;
 +
 +		ReuseDelayAndAnimationStart:
++
++		// SmartSelectLookup moved here from Player.Update so that it can apply between uses, without changing selectedItem prematurely for half the Update method
++		if (selectedItem != 58)
++			SmartSelectLookup();
++
  		ItemCheck_HandleMount();
  		int weaponDamage = GetWeaponDamage(item);
  		ItemCheck_HandleMPItemAnimation(item);


### PR DESCRIPTION
### What is the bug?
- #3775
- #2478

### How did you fix the bug?
Smart select, and hotbar swap buffering was fixed by moving `SmartSelectLookup` call into `ItemCheck` making it run after `itemAnimation--` decrements to 0, allowing the `selectedItem` to be changed and used immediately while holding down the attack button.

### Are there alternatives to your fix?
The `SmartSelectLookup` checks could be changed to `ItemAnimationEndingOrEnded` and the original position of the code restored. This would temporarily produce an invalid state where `selectedItem` has changed and is now in its last frame of animation (`itemAnimation == 1`) during movement updating hooks.