### PR TITLE
Update tMLMod.targets

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -13,6 +13,10 @@
 		<AdditionalFiles Include="**/*.hjson" />
 		<AdditionalFiles Include="**/*.txt" />
 		<AdditionalFiles Include="**/*.png" />
+		<AdditionalFiles Include="**/*.fx" />
+		<!-- Remove the txt files that can be found in build folders, causing them to appear in the editor -->
+		<AdditionalFiles Remove="bin/**" />
+		<AdditionalFiles Remove="obj/**" />
 		<Reference Include="$(tMLSteamPath)$(tMLPath)" />
 		<Reference Include="$(tMLLibraryPath)/**/*.dll" />
 		<Reference Remove="$(tMLLibraryPath)/Native/**" />


### PR DESCRIPTION
### What is the bug?
`ModName.csproj.FileListAbsolute.txt` shows in the editor, causing the obj folder to appear.
Changing the contents of an fx file does not cause MSBuild to realise the project files have changed, and therefore need to rebuild.

### How did you fix the bug?
By adding some `<AdditionalFiles />` tags to `tMLMod.targets`.

### Are there alternatives to your fix?
Letting the modder do it themselves.