### PR TITLE
Unload dependents of a mod which failed to load

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -147,6 +147,7 @@
 		// Mod Errors
 		"LoadError": "An error occurred while loading {0}",
 		"LoadErrorDisabled": "The mod(s) have been automatically disabled.",
+		"LoadErrorDependentsDisabled": "The following mods have also been disabled because they depend on {0}: {1}",
 		"LoadErrorCulpritUnknown": "The mod responsible is unknown and tModLoader must be restarted.",
 		"LoadErrorContentType": "This error was caused by the \"{0}\" class.",
 		"LoadErrorMissingModQualifier": "The asset path \"{0}\" is missing the mod qualifier. Asset paths should start with the mod name or \"Terraria\" followed by a slash (\"/\").",

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -178,8 +178,16 @@ public static class ModLoader
 
 			Logging.tML.Error(msg, e);
 
-			foreach (var mod in responsibleMods)
+			foreach (var mod in responsibleMods) {
 				DisableMod(mod);
+
+				var dependents = from m in availableMods
+					where m.properties.modReferences.Any(reference => reference.mod.Equals(mod))
+					select m.Name;
+				
+				foreach (var dependent in dependents)
+					DisableMod(dependent);
+			}
 
 			isLoading = false; // disable loading flag, because server will just instantly retry reload
 			DisplayLoadError(msg, e, e.Data.Contains("fatal"), responsibleMods.Count == 0);

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -179,9 +179,9 @@ public static class ModLoader
 			foreach (var mod in responsibleMods) {
 				DisableMod(mod);
 
-				var dependents = from m in availableMods
-					where m.properties.modReferences.Any(reference => reference.mod.Equals(mod))
-					select m.Name;
+				var dependents = availableMods
+					.Where(m => m.properties.modReferences.Any(reference => reference.mod.Equals(mod)))
+					.Select(m => m.Name);
 
 				msg += "\n" + Language.GetTextValue("tModLoader.LoadErrorDependentsDisabled", mod,
 					string.Join(", ", dependents));

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -176,18 +176,21 @@ public static class ModLoader
 			if (e.Data.Contains("contentType") && e.Data["contentType"] is Type contentType)
 				msg += "\n" + Language.GetTextValue("tModLoader.LoadErrorContentType", contentType.FullName);
 
-			Logging.tML.Error(msg, e);
-
 			foreach (var mod in responsibleMods) {
 				DisableMod(mod);
 
 				var dependents = from m in availableMods
 					where m.properties.modReferences.Any(reference => reference.mod.Equals(mod))
 					select m.Name;
+
+				msg += "\n" + Language.GetTextValue("tModLoader.LoadErrorDependentsDisabled", mod,
+					string.Join(", ", dependents));
 				
 				foreach (var dependent in dependents)
 					DisableMod(dependent);
 			}
+			
+			Logging.tML.Error(msg, e);
 
 			isLoading = false; // disable loading flag, because server will just instantly retry reload
 			DisplayLoadError(msg, e, e.Data.Contains("fatal"), responsibleMods.Count == 0);

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -180,7 +180,7 @@ public static class ModLoader
 				DisableMod(mod);
 
 				var dependents = availableMods
-					.Where(m => m.properties.modReferences.Any(reference => reference.mod.Equals(mod)))
+					.Where(m => m.properties.RefNames(includeWeak: false).Any(refName => refName.Equals(mod)))
 					.Select(m => m.Name);
 
 				msg += "\n" + Language.GetTextValue("tModLoader.LoadErrorDependentsDisabled", mod,


### PR DESCRIPTION
### What is the bug?
#3821 - If a mod which is a hard dependency of other mods is unloaded due to a load error, the dependency mod is unloaded while the dependent mod(s) are not unloaded. This can cause a load loop since the culprit mod will be loaded again when dependencies are automatically enabled.

### How did you fix the bug?
With this pull request, when a mod is unloaded because of a load error, the mod loader will search for mods which depend on it and disable them. It does this by checking if any of the `availableMods` have the dependency mod in the `modReferences`.

### Are there alternatives to your fix?
I'm not aware of any other way to get the dependents of a mod other than doing the inverse and searching the dependencies of other mods to find them. Another way to get the dependents would likely be more logical for reading the code, and it would be better if not every mod would have to be checked.

I'm also unsure about the message localization. I added a string to the en-US localization so that the message will indicate which dependents were disabled, if any, but I'm unfamiliar with how localization works in tModLoader. Is it OK for me to only add it to the en-US file?