### PR TITLE
Fixes and improvements to smart select while using auto reusing

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2809,6 +2809,18 @@
  		for (int i = 0; i < maxBuffs; i++) {
  			if (buffType[i] <= 0 || !Main.persistentBuff[buffType[i]]) {
  				buffTime[i] = 0;
+@@ -13526,6 +_,11 @@
+ 			controlTorch = false;
+ 
+ 		if (controlTorch && itemAnimation == 0) {
++
++			// TML feature, prevent changing the smart selected item while the use button is held. This prevents switching from pickaxe to torch after mining a block for eg
++			if (controlUseItem && nonTorch != -1)
++				return;
++
+ 			PlayerInput.smartSelectPointer.SmartSelectLookup_GetTargetTile(this, out var tX, out var tY);
+ 			SmartSelect_GetToolStrategy(tX, tY, out var toolStrategy, out var wetTile);
+ 			if (PlayerInput.UsingGamepad && _lastSmartCursorToolStrategy != -1)
 @@ -13538,6 +_,16 @@
  					toolStrategy = 5;
  			}
@@ -5889,7 +5901,7 @@
  					cursorItemIconPush = 6;
  				}
  			}
-@@ -33268,6 +_,59 @@
+@@ -33268,6 +_,66 @@
  			}
  		}
  
@@ -5943,8 +5955,15 @@
 +		ReuseDelayAndAnimationStart:
 +
 +		// SmartSelectLookup moved here from Player.Update so that it can apply between uses, without changing selectedItem prematurely for half the Update method
-+		if (selectedItem != 58)
++		if (selectedItem != 58) {
++			int oldSelect = selectedItem;
 +			SmartSelectLookup();
++			if (selectedItem != oldSelect) {
++				item = inventory[selectedItem];
++				// TML feature, allow the item to be instantly used
++				releaseUseItem = true;
++			}
++		}
 +
  		ItemCheck_HandleMount();
  		int weaponDamage = GetWeaponDamage(item);


### PR DESCRIPTION
### What is the bug?
- Fixes #3838

Additionally:
- When holding smart select and using a pickaxe, the selected item would switch to a torch after mining the block, which is annoying and undesired.

### How did you fix the bug?
- Added `item = inventory[selectedItem]` when smart select changes the `selectedItem` to fix the 'consume wrong item' bug.
- Whenever the selected item is changed (either via hotbar key or smart select) the cursor release flag is set, allowing the item to be used immediately even if it doesn't have `autoReuse`
  - This allows a glowstick to be thrown immediately on switching to it while holding down the mouse, which is fun
- Prevented smart select from changing the item while the use button is held down, so you can't swap from pickaxe to torch or vice versa while auto-reusing.

### Are there alternatives to your fix?
- Perhaps the user doesn't want to immediately use the item if they press shift or a hotbar key while holding the mouse button down, but in this case, just release the mouse first?

