### PR TITLE
Fix ExampleTravelingMerchant Not Saving Shop Items

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
+++ b/ExampleMod/Content/NPCs/ExampleTravelingMerchant.cs
@@ -232,7 +232,7 @@ namespace ExampleMod.Content.NPCs
 		}
 
 		public override void SaveData(TagCompound tag) {
-			tag["itemIds"] = shopItems;
+			tag["shopItems"] = shopItems;
 		}
 
 		public override void LoadData(TagCompound tag) {


### PR DESCRIPTION
### What is the bug?
Example Traveling Merchant does not save and load its shop items due to a mismatching key in `SaveData` and `LoadData`.

### How did you fix the bug?
Changed the key in `SaveData` from "itemIds" to "shopItems", to match the key used in `LoadData`.

### Are there alternatives to your fix?
No.
