### PR TITLE
Add general purpose SDL driver fallbacks, error reporting and cli args

### DIFF
--- a/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
@@ -31,7 +31,7 @@
  						break;
  				}
  
-@@ -100,10 +_,12 @@
+@@ -100,10 +_,13 @@
  
  	public LegacyAudioSystem()
  	{
@@ -40,6 +40,7 @@
 +		var contentManager = (TMLContentManager)Main.instance.Content;
 +
 +		Engine = new AudioEngine(contentManager.GetPath("TerrariaMusic.xgs"));
++		FNALogging.PostAudioInit();
 +		SoundBank = new SoundBank(Engine, contentManager.GetPath("Sound Bank.xsb"));
  		Engine.Update();
 -		WaveBank = new WaveBank(Engine, "Content\\Wave Bank.xwb", 0, 512); //TODO, investigate history of windows looping errors with streaming wavebank from disk in FNA in Windows.

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -46,6 +46,12 @@ internal class ErrorReporting
 
 	public static void FatalExit(string message, Exception e)
 	{
+		try {
+			if (SDL2.SDL.SDL_GetError() is string error)
+				message += "\n\nSDL Error: " + error;
+		}
+		catch { }
+
 		if (e.HelpLink != null) {
 			try {
 				Utils.OpenToURL(e.HelpLink);

--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
@@ -10,13 +10,34 @@ internal static class FNAFixes
 		if (OperatingSystem.IsWindows()) {
 			// FNA sets this to "1" on Windows. Terraria does not want this. See #2020
 			SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+		}
 
-			// only directx is supported. See #2926
-			var videoDriver = Environment.GetEnvironmentVariable("SDL_VIDEODRIVER");
-			if (videoDriver != null && videoDriver != "directx") {
-				Logging.FNA.Debug("Cleared SDL_VIDEODRIVER=" + videoDriver);
-				Environment.SetEnvironmentVariable("SDL_VIDEODRIVER", null);
-			}
+		ConfigureDrivers();
+	}
+
+	private static void ConfigureDrivers()
+	{
+		// https://wiki.libsdl.org/SDL2/FAQUsingSDL
+		// Hints in https://github.com/libsdl-org/SDL/blob/release-2.28.x/include/SDL_hints.h#L2384
+		// Note that env var names change in SDL 3.x
+
+		// Default driver order https://github.com/libsdl-org/SDL/blob/release-2.28.x/src/video/SDL_video.c#L67
+		ConfigureDrivers("SDL_VIDEODRIVER", "-videodriver", "cocoa,x11,wayland,vivante,directfb,windows,winrt,haiku,uikit,android,ps2,psp,vita,n3ds,kmsdrm,riscos,rpi,nacl,emscripten,qnx,ngage,offscreen,dummy,evdev");
+
+		// Default driver order https://github.com/libsdl-org/SDL/blob/release-2.28.x/src/audio/SDL_audio.c#L38
+		ConfigureDrivers("SDL_AUDIODRIVER", "-audiodriver", "pulseaudio,alsa,sndio,netbsd,qsa,wasapi,directsound,haiku,coreaudio,aaudio,openslES,android,ps2,psp,vita,n3ds,emscripten,jack,pipewire,dsp,disk,dummy");
+	}
+
+	private static void ConfigureDrivers(string sdlEnvVar, string launchArg, string defaultDriverList)
+	{
+		if (Program.LaunchParameters.TryGetValue(launchArg, out var launchArgValue)) {
+			Environment.SetEnvironmentVariable(sdlEnvVar, launchArgValue);
+		}
+
+		// Append the default driver list, in case of an old or unsupported env var left on the system (See #2926)
+		if (Environment.GetEnvironmentVariable(sdlEnvVar) is string envVarValue) {
+			Logging.FNA.Info($"Detected {sdlEnvVar}={envVarValue}. Appending default driver list as fallbacks.");
+			Environment.SetEnvironmentVariable(sdlEnvVar, $"{envVarValue},{defaultDriverList}");
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
@@ -67,8 +67,11 @@ internal static class FNALogging
 	internal static void RedirectLogs()
 	{
 		FNALoggerEXT.LogInfo = (s) => {
-			if (DriverIdentifier == null && s.StartsWith("FNA3D Driver: "))
+			if (DriverIdentifier == null && s.StartsWith("FNA3D Driver: ")) {
 				DriverIdentifier = s.Substring("FNA3D Driver: ".Length);
+
+				Logging.FNA.Info($"SDL Video Diver: {SDL2.SDL.SDL_GetCurrentVideoDriver()}");
+			}
 
 			Logging.FNA.Info(s);
 		};
@@ -115,4 +118,9 @@ internal static class FNALogging
 		Logging.Terraria.Debug(sb);
 		creating = false;
 	}
-    }
+
+	internal static void PostAudioInit()
+	{
+		Logging.FNA.Info($"SDL Audio Diver: {SDL2.SDL.SDL_GetCurrentAudioDriver()}");
+	}
+}


### PR DESCRIPTION
### What is the new feature?
- `-videodriver` and `-audiodriver` launch args, which override `SDL_VIDEODRIVER` and `SDL_AUDIODRIVER` env vars respectively.
- Append fallback driver list whenever `SDL_VIDEODRIVER` or `SDL_AUDIODRIVER` is specified.
  - This is a more general solution to #2926
  - Still allows for selecting a default driver, but allows SDL to ignore it and continue on to the normal driver list if it's not present.
- `SDL Error:` if any is appended to `FatalExit` logs
- The _selected_ `SDL Video Driver` and `SDL Audio Driver` are reported in the logs, after `FNA3D` and `FAudio` are initialized respectively.

### Why should this be part of tModLoader?
Sometimes people have bad env vars on their system, particularly for older SDL versions. SDL does not fall-back to the default driver search order internally when an env var is specified, so if the driver in the env var is absent or inoperable, then the game crashes.

Additional launch args and logging make it easier to get users to try alternative drivers when they experience issues.

### Are there alternative designs?

Only in minor ways, we'll see if any issues crop up.

### Sample usage for the new feature

`-audiodriver wsapi`
`-videodriver x11`