### PR TITLE
Fix #2020

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
@@ -10,7 +10,7 @@ internal static class FNAFixes
 	{
 		if (OperatingSystem.IsWindows()) {
 			// FNA sets this to "1" on Windows. Terraria does not want this. See #2020
-			SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0" );
+			SDL.SDL_SetHintWithPriority(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0", SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
 		}
 
 		ConfigureDrivers();


### PR DESCRIPTION
originally fixed in 5161f2e but broken after 88c4e68

## details
when executing `Terraria.ModLoader.Engine.FNAFixes.Init()`, `Microsoft.Xna.Framework.SDL2_FNAPlatform` is not yet initialized

execution routine:
```
// ...
FNAFixes.Init();
// ...
new Main();
base(); // will initialize FNAPlatform and overwrite previously set SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS value
```