### PR TITLE
Disable roll forward when launching using local dotnet install

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -90,6 +90,7 @@ else
 fi
 
 if [[ -f "$install_dir/dotnet" || -f "$install_dir/dotnet.exe" ]]; then
+	export DOTNET_ROLL_FORWARD=Disable
 	echo "Launched Using Local Dotnet"  2>&1 | tee -a "$LogFile"
 	[[ -f "$install_dir/dotnet" ]] && chmod a+x "$install_dir/dotnet"
 	exec "$install_dir/dotnet" tModLoader.dll "$customargs" "$@" 2>"$NativeLog"


### PR DESCRIPTION
There have been various issues related to dotnet caused by the roll forward behavior. By default, even when launching using local dotnet install, dotnet will use the system install if it is larger and the same major version: https://learn.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward

This has confused our Support efforts, as `Launch.log` claims that the game is "Launched Using Local Dotnet" but in reality `client.log` or `Natives.log` shows a different dotnet is being use to run the game:

**User A**: Launch.log shows a broken system dotnet install
```
Cannot use file stream for [C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.14\Microsoft.NETCore.App.deps.json]: No such file or directory
Error initializing the dependency resolver: A fatal error was encountered, missing dependencies manifest at: C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.14\Microsoft.NETCore.App.deps.json
```

**User B**: clieng.log shows game running on 6.0.11 instead of 6.0.0
```
[10:11:52.409] [Main Thread/INFO] [tML]: Running on Windows (v10.0.19045.0) X64 NetCore 6.0.11
[10:11:52.410] [Main Thread/INFO] [tML]: FrameworkDescription: .NET 6.0.11
...
[10:11:53.134] [Main Thread/WARN] [tML]: tModLoader.RuntimeErrorSilentlyCaughtException
System.BadImageFormatException: Could not load file or assembly 'System.Runtime.Serialization.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Format of the executable (.exe) or library (.dll) is invalid.
   at MonoMod.Core.Interop.CoreCLR.V60.InvokeCompileMethod(IntPtr functionPtr, IntPtr thisPtr, IntPtr corJitInfo, CORINFO_METHOD_INFO* methodInfo, UInt32 flags, Byte** nativeEntry, UInt32* nativeSizeOfCode) in Z:\Users\aaron\Source\Repos\MonoModReorg\MonoMod\src\MonoMod.Core\Interop\CoreCLR.V60.cs:line 50
```

This disconnect is confusing. We also strive to ensure that everyone is running the same dotnet version to eliminate any variables, this is why we ship a specific dotnet version. 

As far as supporting users, we typically suggest deleting the dotnet folder, as sometimes the install can be corrupted by antivirus quarantines. Fixing this issue will ensure that the dotnet folder the user is deleting is the actual dotnet being used to run the game. Fixing broken system dotnet installations is a bit more involved for many of our users.

# Fix
`export DOTNET_ROLL_FORWARD=Disable` runs in ScriptCaller.sh for when the game is detected to be launched using local dotnet. Changing `tModLoader.runtimeconfig.json` itself was an option, but that would potentially conflict with tModLoader and modder debugging efforts. A command line parameter could also be supplied via the script, but that seems to be messy.

The fix was tested for debugging mods and tmodloader from Visual Studio, both ran latest system dotnet as expected (latest v6 dotnet). The fix was tested launched directly from the .bat file and from steam, local dotnet was used as expected. (v6.0.0)
