### PR TITLE
translated 2 messages into russian

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -468,8 +468,8 @@
 		"MSUnloading": "Выгрузка: {0}",
 		"MSFinishingResourceLoading": "Завершение загрузки ресурсов",
 		"MSAddingRecipes": "Добавление рецептов...",
-		// "CancellingLoading": "Cancelling loading...",
-		// "LoadingCancelled": "Loading Cancelled",
+		// "CancellingLoading": "Отменение загрузки...",
+		// "LoadingCancelled": "Загрузка отменена",
 
 		// Default Unimplemented
 		"DefaultTownNPCName": "Безымянный",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -468,8 +468,8 @@
 		"MSUnloading": "Выгрузка: {0}",
 		"MSFinishingResourceLoading": "Завершение загрузки ресурсов",
 		"MSAddingRecipes": "Добавление рецептов...",
-		// "CancellingLoading": "Отменение загрузки...",
-		// "LoadingCancelled": "Загрузка отменена",
+		"CancellingLoading": "Отменение загрузки...",
+		"LoadingCancelled": "Загрузка отменена",
 
 		// Default Unimplemented
 		"DefaultTownNPCName": "Безымянный",


### PR DESCRIPTION
### What is the translation?
"CancellingLoading" and "LoadingCancelled" have been translated into Russian. As far as I know, only unused messages are left untranslated into Russian now.

### How did you translate it?
Edited ru-RU/tModLoader.json to change the values in lines 471 and 472 to the translations, and uncommented them.
"CancellingLoading" -> "Отменение загрузки..."
"LoadingCancelled" -> "Загрузка отменена"

### Are there alternatives to your translation?
Both are literal, and I don't know the context they show up in, so they may be clumsy. "Отменение загрузки..." is a noun, which is consistent with the other translations, but sounds a bit unnatural to me.