### PR TITLE
Fix `DrawPlayer` Scale Parameter

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
@@ -30,7 +30,7 @@
  
  	public void DrawPlayer(Camera camera, Player drawPlayer, Vector2 position, float rotation, Vector2 rotationOrigin, float shadow = 0f, float scale = 1f)
  	{
-+		DrawPlayerInternal(camera, drawPlayer, position, rotation, rotationOrigin, shadow, scale);
++		DrawPlayerInternal(camera, drawPlayer, position, rotation, rotationOrigin, shadow, scale: scale);
 +	}
 +
 +	// A split to add some not publicly exposed parameters.


### PR DESCRIPTION
### What is the bug?

`LegacyPlayerRenderer::DrawPlayer` features a `scale` parameter, allowing arbitrary scaling of the drawn player. However, this parameter was being passed into `LegacyPlayerRenderer::DrawPlayerInternal` as the `alpha` parameter.
This creates a slight visual inconsistency with vanilla (character creation screen), as well as forcing modders to use workarounds to draw players at arbitrary scales.

*Vanilla character creation screen:*
![Vanilla character creation screen](https://github.com/tModLoader/tModLoader/assets/33076411/6d694fe2-aa46-459e-99d9-17835d61ec1f)

*Modded character creation screen (without fix):*
![Modded character creation screen without fix](https://github.com/tModLoader/tModLoader/assets/33076411/0b8f5459-d104-4a48-9db8-96e28ae75367)

*Modded character creation screen (with fix):*
![Modded character creation screen with fix](https://github.com/tModLoader/tModLoader/assets/33076411/7e7a2dc4-d5e7-4f00-8c83-e8dafa0fef23)

### How did you fix the bug?


* Qualified the parameter with `scale:`.

### Are there alternatives to your fix?

No.