### PR TITLE
Added Missing Treasure Hunter Set to Goodie Bags

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -1069,6 +1069,7 @@ partial class ItemDropDatabase
 			ItemDropRule.NotScalingWithLuck(ItemID.CatEars),
 			spaceCreatureSet,
 			wolfSet,
+			treasureHunterSet
 		};
 
 		IItemDropRule[] rules = new IItemDropRule[]


### PR DESCRIPTION
### What is the bug?

The Treasure Hunter set is missing from Goodie Bags.
It was defined, but was never added to the list of vanity sets for the drop rule.

### How did you fix the bug?

Added it to the drop rule array.

```diff
IItemDropRule treasureHunterSet = ItemDropRule.NotScalingWithLuck(ItemID.TreasureHunterShirt);
treasureHunterSet.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.TreasureHunterPants));

IItemDropRule[] vanitySets = new IItemDropRule[] {
	catSet,
	creeperSet,
	ghostSet,
	leprechaunSet,
	pixieSet,
	princessSet,
	pumpkinSet,
	robotSet,
	unicornSet,
	vampireSet,
	witchSet,
	aintTypingThatSet,
	karateTortoiseSet,
	reaperSet,
	foxSet,
	ItemDropRule.NotScalingWithLuck(ItemID.CatEars),
	spaceCreatureSet,
	wolfSet,
+	treasureHunterSet
};
```

### Are there alternatives to your fix?

Extremely unlikely.