### PR TITLE
Support loading Effects with .fxc files

### DIFF
--- a/patches/tModLoader/Terraria/Initializers/AssetInitializer.cs.patch
+++ b/patches/tModLoader/Terraria/Initializers/AssetInitializer.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Initializers/AssetInitializer.cs
 +++ src/tModLoader/Terraria/Initializers/AssetInitializer.cs
-@@ -11,22 +_,45 @@
+@@ -11,22 +_,46 @@
  using Terraria.GameContent;
  using Terraria.ID;
  using Terraria.IO;
@@ -24,6 +24,7 @@
 +
 +		// TML readers
 +		assetReaderCollection.RegisterReader(new RawImgReader(Main.instance.Services.Get<IGraphicsDeviceService>().GraphicsDevice), ".rawimg");
++		assetReaderCollection.RegisterReader(new FxcReader(Main.instance.Services.Get<IGraphicsDeviceService>().GraphicsDevice), ".fxc");
 +		assetReaderCollection.RegisterReader(new WavReader(), ".wav");
 +		assetReaderCollection.RegisterReader(new MP3Reader(), ".mp3");
 +		assetReaderCollection.RegisterReader(new OggReader(), ".ogg");

--- a/patches/tModLoader/Terraria/ModLoader/Assets/Readers/FxcReader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Assets/Readers/FxcReader.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using ReLogic.Content.Readers;
+using Terraria.ModLoader.IO;
+
+namespace Terraria.ModLoader.Assets;
+
+public class FxcReader : IAssetReader
+{
+	private readonly GraphicsDevice _graphicsDevice;
+
+	public FxcReader(GraphicsDevice graphicsDevice)
+	{
+		_graphicsDevice = graphicsDevice;
+	}
+
+	public async ValueTask<T> FromStream<T>(Stream stream, MainThreadCreationContext mainThreadCtx) where T : class
+	{
+		if (typeof(T) != typeof(Effect))
+			throw AssetLoadException.FromInvalidReader<FxcReader, T>();
+
+		var ms = new MemoryStream();
+		stream.CopyTo(ms);
+
+		await mainThreadCtx;
+		Debug.Assert(mainThreadCtx.IsCompleted);
+
+		return new Effect(_graphicsDevice, ms.ToArray()) as T;
+	}
+}


### PR DESCRIPTION
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->

### What is the new feature?
Supports loading `.fxc` files as `Effect`s besides `.xnb`s.

### Why should this be part of tModLoader?
The compilers provided in [the shader guide](https://forums.terraria.org/index.php?threads/a-beginners-guide-to-shaders.86128/) `fxcompiler` and `fxcompiler_reach` do not support shader model 3 but [EasyXNB](https://github.com/SuperAndyHero/EasyXnb) does.
However, none of them can `#include` files and sometimes have weird compilation issues.
https://hst.sh/kutucituno.hlsl
https://hst.sh/yejosupopu.hlsl (simpler version)
https://hst.sh/fipewozawa.hlsl (thanks kurti256)
These shaders for example, fail to compile with `(55,23): ID3DXEffectCompiler::CompileEffect: There was an error compiling expression` because of the `atan2` usage, `atan`, `asin` and `acos` also break the shader compilation.
The `fxc` compiler does not have these issues and compiles fine but it can produce a `.fxc` file, which tModLoader currently doesn't support.

### Are there alternative designs?
No.

### Sample usage for the new feature
Run `fxc MyShaderName.fx /T fx_2_0 /Fo MyShaderName.fxc`.
`MyShaderName.fxc` file can be loaded as an `Effect` like an `.xnb` can.


### ExampleMod updates
None. But for example, you could compile DeathEffect.fx and it would load.
<!-- If you also updated ExampleMod for your new feature, let us know here -->


