### PR TITLE
Fix item use sounds playing multiple times for remote clients

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -543,13 +543,13 @@
  						NetMessage.TrySendData(3, whoAmI);
  					}
  					else {
-@@ -1920,7 +_,13 @@
+@@ -1920,16 +_,25 @@
  				float itemRotation = reader.ReadSingle();
  				int itemAnimation = reader.ReadInt16();
  				player15.itemRotation = itemRotation;
 +
 +				// TML changes how item synchronization works, making it based on remote players' already-synchronized input.
-+				// Setting itemAnimation in this packet would interfere with that.
++				// Setting itemAnimation in this packet would interfere with that. #ItemTimeOnAllClients
 +				/*
  				player15.itemAnimation = itemAnimation;
 +				*/
@@ -557,6 +557,18 @@
  				player15.channel = player15.inventory[player15.selectedItem].channel;
  				if (Main.netMode == 2)
  					NetMessage.TrySendData(41, -1, whoAmI, null, num226);
+ 
++				// Sound is played on animation start #ItemTimeOnAllClients
++				/*
+ 				if (Main.netMode == 1) {
+ 					Item item6 = player15.inventory[player15.selectedItem];
+ 					if (item6.UseSound != null)
+ 						SoundEngine.PlaySound(item6.UseSound, player15.Center);
+ 				}
++				*/
+ 
+ 				break;
+ 			}
 @@ -2049,7 +_,11 @@
  				if (Main.tile[num237, num238] == null)
  					Main.tile[num237, num238] = new Tile();


### PR DESCRIPTION
### What is the bug?
- #3741

### How did you fix the bug?

Removed the `PlaySound` call from the handling code for packet 41 (`ShotAnimationAndSound`). This restores 1.4.3 tML behavior in this regard.

### Are there alternatives to your fix?

The sound could instead be suppressed on remote clients for items with `useStyle == Shoot or Rapier`, with a flags to override. This solution can still be investigated in the future, but the current vanilla implementation has a bug with items that shoot multiple times per animation, where the sound plays multiple times instead of once.

It would be good to explore more general solutions to remote animation syncing, as the 'continuous use simulation' which we do at the moment assumes all clients are running the same frame-rate. 
