### PR TITLE
fix princess not using the intended happiness key

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -137,7 +137,7 @@
 -	public void LoveNPCByTypeName(int npcType)
 +	internal void LoveNPCByTypeName(int npcType)
  	{
-+		if (npcType >= NPCID.Count && _currentNPCBeingTalkedTo.type == 633) {
++		if (npcType >= NPCID.Count && _currentNPCBeingTalkedTo.type == 663) {
 +			// Princess text for liking modded npcs located with the text for the modnpc itself, not with the princess text. Revisit this if https://github.com/tModLoader/tModLoader/issues/3493 is ever implemented.
 +			AddHappinessReportText("Princess_LovesNPC", new {
 +				NPCName = NPC.GetFullnameByID(npcType)


### PR DESCRIPTION
### What is the bug?
![Screenshot_1](https://github.com/tModLoader/tModLoader/assets/15894498/5b3b0de1-415e-4369-a71c-5dbedaf505f3)
Princess still trying to access the old key which was changed on May 22: `Move TownNPCMood_Princess.LoveNPC_{ModNPCFullName} to Mods.{ModName}.NPCs.{NPCName}.TownNPCMood.Princess_LovesNPC, if present.`

### How did you fix the bug?
changed 633 magic number to 663 (which is the actual NPCID.Princess)

### Are there alternatives to your fix?
change 663 to NPCID.Princess
