### PR TITLE
Add parameterless constructor to NPCBestiaryDrawModifiers

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleBoneMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleBoneMerchant.cs
@@ -59,7 +59,7 @@ namespace ExampleMod.Content.NPCs
 			//NPCID.Sets.AllowDoorInteraction[Type] = true;
 
 			// Influences how the NPC looks in the Bestiary
-			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Velocity = 1f, // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 				Direction = 1 // -1 is left and 1 is right. NPCs are drawn facing the left by default but ExamplePerson will be drawn facing the right
 			};

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -66,7 +66,7 @@ namespace ExampleMod.Content.NPCs
 			NPCID.Sets.FaceEmote[Type] = ModContent.EmoteBubbleType<ExamplePersonEmote>();
 
 			// Influences how the NPC looks in the Bestiary
-			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Velocity = 1f, // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 				Direction = 1 // -1 is left and 1 is right. NPCs are drawn facing the left by default but ExamplePerson will be drawn facing the right
 				// Rotation = MathHelper.ToRadians(180) // You can also change the rotation of an NPC. Rotation is measured in radians

--- a/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
@@ -192,7 +192,7 @@ namespace ExampleMod.Content.NPCs
 			NPCID.Sets.FaceEmote[Type] = ModContent.EmoteBubbleType<ExampleTravellingMerchantEmote>();
 
 			// Influences how the NPC looks in the Bestiary
-			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Velocity = 2f, // Draws the NPC in the bestiary as if its walking +2 tiles in the x direction
 				Direction = -1 // -1 is left and 1 is right.
 			};

--- a/ExampleMod/Content/NPCs/ExampleWorm.cs
+++ b/ExampleMod/Content/NPCs/ExampleWorm.cs
@@ -16,7 +16,7 @@ namespace ExampleMod.Content.NPCs
 		public override int TailType => ModContent.NPCType<ExampleWormTail>();
 
 		public override void SetStaticDefaults() {
-			var drawModifier = new NPCID.Sets.NPCBestiaryDrawModifiers(0) { // Influences how the NPC looks in the Bestiary
+			var drawModifier = new NPCID.Sets.NPCBestiaryDrawModifiers() { // Influences how the NPC looks in the Bestiary
 				CustomTexturePath = "ExampleMod/Content/NPCs/ExampleWorm_Bestiary", // If the NPC is multiple parts like a worm, a custom texture for the Bestiary is encouraged.
 				Position = new Vector2(40f, 24f),
 				PortraitPositionXOverride = 0f,
@@ -92,7 +92,7 @@ namespace ExampleMod.Content.NPCs
 	internal class ExampleWormBody : WormBody
 	{
 		public override void SetStaticDefaults() {
-			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Hide = true // Hides this NPC from the Bestiary, useful for multi-part NPCs whom you only want one entry.
 			};
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(NPC.type, value);
@@ -111,7 +111,7 @@ namespace ExampleMod.Content.NPCs
 	internal class ExampleWormTail : WormTail
 	{
 		public override void SetStaticDefaults() {
-			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				Hide = true // Hides this NPC from the Bestiary, useful for multi-part NPCs whom you only want one entry.
 			};
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(NPC.type, value);

--- a/ExampleMod/Content/NPCs/ExampleZombieThief.cs
+++ b/ExampleMod/Content/NPCs/ExampleZombieThief.cs
@@ -22,7 +22,7 @@ namespace ExampleMod.Content.NPCs
 		public override void SetStaticDefaults() {
 			Main.npcFrameCount[Type] = Main.npcFrameCount[NPCID.Zombie];
 
-			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				// Influences how the NPC looks in the Bestiary
 				Velocity = 1f // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 			};

--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
@@ -120,7 +120,7 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 			// This boss also becomes immune to OnFire and all buffs that inherit OnFire immunity during the second half of the fight. See the ApplySecondStageBuffImmunities method.
 
 			// Influences how the NPC looks in the Bestiary
-			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			NPCID.Sets.NPCBestiaryDrawModifiers drawModifiers = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 				CustomTexturePath = "ExampleMod/Assets/Textures/Bestiary/MinionBoss_Preview",
 				PortraitScale = 0.6f, // Portrait refers to the full picture when clicking on the icon in the bestiary
 				PortraitPositionYOverride = 0f,

--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossMinion.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossMinion.cs
@@ -52,7 +52,7 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 
 			// Optional: If you don't want this NPC to show on the bestiary (if there is no reason to show a boss minion separately)
 			// Make sure to remove SetBestiary code aswell
-			// NPCID.Sets.NPCBestiaryDrawModifiers bestiaryData = new NPCID.Sets.NPCBestiaryDrawModifiers(0) {
+			// NPCID.Sets.NPCBestiaryDrawModifiers bestiaryData = new NPCID.Sets.NPCBestiaryDrawModifiers() {
 			//	Hide = true // Hides this NPC from the bestiary
 			// };
 			// NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, bestiaryData);

--- a/ExampleMod/Content/NPCs/PartyZombie.cs
+++ b/ExampleMod/Content/NPCs/PartyZombie.cs
@@ -18,7 +18,7 @@ namespace ExampleMod.Content.NPCs
 
 			NPCID.Sets.ShimmerTransformToNPC[NPC.type] = NPCID.Skeleton;
 
-			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers(0) { // Influences how the NPC looks in the Bestiary
+			NPCID.Sets.NPCBestiaryDrawModifiers value = new NPCID.Sets.NPCBestiaryDrawModifiers() { // Influences how the NPC looks in the Bestiary
 				Velocity = 1f // Draws the NPC in the bestiary as if its walking +1 tiles in the x direction
 			};
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, value);

--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Terraria.DataStructures;
 using Terraria.ModLoader;
 
 namespace Terraria.ID;
@@ -10,6 +6,15 @@ public partial class NPCID
 {
 	public static partial class Sets
 	{
+		public partial struct NPCBestiaryDrawModifiers
+		{
+			/// <inheritdoc cref="NPCBestiaryDrawModifiers(int)"/>
+			public NPCBestiaryDrawModifiers()
+			{
+				this = new(0);
+			}
+		}
+
 		//IDs taken from start of NPC.NewNPC when determining num
 		/// <summary>
 		/// Whether or not the spawned NPC will start looking for a suitable slot from the end of <seealso cref="Main.npc"/>, ignoring the Start parameter of <see cref="NPC.NewNPC"/>.

--- a/patches/tModLoader/Terraria/ID/NPCID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/NPCID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/NPCID.cs
 +++ src/tModLoader/Terraria/ID/NPCID.cs
-@@ -3,29 +_,109 @@
+@@ -3,29 +_,110 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Reflection;
  using Terraria.DataStructures;
@@ -109,9 +109,37 @@
 +			/// Creates a new <see cref="NPCBestiaryDrawModifiers"/> with default values.
 +			/// </summary>
 +			/// <param name="seriouslyWhyCantStructsHaveParameterlessConstructors">Unused.</param>
++			[Obsolete("Use the parameterless constructor instead")]// TODO: make internal at some point
  			public NPCBestiaryDrawModifiers(int seriouslyWhyCantStructsHaveParameterlessConstructors)
  			{
  				Position = default(Vector2);
+@@ -42,6 +_,26 @@
+ 				PortraitPositionYOverride = null;
+ 				CustomTexturePath = null;
+ 			}
++
++			/// <summary>
++			/// Creates a new <see cref="NPCBestiaryDrawModifiers"/> with default values.
++			/// </summary>
++			public NPCBestiaryDrawModifiers()
++			{
++				Position = default(Vector2);
++				Rotation = 0f;
++				Scale = 1f;
++				PortraitScale = 1f;
++				Hide = false;
++				IsWet = false;
++				Frame = null;
++				Direction = null;
++				SpriteDirection = null;
++				Velocity = 0f;
++				PortraitPositionXOverride = null;
++				PortraitPositionYOverride = null;
++				CustomTexturePath = null;
++			}
+ 		}
+ 
+ 		private static class LocalBuffID
 @@ -64,7 +_,13 @@
  			public const int BloodButcherer = 344;
  		}

--- a/patches/tModLoader/Terraria/ID/NPCID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/NPCID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/NPCID.cs
 +++ src/tModLoader/Terraria/ID/NPCID.cs
-@@ -3,29 +_,110 @@
+@@ -3,29 +_,109 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Reflection;
  using Terraria.DataStructures;
@@ -14,11 +14,12 @@
 -	public static class Sets
 +	public static partial class Sets
  	{
+-		public struct NPCBestiaryDrawModifiers
 +		/// <summary>
 +		/// Stores the draw parameters for an NPC type (<see cref="NPC.type"/>) in the Bestiary.
 +		/// <br/> <strong>Do not use the parameterless constructor or <c>default</c> to create this struct.</strong> Use <see cref="NPCBestiaryDrawModifiers(int)"/> instead with any parameter -- it sets proper default values.
 +		/// </summary>
- 		public struct NPCBestiaryDrawModifiers
++		public partial struct NPCBestiaryDrawModifiers
  		{
 +			/// <summary>
 +			/// The offset of this <see cref="NPC"/>'s Bestiary image in pixels.
@@ -109,37 +110,9 @@
 +			/// Creates a new <see cref="NPCBestiaryDrawModifiers"/> with default values.
 +			/// </summary>
 +			/// <param name="seriouslyWhyCantStructsHaveParameterlessConstructors">Unused.</param>
-+			[Obsolete("Use the parameterless constructor instead")]// TODO: make internal at some point
  			public NPCBestiaryDrawModifiers(int seriouslyWhyCantStructsHaveParameterlessConstructors)
  			{
  				Position = default(Vector2);
-@@ -42,6 +_,26 @@
- 				PortraitPositionYOverride = null;
- 				CustomTexturePath = null;
- 			}
-+
-+			/// <summary>
-+			/// Creates a new <see cref="NPCBestiaryDrawModifiers"/> with default values.
-+			/// </summary>
-+			public NPCBestiaryDrawModifiers()
-+			{
-+				Position = default(Vector2);
-+				Rotation = 0f;
-+				Scale = 1f;
-+				PortraitScale = 1f;
-+				Hide = false;
-+				IsWet = false;
-+				Frame = null;
-+				Direction = null;
-+				SpriteDirection = null;
-+				Velocity = 0f;
-+				PortraitPositionXOverride = null;
-+				PortraitPositionYOverride = null;
-+				CustomTexturePath = null;
-+			}
- 		}
- 
- 		private static class LocalBuffID
 @@ -64,7 +_,13 @@
  			public const int BloodButcherer = 344;
  		}


### PR DESCRIPTION
### What is the new feature?
Added a parameterless contructor to `NPCBestiaryDrawModifiers` and obsoleted the old one.

### Why should this be part of tModLoader?
The only reason the one with an unused parameter exists is because vanilla uses an old version of .NET that doesn't support parameterless struct constructors.

### Are there alternative designs?
Adding a tModPorter rule (don't know if I can do it with this).
Using a partial class (overkill but less patches).

### Sample usage for the new feature
`new NPCID.Sets.NPCBestiaryDrawModifiers();`

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
Changed all of the `NPCBestiaryDrawModifiers()` to use the new constructor.
