### PR TITLE
Improve error logging and reporting

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2351,7 +2351,7 @@
  		UpdateViewZoomKeys();
  		PlayerInput.SetZoom_Unscaled();
  		UILinkPointNavigator.Update();
-@@ -14667,7 +_,20 @@
+@@ -14667,7 +_,25 @@
  		if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.F8) && !drawingPlayerChat && !editSign && !editChest) {
  			if (netRelease) {
  				SoundEngine.PlaySound(12);
@@ -2359,15 +2359,20 @@
 +				/*
  				shouldDrawNetDiagnosticsUI = !shouldDrawNetDiagnosticsUI;
 +				*/
-+				if (!shouldDrawNetDiagnosticsUI && !ModNet.ShouldDrawModNetDiagnosticsUI)
++				if (!shouldDrawNetDiagnosticsUI && !ModNet.ShouldDrawModNetDiagnosticsUI && !Logging.ShouldDrawModExceptionDiagnosticsUI)
 +					shouldDrawNetDiagnosticsUI = true; // From off to on (vanilla)
 +				else {
 +					if (shouldDrawNetDiagnosticsUI && !ModNet.ShouldDrawModNetDiagnosticsUI) {
 +						shouldDrawNetDiagnosticsUI = false; // From on (vanilla) to off (vanilla)
 +						ModNet.ShouldDrawModNetDiagnosticsUI = true; // +on (modded)
 +					}
-+					else if (ModNet.ShouldDrawModNetDiagnosticsUI)
++					else if (ModNet.ShouldDrawModNetDiagnosticsUI) {
 +						ModNet.ShouldDrawModNetDiagnosticsUI = false; // From on (modded) to off (all)
++						Logging.ShouldDrawModExceptionDiagnosticsUI = true; 
++					}
++					else if (Logging.ShouldDrawModExceptionDiagnosticsUI) {
++						Logging.ShouldDrawModExceptionDiagnosticsUI = false;
++					}
 +				}
  			}
  
@@ -4769,7 +4774,7 @@
  	}
  
  	private static void DrawInterface_20_MultiplayerPlayerNames()
-@@ -37178,10 +_,17 @@
+@@ -37178,10 +_,22 @@
  		num22 = 240;
  		text9 = $"{upTimerMax:F2}ms";
  		spriteBatch.DrawString(FontAssets.MouseText.Value, text9, new Vector2(num22, num23), Microsoft.Xna.Framework.Color.White, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
@@ -4779,6 +4784,11 @@
  
  	private static void DrawInterface_17_DiagnoseNet()
  	{
++		if (Logging.ShouldDrawModExceptionDiagnosticsUI) {
++			Logging.ModExceptionDiagnostics.Draw(spriteBatch);
++			return;
++		}
++
 +		if (ModNet.ShouldDrawModNetDiagnosticsUI) {
 +			ModNet.ModNetDiagnosticsUI.Draw(spriteBatch);
 +			return;

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -14,6 +14,8 @@ using log4net.Layout;
 using Microsoft.Xna.Framework;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.Engine;
+using Terraria.ModLoader.UI;
+using Terraria.UI;
 
 namespace Terraria.ModLoader;
 
@@ -104,10 +106,17 @@ public static partial class Logging
 
 		var appenders = new List<IAppender>();
 		if (logFile == LogFile.Client) {
-			appenders.Add(new ConsoleAppender {
+			var consoleAppender = new ManagedColoredConsoleAppender {
 				Name = "ConsoleAppender",
-				Layout = layout
-			});
+				Layout = layout,
+			};
+			// Color mapping adapted from https://code-maze.com/csharp-log4net-appenders-introduction/
+			consoleAppender.AddMapping(new () { Level = Level.Error, ForeColor = ConsoleColor.DarkRed, BackColor = ConsoleColor.White } );
+			consoleAppender.AddMapping(new() { Level = Level.Warn, ForeColor = ConsoleColor.Yellow });
+			consoleAppender.AddMapping(new() { Level = Level.Info, ForeColor = ConsoleColor.White });
+			consoleAppender.AddMapping(new() { Level = Level.Debug, ForeColor = ConsoleColor.Blue });
+			consoleAppender.ActivateOptions();
+			appenders.Add(consoleAppender);
 		}
 
 		appenders.Add(new DebugAppender {
@@ -265,5 +274,10 @@ public static partial class Logging
 		catch (Exception e) {
 			tML.Error("Failed to dump env vars", e);
 		}
+	}
+
+	internal static void SetModExceptionDiagnosticsUI(Mod[] mods)
+	{
+		ModExceptionDiagnostics = Main.dedServ ? null : new UIModExceptionDiagnostics(mods);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -322,6 +322,7 @@ public static class ModContent
 			ModNet.AssignNetIDs();
 
 		ModNet.SetModNetDiagnosticsUI(ModLoader.Mods);
+		Logging.SetModExceptionDiagnosticsUI(ModLoader.Mods);
 
 		Main.player[255] = new Player();
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModExceptionDiagnostics.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModExceptionDiagnostics.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using ReLogic.Graphics;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria.GameContent;
+
+namespace Terraria.ModLoader.UI;
+
+// Modelled after NetDiagnosticsUI for consistent visuals.
+public class UIModExceptionDiagnostics
+{
+	private const float TextScale = 0.7f;
+	private const string Suffix = ": ";
+	private const string ModString = "Mod";
+	private const string ErrorsString = "Errors";
+
+	private Asset<DynamicSpriteFont> fontAsset;
+	private Asset<DynamicSpriteFont> FontAsset => fontAsset ??= FontAssets.MouseText;
+
+	private readonly Mod[] Mods;
+	private int HighestFoundErrorCount = 1;
+	private float FirstColumnWidth;
+
+	public UIModExceptionDiagnostics(IEnumerable<Mod> mods)
+	{
+		Mods = mods.ToArray();
+		Reset();
+	}
+
+	public void Reset()
+	{
+		var font = FontAsset.Value;
+		FirstColumnWidth = font.MeasureString(ModString).X; // Default in case no mods are loaded
+
+		for (int i = 0; i < Mods.Length; i++) {
+			float length = font.MeasureString(Mods[i].Name).X;
+			if (FirstColumnWidth < length)
+				FirstColumnWidth = length;
+		}
+
+		FirstColumnWidth += font.MeasureString(Suffix).X + 2;
+		FirstColumnWidth *= TextScale;
+	}
+
+	public void Draw(SpriteBatch spriteBatch)
+	{
+		int count = ModLoader.Mods.Length;
+		const int maxLinesPerCol = 50;
+		int numCols = (count - 1) / maxLinesPerCol;
+		int x = 190;
+		int xBuf = x + 10;
+		int y = 110;
+		int yBuf = y + 10;
+
+		int width = 232;
+		// Adjust based on left column width and right column width
+		width += (int)(FirstColumnWidth + fontAsset.Value.MeasureString(HighestFoundErrorCount.ToString()).X * TextScale);
+		int widthBuf = width + 10;
+		int lineHeight = 13;
+
+		for (int i = 0; i <= numCols; i++) {
+			int lineCountInCol = i == numCols ? 1 + (count - 1) % maxLinesPerCol : maxLinesPerCol;
+			int height = lineHeight * (lineCountInCol + 2);
+			int heightBuf = height + 10;
+			if (i == 0) {
+				Utils.DrawInvBG(spriteBatch, x + widthBuf * i, y - 20, width, heightBuf + 20);
+				spriteBatch.DrawString(FontAssets.MouseText.Value, Localization.Language.GetTextValue("tModLoader.PressXToClose", Microsoft.Xna.Framework.Input.Keys.F8), new Vector2(200, 96), Color.White, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
+			}
+			else {
+				Utils.DrawInvBG(spriteBatch, x + widthBuf * i, y, width, heightBuf);
+			}
+
+			Vector2 modPos = new Vector2(xBuf + widthBuf * i, yBuf);
+			Vector2 headerPos = modPos + new Vector2(FirstColumnWidth, 0);
+			DrawText(spriteBatch, ErrorsString, headerPos, Color.White);
+			DrawText(spriteBatch, ModString, modPos, Color.White);
+		}
+
+		Vector2 position = default;
+		for (int j = 0; j < count; j++) {
+			Logging.nonIgnoredExceptionCountByMod.TryGetValue(ModLoader.Mods[j].Name, out int errorCount);
+
+			int colNum = j / maxLinesPerCol;
+			int lineNum = j - colNum * maxLinesPerCol;
+			position.X = xBuf + colNum * widthBuf;
+			position.Y = yBuf + lineHeight + lineNum * lineHeight;
+
+			DrawCounter(spriteBatch, errorCount, ModLoader.Mods[j].Name, position);
+		}
+	}
+
+	private void DrawCounter(SpriteBatch spriteBatch, int errorCount, string title, Vector2 position)
+	{
+		if (HighestFoundErrorCount < errorCount)
+			HighestFoundErrorCount = errorCount;
+
+		Vector2 pos = position;
+		string lineName = title + Suffix;
+		float num = Utils.Remap(errorCount, 0f, HighestFoundErrorCount, 0f, 1f);
+		Color color = Main.hslToRgb(0.3f * (1f - num), 1f, 0.5f);
+
+		string drawText = lineName;
+		DrawText(spriteBatch, drawText, pos, color);
+		pos.X += FirstColumnWidth;
+		drawText = string.Format("{0,0}", errorCount);
+		DrawText(spriteBatch, drawText, pos, color);
+	}
+
+	private void DrawText(SpriteBatch spriteBatch, string text, Vector2 pos, Color color) =>
+		spriteBatch.DrawString(FontAsset.Value, text, pos, color, 0f, Vector2.Zero, TextScale, SpriteEffects.None, 0f);
+}


### PR DESCRIPTION
Users have a hard time investigating errors to fix issues with their mod selections. Currently error messages hint to open up `client.log`, but only if the user is actively modding. Novice modders not using a debugger would see that hint, but would not know how to do that without reading the FAQ here on our wiki. Normal users would only see errors reported if they are thrown during mod loading.

This PR aims to improve error reporting to further facilitate users self-diagnosing issues.

# Repeated Errors
Current behavior is to report an error only once. This behavior hides the severity of some issues. Code has been added to track how many times a specific error has been encountered. Errors will be logged at 1, 10, and 100 repetitions, with 10 and 100 reports escalating to `Error` status and having an accompanying "The following exception has been repeated 100 times:" message. 
![image](https://github.com/tModLoader/tModLoader/assets/4522492/c73a82c9-8a59-42fb-8a68-637ad1b188e4)

# ModExceptionDiagnostics window
As the `UIModNetDiagnostics` window suggests the "health" of a mod's networking usage, a `UIModExceptionDiagnostics` window would suggest the "health" of a mod's code. User can press F8 a few times to arrive at this menu, allowing them to quickly appraise the health of a mod. This window will show errors accumulating in real time, making it even better than using the `tail` command or constantly reloading the client.log file. This is especially true for errors that will be omitted from client.log because they are repeats. Users can open the window and repeat a gameplay action that seems to be buggy or laggy. They will be able to immediately see the error count for the buggy mod increasing, suggesting which mod is causing the unexpected behavior.

TODO: This window can be augmented with additional counters for "ignored" exceptions and for displaying the most recent exception or a listing of all exceptions, whatever is deemed useful.

https://github.com/tModLoader/tModLoader/assets/4522492/8ad58bcd-f4e1-43bc-81e0-170b917b6737

# Open up logs folder directly (TODO)
Users don't know hot to get to client.log. We should provide a way to quickly open the logs folder or the specific log file.

One option is to for clicking on the "see client.log for full trace" message to open client.log directly.
![image](https://github.com/tModLoader/tModLoader/assets/4522492/d1a2f73b-8fbc-42d6-8bac-87bd5db92e1a)

Another option is adding a 📜 button on the main menu to open the logs folder.
![image](https://github.com/tModLoader/tModLoader/assets/4522492/b10927cf-cce9-4c8c-892f-3f282a821ad2)

# Ignored Exceptions (TODO)
We allow modders to silence specific exceptions via `Logging.IgnoreExceptionSource/IgnoreExceptionContents`. This is useful for handling known exceptions, but it could be misused by modders, preventing effective troubleshooting by users.

At the very least, it would be useful to log these additions: "System.InvalidCastException added to exception ignore list by ExampleMod". It might be useful to provide a "verbose" mode via a command line parameter that would ignore all of these filters, just in case a specific bug is not being reported properly in logs. Another thought is to track these exceptions and report them in the ModExceptionDiagnostics window, explained in another section.

# Console
The console is not visible for normal client gameplay after launching, but it would be visible when doing host and play once #2705 is fixed. It is visible when debugging tModLoader itself as well. The colors can be adjusted.

Colors have been added for info/debug/warn/error: 
![image](https://github.com/tModLoader/tModLoader/assets/4522492/463797e5-8db3-4218-a295-7b22127ad82d)






