### PR TITLE
Fix keyboards not working as of 2023.09 stable release by adding workaround for SDL bug/regression

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNAFixes.cs
@@ -13,6 +13,13 @@ internal static class FNAFixes
 			SDL.SDL_SetHintWithPriority(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0", SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
 		}
 
+		if (Environment.GetEnvironmentVariable("SteamDeck") is string steamDeckValue && steamDeckValue == "1") {
+			Logging.FNA.Info("SteamDeck detected, configuring keyboard input workaround.");
+			SDL.SDL_SetHintWithPriority("SDL_ENABLE_SCREEN_KEYBOARD", "0", SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
+			// SDL.SDL_HINT_ENABLE_SCREEN_KEYBOARD const only exists in SDL 2.28+, but FNA is currently targeting 2.26.0, so we use string directly.
+			SDL.SDL_StartTextInput();
+		}
+
 		ConfigureDrivers();
 	}
 


### PR DESCRIPTION
Due to code changes in SDL 2.28+, Steam Decks are specifically singled out for skipping text input events. When launched through steam, "SteamDeck" environment variable is set and SDL notices that and disables text input. This fix works around the issue by setting SDL_HINT_ENABLE_SCREEN_KEYBOARD to disabled and then enabling text input manually.

This fix has been tested in desktop mode, game mode, and manually launching the start-tModLoader.sh in desktop mode. Text input has now been restored. 

I've made an issue on the SDL github (https://github.com/libsdl-org/SDL/issues/8561), if it is resolved we can remove this workaround code in a later release.

Note: Sometimes when leaving a game or after compiling a mod, the USB keyboard/trackpad I was using seems to disconnect and then come back about 30 seconds later. I can't alt-tab during this period, so I think the keyboard is disconnected fully from the OS, not just the game. I can't know for sure if this is a coincidence, existing issue, or some obscure new issue. 
