### PR TITLE
Fixed Moon Lord Treasure Bag Not Dropping Two Weapons

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -205,7 +205,7 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.Common(ItemID.LunarOre, 1, 90, 110));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.MeowmereMinecart, 10));
 		RegisterToItem(item, ItemDropRule.ByCondition(new Conditions.NoPortalGun(), ItemID.PortalGun));
-		RegisterToItem(item, ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.Meowmere, ItemID.Terrarian, ItemID.StarWrath, ItemID.SDMG, ItemID.Celeb2, ItemID.LastPrism, ItemID.LunarFlareBook, ItemID.RainbowCrystalStaff, 3569));
+		RegisterToItem(item, ItemDropRule.FewFromOptionsNotScalingWithLuckWithX(2, 1, 2, ItemID.Meowmere, ItemID.Terrarian, ItemID.StarWrath, ItemID.SDMG, ItemID.Celeb2, ItemID.LastPrism, ItemID.LunarFlareBook, ItemID.RainbowCrystalStaff, ItemID.MoonlordTurretStaff));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.MoonLordCore));
 
 		item = ItemID.BossBagBetsy;


### PR DESCRIPTION
### What is the bug?

Pointed out by `phoupraw` on Discord.
Moon Lord Treasure Bag does not drop two weapons when opening. In 1.4.4, Moon Lord was changed to drop two weapons instead of one. The change was not updated in the declarative grab bag ItemDropDatabase.

### How did you fix the bug?

Changed `OneFromOptionsNotScalingWithLuck` to `FewFromOptionsNotScalingWithLuckWithX` and set it to drop 2 items.

### Are there alternatives to your fix?

Probably not.