### PR TITLE
GlobalNPC.SetDefaultsFromNetId

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -34,9 +34,10 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	public sealed override void SetupContent() => SetStaticDefaults();
 
 	/// <summary>
+	/// Similar to SetDefaults, but only called on NPCs with a negative <see cref="NPC.netID"/>.<br/>
 	/// Vanilla "variant" NPCs which have <see cref="NPC.netID"/> set to a negative value cannot be properly modified through SetDefaults.<br/>
 	/// This method allows you to properly run code you would run in SetDefaults for these NPCs.<br/>
-	/// When running this method, always be sure to check against <see cref="NPC.netID"/> to ensure you're modifying the correct variant.<br/>
+	/// <b><see cref="NPC.type"/> does not support negative numbers! Always be sure to check against <see cref="NPC.netID"/> instead.</b><br/>
 	/// </summary>
 	public virtual void SetDefaultsFromNetId(NPC npc)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -34,6 +34,15 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	public sealed override void SetupContent() => SetStaticDefaults();
 
 	/// <summary>
+	/// Vanilla "variant" NPCs which have <see cref="NPC.netID"/> set to a negative value cannot be properly modified through SetDefaults.<br/>
+	/// This method allows you to properly run code you would run in SetDefaults for these NPCs.<br/>
+	/// When running this method, always be sure to check against <see cref="NPC.netID"/> to ensure you're modifying the correct variant.
+	/// </summary>
+	public virtual void SetVariantDefaults(NPC npc)
+	{
+	}
+
+	/// <summary>
 	/// Gets called when any NPC spawns in world
 	/// </summary>
 	public virtual void OnSpawn(NPC npc, IEntitySource source)

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -36,9 +36,9 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	/// <summary>
 	/// Vanilla "variant" NPCs which have <see cref="NPC.netID"/> set to a negative value cannot be properly modified through SetDefaults.<br/>
 	/// This method allows you to properly run code you would run in SetDefaults for these NPCs.<br/>
-	/// When running this method, always be sure to check against <see cref="NPC.netID"/> to ensure you're modifying the correct variant.
+	/// When running this method, always be sure to check against <see cref="NPC.netID"/> to ensure you're modifying the correct variant.<br/>
 	/// </summary>
-	public virtual void SetVariantDefaults(NPC npc)
+	public virtual void SetDefaultsFromNetId(NPC npc)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -34,10 +34,9 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	public sealed override void SetupContent() => SetStaticDefaults();
 
 	/// <summary>
-	/// Similar to SetDefaults, but only called on NPCs with a negative <see cref="NPC.netID"/>.<br/>
-	/// Vanilla "variant" NPCs which have <see cref="NPC.netID"/> set to a negative value cannot be properly modified through SetDefaults.<br/>
-	/// This method allows you to properly run code you would run in SetDefaults for these NPCs.<br/>
-	/// <b><see cref="NPC.type"/> does not support negative numbers! Always be sure to check against <see cref="NPC.netID"/> instead.</b><br/>
+	/// Called after SetDefaults for NPCs with a negative <see cref="NPC.netID"/><br/>
+	/// This hook is required because <see cref="NPC.SetDefaultsFromNetId"/> only sets <see cref="NPC.netID"/> after SetDefaults<br/>
+	/// Remember that <see cref="NPC.type"/> does not support negative numbers and AppliesToEntity cannot distinguish between NPCs with the same type but differet netID<br/>
 	/// </summary>
 	public virtual void SetDefaultsFromNetId(NPC npc)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -203,6 +203,14 @@ public static class NPCLoader
 		GlobalLoaderUtils<GlobalNPC, NPC>.SetDefaults(npc, ref npc._globals, static n => n.ModNPC?.SetDefaults());
 	}
 
+	private static HookList HookSetVariantDefaults = AddHook<Action<NPC>>(g => g.SetVariantDefaults);
+	internal static void SetVariantDefaults(NPC npc)
+	{
+		foreach (var g in HookSetVariantDefaults.Enumerate(npc)) {
+			g.SetVariantDefaults(npc);
+		}
+	}
+
 	private static HookList HookOnSpawn = AddHook<Action<NPC, IEntitySource>>(g => g.OnSpawn);
 
 	internal static void OnSpawn(NPC npc, IEntitySource source)

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -203,11 +203,11 @@ public static class NPCLoader
 		GlobalLoaderUtils<GlobalNPC, NPC>.SetDefaults(npc, ref npc._globals, static n => n.ModNPC?.SetDefaults());
 	}
 
-	private static HookList HookSetVariantDefaults = AddHook<Action<NPC>>(g => g.SetVariantDefaults);
-	internal static void SetVariantDefaults(NPC npc)
+	private static HookList HookSetVariantDefaults = AddHook<Action<NPC>>(g => g.SetDefaultsFromNetId);
+	internal static void SetDefaultsFromNetId(NPC npc)
 	{
 		foreach (var g in HookSetVariantDefaults.Enumerate(npc)) {
-			g.SetVariantDefaults(npc);
+			g.SetDefaultsFromNetId(npc);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -715,7 +715,7 @@
  			life = lifeMax;
  		}
 +
-+		NPCLoader.SetVariantDefaults(this);
++		NPCLoader.SetDefaultsFromNetId(this);
 +	}
 +
 +	// Added by TML.

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -706,7 +706,7 @@
  		return result;
  	}
  
-@@ -2105,9 +_,25 @@
+@@ -2105,9 +_,27 @@
  		defDamage = damage;
  		defDefense = defense;
  		if (flag) {
@@ -714,6 +714,8 @@
 +			ScaleStats(spawnparams.playerCountForMultiplayerDifficultyOverride, spawnparams.gameModeData ?? Main.GameModeInfo, spawnparams.strengthMultiplierOverride);
  			life = lifeMax;
  		}
++
++		NPCLoader.SetVariantDefaults(this);
 +	}
 +
 +	// Added by TML.


### PR DESCRIPTION
in summation of the followin': `netID` is cringe

### What is the new feature?
a new `GlobalNPC.SetDefaultsFromNetId` hook which allows certain vanilla "variant" enemies that otherwise can't be touched by `SetDefaults` to be modified by mods

### Why should this be part of tModLoader?
`netID` is this funny little vanil- actually, wait a minute. why am I explainin' this again? I opened an issue on it

as described in #3819, NPCs with negative `netID` (a vanilla NPC field which, despite its name, has nothing to do with netcode) can't be modified (correctly) via the `GlobalNPC.SetDefaults` hook

this new hook works around the problem (and technically closes #3819) by addin' a new hook which DOES account for `netID` bein' set, allowin' modders to actually modify these NPC variants in a way that's actually sustainable

### Are there alternative designs?
multiple! I have a thread open in the actual tML discord on this for people who wish to help find one that works best

(ideally, `netID` wouldn't exist and we would just have positive IDs for all these NPC variants, but that's a completely different can of worms that I'm not in the mood to open)

### Sample usage for the new feature
```csharp
public override void SetDefaultsFromNetId(NPC npc)
{
    // suppose you wanna mess around with Pinky. here's how to do it
    if (npc.netID != NPCID.Pinky)
        return; // do nothing

    // do something. easy as you can get
}
```

### ExampleMod updates
none, but can add one if desired