### PR TITLE
Allow Assigned Contributors to Publish to Steam Workshop Items

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -168,7 +168,7 @@
  					UpdateItem();
  				}
  				else {
-@@ -212,14 +_,63 @@
+@@ -212,14 +_,41 @@
  
  			private void CreateItem()
  			{
@@ -206,6 +206,16 @@
 +			// Rewritten to reduce duplicate publishing in the event that user needs to accept workshop agreement.
  			private void CreateItemResult(CreateItemResult_t param, bool bIOFailure)
  			{
++				/*
+ 				if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
+ 					_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
+ 					_endAction(this);
+@@ -232,12 +_,36 @@
+ 					_issueReporter.ReportDelayedUploadProblemWithoutKnownReason("Workshop.ReportIssue_FailedToPublish_WithoutKnownReason", param.m_eResult.ToString());
+ 					_endAction(this);
+ 				}
++				*/
++
 +				_createCallback = param.m_eResult;
 +				if (param.m_eResult != EResult.k_EResultOK) {
 +					_issueReporter.ReportDelayedUploadProblemWithoutKnownReason("Workshop.ReportIssue_FailedToPublish_WithoutKnownReason", param.m_eResult.ToString());
@@ -227,16 +237,6 @@
 +				// On servers we want to control this more tightly due to threading constraints.
 +				if (!Main.dedServ)
 +					UpdateItem();
-+
-+				/*
- 				if (param.m_bUserNeedsToAcceptWorkshopLegalAgreement) {
- 					_issueReporter.ReportDelayedUploadProblem("Workshop.ReportIssue_FailedToPublish_UserDidNotAcceptWorkshopTermsOfService");
- 					_endAction(this);
-@@ -232,12 +_,14 @@
- 					_issueReporter.ReportDelayedUploadProblemWithoutKnownReason("Workshop.ReportIssue_FailedToPublish_WithoutKnownReason", param.m_eResult.ToString());
- 					_endAction(this);
- 				}
-+				*/
  			}
  
  			protected abstract string GetHeaderText();
@@ -247,7 +247,7 @@
  			private void UpdateItem()
  			{
  				string headerText = GetHeaderText();
-@@ -245,39 +_,117 @@
+@@ -245,8 +_,15 @@
  					_endAction(this);
  					return;
  				}
@@ -259,79 +259,20 @@
 +				Utils.LogAndConsoleInfoMessage(Language.GetTextValue("tModLoader.UpdateItem", _entryData.Title));
  
  				PrepareContentForUpdate();
++				/*
  				UGCUpdateHandle_t uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
  				if (_entryData.Title != null)
  					SteamUGC.SetItemTitle(uGCUpdateHandle_t, _entryData.Title);
- 
--				if (_entryData.Description != null)
-+				if (!string.IsNullOrEmpty(_entryData.Description))
- 					SteamUGC.SetItemDescription(uGCUpdateHandle_t, _entryData.Description);
- 
-+				Logging.tML.Info("Adding tags and visibility");
-+
- 				SteamUGC.SetItemContent(uGCUpdateHandle_t, _entryData.ContentFolderPath);
- 				SteamUGC.SetItemTags(uGCUpdateHandle_t, _entryData.Tags);
--				if (_entryData.PreviewImagePath != null)
-+				if (_isOwner && _entryData.PreviewImagePath != null)
- 					SteamUGC.SetItemPreview(uGCUpdateHandle_t, _entryData.PreviewImagePath);
+@@ -261,23 +_,63 @@
  
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
- 
-+				Logging.tML.Info("Setting the language for default description");
-+				SteamUGC.SetItemUpdateLanguage(uGCUpdateHandle_t, SteamedWraps.GetCurrentSteamLangKey());
++				*/
 +
-+				string patchNotes = "";
-+
-+				// Needed for backwards compat on version metadata change
-+				_entryData.BuildData["version"] = "0.0.0";
-+
-+				if (_entryData.BuildData != null) {
-+					Logging.tML.Info("Adding tModLoader Metadata to Workshop Upload");
-+					foreach (var key in MetadataKeys) {
-+						SteamUGC.RemoveItemKeyValueTags(uGCUpdateHandle_t, key);
-+						SteamUGC.AddItemKeyValueTag(uGCUpdateHandle_t, key, _entryData.BuildData[key]);
-+					}
-+
-+					patchNotes = _entryData.ChangeNotes;
-+					// If the modder hasn't supplied any change notes, then we wilil provde some default ones for them
-+					if (string.IsNullOrWhiteSpace(patchNotes)) {
-+						patchNotes = "Version {ModVersion} has been published to {tMLBuildPurpose} tModLoader v{tMLVersion}";
-+						if (!string.IsNullOrWhiteSpace(_entryData.BuildData["homepage"]))
-+							patchNotes += ", learn more at the [url={ModHomepage}]homepage[/url]";
-+					}
-+
-+					// Language.GetText returns the given key if it can't be found, this way we can use LocalizedText.FormatWith
-+					// This allows us to use substitution keys such as {ModVersion}
-+					patchNotes = Language.GetText(patchNotes).FormatWith(new {
-+						ModVersion      = _entryData.BuildData["trueversion"],
-+						ModHomepage     = _entryData.BuildData["homepage"],
-+						tMLVersion      = BuildInfo.tMLVersion.MajorMinor().ToString(),
-+						tMLBuildPurpose = BuildInfo.Purpose.ToString(),
-+					});
-+
-+					string refs = _entryData.BuildData["workshopdeps"];
-+
-+					if (!string.IsNullOrWhiteSpace(refs)) {
-+						Logging.tML.Info("Adding dependencies to Workshop Upload");
-+						string[] dependencies = refs.Split(",", StringSplitOptions.TrimEntries);
-+
-+						foreach (string dependency in dependencies) {
-+							try {
-+								var child = new PublishedFileId_t(uint.Parse(dependency));
-+
-+								SteamUGC.AddDependency(_publishedFileID, child);
-+							}
-+							catch (Exception) {
-+								Logging.tML.Error("Failed to add Workshop dependency: " + dependency + " to " + _publishedFileID);
-+							}
-+						}
-+					}
-+				}
-+
++				var uGCUpdateHandle_t = GenerateUgcUpdateHandle(out var patchNotes);
 +				_updateCallback = EResult.k_EResultNone;
-+
 +				Logging.tML.Info("Submitting workshop update handle to Steam");
+ 
  				CoreSocialModule.SetSkipPulsing(shouldSkipPausing: true);
 -				SteamAPICall_t hAPICall = SteamUGC.SubmitItemUpdate(uGCUpdateHandle_t, "");
 +				SteamAPICall_t hAPICall = SteamUGC.SubmitItemUpdate(uGCUpdateHandle_t, patchNotes);
@@ -339,6 +280,7 @@
  				_updateItemHook.Set(hAPICall, UpdateItemResult);
  				CoreSocialModule.SetSkipPulsing(shouldSkipPausing: false);
 +
++				// Below Added by tModLoader for command-line/server publishing
 +				Logging.tML.Info("Handle submitted. Waiting on Steam");
 +
 +				if (!Main.dedServ || creatingItem)
@@ -349,6 +291,24 @@
 +					SteamedWraps.RunCallbacks();
 +				}
 +				while (_updateCallback == EResult.k_EResultNone);
++			}
++
++			internal UGCUpdateHandle_t GenerateUgcUpdateHandle(out string patchNotes)
++			{
++				var uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
++
++				SteamedWraps.ModifyUgcUpdateHandleCommon(ref uGCUpdateHandle_t, _entryData);
++
++				patchNotes = "";
++
++				if (_entryData.BuildData != null) {
++					// Needed for backwards compat on version metadata change
++					_entryData.BuildData["version"] = "0.0.0";
++
++					SteamedWraps.ModifyUgcUpdateHandleTModLoader(ref uGCUpdateHandle_t, ref patchNotes, _entryData, _publishedFileID);
++				}
++
++				return uGCUpdateHandle_t;
  			}
  
  			private void UpdateItemResult(SubmitItemUpdateResult_t param, bool bIOFailure)

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -88,7 +88,7 @@
  						}
  						else {
  							WorldPaths.Add(listOfSubscribedItemsPath);
-@@ -155,19 +_,32 @@
+@@ -155,19 +_,31 @@
  
  			protected WorkshopItemPublicSettingId _publicity;
  			protected SteamWorkshopItem _entryData;
@@ -107,7 +107,7 @@
  
 -			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags)
 +			//TML: Added 'buildData', 'existingID', 'changeNotes' parameters.
-+			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags, NameValueCollection buildData = null, ulong existingID = 0, string changeNotes = null, bool isOwner = true)
++			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags, NameValueCollection buildData = null, ulong existingID = 0, string changeNotes = null)
  			{
 +				Utils.LogAndConsoleInfoMessage(Language.GetTextValueWith("tModLoader.PublishItem", _entryData.Title));
  				_issueReporter = issueReporter;
@@ -117,7 +117,6 @@
 +
 +				//TML: Looks like vanilla forgot to set this.
 +				_publicity = publicity;
-+				_isOwner = isOwner;
 +				
  				ERemoteStoragePublishedFileVisibility visibility = GetVisibility(publicity);
  				_entryData = new SteamWorkshopItem {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -88,9 +88,11 @@
  						}
  						else {
  							WorldPaths.Add(listOfSubscribedItemsPath);
-@@ -156,18 +_,29 @@
+@@ -155,19 +_,32 @@
+ 
  			protected WorkshopItemPublicSettingId _publicity;
  			protected SteamWorkshopItem _entryData;
++			protected bool _isOwner;
  			protected PublishedFileId_t _publishedFileID;
 +
 +			// Fields added by TML:
@@ -105,7 +107,7 @@
  
 -			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags)
 +			//TML: Added 'buildData', 'existingID', 'changeNotes' parameters.
-+			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags, NameValueCollection buildData = null, ulong existingID = 0, string changeNotes = null)
++			public void PublishContent(PublishedItemsFinder finder, WorkshopIssueReporter issueReporter, FinishedPublishingAction endAction, string itemTitle, string itemDescription, string contentFolderPath, string previewImagePath, WorkshopItemPublicSettingId publicity, string[] tags, NameValueCollection buildData = null, ulong existingID = 0, string changeNotes = null, bool isOwner = true)
  			{
 +				Utils.LogAndConsoleInfoMessage(Language.GetTextValueWith("tModLoader.PublishItem", _entryData.Title));
  				_issueReporter = issueReporter;
@@ -115,6 +117,7 @@
 +
 +				//TML: Looks like vanilla forgot to set this.
 +				_publicity = publicity;
++				_isOwner = isOwner;
 +				
  				ERemoteStoragePublishedFileVisibility visibility = GetVisibility(publicity);
  				_entryData = new SteamWorkshopItem {
@@ -244,7 +247,7 @@
  			private void UpdateItem()
  			{
  				string headerText = GetHeaderText();
-@@ -245,15 +_,23 @@
+@@ -245,39 +_,117 @@
  					_endAction(this);
  					return;
  				}
@@ -268,8 +271,10 @@
 +
  				SteamUGC.SetItemContent(uGCUpdateHandle_t, _entryData.ContentFolderPath);
  				SteamUGC.SetItemTags(uGCUpdateHandle_t, _entryData.Tags);
- 				if (_entryData.PreviewImagePath != null)
-@@ -262,22 +_,92 @@
+-				if (_entryData.PreviewImagePath != null)
++				if (_isOwner && _entryData.PreviewImagePath != null)
+ 					SteamUGC.SetItemPreview(uGCUpdateHandle_t, _entryData.PreviewImagePath);
+ 
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
  

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Net;
-using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.ModLoader.Core;
@@ -39,9 +37,10 @@ public partial class WorkshopSocialModule
 		existingAuthorID = ulong.Parse(mods[0].OwnerId);
 
 		// Update the subscribed mod to be the latest version published, so keeps all versions (stable, preview) together
-		SteamedWraps.Download(new Steamworks.PublishedFileId_t(currPublishID), forceUpdate: true);
+		WorkshopBrowserModule.Instance.DownloadItem(mods[0], uiProgress: null);
 
 		// Grab the tags from workshop.json
+		ModOrganizer.WorkshopFileFinder.Refresh(new WorkshopIssueReporter()); // Force detection in case mod wasn't installed
 		string searchFolder = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{currPublishID}");
 
 		return ModOrganizer.TryReadManifest(searchFolder, out info);
@@ -128,6 +127,7 @@ public partial class WorkshopSocialModule
 		
 		string contentFolderPath = $"{workshopFolderPath}/{BuildInfo.tMLVersion.Major}.{BuildInfo.tMLVersion.Minor}";
 
+		//TODO: We ought to delete the TemporaryFolder after successful publishing to prevent future issues if they delete and attempt to re-pub
 		if (MakeTemporaryFolder(contentFolderPath)) {
 			string modPath = Path.Combine(contentFolderPath, modFile.Name + ".tmod");
 
@@ -238,10 +238,9 @@ public partial class WorkshopSocialModule
 		Program.LaunchParameters.TryGetValue("-uploadfolder", out string uploadFolder); 
 
 		// The Folder where we will put all the files that should be included in the build artifact
-		string publishFolder = $"{ModOrganizer.modPath}/Workshop"; 
+		string publishFolder = $"{ModOrganizer.modPath}/Workshop";
 
 		string modName = Directory.GetParent(modFolder).Name;
-
 
 		// Create a namevalue collection for checking versioning
 		string newModPath = Path.Combine(ModOrganizer.modPath, $"{modName}.tmod");
@@ -250,22 +249,25 @@ public partial class WorkshopSocialModule
 		var buildData = new NameValueCollection() {
 			["version"] = newMod.properties.version.ToString(),
 			["versionsummary"] = $"{newMod.tModLoaderVersion}:{newMod.properties.version}",
-			["description"] = newMod.properties.description
+			["description"] = newMod.properties.description,
+			["homepage"] = newMod.properties.homepage
 		};
+
+		// Needed for backwards compat from previous version metadata
+		//TODO: why 'trueversion'?????
+		buildData["trueversion"] = buildData["version"];
 
 		if (!CalculateVersionsData(publishedModFiles, ref buildData)) {
 			Utils.LogAndConsoleErrorMessage($"Unable to update mod. {buildData["version"]} is not higher than existing version");
 			return;
 		}
 
-		Console.WriteLine($"Built Mod Version is: {buildData["version"]}. tMod Version is: {BuildInfo.tMLVersion}");
-
+		Console.WriteLine($"Built Mod Version is: {buildData["trueversion"]}. tMod Version is: {BuildInfo.tMLVersion}");
 
 		// Create the directory that the new tmod file will be added to, if it doesn't exist
 		string contentFolder = $"{publishFolder}/{BuildInfo.tMLVersion.MajorMinor()}";
 		if (!Directory.Exists(contentFolder))
 			Directory.CreateDirectory(contentFolder);
-
 
 		// Ensure the publish folder has all published information needed.
 		FileUtilities.CopyFolder(publishedModFiles, publishFolder); // Copy all existing workshop files to output
@@ -273,7 +275,6 @@ public partial class WorkshopSocialModule
 
 		// Cleanup Old Folders
 		ModOrganizer.CleanupOldPublish(publishFolder);
-
 
 		// Assign Workshop Description
 		string workshopDescFile = Path.Combine(modFolder, "description_workshop.txt");
@@ -287,6 +288,7 @@ public partial class WorkshopSocialModule
 		string descriptionFinal = $"[quote=GithubActions(Don't Modify)]Version Summary {buildData["versionsummary"]}\nDeveloped By {buildData["author"]}[/quote]" +
 			$"{workshopDesc}";
 
+		SteamedWraps.UpdatePatchNotesWithModData(ref changeNotes, buildData);
 
 		// Make the publish.vdf file
 		string manifest = Path.Combine(publishedModFiles, "workshop.json");

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -69,7 +69,7 @@ public partial class WorkshopSocialModule
 			return false;
 		}
 
-		if (!BuildInfo.IsDev) {
+		if (BuildInfo.IsDev) {
 			IssueReporter.ReportInstantUploadProblem("tModLoader.BetaModCantPublishError");
 			return false;
 		}
@@ -79,20 +79,7 @@ public partial class WorkshopSocialModule
 		// Needed for backwards compat from previous version metadata
 		buildData["trueversion"] = buildData["version"];
 
-		bool owner = true;
 		if (currPublishID != 0) {
-			var currID = Steamworks.SteamUser.GetSteamID();
-
-
-			// Reject posting the mod if you don't 'own' the mod copy. NOTE: Steam doesn't support updating via contributor role anyways.
-			owner = existingAuthorID == currID.m_SteamID;
-			/*
-			if () {
-				IssueReporter.ReportInstantUploadProblem("tModLoader.ModAlreadyUploaded");
-				return false;
-			}
-			*/
-
 			// Publish by updating the files available on the current published version
 			workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{currPublishID}");
 
@@ -145,7 +132,7 @@ public partial class WorkshopSocialModule
 
 			_publisherInstances.Add(modPublisherInstance);
 
-			modPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, description, workshopFolderPath, settings.PreviewImagePath, settings.Publicity, tagsList.ToArray(), buildData, currPublishID, settings.ChangeNotes, isOwner: owner);
+			modPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, description, workshopFolderPath, settings.PreviewImagePath, settings.Publicity, tagsList.ToArray(), buildData, currPublishID, settings.ChangeNotes);
 
 			return true;
 		}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -70,7 +70,7 @@ public partial class WorkshopSocialModule
 			return false;
 		}
 
-		if (BuildInfo.IsDev) {
+		if (!BuildInfo.IsDev) {
 			IssueReporter.ReportInstantUploadProblem("tModLoader.BetaModCantPublishError");
 			return false;
 		}
@@ -84,10 +84,12 @@ public partial class WorkshopSocialModule
 			var currID = Steamworks.SteamUser.GetSteamID();
 
 			// Reject posting the mod if you don't 'own' the mod copy. NOTE: Steam doesn't support updating via contributor role anyways.
+			/*
 			if (existingAuthorID != currID.m_SteamID) {
 				IssueReporter.ReportInstantUploadProblem("tModLoader.ModAlreadyUploaded");
 				return false;
 			}
+			*/
 
 			// Publish by updating the files available on the current published version
 			workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{currPublishID}");

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -80,12 +80,15 @@ public partial class WorkshopSocialModule
 		// Needed for backwards compat from previous version metadata
 		buildData["trueversion"] = buildData["version"];
 
+		bool owner = true;
 		if (currPublishID != 0) {
 			var currID = Steamworks.SteamUser.GetSteamID();
 
+
 			// Reject posting the mod if you don't 'own' the mod copy. NOTE: Steam doesn't support updating via contributor role anyways.
+			owner = existingAuthorID == currID.m_SteamID;
 			/*
-			if (existingAuthorID != currID.m_SteamID) {
+			if () {
 				IssueReporter.ReportInstantUploadProblem("tModLoader.ModAlreadyUploaded");
 				return false;
 			}
@@ -142,7 +145,7 @@ public partial class WorkshopSocialModule
 
 			_publisherInstances.Add(modPublisherInstance);
 
-			modPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, description, workshopFolderPath, settings.PreviewImagePath, settings.Publicity, tagsList.ToArray(), buildData, currPublishID, settings.ChangeNotes);
+			modPublisherInstance.PublishContent(_publishedItems, base.IssueReporter, Forget, name, description, workshopFolderPath, settings.PreviewImagePath, settings.Publicity, tagsList.ToArray(), buildData, currPublishID, settings.ChangeNotes, isOwner: owner);
 
 			return true;
 		}


### PR DESCRIPTION
This PR does the following:
- Clean up change notes text replacement in CI environments for 'SteamCMD publishing' like ExampleMod.
- Removes the 'Owner' check from publishing workflow now that Steam supports it. NOTE: Icon publishing still bugged and should be fixed as of October 24th.
- Fixes some issue with command line publishing from testing in another branch with a different attempt
- Fixes an issue with publishing mods when doing so for first time on that computer
- Reorganize some code chunks to SteamedWraps to help with maintaining it.