### PR TITLE
Enable tModPorter on Linux from develop mods menu

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -249,7 +249,6 @@ internal class UIModSourceItem : UIPanel
 
 					string args = $"\"{csprojFile}\"";
 					var tMLPath = Path.GetFileName(Assembly.GetExecutingAssembly().Location);
-					// TODO: We need to find some way of launching Linux scripts in a console window that is shown, not hidden. Probably requires logic to call "gnome-terminal/xterm/konsole -e command" depending on whatever is installed (https://askubuntu.com/a/46630)
 					var porterPath =  Path.Combine(Path.GetDirectoryName(tMLPath), "tModPorter", (Platform.IsWindows ? "tModPorter.bat" : "tModPorter.sh"));
 
 					var porterInfo = new ProcessStartInfo() {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -235,8 +235,8 @@ internal class UIModSourceItem : UIPanel
 			}
 
 
-			// Display Run tModPorter for Windows when .csproj is valid
-			if (Platform.IsWindows && !projNeedsUpdate) {
+			// Display Run tModPorter when .csproj is valid
+			if (!projNeedsUpdate) {
 				var pIcon = UICommon.ButtonExclamationTexture;
 				var portModButton = new UIHoverImage(pIcon, Language.GetTextValue("tModLoader.MSPortToLatest")) {
 					Left = { Pixels = contextButtonsLeft, Percent = 1f },
@@ -249,7 +249,8 @@ internal class UIModSourceItem : UIPanel
 
 					string args = $"\"{csprojFile}\"";
 					var tMLPath = Path.GetFileName(Assembly.GetExecutingAssembly().Location);
-					var porterPath =  Path.Combine(Path.GetDirectoryName(tMLPath), "tModPorter", "tModPorter.bat");
+					// TODO: We need to find some way of launching Linux scripts in a console window that is shown, not hidden. Probably requires logic to call "gnome-terminal/xterm/konsole -e command" depending on whatever is installed (https://askubuntu.com/a/46630)
+					var porterPath =  Path.Combine(Path.GetDirectoryName(tMLPath), "tModPorter", (Platform.IsWindows ? "tModPorter.bat" : "tModPorter.sh"));
 
 					var porterInfo = new ProcessStartInfo() {
 						FileName = porterPath,

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -316,6 +316,9 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 			yield return $"{dotnetRoot}/dotnet";
 		}
 
+		// The Scripted install installs the SDK to "$HOME/.dotnet" by default on Linux/Mac but will not permanently change $PATH. (Many Linux distributions have package manager instructions, but not all, so some might use scripted install: "./dotnet-install.sh -channel 6.0".) https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script
+		yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", "dotnet");
+
 		// general unix fallback
 		yield return "/usr/bin/dotnet";
 	}

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"/..
-dotnet tModLoader.dll -tModPorter $@
+./start-tModLoader.sh -tModPorter $@

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 if [ ! -t 0 ]; then
 	cd "$(dirname "$0")"
-	echo "Not in a terminal, attempting to open terminal"
+	echo "Not in a terminal, attempting to open terminal" >&2
 	. ../LaunchUtils/BashUtils.sh
 	if machine_has "konsole"; then
 		konsole -e "$0" "$@"
 	elif machine_has "gnome-terminal"; then
 		gnome-terminal -- "$0" "$@"
 	elif machine_has "gnome-xterm"; then
+		gnome-xterm -- "$0" "$@"
+	elif machine_has "xterm"; then
 		xterm -e "$0" "$@"
 	elif [ "$_uname" = Darwin ]; then
 		osascript \

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"/..
-./start-tModLoader.sh -tModPorter $@
+if [[ ! -z "$DOTNET_ROOT" ]]; then
+	echo "DOTNET_ROOT is $DOTNET_ROOT"
+	export DOTNET_ROOT=$HOME/.dotnet
+    export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+fi
+export DOTNET_ROLL_FORWARD=Minor
+dotnet tModLoader.dll -tModPorter $@ &> ./tModLoader-Logs/tModPorter.log

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -3,7 +3,7 @@ cd "$(dirname "$0")"/..
 if [[ ! -z "$DOTNET_ROOT" ]]; then
 	echo "DOTNET_ROOT is $DOTNET_ROOT"
 	export DOTNET_ROOT=$HOME/.dotnet
-    export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+	export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 fi
 export DOTNET_ROLL_FORWARD=Minor
 dotnet tModLoader.dll -tModPorter $@ &> ./tModLoader-Logs/tModPorter.log

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+if [ ! -t 0 ]; then
+	cd "$(dirname "$0")"
+	echo "Not in a terminal, attempting to open terminal"
+	. ../LaunchUtils/BashUtils.sh
+	if machine_has "konsole"; then
+		konsole -e "$0 $@"
+	elif machine_has "gnome-terminal"; then
+		gnome-terminal -- "$0 $@"
+	else
+		xterm -e "$0 $@"
+	fi
+	echo "Done"
+	exit
+fi
+
 cd "$(dirname "$0")"/..
 if [[ ! -z "$DOTNET_ROOT" ]]; then
 	echo "DOTNET_ROOT is $DOTNET_ROOT"
@@ -6,4 +21,4 @@ if [[ ! -z "$DOTNET_ROOT" ]]; then
 	export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 fi
 export DOTNET_ROLL_FORWARD=Minor
-dotnet tModLoader.dll -tModPorter $@ &> ./tModLoader-Logs/tModPorter.log
+dotnet tModLoader.dll -tModPorter $@ 2>&1 | tee ./tModLoader-Logs/tModPorter.log

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -7,8 +7,6 @@ if [ ! -t 0 ]; then
 		konsole -e "$0" "$@"
 	elif machine_has "gnome-terminal"; then
 		gnome-terminal -- "$0" "$@"
-	elif machine_has "gnome-xterm"; then
-		gnome-xterm -- "$0" "$@"
 	elif machine_has "xterm"; then
 		xterm -e "$0" "$@"
 	elif [ "$_uname" = Darwin ]; then

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -4,13 +4,25 @@ if [ ! -t 0 ]; then
 	echo "Not in a terminal, attempting to open terminal"
 	. ../LaunchUtils/BashUtils.sh
 	if machine_has "konsole"; then
-		konsole -e "$0 $@"
+		konsole -e "$0" "$@"
 	elif machine_has "gnome-terminal"; then
-		gnome-terminal -- "$0 $@"
+		gnome-terminal -- "$0" "$@"
+	elif machine_has "gnome-xterm"; then
+		xterm -e "$0" "$@"
+	elif [ "$_uname" = Darwin ]; then
+		osascript \
+			-e "on run(argv)" \
+			-e "set tmodporter to item 1 of argv" \
+			-e "set csproj to item 2 of argv" \
+			-e "tell application \"Terminal\" to activate" \
+			-e "tell application \"Terminal\" to do script the quoted form of tmodporter & \" \" & the quoted form of csproj" \
+			-e "end" \
+			-- "$0" "$@"
 	else
-		xterm -e "$0 $@"
+		echo "Could not find terminal app"
+		exit 1
 	fi
-	echo "Done"
+	echo "Launched in another terminal. See tModPorter.log for details"
 	exit
 fi
 
@@ -21,4 +33,4 @@ if [[ ! -z "$DOTNET_ROOT" ]]; then
 	export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 fi
 export DOTNET_ROLL_FORWARD=Minor
-dotnet tModLoader.dll -tModPorter $@ 2>&1 | tee ./tModLoader-Logs/tModPorter.log
+dotnet tModLoader.dll -tModPorter "$@" 2>&1 | tee ./tModLoader-Logs/tModPorter.log

--- a/tModPorter/tModPorter/Program.cs
+++ b/tModPorter/tModPorter/Program.cs
@@ -24,7 +24,8 @@ public class Program {
 		WriteLine();
 		WriteLine();
 		WriteLine("Press any key to exit...");
-		ReadKey();
+		if (!IsInputRedirected) // ReadKey will throw error when no console is present, such as launching on Linux
+			ReadKey();
 	}
 
 	private static string GetProjectPath(string path) {

--- a/tModPorter/tModPorter/tModPorter.csproj
+++ b/tModPorter/tModPorter/tModPorter.csproj
@@ -5,7 +5,7 @@
     <UseAppHost>false</UseAppHost>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FlowAnalysis.Utilities" Version="2.9.6" />


### PR DESCRIPTION
Fixes #3933

tModPorter.sh changed so that it works with `DOTNET_ROLL_FORWARD=Disable` set, as it would be if launched from in-game. `DOTNET_ROOT` is also checked just in case `dotnet` not on `PATH`, such as it would be on a Steam Deck. A console window still does not appear, so a log file was added.

tModPorter has a little fix for an input issue with no console present, and an update to Microsoft.Build.Locator version to take advantage of fixes to locating dotnet. The old code could not locate dotnet in DOTNET_ROOT, for example. 

Additionally, `GetPossibleSystemDotnetPaths` has been updated with `~/.dotnet` as a possible path because that is where the install script will install dotnet to. 