### PR TITLE
Fix issue with bad TileObjectData code causing "leaks" into other TileObjectData instances.

### DIFF
--- a/patches/tModLoader/Terraria/ObjectData/TileObjectData.cs.patch
+++ b/patches/tModLoader/Terraria/ObjectData/TileObjectData.cs.patch
@@ -97,6 +97,24 @@
  		get {
  			if (_subTiles == null)
  				return _baseObject.SubTiles;
+@@ -1259,6 +_,17 @@
+ 			_tileObjectDraw = copy._tileObjectDraw;
+ 			_tileObjectStyle = copy._tileObjectStyle;
+ 			_tileObjectCoords = copy._tileObjectCoords;
++			// TML: Fix modder error that would result in modder inadvertently changing _baseObject, which would cause many other tiles to be broken. Assigning DrawYOffset and then calling CopyFrom would result in _hasOwnTileObjectDraw being true but sharing a _tileObjectDraw reference with _baseObject. A subsequent DrawYOffset assignment (likely in the next ModTile to load) would modify the shared _tileObjectDraw instead of creating a new _tileObjectDraw.
++			if (_hasOwnAlternates || _hasOwnAnchor || _hasOwnAnchorTiles || _hasOwnLiquidDeath || _hasOwnLiquidPlacement || _hasOwnPlacementHooks || _hasOwnSubTiles || _hasOwnTileObjectBase || _hasOwnTileObjectDraw || _hasOwnTileObjectStyle || _hasOwnTileObjectCoords) {
++				_hasOwnAlternates = _hasOwnAnchor = _hasOwnAnchorTiles = _hasOwnLiquidDeath = _hasOwnLiquidPlacement = _hasOwnPlacementHooks = _hasOwnSubTiles = _hasOwnTileObjectBase = _hasOwnTileObjectDraw = _hasOwnTileObjectStyle = _hasOwnTileObjectCoords = false;
++				// Force modder to fix. Silently fixing would keep modders in the dark about their code mistake and lead to confusion about the correct behavior of TileObjectData. Don't crash in normal usage.
++				if (ModLoader.Core.ModCompile.activelyModding) {
++					throw new Exception($"Bad TileObjectData values detected.\nLook at this ModTile and the ModTile that would load immediately before this ModTile and ensure that all modifications to TileObjectData.newTile are done between CopyFrom and AddTile.\nThe previous ModTile would typically be alphabetically before the tile in this stack trace.") {
++						HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-Tile#basic-tileobjectdatanewtile-structure"
++					};
++				}
++				return;
++			}
+ 		}
+ 	}
+ 
 @@ -1372,6 +_,19 @@
  			if (_liquidDeath.water)
  				WaterPlacement = LiquidPlacement.NotAllowed;
@@ -185,6 +203,20 @@
  		addTile(488);
  		newTile.CopyFrom(Style3x2);
  		newTile.DrawYOffset = 2;
+@@ -3842,11 +_,13 @@
+ 		};
+ 
+ 		newTile.StyleHorizontal = true;
++		/* Unused, addAlternate never called.
+ 		newAlternate.CopyFrom(newTile);
+ 		newAlternate.Origin = new Point16(0, 1);
+ 		newAlternate.AnchorAlternateTiles = new int[1] {
+ 			419
+ 		};
++		*/
+ 
+ 		addTile(419);
+ 		newTile.CopyFrom(Style1x1);
 @@ -4579,7 +_,10 @@
  		newTile.StyleMultiplier = 3;
  		newTile.StyleHorizontal = true;

--- a/patches/tModLoader/Terraria/ObjectData/TileObjectData.cs.patch
+++ b/patches/tModLoader/Terraria/ObjectData/TileObjectData.cs.patch
@@ -97,7 +97,7 @@
  		get {
  			if (_subTiles == null)
  				return _baseObject.SubTiles;
-@@ -1259,6 +_,17 @@
+@@ -1259,6 +_,15 @@
  			_tileObjectDraw = copy._tileObjectDraw;
  			_tileObjectStyle = copy._tileObjectStyle;
  			_tileObjectCoords = copy._tileObjectCoords;
@@ -106,9 +106,7 @@
 +				_hasOwnAlternates = _hasOwnAnchor = _hasOwnAnchorTiles = _hasOwnLiquidDeath = _hasOwnLiquidPlacement = _hasOwnPlacementHooks = _hasOwnSubTiles = _hasOwnTileObjectBase = _hasOwnTileObjectDraw = _hasOwnTileObjectStyle = _hasOwnTileObjectCoords = false;
 +				// Force modder to fix. Silently fixing would keep modders in the dark about their code mistake and lead to confusion about the correct behavior of TileObjectData. Don't crash in normal usage.
 +				if (ModLoader.Core.ModCompile.activelyModding) {
-+					throw new Exception($"Bad TileObjectData values detected.\nLook at this ModTile and the ModTile that would load immediately before this ModTile and ensure that all modifications to TileObjectData.newTile are done between CopyFrom and AddTile.\nThe previous ModTile would typically be alphabetically before the tile in this stack trace.") {
-+						HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-Tile#basic-tileobjectdatanewtile-structure"
-+					};
++					Logging.tML.Warn($"Bad TileObjectData values detected.\nLook at this ModTile and the ModTile that would load immediately before this ModTile and ensure that all modifications to TileObjectData.newTile are done between CopyFrom and AddTile.\nThe previous ModTile would typically be alphabetically before the tile in this stack trace.\nSee https://github.com/tModLoader/tModLoader/wiki/Basic-Tile#basic-tileobjectdatanewtile-structure for more information.\n{new System.Diagnostics.StackTrace(true)}");
 +				}
 +				return;
 +			}


### PR DESCRIPTION
Over the years there have been mysterious reports of incorrectly behaving tiles. These reports usually involve tiles untouched by the mod's code to be adversely affected.

Most recently, this has been reported with TheDepths mod. Somehow tiles that previously looked correct are now incorrect:

![image](https://github.com/tModLoader/tModLoader/assets/4522492/496db0a3-1343-4807-814b-7fa4053770fd)

These issues are caused by improper ordering of `TileObjectData` methods and properties. Assigning properties after `AddTile` or before `CopyFrom` leaves the `TileObjectData` in an improper state. Annoyingly, these issues are sometimes caused by incorrect code in the ModTile loading immediately before the 1st affected ModTile, leading to bugs that are hard to track down.

In this case, `TileObjectData.newTile.DrawYOffset = -2;` was written after `TileObjectData.addTile(Type);` in a ModTile, causing the next ModTile to exhibit the effects of the error. 

This PR fixes the issue by resetting the affected fields in `CopyFrom`. This PR also throws errors in `CopyFrom` to instruct the modder that their code is not doing what they think it is. 

# Thoughts or Discussion
Alternatively, this issue could be fixed with resetting the affected fields in `CopyFrom` only, but I feel that not throwing errors will hamper  productivity and lead to modders confused about why their code is not affecting the behavior of their tile.

One concern is that the `ModCompile.activelyModding` check will prevent other mods from loading when debugging a working mod, but I think that the preview period should help with that.