### PR TITLE
Remove HM Bars from Pre-HM Dungeon Crate

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -778,8 +778,8 @@ partial class ItemDropDatabase
 			bc_book,
 
 			bc_goldCoin,
-			hardmodeBiomeCrateOres,
-			hardmodeBiomeCrateBars,
+			new OneFromRulesRule(7, ores),
+			new OneFromRulesRule(4, bars),
 			new OneFromRulesRule(3, potions),
 		};
 		IItemDropRule[] stockade = new IItemDropRule[] {


### PR DESCRIPTION
### What is the bug?
Both the Dungeon Crate (Pre-HM) and Stockade Crate (HM) were dropping Hardmode bars and ores.

### How did you fix the bug?
Replaced the HM ores/bars in the Dungeon Crate with the pre-HM ores/bars that other biome crates drop.

### Are there alternatives to your fix?
No.