### PR TITLE
Qualify the dotnet path of created mod to solve error on editors such as Rider

### DIFF
--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -6,6 +6,9 @@
     <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
+    <DotNetPath Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetPath>
+    <DotNetPath Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetPath>
+    <DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -6,9 +6,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
-    <DotNetPath Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetPath>
-    <DotNetPath Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetPath>
-    <DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />

--- a/ExampleMod/Properties/launchSettings.json
+++ b/ExampleMod/Properties/launchSettings.json
@@ -2,13 +2,13 @@
   "profiles": {
     "Terraria": {
       "commandName": "Executable",
-      "executablePath": "$(DotnetPath)",
+      "executablePath": "$(DotNetName)",
       "commandLineArgs": "$(tMLPath)",
       "workingDirectory": "$(tMLSteamPath)"
     },
     "TerrariaServer": {
       "commandName": "Executable",
-      "executablePath": "$(DotnetPath)",
+      "executablePath": "$(DotNetName)",
       "commandLineArgs": "$(tMLServerPath)",
       "workingDirectory": "$(tMLSteamPath)"
     }

--- a/ExampleMod/Properties/launchSettings.json
+++ b/ExampleMod/Properties/launchSettings.json
@@ -2,13 +2,13 @@
   "profiles": {
     "Terraria": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "$(DotnetPath)",
       "commandLineArgs": "$(tMLPath)",
       "workingDirectory": "$(tMLSteamPath)"
     },
     "TerrariaServer": {
       "commandName": "Executable",
-      "executablePath": "dotnet",
+      "executablePath": "$(DotnetPath)",
       "commandLineArgs": "$(tMLServerPath)",
       "workingDirectory": "$(tMLSteamPath)"
     }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UICreateMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UICreateMod.cs
@@ -262,6 +262,9 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
+    <DotNetPath Condition="" '$(OS)' == 'Windows_NT' "">dotnet.exe</DotNetPath>
+    <DotNetPath Condition="" '$(OS)' == 'Unix' "">dotnet</DotNetPath>
+    <DotNetPath Condition="" '$(DotNetPath)' == '' "">dotnet</DotNetPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""tModLoader.CodeAssist"" Version=""0.1.*"" />
@@ -286,13 +289,13 @@ $@"{{
   ""profiles"": {{
     ""Terraria"": {{
       ""commandName"": ""Executable"",
-      ""executablePath"": ""dotnet"",
+      ""executablePath"": ""$(DotNetPath)"",
       ""commandLineArgs"": ""$(tMLPath)"",
       ""workingDirectory"": ""$(tMLSteamPath)""
     }},
     ""TerrariaServer"": {{
       ""commandName"": ""Executable"",
-      ""executablePath"": ""dotnet"",
+      ""executablePath"": ""$(DotNetPath)"",
       ""commandLineArgs"": ""$(tMLServerPath)"",
       ""workingDirectory"": ""$(tMLSteamPath)""
     }}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UICreateMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UICreateMod.cs
@@ -262,9 +262,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
     <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
-    <DotNetPath Condition="" '$(OS)' == 'Windows_NT' "">dotnet.exe</DotNetPath>
-    <DotNetPath Condition="" '$(OS)' == 'Unix' "">dotnet</DotNetPath>
-    <DotNetPath Condition="" '$(DotNetPath)' == '' "">dotnet</DotNetPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include=""tModLoader.CodeAssist"" Version=""0.1.*"" />
@@ -289,13 +286,13 @@ $@"{{
   ""profiles"": {{
     ""Terraria"": {{
       ""commandName"": ""Executable"",
-      ""executablePath"": ""$(DotNetPath)"",
+      ""executablePath"": ""$(DotNetName)"",
       ""commandLineArgs"": ""$(tMLPath)"",
       ""workingDirectory"": ""$(tMLSteamPath)""
     }},
     ""TerrariaServer"": {{
       ""commandName"": ""Executable"",
-      ""executablePath"": ""$(DotNetPath)"",
+      ""executablePath"": ""$(DotNetName)"",
       ""commandLineArgs"": ""$(tMLServerPath)"",
       ""workingDirectory"": ""$(tMLSteamPath)""
     }}

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -7,6 +7,9 @@
 		<tMLName>tModLoader</tMLName>
 		<tMLPath>$(tMLName).dll</tMLPath>
 		<tMLServerPath>$(tMLPath) -server</tMLServerPath>
+    	<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
+    	<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
+    	<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
 		<!-- TML stable version define placeholder -->
 	</PropertyGroup>
 	<ItemGroup>


### PR DESCRIPTION
**Code written by: [steviegt6](https://github.com/steviegt6) (tomat)**

Fixes #3942
Editors such as Rider don't handle extensions. A more fully-qualified name has to be given instead

### How did I fix it?
Added this to `.csproj` file of created mod
```
<DotNetPath Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetPath>
<DotNetPath Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetPath>
<DotNetPath Condition=" '$(DotNetPath)' == '' ">dotnet</DotNetPath>
```

And replaced `dotnet` with `$(DotnetPath)` inside of launchSettings.json.