### PR TITLE
Fix crate ore/bar drops. Fix droprate calculations for several rule classes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsNotScaledWithLuckDropRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromOptionsNotScaledWithLuckDropRule.cs
@@ -62,7 +62,7 @@ public class FewFromOptionsNotScaledWithLuckDropRule : IItemDropRule
 	{
 		float pesonalDroprate = (float)chanceNumerator / (float)chanceDenominator;
 		float num2 = pesonalDroprate * ratesInfo.parentDroprateChance;
-		float dropRate = 1f / (float)(dropIds.Length - amount) * num2;
+		float dropRate = amount / (float)dropIds.Length * num2;
 		for (int i = 0; i < dropIds.Length; i++) {
 			drops.Add(new DropRateInfo(dropIds[i], 1, 1, dropRate, ratesInfo.conditions));
 		}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromRulesRule.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/FewFromRulesRule.cs
@@ -64,9 +64,8 @@ public class FewFromRulesRule : IItemDropRule, INestedItemDropRule
 
 	public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
 	{
-		float personalDroprate = 1f / (float)chanceDenominator;
-		float num2 = personalDroprate * ratesInfo.parentDroprateChance;
-		float multiplier = 1f / (float)(options.Length - amount) * num2;
+		float personalDroprate = 1f / chanceDenominator;
+		float multiplier = amount / (float)options.Length * personalDroprate;
 		for (int i = 0; i < options.Length; i++) {
 			options[i].ReportDroprates(drops, ratesInfo.With(multiplier));
 		}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -311,12 +311,14 @@ partial class ItemDropDatabase
 
 		IItemDropRule bc_surfaceLoot = ItemDropRule.OneFromOptionsNotScalingWithLuck(20, ItemID.Aglet, ItemID.ClimbingClaws, ItemID.PortableStool, ItemID.CordageGuide, ItemID.Radar);
 
-		List<IItemDropRule> oresList = new List<IItemDropRule>();
-		List<IItemDropRule> barsList = new List<IItemDropRule>();
-		oresList.AddRange(oresTier1);
-		oresList.AddRange(hardmodeOresTier1);
-		barsList.AddRange(barsTier1);
-		barsList.AddRange(hardmodeBarsTier1);
+		IItemDropRule oreDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(2, hardmodeOresTier1),
+			new OneFromRulesRule(1, oresTier1)
+		);
+		IItemDropRule barDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(2, hardmodeBarsTier1),
+			new OneFromRulesRule(1, barsTier1)
+		);
 		IItemDropRule[] woodenCrateDrop = new IItemDropRule[]
 		{
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
@@ -330,7 +332,7 @@ partial class ItemDropDatabase
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
 			bc_surfaceLoot,
 			ItemDropRule.SequentialRulesNotScalingWithLuck(7, coin),
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(7, oresList.ToArray()), new OneFromRulesRule(8, barsList.ToArray())),
+			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined), new SequentialRulesNotScalingWithLuckRule(8, barDropsCombined)),
 			new OneFromRulesRule(7, potions),
 		};
 
@@ -338,8 +340,6 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.WoodenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(pearlwoodCrateDrop));
 		RegisterToMultipleItems(new OneFromRulesRule(3, extraPotions), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
 		RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(3, extraBait), ItemID.WoodenCrate, ItemID.WoodenCrateHard);
-		oresList.Clear();
-		barsList.Clear();
 		#endregion
 
 		#region Iron Crate and Mythril Crate
@@ -414,10 +414,14 @@ partial class ItemDropDatabase
 			ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 4)
 		};
 
-		oresList.AddRange(oresTier1);
-		oresList.AddRange(hardmodeOresTier1);
-		barsList.AddRange(barsTier1);
-		barsList.AddRange(hardmodeBarsTier1);
+		oreDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(2, hardmodeOresTier1),
+			new OneFromRulesRule(1, oresTier1)
+		);
+		barDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(3, 2, hardmodeBarsTier1),
+			new OneFromRulesRule(1, barsTier1)
+		);
 		IItemDropRule[] ironCrate = new IItemDropRule[]
 		{
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
@@ -429,7 +433,7 @@ partial class ItemDropDatabase
 		{
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
 			ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 4, 5, 10),
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oresList.ToArray()), new OneFromRulesRule(4, barsList.ToArray())),
+			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(6, oreDropsCombined), new OneFromRulesRule(4, barDropsCombined)),
 			new OneFromRulesRule(4, potions),
 		};
 
@@ -437,8 +441,6 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.IronCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(mythrilCrate));
 		RegisterToMultipleItems(new OneFromRulesRule(2, extraPotions), ItemID.IronCrate, ItemID.IronCrateHard);
 		RegisterToMultipleItems(ItemDropRule.SequentialRulesNotScalingWithLuck(2, extraBait), ItemID.IronCrate, ItemID.IronCrateHard);
-		oresList.Clear();
-		barsList.Clear();
 		#endregion
 
 		#region Gold Crate and Titanium Crate
@@ -495,10 +497,14 @@ partial class ItemDropDatabase
 			ItemDropRule.NotScalingWithLuck(ItemID.ManaPotion, 1, 5, 20)
 		};
 
-		oresList.AddRange(oresTier1);
-		oresList.AddRange(hardmodeOresTier1);
-		barsList.AddRange(barsTier1);
-		barsList.AddRange(hardmodeBarsTier1);
+		oreDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(2, hardmodeOresTier1),
+			new OneFromRulesRule(1, oresTier1)
+		);
+		barDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(3, 2, hardmodeBarsTier1),
+			new OneFromRulesRule(1, barsTier1)
+		);
 		IItemDropRule[] goldCrate = new IItemDropRule[] {
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, themed),
 			ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 20),
@@ -509,7 +515,7 @@ partial class ItemDropDatabase
 		IItemDropRule[] titaniumCrate = new IItemDropRule[] {
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, hardmodeThemed),
 			ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 3, 8, 20),
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oreDropsCombined), new OneFromRulesRule(3, 2, barDropsCombined)),
 			new OneFromRulesRule(3, potions),
 			ItemDropRule.NotScalingWithLuck(ItemID.EnchantedSword, 15),
 		};
@@ -518,8 +524,6 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.GoldenCrateHard, ItemDropRule.AlwaysAtleastOneSuccess(titaniumCrate));
 		RegisterToMultipleItems(new OneFromRulesRule(2, extraPotions), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
 		RegisterToMultipleItems(new CommonDrop(ItemID.MasterBait, 3, 3, 7, 2), ItemID.GoldenCrate, ItemID.GoldenCrateHard);
-		oresList.Clear();
-		barsList.Clear();
 		#endregion
 
 		#region Biome Crates
@@ -656,17 +660,22 @@ partial class ItemDropDatabase
 		};
 		#endregion
 
-		oresList.AddRange(oresTier1);
-		oresList.AddRange(hardmodeOresTier1);
-		barsList.AddRange(barsTier1);
-		barsList.AddRange(hardmodeBarsTier1);
+		oreDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(2, hardmodeOresTier1),
+			new OneFromRulesRule(1, oresTier1)
+		);
+		barDropsCombined = ItemDropRule.SequentialRulesNotScalingWithLuck(1,
+			new OneFromRulesRule(3, 2, hardmodeBarsTier1),
+			new OneFromRulesRule(1, barsTier1)
+		);
 
 		IItemDropRule[] jungle = new IItemDropRule[]
 		{
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 
 			bc_bamboo,
@@ -677,7 +686,8 @@ partial class ItemDropDatabase
 			ItemDropRule.SequentialRulesNotScalingWithLuck(1, bc_jungle),
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_bamboo,
@@ -691,7 +701,8 @@ partial class ItemDropDatabase
 			bc_skyPaintings,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] azure = new IItemDropRule[]
@@ -702,21 +713,24 @@ partial class ItemDropDatabase
 			bc_skyPaintings,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] corrupt = new IItemDropRule[] {
 			bc_corrupt,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] defiled = new IItemDropRule[] {
 			bc_corrupt,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_son,
@@ -726,14 +740,16 @@ partial class ItemDropDatabase
 			bc_crimson,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] hematic = new IItemDropRule[] {
 			bc_crimson,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_son,
@@ -741,12 +757,14 @@ partial class ItemDropDatabase
 		};
 		IItemDropRule[] hallowed = new IItemDropRule[] {
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] divine = new IItemDropRule[] {
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_sol,
@@ -757,7 +775,8 @@ partial class ItemDropDatabase
 			bc_book,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] stockade = new IItemDropRule[] {
@@ -765,14 +784,16 @@ partial class ItemDropDatabase
 			bc_book,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] frozen = new IItemDropRule[] {
 			bc_ice,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 
 			bc_fish,
@@ -781,7 +802,8 @@ partial class ItemDropDatabase
 			bc_ice,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_fish,
@@ -793,7 +815,8 @@ partial class ItemDropDatabase
 
 			bc_goldCoin,
 			bc_fossil,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] mirage = new IItemDropRule[] {
@@ -803,7 +826,8 @@ partial class ItemDropDatabase
 
 			bc_goldCoin,
 			bc_fossil,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] obsidian = new IItemDropRule[] {
@@ -816,7 +840,8 @@ partial class ItemDropDatabase
 			bc_hellcart,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 
 			bc_ornate,
@@ -832,7 +857,8 @@ partial class ItemDropDatabase
 			bc_hellcart,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_ornate,
@@ -843,7 +869,8 @@ partial class ItemDropDatabase
 			bc_sharkbait,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresTier1), new OneFromRulesRule(3, 2, barsTier1)),
+			new OneFromRulesRule(7, oresTier1),
+			new OneFromRulesRule(4, barsTier1),
 			new OneFromRulesRule(3, potions),
 
 			bc_pile,
@@ -854,7 +881,8 @@ partial class ItemDropDatabase
 			bc_sharkbait,
 
 			bc_goldCoin,
-			ItemDropRule.SequentialRulesNotScalingWithLuck(1, new OneFromRulesRule(5, oresList.ToArray()), new OneFromRulesRule(3, 2, barsList.ToArray())),
+			new SequentialRulesNotScalingWithLuckRule(7, oreDropsCombined),
+			new SequentialRulesNotScalingWithLuckRule(4, barDropsCombined),
 			new OneFromRulesRule(3, potions),
 
 			bc_pile,

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropRule.TML.cs
@@ -8,6 +8,7 @@ partial class ItemDropRule
 	public static IItemDropRule FewFromOptionsWithNumerator(int amount, int chanceDenominator, int chanceNumerator, params int[] options) => new FewFromOptionsDropRule(amount, chanceDenominator, chanceNumerator, options);
 	public static IItemDropRule SequentialRules(int chanceDenominator, params IItemDropRule[] rules) => new SequentialRulesRule(chanceDenominator, rules);
 	public static IItemDropRule SequentialRulesNotScalingWithLuck(int chanceDenominator, params IItemDropRule[] rules) => new SequentialRulesNotScalingWithLuckRule(chanceDenominator, rules);
+	public static IItemDropRule SequentialRulesNotScalingWithLuckWithNumerator(int chanceDenominator, int chanceNumerator, params IItemDropRule[] rules) => new SequentialRulesNotScalingWithLuckRule(chanceDenominator, chanceNumerator, rules);
 	public static IItemDropRule Coins(long value, bool withRandomBonus) => new CoinsRule(value, withRandomBonus);
 	public static IItemDropRule CoinsBasedOnNPCValue(int npcId)
 	{

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
@@ -42,15 +42,18 @@
  			num = info.rng.Next(options.Length);
  			resolveAction(options[num], info);
  			result = default(ItemDropAttemptResult);
-@@ -44,8 +_,9 @@
+@@ -44,9 +_,14 @@
  
  	public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
  	{
--		float num = 1f / (float)chanceDenominator;
--		float num2 = num * ratesInfo.parentDroprateChance;
 +		//TML: chanceNumerator inserted in place of '1.0'. Fix double application of ratesInfo.parentDroprateChance
 +		float num = chanceNumerator / (float)chanceDenominator;
-+		float num2 = num;
++		float multiplier = 1f / (float)options.Length * num;
++		/*
+ 		float num = 1f / (float)chanceDenominator;
+ 		float num2 = num * ratesInfo.parentDroprateChance;
  		float multiplier = 1f / (float)options.Length * num2;
++		*/
  		for (int i = 0; i < options.Length; i++) {
  			options[i].ReportDroprates(drops, ratesInfo.With(multiplier));
+ 		}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs.patch
@@ -1,6 +1,11 @@
 --- src/TerrariaNetCore/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs
 +++ src/tModLoader/Terraria/GameContent/ItemDropRules/OneFromRulesRule.cs
-@@ -6,12 +_,18 @@
+@@ -1,3 +_,4 @@
++using System;
+ using System.Collections.Generic;
+ 
+ namespace Terraria.GameContent.ItemDropRules;
+@@ -6,14 +_,24 @@
  {
  	public IItemDropRule[] options;
  	public int chanceDenominator;
@@ -18,7 +23,13 @@
 +		this.chanceNumerator = chanceNumerator;
  		this.options = options;
  		ChainedRules = new List<IItemDropRuleChainAttempt>();
++
++		if (chanceNumerator > chanceDenominator) {
++			throw new ArgumentOutOfRangeException(nameof(chanceNumerator), $"{nameof(chanceNumerator)} must be lesser or equal to {nameof(chanceDenominator)}.");
++		}
  	}
+ 
+ 	public bool CanDrop(DropAttemptInfo info) => true;
 @@ -29,7 +_,11 @@
  	{
  		int num = -1;
@@ -31,13 +42,15 @@
  			num = info.rng.Next(options.Length);
  			resolveAction(options[num], info);
  			result = default(ItemDropAttemptResult);
-@@ -44,7 +_,8 @@
+@@ -44,8 +_,9 @@
  
  	public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
  	{
-+		//TML: chanceNumerator inserted in place of '1.0'.
 -		float num = 1f / (float)chanceDenominator;
+-		float num2 = num * ratesInfo.parentDroprateChance;
++		//TML: chanceNumerator inserted in place of '1.0'. Fix double application of ratesInfo.parentDroprateChance
 +		float num = chanceNumerator / (float)chanceDenominator;
- 		float num2 = num * ratesInfo.parentDroprateChance;
++		float num2 = num;
  		float multiplier = 1f / (float)options.Length * num2;
  		for (int i = 0; i < options.Length; i++) {
+ 			options[i].ReportDroprates(drops, ratesInfo.With(multiplier));


### PR DESCRIPTION
More item drop fixes. The old ore/bar logic for hardmode crates didn't prioritize hardmode ores/bars. Each item had the same drop rate, but in reality each set (prehardmode and hardmode) has their own rate and an item is selected from within the set.

SequentialRulesNotScalingWithLuckWithNumerator added since the functionality was missing.

FewFromOptionsNotScaledWithLuckDropRule and FewFromRulesRule had inverse logic for X of Y drops.

Several of the IItemDropRules classes had logic in ReportDroprates that would apply `ratesInfo.parentDroprateChance` to the calculated drop chance twice, resulting in incorrect results, these have been fixed.

~~We probably want to make sure OneFromRulesRule is fixed in Terraria as well.~~ (Done)

I verified drop rates for ores and bars, all look correct now.