### PR TITLE
Add useTurnOnAnimationStart to restore turn behavior of earlygame vanilla swords

### DIFF
--- a/patches/tModLoader/Terraria/Item.TML.cs
+++ b/patches/tModLoader/Terraria/Item.TML.cs
@@ -74,6 +74,12 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	public bool AllowReforgeForStackableItem { get; set; }
 
 	/// <summary>
+	/// Similar to useTurn, but only allows turning when an animation starts (eg between swings). Many early-game vanilla swords use this as it makes them clunky and hard to kite with.
+	/// <br/> Defaults to <see langword="false"/>.
+	/// </summary>
+	public bool useTurnOnAnimationStart { get; set; }
+
+	/// <summary>
 	/// Dictates the amount of times a weapon can be used (shot, etc) each time it animates (is swung, clicked, etc).<br/>
 	/// Defaults to null.<br/>
 	/// Used in vanilla by the following:<br/>
@@ -263,6 +269,12 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 		if (type < ItemID.Count && autoReuse && !noMelee) {
 			useAnimation--;
 			currentUseAnimationCompensation--;
+		}
+
+		// in vanilla, items without autoReuse get a frame where itemAnimation == 0 between uses allowing the direction change checks in HorizontalMovement to apply
+		// in tML we need to explicitly enable this behavior
+		if (type < ItemID.Count && useStyle != 0 && !autoReuse && !useTurn && shoot == 0 && damage > 0) {
+			useTurnOnAnimationStart = true;
 		}
 	}
 

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1853,7 +1853,7 @@
  		if (type == 5437)
  			SetDefaults(5358);
  	}
-@@ -47318,14 +_,31 @@
+@@ -47318,14 +_,32 @@
  	{
  		tooltipContext = -1;
  		BestiaryNotes = null;
@@ -1863,6 +1863,7 @@
 +		_globals = null;
 +		StatsModifiedBy = new();
 +		AllowReforgeForStackableItem = false;
++		useTurnOnAnimationStart = false;
 +		attackSpeedOnlyAffectsWeaponAnimation = false;
 +		useLimitPerAnimation = null;
 +		consumeAmmoOnFirstShotOnly = false;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6883,6 +6883,15 @@
  		if (Main.dedServ)
  			return;
  
+@@ -39713,7 +_,7 @@
+ 		if (sItem.pick > 0 || sItem.axe > 0 || sItem.hammer > 0 || flag)
+ 			toolTime = 1;
+ 
+-		if (grappling[0] > -1) {
++		if (grappling[0] > -1 || sItem.useTurnOnAnimationStart) { // useTurnOnAnimationStart check added by tML
+ 			pulley = false;
+ 			pulleyDir = 1;
+ 			if (controlRight)
 @@ -39780,7 +_,10 @@
  			}
  


### PR DESCRIPTION
### What is the bug?
- #1770

### How did you fix the bug?
Added `Item.useTurnOnAnimationStart` to allow items to change direction based on `controlLeft` and `controlRight` only between animations, and applied this to the relevant vanilla items.

### Are there alternatives to your fix?
The new flag could instead be checked in `HorizontalMovement` alongside `itemAnimation == 0 || inventory[selectedItem].useTurn`, but this would require more patches, grant no additional useful functionality, and generally be more confusing.

### Porting Notes
- Modders with early-game weapons which want to replicate this behavior should set `useTurnOnAnimationStart` on their items. Note that this removes the ability to kite backwards, and there is little reason not to set `useTurn` instead to allow the player to turn instantly while using the item.