### PR TITLE
Mod.GetLocalization method

### DIFF
--- a/ExampleMod/Common/GlobalBuffs/ExampleGlobalBuff.cs
+++ b/ExampleMod/Common/GlobalBuffs/ExampleGlobalBuff.cs
@@ -15,7 +15,7 @@ namespace ExampleMod.Common.GlobalBuffs
 		public static LocalizedText RemainingTimeText { get; private set; }
 
 		public override void SetStaticDefaults() {
-			RemainingTimeText = Language.GetOrRegister(Mod.GetLocalizationKey($"{nameof(ExampleGlobalBuff)}.RemainingTime"));
+			RemainingTimeText = Mod.GetLocalization($"{nameof(ExampleGlobalBuff)}.RemainingTime");
 		}
 
 		public override void Update(int type, Player player, ref int buffIndex) {

--- a/ExampleMod/Common/UI/ExampleResourceUI/ExampleResourceBar.cs
+++ b/ExampleMod/Common/UI/ExampleResourceUI/ExampleResourceBar.cs
@@ -114,7 +114,7 @@ namespace ExampleMod.Common.UI.ExampleResourceUI
 			ExampleResourceBarUserInterface.SetState(ExampleResourceBar);
 
 			string category = "UI";
-			ExampleResourceText ??= Language.GetOrRegister(Mod.GetLocalizationKey($"{category}.ExampleResource"));
+			ExampleResourceText ??= Mod.GetLocalization($"{category}.ExampleResource");
 		}
 
 		public override void UpdateUI(GameTime gameTime) {

--- a/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
+++ b/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
@@ -38,7 +38,7 @@ namespace ExampleMod.Content.Buffs
 				// These lines zero out any positive lifeRegen. This is expected for all bad life regeneration effects
 				if (Player.lifeRegen > 0)
 					Player.lifeRegen = 0;
-				// Player.lifeRegenTime uses to increase the speed at which the player reaches its maximum natural life regeneration
+				// Player.lifeRegenTime used to increase the speed at which the player reaches its maximum natural life regeneration
 				// So we set it to 0, and while this debuff is active, it never reaches it
 				Player.lifeRegenTime = 0;
 				// lifeRegen is measured in 1/2 life per second. Therefore, this effect causes 8 life lost per second

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -75,7 +75,7 @@ namespace ExampleMod.Content.Prefixes
 
 		public override void SetStaticDefaults() {
 			// this.GetLocalization is not used here because we want to use a shared key
-			PowerTooltip = Language.GetOrRegister(Mod.GetLocalizationKey($"{LocalizationCategory}.{nameof(PowerTooltip)}"));
+			PowerTooltip = Mod.GetLocalization($"{LocalizationCategory}.{nameof(PowerTooltip)}");
 			// This seemingly useless code is required to properly register the key for AdditionalTooltip
 			_ = AdditionalTooltip;
 		}

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -42,7 +42,7 @@ namespace ExampleMod.Content.Tiles
 		public static LocalizedText ExampleOrePassMessage { get; private set; }
 
 		public override void SetStaticDefaults() {
-			ExampleOrePassMessage = Language.GetOrRegister(Mod.GetLocalizationKey($"WorldGen.{nameof(ExampleOrePassMessage)}"));
+			ExampleOrePassMessage = Mod.GetLocalization($"WorldGen.{nameof(ExampleOrePassMessage)}");
 		}
 
 		// World generation is explained more in https://github.com/tModLoader/tModLoader/wiki/World-Generation

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -168,11 +168,21 @@ public partial class Mod
 	public bool TryFind<T>(string name, out T value) where T : IModType => ModContent.TryFind(Name, name, out value);
 
 	/// <summary>
-	/// Creates a localization key following the pattern of "Mods.{ModName}.{suffix}". Use this with <see cref="Language.GetOrRegister(string, Func{string})"/> to retrieve a <see cref="LocalizedText"/> for custom localization keys. Custom localization keys need to be registered during the mod loading process to appear automtaically in the localization files.
+	/// Creates a localization key following the pattern of "Mods.{ModName}.{suffix}". Use this with <see cref="Language.GetOrRegister(string, Func{string})"/> to retrieve a <see cref="LocalizedText"/> for custom localization keys. Alternatively <see cref="GetLocalization(string, Func{string})"/> can be used directly instead. Custom localization keys need to be registered during the mod loading process to appear automtaically in the localization files.
 	/// </summary>
 	/// <param name="suffix"></param>
 	/// <returns></returns>
 	public string GetLocalizationKey(string suffix) => $"Mods.{Name}.{suffix}";
+
+	/// <summary>
+	/// Returns a <see cref="LocalizedText"/> for this Mod with the provided <paramref name="suffix"/>. The suffix will be used to generate a key by providing it to <see cref="GetLocalizationKey(string)"/>.
+	/// <br/>If no existing localization exists for the key, it will be defined so it can be exported to a matching mod localization file.
+	/// </summary>
+	/// <param name="suffix"></param>
+	/// <param name="makeDefaultValue">A factory method for creating the default value, used to update localization files with missing entries</param>
+	/// <returns></returns>
+	public LocalizedText GetLocalization(string suffix, Func<string> makeDefaultValue = null) =>
+		Language.GetOrRegister(GetLocalizationKey(suffix), makeDefaultValue);
 
 	/// <summary>
 	/// Assigns a head texture to the given town NPC type.


### PR DESCRIPTION
Implements `Mod.GetLocalization` to simplify the common pattern of `Language.GetOrRegister(Mod.GetLocalizationKey(suffix));`

Seems straightforward, not sure if there was a reason it didn't exists. I think one fear is that modders will use this rather than properly use ILocalizedModType, but I think modders are happy to use ILocalizedModType approach when appropriate.