### PR TITLE
Make switching back from Proton less error prone

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -34,6 +34,10 @@ if [[ "$_uname" == *"_NT"* ]]; then
 	fi
 fi
 
+if [[ "$WINDOWS_MAJOR" == "0" || ! -z "$WINEHOMEDIR" ]]; then
+	echo "Proton has been detected. It is highly recommended to not use it as it causes all manner of issues. Please disable Proton and launch again. See https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#disable-proton for information on moving save data to the correct location." 2>&1 | tee -a "$LogFile"
+fi
+
 echo "Verifying .NET...."  2>&1 | tee -a "$LogFile"
 echo "This may take a few moments."
 
@@ -49,6 +53,20 @@ if [[ ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" ]]; then
 	echo "Last Run Attempt Failed to Start tModLoader. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 	rm -rf "$dotnet_dir"
 	mkdir "$dotnet_dir"
+fi
+
+if [[ "$_uname" == *"_NT"* ]]; then
+	if [[ -f "$install_dir/dotnet" ]]; then
+		echo "A non-Windows dotnet executable was detected. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
+		rm -rf "$dotnet_dir"
+		mkdir "$dotnet_dir"
+	fi
+else
+	if [[ -f "$install_dir/dotnet.exe" ]]; then
+		echo "A Windows dotnet executable was detected, possibly from a previous Proton launch. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
+		rm -rf "$dotnet_dir"
+		mkdir "$dotnet_dir"
+	fi
 fi
 
 run_script ./InstallDotNet.sh  2>&1 | tee -a "$LogFile"


### PR DESCRIPTION
There have been many errors in the past attributed to Proton. I was not able to replicate any of them at this time personally, but it is quite common in the Discord support to suggest to Linux users to disable Proton. When disabling Proton, we also have to tell the user to delete the `dotnet` folder. Failure to do so results in the game not launching, suggesting to the user that the fix doesn't work.

This PR ensures that the dotnet folder will be deleted automatically if `dotnet.exe` file is detected on non-Windows or if `dotnet` file is detected on Windows. This change allows a Linux user to seamlessly switch between enabling and disabling Proton. A warning has been added and the wiki updated (https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#disable-proton) with information on moving saves from the Proton prefix saves folder to the native saves folder.

Issues with Proton that I was able to confirm today:
- Manually launching, such as manually launching a dedicated server, will use a different saves folder. This is confusing.
- Manually launching will also require the native `dotnet` executable. With this fix it will delete and reinstall dotnet each time, without this fix the game just won't launch. (Users will see a `./LaunchUtils/ScriptCaller.sh: line 95: /run/media/mmcblk0p1/steamapps/common/tModLoader/dotnet/6.0.14/dotnet: No such file or directory` error in Launch.log because `dotnet.exe` exists but `dotnet` doesn't.)
- Saves will be located deep in the file tree in a place unfamiliar to our FAQ and instructions, `/home/[username]/.local/share/Steam/steamapps/compatdata/1281930/pfx/drive_c/users/steamuser/Documents/My Games/Terraria/tModLoader`, making support confusing.
- Other issues have been brought up in the past, but I was unable to confirm.

# Discussion
1. We could force detecting Proton to not launch, but I think some Linux users insist that it is needed for their system. This might be a result of the `dotnet` folder not being deleted during testing, in my opinion, but it might have some merit
2. `WINDOWS_MAJOR` set to `0` and `WINEHOMEDIR` existing were the environment variables I found consistently set on my Linux machine (Steam Deck), but it is possible they might not be 100% reliable. I did not test launching through Wine directly, just through Proton. 
3. Automated porting from Prefix folder. Pretty annoying, but I think the wiki update is sufficient. 