### PR TITLE
#3887 Allow Player.Save/LoadPlayer from stream

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/PlayerIO.cs
@@ -87,22 +87,13 @@ internal static class PlayerIO
 		LoadHair(player, tag.GetString("hair"));
 	}
 
-	internal static bool TryLoadData(string path, bool isCloudSave, out TagCompound tag)
+	internal static byte[] ReadDataBytes(string path, bool isCloudSave)
 	{
 		path = Path.ChangeExtension(path, ".tplr");
-		tag = new TagCompound();
-
 		if (!FileUtilities.Exists(path, isCloudSave))
-			return false;
+			return null;
 
-		byte[] buf = FileUtilities.ReadAllBytes(path, isCloudSave);
-
-		if (buf[0] != 0x1F || buf[1] != 0x8B) {
-			throw new IOException($"{Path.GetFileName(path)}:: File Corrupted during Last Save Step. Aborting... ERROR: Missing NBT Header");
-		}
-
-		tag = TagIO.FromStream(buf.ToMemoryStream());
-		return true;
+		return FileUtilities.ReadAllBytes(path, isCloudSave);
 	}
 
 	public static List<TagCompound> SaveInventory(Item[] inv)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7787,11 +7787,12 @@
  			throw;
  		}
  	}
-@@ -41979,21 +_,70 @@
+@@ -41979,21 +_,71 @@
  		if (string.IsNullOrEmpty(path))
  			return;
  
 +		// TML: Split method into several methods to facilitate separation between saving to disk and generating save data.
++		// TML: Delay vanilla saving until modded data is serialized(in case of exceptions)
 +		// Moved to UpdateLocalPlayerFile
 +		/*
  		if (FileUtilities.Exists(path, isCloudSave))
@@ -8032,13 +8033,12 @@
  		catch {
  		}
  
-@@ -42308,7 +_,8 @@
+@@ -42308,7 +_,7 @@
  			player2.name = player.name;
  		}
  		else {
 -			string[] array = playerPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
-+			string[] array = playerFileData.Path.Replace('/', Path.DirectorySeparatorChar)
-+				.Split(Path.DirectorySeparatorChar);
++			string[] array = playerFileData.Path.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
  			player2.name = array[array.Length - 1].Split('.')[0];
  		}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7792,8 +7792,8 @@
  			return;
  
 +		// TML: Split method into several methods to facilitate separation between saving to disk and generating save data.
-+		// TML: Delay vanilla saving until modded data is serialized(in case of exceptions)
-+		// Moved to UpdateLocalPlayerFile
++		// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
++		// Moved to SavePlayerFile_Write
 +		/*
  		if (FileUtilities.Exists(path, isCloudSave))
  			FileUtilities.Copy(path, path + ".bak", isCloudSave);
@@ -7824,8 +7824,9 @@
  		binaryWriter.Flush();
  		cryptoStream.FlushFinalBlock();
  		stream.Flush();
++
 +		// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+		// Replaced with FileUtilities.WriteAllBytes in UpdateLocalPlayerFile
++		// Replaced with FileUtilities.WriteAllBytes in SavePlayerFile_Write
 +		/*
  		if (isCloudSave && SocialAPI.Cloud != null)
  			SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
@@ -7837,7 +7838,6 @@
 +	private static void SavePlayerFile_Write(PlayerFileData playerFile, byte[] plrData, TagCompound tplrData)
 +	{
 +		string path = playerFile.Path;
-+		Player player = playerFile.Player;
 +		bool isCloudSave = playerFile.IsCloudSave;
 +		if (string.IsNullOrEmpty(path))
 +			return;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7975,20 +7975,16 @@
  			fileIO.Write(newPlayer.builderAccStatus[num9]);
  		}
  
-@@ -42270,12 +_,27 @@
+@@ -42270,12 +_,23 @@
  		if (Main.rand == null)
  			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
  
 +		var plrData = FileUtilities.ReadAllBytes(playerPath, cloudSave);
-+		// Read data in advance instead of halfway
-+		// What if there is an exception in PlayerIO.TryLoadData? It is not handled the same as before
-+		if (!PlayerIO.TryLoadData(playerFileData.Path, playerFileData.IsCloudSave, out var tplrData))
-+			tplrData = null;
-+
++		var tplrData = PlayerIO.ReadDataBytes(playerPath, cloudSave);
 +		return LoadPlayerFromStream(playerFileData, plrData, tplrData);
 +	}
 +
-+	public static PlayerFileData LoadPlayerFromStream(PlayerFileData playerFileData, byte[] plrData,TagCompound tplrData)
++	public static PlayerFileData LoadPlayerFromStream(PlayerFileData playerFileData, byte[] plrData, byte[] tplrData)
 +	{
  		Player player = new Player();
  		bool gotToReadName = false;
@@ -8032,20 +8028,36 @@
  			player2.name = array[array.Length - 1].Split('.')[0];
  		}
  
-@@ -42322,11 +_,11 @@
+@@ -42322,8 +_,28 @@
  		_visualCloneStream.Seek(0L, SeekOrigin.Begin);
  		Serialize(_visualCloneDummyData, this, _visualCloneWriter);
  		_visualCloneStream.Seek(0L, SeekOrigin.Begin);
 -		Deserialize(_visualCloneDummyData, player, _visualCloneReader, 279, out var _);
 +		Deserialize(_visualCloneDummyData, player, _visualCloneReader, PlayerIO.SaveData(this), Main.curRelease, out var _); // Added PlayerIO.SaveData argument
  		return player;
++	}
++
++	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, TagCompound tplrData, int release, out bool gotToReadName)
++	{
++		Deserialize(data, newPlayer, fileIO, release, out gotToReadName);
++
++		if (tplrData != null)
++			PlayerIO.Load(newPlayer, tplrData);
++
++		LoadPlayer_LastMinuteFixes(newPlayer);
++	}
++
++	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, byte[] tplrData, int release, out bool gotToReadName)
++	{
++		Deserialize(data, newPlayer, fileIO, release, out gotToReadName);
++
++		if (tplrData != null)
++			PlayerIO.Load(newPlayer, TagIO.FromStream(tplrData.ToMemoryStream()));
++
++		LoadPlayer_LastMinuteFixes(newPlayer);
  	}
  
--	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, int release, out bool gotToReadName)
-+	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, TagCompound modData, int release, out bool gotToReadName)
- 	{
- 		gotToReadName = false;
- 		newPlayer.name = fileIO.ReadString();
+ 	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, int release, out bool gotToReadName)
 @@ -42394,8 +_,16 @@
  		if (newPlayer.statManaMax > 200)
  			newPlayer.statManaMax = 200;
@@ -8063,16 +8075,17 @@
  
  		if (release >= 125)
  			newPlayer.extraAccessory = fileIO.ReadBoolean();
-@@ -42795,6 +_,9 @@
+@@ -42795,7 +_,10 @@
  			}
  		}
  
-+		if (modData != null)
-+			PlayerIO.Load(newPlayer, modData);
-+
++		// Moved to the tplr variants of Deserialize, after modded data is read
++		/*
  		LoadPlayer_LastMinuteFixes(newPlayer);
++		*/
  	}
  
+ 	private static void AdjustRespawnTimerForWorldJoining(Player newPlayer)
 @@ -42834,7 +_,7 @@
  	{
  		for (int i = 3; i < 10; i++) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -8140,12 +8140,9 @@
  	}
  
  	public static PlayerFileData GetFileData(string file, bool cloudSave)
-@@ -42886,13 +_,20 @@
- 
+@@ -42887,12 +_,17 @@
  		PlayerFileData playerFileData = LoadPlayer(file, cloudSave);
  		if (playerFileData.Player != null) {
-+			// When loading fails, backup will overwrite. So how about loading plr success && loading tplr fail?
-+			// Just tplrData = null, will result in different versions of PLR and TPLR. (feature)
  			if (playerFileData.Player.loadStatus != 0 && playerFileData.Player.loadStatus != 1) {
 +				CustomModDataException customDataFail = playerFileData.customDataFail;
 -				if (FileUtilities.Exists(file + ".bak", cloudSave))

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7787,7 +7787,7 @@
  			throw;
  		}
  	}
-@@ -41979,21 +_,71 @@
+@@ -41979,21 +_,60 @@
  		if (string.IsNullOrEmpty(path))
  			return;
  
@@ -7845,19 +7845,8 @@
 +		if (FileUtilities.Exists(path, isCloudSave))
 +			FileUtilities.Copy(path, path + ".bak", isCloudSave);
 +
-+		Exception error = null;
-+		try { // Why was this added?
-+			FileUtilities.WriteAllBytes(path, plrData, isCloudSave);
-+		}
-+		catch (Exception e) {
-+			error = e;
-+		}
-+
++		FileUtilities.WriteAllBytes(path, plrData, isCloudSave);
 +		PlayerIO.Save(tplrData, path, isCloudSave);
-+
-+		if (error != null) {
-+			throw error;
-+		}
  	}
  
  	private static void Serialize(PlayerFileData playerFile, Player newPlayer, BinaryWriter fileIO)
@@ -8151,9 +8140,12 @@
  	}
  
  	public static PlayerFileData GetFileData(string file, bool cloudSave)
-@@ -42887,12 +_,17 @@
+@@ -42886,13 +_,20 @@
+ 
  		PlayerFileData playerFileData = LoadPlayer(file, cloudSave);
  		if (playerFileData.Player != null) {
++			// When loading fails, backup will overwrite. So how about loading plr success && loading tplr fail?
++			// Just tplrData = null, will result in different versions of PLR and TPLR. (feature)
  			if (playerFileData.Player.loadStatus != 0 && playerFileData.Player.loadStatus != 1) {
 +				CustomModDataException customDataFail = playerFileData.customDataFail;
 -				if (FileUtilities.Exists(file + ".bak", cloudSave))

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7787,7 +7787,7 @@
  			throw;
  		}
  	}
-@@ -41979,21 +_,60 @@
+@@ -41979,11 +_,32 @@
  		if (string.IsNullOrEmpty(path))
  			return;
  
@@ -7798,28 +7798,29 @@
  		if (FileUtilities.Exists(path, isCloudSave))
  			FileUtilities.Copy(path, path + ".bak", isCloudSave);
 +		*/
-+		PlayerLoader.PreSavePlayer(player);
- 
-+		byte[] plrData = GeneratePlayerData(playerFile);
 +
++		PlayerLoader.PreSavePlayer(player);
++		byte[] plrData = SavePlayerFile_Vanilla(playerFile);
 +		PlayerLoader.PostSavePlayer(player);
 +
 +		TagCompound tplrData = PlayerIO.SaveData(player);
 +
-+		UpdateLocalPlayerFile(playerFile, plrData, tplrData);
++		SavePlayerFile_Write(playerFile, plrData, tplrData);
 +	}
 +
-+	public static byte[] GeneratePlayerData(PlayerFileData playerFile)
++	public static byte[] SavePlayerFile_Vanilla(PlayerFileData playerFile)
 +	{
++		var player = playerFile.Player;
+ 
  		RijndaelManaged rijndaelManaged = new RijndaelManaged();
--		using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
++		/*
+ 		using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
++		*/
 +		using Stream stream = new MemoryStream(2000);
  		using CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write);
  		using BinaryWriter binaryWriter = new BinaryWriter(cryptoStream);
  		binaryWriter.Write(279);
- 		playerFile.Metadata.Write(binaryWriter);
--		Serialize(playerFile, player, binaryWriter);
-+		Serialize(playerFile, playerFile.Player, binaryWriter);
+@@ -41992,8 +_,30 @@
  		binaryWriter.Flush();
  		cryptoStream.FlushFinalBlock();
  		stream.Flush();
@@ -7833,7 +7834,7 @@
 +		return ((MemoryStream)stream).ToArray();
 +	}
 +
-+	private static void UpdateLocalPlayerFile(PlayerFileData playerFile, byte[] plrData, TagCompound tplrData)
++	private static void SavePlayerFile_Write(PlayerFileData playerFile, byte[] plrData, TagCompound tplrData)
 +	{
 +		string path = playerFile.Path;
 +		Player player = playerFile.Player;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7975,7 +7975,7 @@
  			fileIO.Write(newPlayer.builderAccStatus[num9]);
  		}
  
-@@ -42270,12 +_,23 @@
+@@ -42270,12 +_,28 @@
  		if (Main.rand == null)
  			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
  
@@ -7986,6 +7986,8 @@
 +
 +	public static PlayerFileData LoadPlayerFromStream(PlayerFileData playerFileData, byte[] plrData, byte[] tplrData)
 +	{
++		string playerPath = playerFileData.Path;
++
  		Player player = new Player();
  		bool gotToReadName = false;
 +
@@ -7995,7 +7997,9 @@
  		try {
  			RijndaelManaged rijndaelManaged = new RijndaelManaged();
  			rijndaelManaged.Padding = PaddingMode.None;
--			using (MemoryStream stream = new MemoryStream(FileUtilities.ReadAllBytes(playerPath, cloudSave))) {
++			/*
+ 			using (MemoryStream stream = new MemoryStream(FileUtilities.ReadAllBytes(playerPath, cloudSave))) {
++			*/
 +			using (MemoryStream stream = new MemoryStream(plrData)) {
  				using CryptoStream input = new CryptoStream(stream, rijndaelManaged.CreateDecryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Read);
  				using BinaryReader binaryReader = new BinaryReader(input);
@@ -8005,7 +8009,7 @@
  				}
  
 -				Deserialize(playerFileData, player, binaryReader, num, out gotToReadName);
-+				Deserialize(playerFileData, player, binaryReader, tplrData, num, out gotToReadName);
++				Deserialize(playerFileData, player, binaryReader, tplrData, num, out gotToReadName); // Added tplrData argument
  			}
  
  			player.PlayerFrame();
@@ -8017,15 +8021,6 @@
 +			playerFileData.customDataFail = e;
 +		}
  		catch {
- 		}
- 
-@@ -42308,7 +_,7 @@
- 			player2.name = player.name;
- 		}
- 		else {
--			string[] array = playerPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
-+			string[] array = playerFileData.Path.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
- 			player2.name = array[array.Length - 1].Split('.')[0];
  		}
  
 @@ -42322,8 +_,28 @@

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7773,7 +7773,7 @@
  			return false;
  
  		for (int i = x - 1; i <= x + 1; i++) {
-@@ -41963,7 +_,13 @@
+@@ -41963,11 +_,76 @@
  			}
  		}
  		catch (Exception exception) {
@@ -7787,56 +7787,134 @@
  			throw;
  		}
  	}
-@@ -41979,21 +_,52 @@
+ 
++	// private static void InternalSavePlayerFile(PlayerFileData playerFile)
++	// {
++	// 	if (playerFile.ServerSideCharacter)
++	// 		return;
++	//
++	// 	string path = playerFile.Path;
++	// 	Player player = playerFile.Player;
++	// 	bool isCloudSave = playerFile.IsCloudSave;
++	// 	if (string.IsNullOrEmpty(path))
++	// 		return;
++	//
++	// 	// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
++	// 	// Moved to the bottom
++	// 	/*
++	// 	if (FileUtilities.Exists(path, isCloudSave))
++	// 		FileUtilities.Copy(path, path + ".bak", isCloudSave);
++	// 	*/
++	//
++	// 	RijndaelManaged rijndaelManaged = new RijndaelManaged();
++	//
++	// 	/*
++	// 	using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
++	// 	*/
++	// 	using Stream stream = new MemoryStream(2000);
++	// 	using CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write);
++	// 	using BinaryWriter binaryWriter = new BinaryWriter(cryptoStream);
++	//
++	// 	PlayerLoader.PreSavePlayer(player);
++	//
++	// 	binaryWriter.Write(279);
++	// 	playerFile.Metadata.Write(binaryWriter);
++	// 	Serialize(playerFile, player, binaryWriter);
++	// 	binaryWriter.Flush();
++	// 	cryptoStream.FlushFinalBlock();
++	// 	stream.Flush();
++	//
++	// 	// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
++	// 	// Replaced with FileUtilities.WriteAllBytes at the bottom
++	// 	/*
++	// 	if (isCloudSave && SocialAPI.Cloud != null)
++	// 		SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
++	// 	*/
++	//
++	// 	byte[] bytes = ((MemoryStream)stream).ToArray();
++	//
++	// 	PlayerLoader.PostSavePlayer(player); // For native data only
++	//
++	// 	//TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
++	// 	var tag = PlayerIO.SaveData(player);
++	//
++	// 	BackupIO.Player.ArchivePlayer(path, isCloudSave);
++	// 	if (FileUtilities.Exists(path, isCloudSave))
++	// 		FileUtilities.Copy(path, path + ".bak", isCloudSave);
++	//
++	// 	FileUtilities.WriteAllBytes(path, bytes, isCloudSave);
++	//
++	// 	PlayerIO.Save(tag, path, isCloudSave);
++	// }
++
+ 	private static void InternalSavePlayerFile(PlayerFileData playerFile)
+ 	{
+ 		if (playerFile.ServerSideCharacter)
+@@ -41979,21 +_,60 @@
  		if (string.IsNullOrEmpty(path))
  			return;
  
-+		// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+		// Moved to the bottom
-+		/*
- 		if (FileUtilities.Exists(path, isCloudSave))
- 			FileUtilities.Copy(path, path + ".bak", isCloudSave);
-+		*/
- 
- 		RijndaelManaged rijndaelManaged = new RijndaelManaged();
+-		if (FileUtilities.Exists(path, isCloudSave))
+-			FileUtilities.Copy(path, path + ".bak", isCloudSave);
+-
++		PlayerLoader.PreSavePlayer(player);
 +
-+		/*
- 		using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
-+		*/
++		var plrData = GeneratePlayerData(playerFile);
++
++		PlayerLoader.PostSavePlayer(player);
++
++		var tplrData = PlayerIO.SaveData(player);
++
++		UpdateLocalPlayerFile(playerFile, plrData, tplrData);
++	}
++
++	public static byte[] GeneratePlayerData(PlayerFileData playerFile)
++	{
+ 		RijndaelManaged rijndaelManaged = new RijndaelManaged();
+-		using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
++
 +		using Stream stream = new MemoryStream(2000);
  		using CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write);
  		using BinaryWriter binaryWriter = new BinaryWriter(cryptoStream);
 +
-+		PlayerLoader.PreSavePlayer(player);
-+
  		binaryWriter.Write(279);
  		playerFile.Metadata.Write(binaryWriter);
- 		Serialize(playerFile, player, binaryWriter);
+-		Serialize(playerFile, player, binaryWriter);
++		Serialize(playerFile, playerFile.Player, binaryWriter);
  		binaryWriter.Flush();
  		cryptoStream.FlushFinalBlock();
  		stream.Flush();
+-		if (isCloudSave && SocialAPI.Cloud != null)
+-			SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
 +
-+		// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+		// Replaced with FileUtilities.WriteAllBytes at the bottom
-+		/*
- 		if (isCloudSave && SocialAPI.Cloud != null)
- 			SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
-+		*/
++		return ((MemoryStream)stream).ToArray();
++	}
 +
-+		byte[] bytes = ((MemoryStream)stream).ToArray();
-+
-+		PlayerLoader.PostSavePlayer(player); // For native data only
-+
-+		//TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+		var tag = PlayerIO.SaveData(player);
++	private static void UpdateLocalPlayerFile(PlayerFileData playerFile, byte[] plrData, TagCompound tplrData)
++	{
++		string path = playerFile.Path;
++		Player player = playerFile.Player;
++		bool isCloudSave = playerFile.IsCloudSave;
++		if (string.IsNullOrEmpty(path))
++			return;
 +
 +		BackupIO.Player.ArchivePlayer(path, isCloudSave);
 +		if (FileUtilities.Exists(path, isCloudSave))
 +			FileUtilities.Copy(path, path + ".bak", isCloudSave);
 +
-+		FileUtilities.WriteAllBytes(path, bytes, isCloudSave);
++		Exception error = null;
++		try {
++			FileUtilities.WriteAllBytes(path, plrData, isCloudSave);
++		}
++		catch (Exception e) {
++			error = e;
++		}
 +
-+		PlayerIO.Save(tag, path, isCloudSave);
++		PlayerIO.Save(tplrData, path, isCloudSave);
++
++		if (error != null) {
++			throw error;
++		}
  	}
  
  	private static void Serialize(PlayerFileData playerFile, Player newPlayer, BinaryWriter fileIO)
@@ -7964,8 +8042,89 @@
  			fileIO.Write(newPlayer.builderAccStatus[num9]);
  		}
  
-@@ -42272,6 +_,10 @@
+@@ -42261,6 +_,68 @@
+ 			Utils.TryCreatingDirectory(Main.PlayerPath);
+ 	}
  
++	// public static PlayerFileData LoadPlayer(string playerPath, bool cloudSave)
++	// {
++	// 	PlayerFileData playerFileData = new PlayerFileData(playerPath, cloudSave);
++	// 	if (cloudSave && SocialAPI.Cloud == null)
++	// 		return playerFileData;
++	//
++	// 	if (Main.rand == null)
++	// 		Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
++	//
++	// 	Player player = new Player();
++	// 	bool gotToReadName = false;
++	//
++	// 	// Override Main.CurrentPlayer until the end of this method.
++	// 	using var _currentPlr = new Main.CurrentPlayerOverride(player);
++	//
++	// 	try {
++	// 		RijndaelManaged rijndaelManaged = new RijndaelManaged();
++	// 		rijndaelManaged.Padding = PaddingMode.None;
++	// 		using (MemoryStream stream = new MemoryStream(FileUtilities.ReadAllBytes(playerPath, cloudSave))) {
++	// 			using CryptoStream input = new CryptoStream(stream, rijndaelManaged.CreateDecryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Read);
++	// 			using BinaryReader binaryReader = new BinaryReader(input);
++	// 			int num = binaryReader.ReadInt32();
++	// 			if (num >= 135)
++	// 				playerFileData.Metadata = FileMetadata.Read(binaryReader, FileType.Player);
++	// 			else
++	// 				playerFileData.Metadata = FileMetadata.FromCurrentSettings(FileType.Player);
++	//
++	// 			if (num > 279) {
++	// 				player.loadStatus = 1;
++	// 				player.name = binaryReader.ReadString();
++	// 				playerFileData.Player = player;
++	// 				return playerFileData;
++	// 			}
++	//
++	// 			Deserialize(playerFileData, player, binaryReader, num, out gotToReadName);
++	// 		}
++	//
++	// 		player.PlayerFrame();
++	// 		player.loadStatus = 0;
++	// 		playerFileData.Player = player;
++	// 		return playerFileData;
++	// 	}
++	// 	catch (CustomModDataException e) {
++	// 		playerFileData.customDataFail = e;
++	// 	}
++	// 	catch {
++	// 	}
++	//
++	// 	Player player2 = new Player();
++	// 	player2.loadStatus = 2;
++	// 	if (gotToReadName && player.name.Length <= nameLen) {
++	// 		player2.name = player.name;
++	// 	}
++	// 	else {
++	// 		string[] array = playerPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
++	// 		player2.name = array[array.Length - 1].Split('.')[0];
++	// 	}
++	//
++	// 	playerFileData.Player = player2;
++	// 	return playerFileData;
++	// }
++
+ 	public static PlayerFileData LoadPlayer(string playerPath, bool cloudSave)
+ 	{
+ 		PlayerFileData playerFileData = new PlayerFileData(playerPath, cloudSave);
+@@ -42270,12 +_,26 @@
+ 		if (Main.rand == null)
+ 			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
+ 
++		var plrData = FileUtilities.ReadAllBytes(playerPath, cloudSave);
++		// Read data in advance instead of halfway
++		if (!PlayerIO.TryLoadData(playerFileData.Path, playerFileData.IsCloudSave, out var tplrData))
++			tplrData = null;
++
++		return LoadPlayerFromStream(playerFileData, plrData, tplrData);
++	}
++
++	public static PlayerFileData LoadPlayerFromStream(PlayerFileData playerFileData, byte[] plrData,TagCompound tplrData)
++	{
  		Player player = new Player();
  		bool gotToReadName = false;
 +
@@ -7975,6 +8134,20 @@
  		try {
  			RijndaelManaged rijndaelManaged = new RijndaelManaged();
  			rijndaelManaged.Padding = PaddingMode.None;
+-			using (MemoryStream stream = new MemoryStream(FileUtilities.ReadAllBytes(playerPath, cloudSave))) {
++			using (MemoryStream stream = new MemoryStream(plrData)) {
+ 				using CryptoStream input = new CryptoStream(stream, rijndaelManaged.CreateDecryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Read);
+ 				using BinaryReader binaryReader = new BinaryReader(input);
+ 				int num = binaryReader.ReadInt32();
+@@ -42291,7 +_,7 @@
+ 					return playerFileData;
+ 				}
+ 
+-				Deserialize(playerFileData, player, binaryReader, num, out gotToReadName);
++				Deserialize(playerFileData, player, binaryReader, tplrData, num, out gotToReadName);
+ 			}
+ 
+ 			player.PlayerFrame();
 @@ -42299,6 +_,9 @@
  			playerFileData.Player = player;
  			return playerFileData;
@@ -7985,7 +8158,17 @@
  		catch {
  		}
  
-@@ -42322,12 +_,20 @@
+@@ -42308,7 +_,8 @@
+ 			player2.name = player.name;
+ 		}
+ 		else {
+-			string[] array = playerPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
++			string[] array = playerFileData.Path.Replace('/', Path.DirectorySeparatorChar)
++				.Split(Path.DirectorySeparatorChar);
+ 			player2.name = array[array.Length - 1].Split('.')[0];
+ 		}
+ 
+@@ -42322,11 +_,11 @@
  		_visualCloneStream.Seek(0L, SeekOrigin.Begin);
  		Serialize(_visualCloneDummyData, this, _visualCloneWriter);
  		_visualCloneStream.Seek(0L, SeekOrigin.Begin);
@@ -7994,19 +8177,11 @@
  		return player;
  	}
  
- 	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, int release, out bool gotToReadName)
- 	{
-+		if (!PlayerIO.TryLoadData(data.Path, data.IsCloudSave, out var tag))
-+			tag = null;
-+
-+		Deserialize(data, newPlayer, fileIO, tag, release, out gotToReadName);
-+	}
-+
+-	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, int release, out bool gotToReadName)
 +	private static void Deserialize(PlayerFileData data, Player newPlayer, BinaryReader fileIO, TagCompound modData, int release, out bool gotToReadName)
-+	{
+ 	{
  		gotToReadName = false;
  		newPlayer.name = fileIO.ReadString();
- 		gotToReadName = true;
 @@ -42394,8 +_,16 @@
  		if (newPlayer.statManaMax > 200)
  			newPlayer.statManaMax = 200;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7773,7 +7773,7 @@
  			return false;
  
  		for (int i = x - 1; i <= x + 1; i++) {
-@@ -41963,11 +_,76 @@
+@@ -41963,7 +_,13 @@
  			}
  		}
  		catch (Exception exception) {
@@ -7787,83 +7787,23 @@
  			throw;
  		}
  	}
- 
-+	// private static void InternalSavePlayerFile(PlayerFileData playerFile)
-+	// {
-+	// 	if (playerFile.ServerSideCharacter)
-+	// 		return;
-+	//
-+	// 	string path = playerFile.Path;
-+	// 	Player player = playerFile.Player;
-+	// 	bool isCloudSave = playerFile.IsCloudSave;
-+	// 	if (string.IsNullOrEmpty(path))
-+	// 		return;
-+	//
-+	// 	// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+	// 	// Moved to the bottom
-+	// 	/*
-+	// 	if (FileUtilities.Exists(path, isCloudSave))
-+	// 		FileUtilities.Copy(path, path + ".bak", isCloudSave);
-+	// 	*/
-+	//
-+	// 	RijndaelManaged rijndaelManaged = new RijndaelManaged();
-+	//
-+	// 	/*
-+	// 	using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
-+	// 	*/
-+	// 	using Stream stream = new MemoryStream(2000);
-+	// 	using CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write);
-+	// 	using BinaryWriter binaryWriter = new BinaryWriter(cryptoStream);
-+	//
-+	// 	PlayerLoader.PreSavePlayer(player);
-+	//
-+	// 	binaryWriter.Write(279);
-+	// 	playerFile.Metadata.Write(binaryWriter);
-+	// 	Serialize(playerFile, player, binaryWriter);
-+	// 	binaryWriter.Flush();
-+	// 	cryptoStream.FlushFinalBlock();
-+	// 	stream.Flush();
-+	//
-+	// 	// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+	// 	// Replaced with FileUtilities.WriteAllBytes at the bottom
-+	// 	/*
-+	// 	if (isCloudSave && SocialAPI.Cloud != null)
-+	// 		SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
-+	// 	*/
-+	//
-+	// 	byte[] bytes = ((MemoryStream)stream).ToArray();
-+	//
-+	// 	PlayerLoader.PostSavePlayer(player); // For native data only
-+	//
-+	// 	//TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
-+	// 	var tag = PlayerIO.SaveData(player);
-+	//
-+	// 	BackupIO.Player.ArchivePlayer(path, isCloudSave);
-+	// 	if (FileUtilities.Exists(path, isCloudSave))
-+	// 		FileUtilities.Copy(path, path + ".bak", isCloudSave);
-+	//
-+	// 	FileUtilities.WriteAllBytes(path, bytes, isCloudSave);
-+	//
-+	// 	PlayerIO.Save(tag, path, isCloudSave);
-+	// }
-+
- 	private static void InternalSavePlayerFile(PlayerFileData playerFile)
- 	{
- 		if (playerFile.ServerSideCharacter)
-@@ -41979,21 +_,60 @@
+@@ -41979,21 +_,70 @@
  		if (string.IsNullOrEmpty(path))
  			return;
  
--		if (FileUtilities.Exists(path, isCloudSave))
--			FileUtilities.Copy(path, path + ".bak", isCloudSave);
--
++		// TML: Split method into several methods to facilitate separation between saving to disk and generating save data.
++		// Moved to UpdateLocalPlayerFile
++		/*
+ 		if (FileUtilities.Exists(path, isCloudSave))
+ 			FileUtilities.Copy(path, path + ".bak", isCloudSave);
++		*/
 +		PlayerLoader.PreSavePlayer(player);
-+
-+		var plrData = GeneratePlayerData(playerFile);
+ 
++		byte[] plrData = GeneratePlayerData(playerFile);
 +
 +		PlayerLoader.PostSavePlayer(player);
 +
-+		var tplrData = PlayerIO.SaveData(player);
++		TagCompound tplrData = PlayerIO.SaveData(player);
 +
 +		UpdateLocalPlayerFile(playerFile, plrData, tplrData);
 +	}
@@ -7872,11 +7812,9 @@
 +	{
  		RijndaelManaged rijndaelManaged = new RijndaelManaged();
 -		using Stream stream = (isCloudSave ? ((Stream)new MemoryStream(2000)) : ((Stream)new FileStream(path, FileMode.Create)));
-+
 +		using Stream stream = new MemoryStream(2000);
  		using CryptoStream cryptoStream = new CryptoStream(stream, rijndaelManaged.CreateEncryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Write);
  		using BinaryWriter binaryWriter = new BinaryWriter(cryptoStream);
-+
  		binaryWriter.Write(279);
  		playerFile.Metadata.Write(binaryWriter);
 -		Serialize(playerFile, player, binaryWriter);
@@ -7884,8 +7822,12 @@
  		binaryWriter.Flush();
  		cryptoStream.FlushFinalBlock();
  		stream.Flush();
--		if (isCloudSave && SocialAPI.Cloud != null)
--			SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
++		// TML: Delay vanilla saving until modded data is serialized (in case of exceptions)
++		// Replaced with FileUtilities.WriteAllBytes in UpdateLocalPlayerFile
++		/*
+ 		if (isCloudSave && SocialAPI.Cloud != null)
+ 			SocialAPI.Cloud.Write(playerFile.Path, ((MemoryStream)stream).ToArray());
++		*/
 +
 +		return ((MemoryStream)stream).ToArray();
 +	}
@@ -7903,7 +7845,7 @@
 +			FileUtilities.Copy(path, path + ".bak", isCloudSave);
 +
 +		Exception error = null;
-+		try {
++		try { // Why was this added?
 +			FileUtilities.WriteAllBytes(path, plrData, isCloudSave);
 +		}
 +		catch (Exception e) {
@@ -8042,81 +7984,13 @@
  			fileIO.Write(newPlayer.builderAccStatus[num9]);
  		}
  
-@@ -42261,6 +_,68 @@
- 			Utils.TryCreatingDirectory(Main.PlayerPath);
- 	}
- 
-+	// public static PlayerFileData LoadPlayer(string playerPath, bool cloudSave)
-+	// {
-+	// 	PlayerFileData playerFileData = new PlayerFileData(playerPath, cloudSave);
-+	// 	if (cloudSave && SocialAPI.Cloud == null)
-+	// 		return playerFileData;
-+	//
-+	// 	if (Main.rand == null)
-+	// 		Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
-+	//
-+	// 	Player player = new Player();
-+	// 	bool gotToReadName = false;
-+	//
-+	// 	// Override Main.CurrentPlayer until the end of this method.
-+	// 	using var _currentPlr = new Main.CurrentPlayerOverride(player);
-+	//
-+	// 	try {
-+	// 		RijndaelManaged rijndaelManaged = new RijndaelManaged();
-+	// 		rijndaelManaged.Padding = PaddingMode.None;
-+	// 		using (MemoryStream stream = new MemoryStream(FileUtilities.ReadAllBytes(playerPath, cloudSave))) {
-+	// 			using CryptoStream input = new CryptoStream(stream, rijndaelManaged.CreateDecryptor(ENCRYPTION_KEY, ENCRYPTION_KEY), CryptoStreamMode.Read);
-+	// 			using BinaryReader binaryReader = new BinaryReader(input);
-+	// 			int num = binaryReader.ReadInt32();
-+	// 			if (num >= 135)
-+	// 				playerFileData.Metadata = FileMetadata.Read(binaryReader, FileType.Player);
-+	// 			else
-+	// 				playerFileData.Metadata = FileMetadata.FromCurrentSettings(FileType.Player);
-+	//
-+	// 			if (num > 279) {
-+	// 				player.loadStatus = 1;
-+	// 				player.name = binaryReader.ReadString();
-+	// 				playerFileData.Player = player;
-+	// 				return playerFileData;
-+	// 			}
-+	//
-+	// 			Deserialize(playerFileData, player, binaryReader, num, out gotToReadName);
-+	// 		}
-+	//
-+	// 		player.PlayerFrame();
-+	// 		player.loadStatus = 0;
-+	// 		playerFileData.Player = player;
-+	// 		return playerFileData;
-+	// 	}
-+	// 	catch (CustomModDataException e) {
-+	// 		playerFileData.customDataFail = e;
-+	// 	}
-+	// 	catch {
-+	// 	}
-+	//
-+	// 	Player player2 = new Player();
-+	// 	player2.loadStatus = 2;
-+	// 	if (gotToReadName && player.name.Length <= nameLen) {
-+	// 		player2.name = player.name;
-+	// 	}
-+	// 	else {
-+	// 		string[] array = playerPath.Replace('/', Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
-+	// 		player2.name = array[array.Length - 1].Split('.')[0];
-+	// 	}
-+	//
-+	// 	playerFileData.Player = player2;
-+	// 	return playerFileData;
-+	// }
-+
- 	public static PlayerFileData LoadPlayer(string playerPath, bool cloudSave)
- 	{
- 		PlayerFileData playerFileData = new PlayerFileData(playerPath, cloudSave);
-@@ -42270,12 +_,26 @@
+@@ -42270,12 +_,27 @@
  		if (Main.rand == null)
  			Main.rand = new UnifiedRandom((int)DateTime.Now.Ticks);
  
 +		var plrData = FileUtilities.ReadAllBytes(playerPath, cloudSave);
 +		// Read data in advance instead of halfway
++		// What if there is an exception in PlayerIO.TryLoadData? It is not handled the same as before
 +		if (!PlayerIO.TryLoadData(playerFileData.Path, playerFileData.IsCloudSave, out var tplrData))
 +			tplrData = null;
 +


### PR DESCRIPTION
### What is the new feature?

Refine save/load functions.

### Why should this be part of tModLoader?

Original request: #3887

The current save and load parameters only allow file path or cloud save, which means that data generation and writing are inseparable. Additionally, because the player data is divided into two parts, `.plr` and `.tplr`, it is difficult to use `Hook` to obtain both files simultaneously when intercepting saving.

This change does not break the original interface and allows developers to obtain players directly from binary data without using path, making “memory player” possible.

### Are there alternative designs?

No, 

### Sample usage for the new feature

If you have a player's data, it can be used without writing files or hooks.

```cs
byte[] plr_data = ... // from plr file or packet
byte[] tplr_data = ... // from tplr file or packet
var streamPlayer = Player.LoadPlayerFromStream(new PlayerFileData, plr_data, tplr_data);
```

```cs
PlayerLoader.PreSavePlayer(player);
byte[] plrData = SavePlayerFile_Vanilla(playerFile);
PlayerLoader.PostSavePlayer(player);
TagCompound tplrData = PlayerIO.SaveData(player);
```

The `SavePlayerFile_Write` function can be hooked to redirect save data to a different storage medium
