### PR TITLE
Add Getters for UIScrollbar visible view sizes values

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.TML.cs
@@ -6,6 +6,9 @@ namespace Terraria.GameContent.UI.Elements;
 
 public partial class UIScrollbar : UIElement
 {
+	public float ViewSize => _viewSize;
+	public float MaxViewSize => _maxViewSize;
+
 	public override void MouseOver(UIMouseEvent evt)
 	{
 		base.MouseOver(evt);

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UIScrollbar.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs
-@@ -6,11 +_,13 @@
+@@ -6,7 +_,7 @@
  
  namespace Terraria.GameContent.UI.Elements;
  
@@ -9,12 +9,6 @@
  {
  	private float _viewPosition;
  	private float _viewSize = 1f;
- 	private float _maxViewSize = 20f;
-+	public float ViewSize => _viewSize;
-+	public float MaxViewSize => _maxViewSize;
- 	private bool _isDragging;
- 	private bool _isHoveringOverHandle;
- 	private float _dragYOffset;
 @@ -64,7 +_,7 @@
  		return new Rectangle((int)innerDimensions.X, (int)(innerDimensions.Y + innerDimensions.Height * (_viewPosition / _maxViewSize)) - 3, 20, (int)(innerDimensions.Height * (_viewSize / _maxViewSize)) + 7);
  	}

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UIScrollbar.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs
-@@ -6,7 +_,7 @@
+@@ -6,11 +_,13 @@
  
  namespace Terraria.GameContent.UI.Elements;
  
@@ -9,6 +9,12 @@
  {
  	private float _viewPosition;
  	private float _viewSize = 1f;
+ 	private float _maxViewSize = 20f;
++	public float ViewSize => _viewSize;
++	public float MaxViewSize => _maxViewSize;
+ 	private bool _isDragging;
+ 	private bool _isHoveringOverHandle;
+ 	private float _dragYOffset;
 @@ -64,7 +_,7 @@
  		return new Rectangle((int)innerDimensions.X, (int)(innerDimensions.Y + innerDimensions.Height * (_viewPosition / _maxViewSize)) - 3, 20, (int)(innerDimensions.Height * (_viewSize / _maxViewSize)) + 7);
  	}


### PR DESCRIPTION
### **What is the new feature?**

Getters for view size and max view size in UIScrollbar for use in setting correct ViewPosition.

### **Why should this be part of tModLoader?**

If you want to stray away from usual vanilla scroll bar style, you need to get these two values to calculate ViewPosition on your own.

### **Are there alternative designs?**

No, those two values must be visible without them you either use vanilla scrollbar, get values via reflection or calculate them yourself which is quite difficult.

### **Sample usage for the new feature**

ViewPosition = currentOffset / maxOffset * (MaxViewSize - ViewSize);

where currentOffset is your own calculated progress of handle along sliding area in pixels and maxOffset being maximum value handle can get to. Getting MaxViewSize and ViewSize simplify things a lot towards getting correct ViewPosition.