### PR TITLE
Config List Rework (Config Rework Part 1)

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Gib einen Befehl ein: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		"ModConfigFilterOptions": "Filtereinstellungen",
 		"ModConfigNotification": "Benachrichtigung: ",
 		"ModConfigModConfig": "Modkonfiguration",
@@ -106,6 +107,8 @@
 		"ModConfigRestoreDefaults": "Einstellungen zurücksetzen",
 		"ModConfigAskingServerToAcceptChanges": "Anfrage an Server, die Änderungen zu akzeptieren...",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Kann nicht gespeichert werden, da Änderungen neu laden erfordern würden",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Type a command: ",
 
 		//Mod Config
+		"ModConfigs": "Configs",
 		"ModConfigFilterOptions": "Filter Options",
 		"ModConfigNotification": "Notification: ",
 		"ModConfigModConfig": "Mod Config",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -107,6 +107,8 @@
 		"ModConfigRestoreDefaults": "Restore Defaults",
 		"ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		"ModConfigServerSide": "Server Side Config",
+		"ModConfigClientSide": "Client Side Config",
 		"ModConfigAdd": "Add",
 		"ModConfigRemove": "Remove",
 		"ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Escribe un comando: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		"ModConfigFilterOptions": "Opciones de filtro",
 		"ModConfigNotification": "Notificación: ",
 		"ModConfigModConfig": "Config. del mod",
@@ -106,6 +107,8 @@
 		"ModConfigRestoreDefaults": "Restablecer valores",
 		"ModConfigAskingServerToAcceptChanges": "Solicitando al servidor aceptar los cambios...",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "No se puede guardar porque los cambios requieren recargar el mod",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Tapez une commande: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		// "ModConfigFilterOptions": "Filter Options",
 		// "ModConfigNotification": "Notification: ",
 		// "ModConfigModConfig": "Mod Config",
@@ -106,6 +107,8 @@
 		// "ModConfigRestoreDefaults": "Restore Defaults",
 		// "ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
 		// "ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -99,6 +99,7 @@
 		// "AskForCommand": "Type a command: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		// "ModConfigFilterOptions": "Filter Options",
 		// "ModConfigNotification": "Notification: ",
 		// "ModConfigModConfig": "Mod Config",
@@ -108,6 +109,8 @@
 		// "ModConfigRestoreDefaults": "Restore Defaults",
 		// "ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
 		// "ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Wpisz komendę: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		// "ModConfigFilterOptions": "Filter Options",
 		// "ModConfigNotification": "Notification: ",
 		// "ModConfigModConfig": "Mod Config",
@@ -106,6 +107,8 @@
 		// "ModConfigRestoreDefaults": "Restore Defaults",
 		// "ModConfigAskingServerToAcceptChanges": "Asking server to accept changes...",
 		// "ModConfigCantSaveBecauseChangesWouldRequireAReload": "Can't save because changes would require a reload",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Digite um comando: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		"ModConfigFilterOptions": "Opções de Filtro",
 		"ModConfigNotification": "Notificação: ",
 		"ModConfigModConfig": "Config. do Mod",
@@ -106,6 +107,8 @@
 		"ModConfigRestoreDefaults": "Restaurar Padrões",
 		"ModConfigAskingServerToAcceptChanges": "Solicitando ao servidor para aceitar as mudanças...",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Não foi possível salvar pois as mudanças exigiriam um recarregamento",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -97,6 +97,7 @@
 		"AskForCommand": "Введите команду: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		"ModConfigFilterOptions": "Фильтр",
 		"ModConfigNotification": "Уведомление: ",
 		"ModConfigModConfig": "Конфигурация мода",
@@ -106,6 +107,8 @@
 		"ModConfigRestoreDefaults": "Сбросить по умолчанию",
 		"ModConfigAskingServerToAcceptChanges": "Запрос сервера на принятие изменений...",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "Не удаётся сохранить, поскольку изменения требуют перезагрузки",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		"ModConfigAdd": "Добавить",
 		"ModConfigRemove": "Удалить",
 		"ModConfigInitialize": "Инициализировать",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -98,6 +98,7 @@
 		"AskForCommand": "请输入命令: ",
 
 		//Mod Config
+		// "ModConfigs": "Configs",
 		"ModConfigFilterOptions": "筛选选项",
 		"ModConfigNotification": "通知：",
 		"ModConfigModConfig": "模组设置",
@@ -107,6 +108,8 @@
 		"ModConfigRestoreDefaults": "重设为默认",
 		"ModConfigAskingServerToAcceptChanges": "正在请求服务器接受改动……",
 		"ModConfigCantSaveBecauseChangesWouldRequireAReload": "由于需要重载模组而无法保存改动（请从主菜单进入模组列表以调整配置）",
+		// "ModConfigServerSide": "Server Side Config",
+		// "ModConfigClientSide": "Client Side Config",
 		// "ModConfigAdd": "Add",
 		// "ModConfigRemove": "Remove",
 		// "ModConfigInitialize": "Initialize",

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -184,20 +184,13 @@ internal class UIModConfig : UIState
 	private void BackClick(UIMouseEvent evt, UIElement listeningElement)
 	{
 		SoundEngine.PlaySound(SoundID.MenuClose);
-		Main.menuMode = Interface.modsMenuID;
 
-		//Main.menuMode = 1127;
 		if (!Main.gameMenu) {
 			Main.InGameUI.SetState(Interface.modConfigList);
 		}
-
-		/*
-		IngameFancyUI.Close();
-
-		if (ConfigManager.ModNeedsReload(mod)) {
-			Main.menuMode = Interface.reloadModsID;
+		else {
+			Main.menuMode = Interface.modConfigListID;
 		}
-		*/
 	}
 
 	internal void Unload()

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -393,7 +393,7 @@ internal class UIModConfig : UIState
 		}
 
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 100;
-		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modsMenuID;
+		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modConfigListID;
 	}
 
 	// do we need 2 copies? We can discard changes by reloading.

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -1,9 +1,8 @@
-using Microsoft.Xna.Framework;
-using Steamworks;
-using System;
+using System.Linq;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
-using Terraria.GameContent.UI.States;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
@@ -12,153 +11,223 @@ namespace Terraria.ModLoader.Config.UI;
 
 internal class UIModConfigList : UIState
 {
-	//internal readonly List<UICycleImage> _categoryButtons = new List<UICycleImage>();
+	public Mod SelectedMod;
 
 	private UIElement uIElement;
 	private UIPanel uIPanel;
+	private UITextPanel<LocalizedText> backButton;
 	private UIList modList;
-	private UITextPanel<string> buttonB;
-	//private bool needToRemoveLoading;
-	//private readonly List<UIModItem> items = new List<UIModItem>();
-	//private bool updateNeeded;
-	//private UITextPanel<string> buttonOMF;
+	private UIList configList;
 
 	public override void OnInitialize()
 	{
-		uIElement = new UIElement();
-		uIElement.Width.Set(0f, 0.8f);
-		uIElement.MaxWidth.Set(600f, 0f);
-		uIElement.Top.Set(220f, 0f);
-		uIElement.Height.Set(-220f, 1f);
-		uIElement.HAlign = 0.5f;
+		uIElement = new UIElement {
+			Width = { Percent = 0.8f },
+			MaxWidth = { Pixels = 800, Percent = 0f },
+			Top = { Pixels = 220 },
+			Height = { Pixels = -220, Percent = 1f },
+			HAlign = 0.5f,
+		};
+		Append(uIElement);
 
-		uIPanel = new UIPanel();
-		uIPanel.Width.Set(0f, 1f);
-		uIPanel.Height.Set(-110f, 1f);
-		uIPanel.BackgroundColor = UICommon.MainPanelBackground;
-		uIPanel.PaddingTop = 0f;
+		uIPanel = new UIPanel {
+			Width = { Percent = 1f },
+			Height = { Pixels = -110, Percent = 1f },
+			BackgroundColor = UICommon.MainPanelBackground,
+		};
 		uIElement.Append(uIPanel);
 
-		modList = new UIList();
-		modList.Width.Set(-25f, 1f);
-		modList.Height.Set(-50f, 1f);
-		modList.Top.Set(50f, 0f);
-		modList.ListPadding = 5f;
-		uIPanel.Append(modList);
+		var uIHeaderTextPanel = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModConfiguration"), 0.8f, true) {
+			HAlign = 0.5f,
+			Top = { Pixels = -35f },
+			BackgroundColor = UICommon.DefaultUIBlue,
+		}.WithPadding(15f);
+		uIElement.Append(uIHeaderTextPanel);
 
-		UIScrollbar uIScrollbar = new UIScrollbar();
-		uIScrollbar.SetView(100f, 1000f);
-		uIScrollbar.Height.Set(-50f, 1f);
-		uIScrollbar.Top.Set(50f, 0f);
-		uIScrollbar.HAlign = 1f;
-		uIPanel.Append(uIScrollbar);
+		var modListPanel = new UIPanel {
+			Width = { Pixels = uIPanel.PaddingTop / -2, Percent = 0.5f },
+			Height = { Percent = 1f },
+		};
+		uIPanel.Append(modListPanel);
 
-		modList.SetScrollbar(uIScrollbar);
+		var configListPanel = new UIPanel {
+			Width = { Pixels = uIPanel.PaddingTop / -2, Percent = 0.5f },
+			Height = { Percent = 1f },
+			HAlign = 1f,
+		};
+		uIPanel.Append(configListPanel);
 
-		UITextPanel<string> uIHeaderTexTPanel = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModConfiguration"), 0.8f, true);
-		uIHeaderTexTPanel.HAlign = 0.5f;
-		uIHeaderTexTPanel.Top.Set(-35f, 0f);
-		uIHeaderTexTPanel.SetPadding(15f);
-		uIHeaderTexTPanel.BackgroundColor = UICommon.DefaultUIBlue;
-		uIElement.Append(uIHeaderTexTPanel);
+		float headerHeight = 35;
+		var modListHeader = new UIText(Language.GetText("tModLoader.MenuMods"), 0.5f, true) {
+			Top = { Pixels = 5 },
+			Left = { Pixels = 12.5f },
+			HAlign = 0.5f,
+		};
+		modListPanel.Append(modListHeader);
 
-		buttonB = new UITextPanel<string>(Language.GetTextValue("UI.Back"), 0.7f, large: true);
-		buttonB.Width.Set(-10f, 0.5f);
-		buttonB.Height.Set(50f, 0f);
-		buttonB.VAlign = 1f;
-		buttonB.HAlign = 0.5f;
-		buttonB.Top.Set(-45f, 0f);
-		buttonB.WithFadedMouseOver();
-		buttonB.OnLeftClick += BackClick;
-		uIElement.Append(buttonB);
+		var configListHeader = new UIText(Language.GetText("tModLoader.ModConfigs"), 0.5f, true) {
+			Top = { Pixels = 5 },
+			Left = { Pixels = -12.5f },
+			HAlign = 0.5f,
+		};
+		configListPanel.Append(configListHeader);
 
-		/*
-		buttonOMF = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModsOpenModsFolders"), 1f, false);
-		buttonOMF.CopyStyle(buttonB);
-		buttonOMF.HAlign = 0.5f;
-		buttonOMF.OnMouseOver += UICommon.FadedMouseOver;
-		buttonOMF.OnMouseOut += UICommon.FadedMouseOut;
-		buttonOMF.OnLeftClick += OpenModsFolder;
-		uIElement.Append(buttonOMF);
-		*/
+		modList = new UIList {
+			Top = { Pixels = headerHeight },
+			Width = { Pixels = -25, Percent = 1f },
+			Height = { Pixels = -headerHeight, Percent = 1f },
+			ListPadding = 5f,
+			HAlign = 1f,
+		};
+		modListPanel.Append(modList);
 
-		Append(uIElement);
+		configList = new UIList {
+			Top = { Pixels = headerHeight },
+			Width = { Pixels = -25f, Percent = 1f },
+			Height = { Pixels = -headerHeight, Percent = 1f },
+			ListPadding = 5f,
+			HAlign = 0f,
+		};
+		configListPanel.Append(configList);
+
+		var modListScrollbar = new UIScrollbar {
+			Top = { Pixels = headerHeight },
+			Height = { Pixels = -headerHeight, Percent = 1f },
+		};
+		modListScrollbar.SetView(100f, 1000f);
+		modList.SetScrollbar(modListScrollbar);
+		modListPanel.Append(modListScrollbar);
+
+		var configListScrollbar = new UIScrollbar {
+			Top = { Pixels = headerHeight },
+			Height = { Pixels = -headerHeight, Percent = 1f },
+			HAlign = 1f,
+		};
+		configListScrollbar.SetView(100f, 1000f);
+		configList.SetScrollbar(configListScrollbar);
+		configListPanel.Append(configListScrollbar);
+
+		backButton = new UITextPanel<LocalizedText>(Language.GetText("UI.Back"), 0.7f, large: true) {
+			Width = { Pixels = -10f, Percent = 0.5f },
+			Height = { Pixels = 50f },
+			Top = { Pixels = -45f },
+			VAlign = 1f,
+			HAlign = 0.5f,
+		}.WithFadedMouseOver();
+		backButton.OnLeftClick += (_, _) => {
+			SoundEngine.PlaySound(SoundID.MenuClose);
+			SelectedMod = null;
+
+			if (Main.gameMenu)
+				Main.menuMode = Interface.modsMenuID;
+			else
+				IngameFancyUI.Close();
+		};
+
+		uIElement.Append(backButton);
 	}
-
-	private static void BackClick(UIMouseEvent evt, UIElement listeningElement)
-	{
-		SoundEngine.PlaySound(11, -1, -1, 1);
-		//Main.menuMode = 0;
-
-		//Main.menuMode = 1127;
-		IngameFancyUI.Close();
-	}
-
-	/*
-	private static void OpenModsFolder(UIMouseEvent evt, UIElement listeningElement)
-	{
-		SoundEngine.PlaySound(10, -1, -1, 1);
-		Directory.CreateDirectory(ModLoader.ModPath);
-		Process.Start(ModLoader.ModPath);
-	}
-
-	public override void Draw(SpriteBatch spriteBatch)
-	{
-		base.Draw(spriteBatch);
-		UILinkPointNavigator.Shortcuts.BackButtonCommand = 1;
-	}
-	*/
 
 	internal void Unload()
 	{
 		modList?.Clear();
+		configList?.Clear();
+		SelectedMod = null;
 	}
 
 	public override void OnActivate()
 	{
-		Main.clrInput();
-		modList.Clear();
-		//	items.Clear();
-		Populate();
+		modList?.Clear();
+		configList?.Clear();
+		PopulateMods();
+
+		if (SelectedMod != null)
+			PopulateConfigs();
 	}
 
-	internal void Populate()
+	private void PopulateMods()
 	{
-		int i = 0;
+		modList?.Clear();
 
-		foreach (var item in ConfigManager.Configs) {
-			foreach (var config in item.Value) {
-				/*
-				if (config.Mode != ConfigScope.ClientSide) {
-					continue;
-				}
-				*/
+		// Have to sort by display name because normally mods are sorted by internal names
+		var mods = ModLoader.Mods.ToList();
+		mods.Sort((x, y) => x.DisplayName.CompareTo(y.DisplayName));
 
-				string configDisplayName = config.DisplayName.Value;
-				var t = new UITextPanel<string>(item.Key.DisplayName + ": " + configDisplayName);
-				//UIText t = new UIText(item.Key.DisplayName + ": " + item.Value.Count);
-
-				t.OnLeftClick += (a, b) => {
-					Interface.modConfig.SetMod(item.Key, config);
-					Main.InGameUI.SetState(Interface.modConfig);
+		foreach (var mod in mods) {
+			if (ConfigManager.Configs.TryGetValue(mod, out _)) {
+				var modPanel = new UIButton<string>(mod.DisplayName) {
+					MaxWidth = { Percent = 0.95f },
+					HAlign = 0.5f,
+					ScalePanel = true,
+					AltPanelColor = UICommon.MainPanelBackground,
+					AltHoverPanelColor = UICommon.MainPanelBackground * (1 / 0.8f),
+					UseAltColours = () => SelectedMod != mod,
+					ClickSound = SoundID.MenuTick,
 				};
 
-				t.WithFadedMouseOver();
-				t.HAlign = 0.5f;
+				modPanel.OnLeftClick += delegate (UIMouseEvent evt, UIElement listeningElement) {
+					SelectedMod = mod;
+					PopulateConfigs();
+				};
 
-				UIElement container = new UISortableElement(i++);
-				container.Width.Set(0f, 1f);
-				container.Height.Set(40f, 0f);
-				container.HAlign = 1f;
-				container.Append(t);
-				modList.Add(container);
-
-				if (config.Mode == ConfigScope.ServerSide) {
-					t.BackgroundColor = Color.Pink * 0.7f;
-					t.OnMouseOver += (a, b) => t.BackgroundColor = Color.Pink;
-					t.OnMouseOut += (a, b) => t.BackgroundColor = Color.Pink * 0.7f;
-				}
+				modList.Add(modPanel);
 			}
+		}
+	}
+
+	private void PopulateConfigs()
+	{
+		configList?.Clear();
+
+		if (SelectedMod == null || !ConfigManager.Configs.TryGetValue(SelectedMod, out var configs))
+			return;
+
+		// Have to sort by display name because normally configs are sorted by internal names
+		configs.Sort((x, y) => x.DisplayName.Value.CompareTo(y.DisplayName.Value));
+
+		foreach (var config in configs) {
+			float indicatorOffset = 20;
+
+			var configPanel = new UIButton<LocalizedText>(config.DisplayName) {
+				MaxWidth = { Percent = 0.95f },
+				HAlign = 0.5f,
+				ScalePanel = true,
+				UseInnerDimensions = true,
+				ClickSound = SoundID.MenuOpen,
+			};
+			configPanel.PaddingRight += indicatorOffset;
+
+			configPanel.OnLeftClick += delegate (UIMouseEvent evt, UIElement listeningElement) {
+				Interface.modConfig.SetMod(SelectedMod, config);
+				if (Main.gameMenu)
+					Main.menuMode = Interface.modConfigID;
+				else
+					Main.InGameUI.SetState(Interface.modConfig);
+			};
+
+			configList.Add(configPanel);
+
+			// ConfigScope indicator
+			var indicatorTexture = Main.Assets.Request<Texture2D>("Images/UI/Settings_Toggle");
+			var indicatorFrame = indicatorTexture.Frame(2, 1, 1, 0);
+			var serverColor = Colors.RarityRed;
+			var clientColor = Colors.RarityCyan;
+
+			var sideIndicator = new UIImageFramed(indicatorTexture, indicatorFrame) {
+				VAlign = 0.5f,
+				HAlign = 1f,
+				Color = config.Mode == ConfigScope.ServerSide ? serverColor : clientColor,
+				MarginRight = -indicatorOffset
+			};
+
+			sideIndicator.OnUpdate += delegate (UIElement affectedElement) {
+				if (sideIndicator.IsMouseHovering) {
+					string colourCode = config.Mode == ConfigScope.ServerSide ? serverColor.Hex3() : clientColor.Hex3();
+					string hoverText = Language.GetTextValue(config.Mode == ConfigScope.ServerSide ? "tModLoader.ModConfigServerSide" : "tModLoader.ModConfigClientSide");
+					Main.instance.MouseText($"[c/{colourCode}:{hoverText}]");
+				}
+			};
+
+			configPanel.Append(sideIndicator);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -6,6 +6,7 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace Terraria.ModLoader.Config.UI;
 
@@ -160,7 +161,7 @@ internal class UIModConfigList : UIState
 					ScalePanel = true,
 					AltPanelColor = UICommon.MainPanelBackground,
 					AltHoverPanelColor = UICommon.MainPanelBackground * (1 / 0.8f),
-					UseAltColours = () => SelectedMod != mod,
+					UseAltColors = () => SelectedMod != mod,
 					ClickSound = SoundID.MenuTick,
 				};
 
@@ -182,6 +183,7 @@ internal class UIModConfigList : UIState
 			return;
 
 		// Have to sort by display name because normally configs are sorted by internal names
+		// TODO: Support sort by attribute or some other custom ordering.
 		configs.Sort((x, y) => x.DisplayName.Value.CompareTo(y.DisplayName.Value));
 
 		foreach (var config in configs) {
@@ -221,13 +223,21 @@ internal class UIModConfigList : UIState
 
 			sideIndicator.OnUpdate += delegate (UIElement affectedElement) {
 				if (sideIndicator.IsMouseHovering) {
-					string colourCode = config.Mode == ConfigScope.ServerSide ? serverColor.Hex3() : clientColor.Hex3();
+					string colorCode = config.Mode == ConfigScope.ServerSide ? serverColor.Hex3() : clientColor.Hex3();
 					string hoverText = Language.GetTextValue(config.Mode == ConfigScope.ServerSide ? "tModLoader.ModConfigServerSide" : "tModLoader.ModConfigClientSide");
-					Main.instance.MouseText($"[c/{colourCode}:{hoverText}]");
+					Main.instance.MouseText($"[c/{colorCode}:{hoverText}]");
 				}
 			};
 
 			configPanel.Append(sideIndicator);
 		}
+	}
+
+	public override void Draw(SpriteBatch spriteBatch)
+	{
+		base.Draw(spriteBatch);
+
+		UILinkPointNavigator.Shortcuts.BackButtonCommand = 100;
+		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modsMenuID;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -49,6 +49,7 @@ internal static class Interface
 	internal const int modConfigID = 10024;
 	internal const int createModID = 10025;
 	internal const int exitID = 10026;
+	internal const int modConfigListID = 10027;
 	internal static UIMods modsMenu = new UIMods();
 	internal static UILoadMods loadMods = new UILoadMods();
 	internal static UIModSources modSources = new UIModSources();
@@ -364,6 +365,11 @@ internal static class Interface
 		else if (Main.menuMode == modConfigID)
 		{
 			Main.MenuUI.SetState(modConfig);
+			Main.menuMode = 888;
+		}
+		else if (Main.menuMode == modConfigListID)
+		{
+			Main.MenuUI.SetState(modConfigList);
 			Main.menuMode = 888;
 		}
 		else if (Main.menuMode == exitID) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIAutoScaleTextTextPanel.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIAutoScaleTextTextPanel.cs
@@ -18,6 +18,10 @@ public class UIAutoScaleTextTextPanel<T> : UIPanel
 	public float TextScale { get; set; } = 1f;
 	public Vector2 TextSize { get; private set; } = Vector2.Zero;
 	public Color TextColor { get; set; } = Color.White;
+	public bool ScalePanel = false;
+	public bool UseInnerDimensions = false;
+	public float TextOriginX = 0.5f;
+	public float TextOriginY = 0.5f;
 
 	private Rectangle oldInnerDimensions;
 	private T _text = default;
@@ -43,7 +47,17 @@ public class UIAutoScaleTextTextPanel<T> : UIPanel
 
 	public virtual void SetText(T text, float textScaleMax, bool large)
 	{
-		var innerDimensionsRectangle = GetDimensions().ToRectangle();
+		if (ScalePanel) {
+			var dynamicSpriteFont = IsLarge ? FontAssets.DeathText.Value : FontAssets.MouseText.Value;
+			var textSize = ChatManager.GetStringSize(dynamicSpriteFont, Text, new Vector2(TextScaleMax));
+
+			Width.Set(PaddingLeft + textSize.X + PaddingRight, 0f);
+			Height.Set(PaddingTop + (IsLarge ? 32f : 16f) + PaddingBottom, 0f);
+
+			base.Recalculate();
+		}
+
+		var innerDimensionsRectangle = UseInnerDimensions ? GetInnerDimensions().ToRectangle() : GetDimensions().ToRectangle();
 
 		if (text.ToString() != oldText || oldInnerDimensions != innerDimensionsRectangle) {
 			oldInnerDimensions = innerDimensionsRectangle;
@@ -52,7 +66,10 @@ public class UIAutoScaleTextTextPanel<T> : UIPanel
 			DynamicSpriteFont dynamicSpriteFont = large ? FontAssets.DeathText.Value : FontAssets.MouseText.Value;
 			Vector2 textSize = ChatManager.GetStringSize(dynamicSpriteFont, text.ToString(), new Vector2(TextScaleMax));
 
-			innerDimensionsRectangle.Inflate(-4, 0);
+			if (UseInnerDimensions)
+				innerDimensionsRectangle.Inflate(0, 6);
+			else
+				innerDimensionsRectangle.Inflate(-4, 0);// Why not put -8 in inflate parameter here?
 
 			var availableSpace = new Vector2(innerDimensionsRectangle.Width, innerDimensionsRectangle.Height);
 
@@ -64,21 +81,30 @@ public class UIAutoScaleTextTextPanel<T> : UIPanel
 			else {
 				TextScale = TextScaleMax;
 			}
-			innerDimensionsRectangle.Y += 8;
-			innerDimensionsRectangle.Height -= 8;
+
+			if (!UseInnerDimensions) {
+				innerDimensionsRectangle.Y += 8;
+				innerDimensionsRectangle.Height -= 8;
+			}
 			_text = text;
 			oldText = _text?.ToString();
-			//this.TextScale = textScaleMax;
 			TextSize = textSize;
 			IsLarge = large;
 			textStrings = text.ToString().Split('\n');
-			// offset off left corner for centering
+
+			// Offset of left corner for centering
 			drawOffsets = new Vector2[textStrings.Length];
 			for (int i = 0; i < textStrings.Length; i++) {
 				Vector2 size = ChatManager.GetStringSize(dynamicSpriteFont, textStrings[i], new Vector2(TextScale));
-				//size.Y = size.Y * 0.9f;
-				float x = (innerDimensionsRectangle.Width - size.X) * 0.5f;
-				float y = (-textStrings.Length * size.Y * 0.5f) + i * size.Y + innerDimensionsRectangle.Height * 0.5f;
+				if (UseInnerDimensions)
+					size.Y = IsLarge ? 32f : 16f;
+
+				float x = (innerDimensionsRectangle.Width - size.X) * TextOriginX;
+				float y = (-textStrings.Length * size.Y * TextOriginY) + i * size.Y + innerDimensionsRectangle.Height * TextOriginY;
+
+				if (UseInnerDimensions)
+					y -= 2;
+
 				drawOffsets[i] = new Vector2(x, y);
 			}
 			//this.MinWidth.Set(textSize.X + this.PaddingLeft + this.PaddingRight, 0f);
@@ -94,10 +120,12 @@ public class UIAutoScaleTextTextPanel<T> : UIPanel
 		if (DrawPanel)
 			base.DrawSelf(spriteBatch);
 
-		var innerDimensions = GetDimensions().ToRectangle();
-		innerDimensions.Inflate(-4, 0);
-		innerDimensions.Y += 8;
-		innerDimensions.Height -= 8;
+		var innerDimensions = UseInnerDimensions ? GetInnerDimensions().ToRectangle() : GetDimensions().ToRectangle();
+		if (UseInnerDimensions)
+			innerDimensions.Inflate(0, 6);
+		else
+			innerDimensions.Inflate(-4, -8);
+
 		for (int i = 0; i < textStrings.Length; i++) {
 			//Vector2 pos = innerDimensions.Center.ToVector2() + drawOffsets[i];
 			Vector2 pos = innerDimensions.TopLeft() + drawOffsets[i];

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIButton.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIButton.cs
@@ -7,7 +7,7 @@ using Terraria.UI;
 namespace Terraria.ModLoader.UI;
 
 /// <summary>
-/// A text panel that supports hover and click sounds, hover colours, and alternate colours.
+/// A text panel that supports hover and click sounds, hover colors, and alternate colors.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public class UIButton<T> : UIAutoScaleTextTextPanel<T>
@@ -28,7 +28,7 @@ public class UIButton<T> : UIAutoScaleTextTextPanel<T>
 	public Color? AltHoverPanelColor = null;
 	public Color? AltHoverBorderColor = null;
 
-	public Func<bool> UseAltColours = () => false;
+	public Func<bool> UseAltColors = () => false;
 
 	private Color? _panelColor = null;
 	private Color? _borderColor = null;
@@ -51,9 +51,9 @@ public class UIButton<T> : UIAutoScaleTextTextPanel<T>
 		AltHoverBorderColor ??= HoverBorderColor;
 	}
 
-	protected void SetPanelColours()
+	protected void SetPanelColors()
 	{
-		bool altCondition = UseAltColours();
+		bool altCondition = UseAltColors();
 		if (IsMouseHovering) {
 			BackgroundColor = altCondition ? AltHoverPanelColor.Value : HoverPanelColor;
 			BorderColor = altCondition ? AltHoverBorderColor.Value : HoverBorderColor;
@@ -66,17 +66,17 @@ public class UIButton<T> : UIAutoScaleTextTextPanel<T>
 
 	public override void OnActivate()
 	{
-		SetPanelColours();
+		SetPanelColors();
 	}
 
 	public override void Draw(SpriteBatch spriteBatch)
 	{
 		base.Draw(spriteBatch);
 
-		SetPanelColours();
+		SetPanelColors();
 
 		if (IsMouseHovering) {
-			string text = UseAltColours() ? AltHoverText?.ToString() : HoverText?.ToString();
+			string text = UseAltColors() ? AltHoverText?.ToString() : HoverText?.ToString();
 
 			if (text is null)
 				return;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIButton.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIButton.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria.Audio;
+using Terraria.UI;
+
+namespace Terraria.ModLoader.UI;
+
+/// <summary>
+/// A text panel that supports hover and click sounds, hover colours, and alternate colours.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class UIButton<T> : UIAutoScaleTextTextPanel<T>
+{
+	public SoundStyle? HoverSound = null;
+	public SoundStyle? ClickSound = null;
+
+	public T HoverText = default;
+	public T AltHoverText = default;
+	public bool TooltipText = false;
+
+	public Color HoverPanelColor = UICommon.DefaultUIBlue;
+	public Color HoverBorderColor = UICommon.DefaultUIBorderMouseOver;
+
+	public Color? AltPanelColor = null;
+	public Color? AltBorderColor = null;
+
+	public Color? AltHoverPanelColor = null;
+	public Color? AltHoverBorderColor = null;
+
+	public Func<bool> UseAltColours = () => false;
+
+	private Color? _panelColor = null;
+	private Color? _borderColor = null;
+
+	public UIButton(T text, float textScaleMax = 1, bool large = false) : base(text, textScaleMax, large)
+	{
+	}
+
+	public override void Recalculate()
+	{
+		base.Recalculate();
+
+		_panelColor ??= BackgroundColor;
+		_borderColor ??= BorderColor;
+
+		AltPanelColor ??= BackgroundColor;
+		AltBorderColor ??= BorderColor;
+
+		AltHoverPanelColor ??= HoverPanelColor;
+		AltHoverBorderColor ??= HoverBorderColor;
+	}
+
+	protected void SetPanelColours()
+	{
+		bool altCondition = UseAltColours();
+		if (IsMouseHovering) {
+			BackgroundColor = altCondition ? AltHoverPanelColor.Value : HoverPanelColor;
+			BorderColor = altCondition ? AltHoverBorderColor.Value : HoverBorderColor;
+		}
+		else {
+			BackgroundColor = altCondition ? AltPanelColor.Value : _panelColor.Value;
+			BorderColor = altCondition ? AltBorderColor.Value : _borderColor.Value;
+		}
+	}
+
+	public override void OnActivate()
+	{
+		SetPanelColours();
+	}
+
+	public override void Draw(SpriteBatch spriteBatch)
+	{
+		base.Draw(spriteBatch);
+
+		SetPanelColours();
+
+		if (IsMouseHovering) {
+			string text = UseAltColours() ? AltHoverText?.ToString() : HoverText?.ToString();
+
+			if (text is null)
+				return;
+
+			if (TooltipText)
+				UICommon.TooltipMouseText(text);
+			else
+				Main.instance.MouseText(text);
+		}
+	}
+
+	public override void MouseOver(UIMouseEvent evt)
+	{
+		base.MouseOver(evt);
+
+		if (HoverSound != null)
+			SoundEngine.PlaySound(HoverSound.Value);
+	}
+
+	public override void LeftClick(UIMouseEvent evt)
+	{
+		base.LeftClick(evt);
+
+		if (ClickSound != null)
+			SoundEngine.PlaySound(ClickSound.Value);
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -454,8 +454,8 @@ internal class UIModItem : UIPanel
 	internal void OpenConfig(UIMouseEvent evt, UIElement listeningElement)
 	{
 		SoundEngine.PlaySound(SoundID.MenuOpen);
-		Interface.modConfig.SetMod(ModLoader.GetMod(ModName));
-		Main.menuMode = Interface.modConfigID;
+		Interface.modConfigList.SelectedMod = ModLoader.GetMod(ModName);
+		Main.menuMode = Interface.modConfigListID;
 	}
 
 	public override int CompareTo(object obj)

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -41,7 +41,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 	private UIAutoScaleTextTextPanel<LocalizedText> buttonRM;
 	private UIAutoScaleTextTextPanel<LocalizedText> buttonB;
 	private UIAutoScaleTextTextPanel<LocalizedText> buttonOMF;
-	private UIAutoScaleTextTextPanel<string> buttonMP;
+	private UIAutoScaleTextTextPanel<LocalizedText> buttonCL;
 	private CancellationTokenSource _cts;
 	private bool forceReloadHidden => ModLoader.autoReloadRequiredModsLeavingModsScreen && !ModCompile.DeveloperMode;
 
@@ -238,12 +238,12 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		_categoryButtons.Add(SearchFilterToggle);
 		upperMenuContainer.Append(SearchFilterToggle);
 
-		buttonMP = new UIAutoScaleTextTextPanel<string>("TBD");
-		buttonMP.CopyStyle(buttonOMF);
-		buttonMP.HAlign = 1f;
-		buttonMP.WithFadedMouseOver();
-		buttonMP.OnLeftClick += null;
-		//uIElement.Append(buttonMP);
+		buttonCL = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.ModConfiguration"));
+		buttonCL.CopyStyle(buttonOMF);
+		buttonCL.HAlign = 1f;
+		buttonCL.WithFadedMouseOver();
+		buttonCL.OnLeftClick += GotoModConfigList;
+		uIElement.Append(buttonCL);
 
 		uIPanel.Append(upperMenuContainer);
 		Append(uIElement);
@@ -317,6 +317,12 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		foreach (UIModItem modItem in items) {
 			modItem.Disable();
 		}
+	}
+
+	private void GotoModConfigList(UIMouseEvent evt, UIElement listeningElement)
+	{
+		SoundEngine.PlaySound(10, -1, -1, 1);
+		Main.menuMode = Interface.modConfigListID;
 	}
 
 	public UIModItem FindUIModItem(string modName)

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 73
-ru-RU 13
-pt-BR 42
-pl-PL 403
-it-IT 843
-fr-FR 458
-es-ES 367
-de-DE 388
+zh-Hans 76
+ru-RU 16
+pt-BR 45
+pl-PL 406
+it-IT 846
+fr-FR 461
+es-ES 370
+de-DE 391


### PR DESCRIPTION
Split off from Config UI Rework: https://github.com/tModLoader/tModLoader/pull/3556

### What is the new feature?
Completely reworked config list UI
- Can now be accessed in the main menu as well as in game
- Has a list for mods and a list for configs
- Selecting a mod will show all it's available configs
- Clicking a config will open it
- Made the config button on `UIModItem` in the mods menu to open the config list with the mod selected
- Added a button to open the mod config list from the mods menu
- Each config has a red or blue dot indicating whether it is client or server side
  - Red is server, blue is client
  - Hovering over the dot will also say if it is a server side or client side config

<details>
<summary><h3>Before</h3></summary>
<br>

![Screenshot_20230617_011615](https://github.com/tModLoader/tModLoader/assets/62684035/8cfcfa1e-f75b-44e8-a4e8-5cdd7124d254)

</details>

<details>
<summary><h3>After</h3></summary>
<br>

![image](https://github.com/tModLoader/tModLoader/assets/62684035/b3545cae-fb51-48da-8915-5e78feed7d18)

![Screenshot_20230726_083406](https://github.com/tModLoader/tModLoader/assets/62684035/3fd32f01-a69d-4fc3-9f52-79325336aa32)

![Screenshot_20230617_120026](https://github.com/tModLoader/tModLoader/assets/62684035/c49513f0-402d-4d9f-90fc-7d8f42f2e8ba)

</details>

### Why should this be part of tModLoader?
Currently the UI for the configs is ugly and confusing and it has been stated many times on the tML discord server that it should be changed. It is also difficult for users to find configs. In the main menu, the only ways to access configs was through the config button (but that only took you to the first one a mod registered), and the rest through the difficult to notice next and previous buttons. In game, there was the config list, which is how I usually changed configs, but you couldn't change the values that would require a reload, so you had to deal with the main menus config UI. In many cases I have never even realized that a mod has multiple configs because of this.

### Are there alternative designs?
- It's UI so yes
- A filter for the mods menu that only shows mods that have a config could be implemented like https://github.com/tModLoader/tModLoader/issues/2762 suggested, but it is mostly irrelevant now with the new UI

### Sample usage for the new feature
N/A

### ExampleMod updates
N/A