### PR TITLE
Reimplemented custom Terraria.csproj logic using C# MSBuild Tasks, fixed ".Remove(-1)".

### DIFF
--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -1,11 +1,13 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/TerrariaNetCore/Terraria/Terraria.csproj
-@@ -1,90 +_,116 @@
+@@ -1,90 +_,118 @@
  <Project Sdk="Microsoft.NET.Sdk">
++
  	<Import Project="../Configuration.targets" />
  	<Import Project="../../WorkspaceInfo.targets" />
 +	<Import Project="../../../tModBuildTasks/BuildTasks.targets" />
 +
++	<!-- General -->
  	<PropertyGroup>
 -		<OutputType>WinExe</OutputType>
 +		<OutputType>Exe</OutputType>
@@ -15,29 +17,33 @@
  		<RootNamespace>Terraria</RootNamespace>
 -		<OutputName>Terraria</OutputName>
 +		<AssemblyName>Terraria</AssemblyName>
+-	</PropertyGroup>
+-	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
+-		<OutputType>Exe</OutputType>
+-		<OutputName>$(OutputName)Server</OutputName>
+-	</PropertyGroup>
+-	<PropertyGroup Condition="$(Configuration.Contains('Debug'))">
+-		<OutputName>$(OutputName)Debug</OutputName>
+-	</PropertyGroup>
+-	<PropertyGroup>
+-		<PdbFile>bin\$(OutputName)</PdbFile>
+ 		<ApplicationIcon>Icon.ico</ApplicationIcon>
 +
++		<!-- Avoid overwriting Terraria.exe (if it's not Debug it's release) -->
++		<AssemblyName Condition="$(Configuration.Contains('Debug'))">$(AssemblyName)Debug</AssemblyName>
++		<AssemblyName Condition="!$(Configuration.Contains('Debug'))">$(AssemblyName)Release</AssemblyName>
++		<OutputName>$(AssemblyName)</OutputName>
+ 	</PropertyGroup>
++
++	<!-- Build Configuration -->
++	<PropertyGroup>
++		<LibrariesDirectory>Libraries</LibrariesDirectory>
 +		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
 +		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
 +		<CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
- 	</PropertyGroup>
- 	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
--		<OutputType>Exe</OutputType>
--		<OutputName>$(OutputName)Server</OutputName>
-+		<AssemblyName>$(AssemblyName)Server</AssemblyName>
- 	</PropertyGroup>
- 	<PropertyGroup Condition="$(Configuration.Contains('Debug'))">
--		<OutputName>$(OutputName)Debug</OutputName>
-+		<AssemblyName>$(AssemblyName)Debug</AssemblyName>
 +	</PropertyGroup>
-+	<!-- Avoid overwriting Terraria(Server).exe (if it's not Debug it's release) -->
-+	<PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
-+		<AssemblyName>$(AssemblyName)Release</AssemblyName>
- 	</PropertyGroup>
- 	<PropertyGroup>
--		<PdbFile>bin\$(OutputName)</PdbFile>
-+		<OutputName>$(AssemblyName)</OutputName>
- 		<ApplicationIcon>Icon.ico</ApplicationIcon>
- 	</PropertyGroup>
++
++	<!-- References -->
  	<ItemGroup>
 +		<ProjectReference Include="../../../FNA/FNA.Core.csproj" />
  		<ProjectReference Include="../ReLogic/ReLogic.csproj" />
@@ -45,6 +51,7 @@
  			<Link>Libraries/ReLogic/ReLogic.dll</Link>
  			<LogicalName>Terraria.Libraries.ReLogic.ReLogic.dll</LogicalName>
  		</EmbeddedResource>
++
  		<Reference Include="CsvHelper" />
 -		<Reference Include="FNA" Condition="$(DefineConstants.Contains('FNA'))" />
  		<Reference Include="Ionic.Zip.CF" />
@@ -72,7 +79,11 @@
 -			<HintPath Condition="$(DefineConstants.Contains('Mono'))">Libraries/Mono/System.Windows.Forms.dll</HintPath>
 -		</Reference>
 -		<Reference Include="WindowsBase" />
++
++		<PackageReference Include="Steamworks.NET" Version="20.1.0" />
  	</ItemGroup>
++
++	<!-- Embedded Resources -->
  	<ItemGroup>
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
@@ -87,57 +98,17 @@
  		<EmbeddedResource Include="Localization/Content/**" />
  		<EmbeddedResource Include="Microsoft/**" />
  	</ItemGroup>
++
++	<!-- Files -->
  	<ItemGroup>
 -		<None Remove="Libraries/Native/**" />
--	</ItemGroup>
--	<Target Name="EditBin" AfterTargets="Build">
 +		<None Remove="Libraries/Mono/**" />
 +		<None Remove="Libraries/Windows/**" />
 +		<None Remove="Libraries/XNA/**" />
 +		<Content Include="Libraries/Native/**" CopyToOutputDirectory="PreserveNewest" />
-+	</ItemGroup>
-+	<ItemGroup>
-+		<PackageReference Include="Steamworks.NET" Version="20.1.0" />
-+	</ItemGroup>
-+
-+	<PropertyGroup>
-+		<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
-+	</PropertyGroup>
-+
-+	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
-+		<!-- Copy files systematically to output folder -->
-+		<ItemGroup>
-+			<BinFiles Include="$(TargetDir)**" />
-+		</ItemGroup>
-+
-+		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
-+		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
-+
-+		<!-- Copy the Libraries folder, purging excessive files -->
-+		<SynchronizeDirectories
-+			Source="$(TargetDir)Libraries"
-+			Destination="$(_ActualOutputDirectory)/Libraries"
-+		/>
-+	</Target>
-+
-+	<!-- Organizes output copies of Project, NuGet, and directly referenced libraries under a single tidy folder. -->
-+	<Target Name="OrganizeAllReferences" AfterTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBuildDependencyFile;CopyFilesToOutputDirectory">
-+		<OrganizeReferenceDestinations
-+			BaseDirectory="Libraries"
-+			ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
-+		>
-+			<Output TaskParameter="ReferenceCopyLocalPaths" ItemName="ReferenceCopyLocalPaths_New" />
-+		</OrganizeReferenceDestinations>
-+
-+		<!-- This has to be done because the Output element above can only append items, and is unable to replace them. -->
-+		<ItemGroup>
-+			<ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
-+			<ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths_New)" />
-+		</ItemGroup>
-+	</Target>
-+
-+	<Target Name="OverwriteDevRuntimeTargets" AfterTargets="GenerateBuildRuntimeConfigurationFiles" Condition="$(GenerateRuntimeConfigDevFile) == 'true'">
- 		<PropertyGroup>
+ 	</ItemGroup>
+-	<Target Name="EditBin" AfterTargets="Build">
+-		<PropertyGroup>
 -			<EditBinOpts>/largeaddressaware</EditBinOpts>
 -			<DumpBin>/headers</DumpBin>
 -		</PropertyGroup>
@@ -154,16 +125,53 @@
 -		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TerrariaSteamPath)\$(OutputName).exe" />
 -		<Copy SourceFiles="$(TargetDir)$(OutputName).pdb" DestinationFolder="$(TerrariaSteamPath)" />
 -	</Target>
++
++	<!-- Installs the build's output into the relevant game folder. -->
++	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
++		<PropertyGroup>
++			<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
++		</PropertyGroup>
++
++		<!-- Copy files systematically to output folder -->
++		<ItemGroup>
++			<BinFiles Include="$(TargetDir)**" />
++		</ItemGroup>
++
++		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
++		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
++
++		<!-- Copy the Libraries folder, purging excessive files -->
++		<SynchronizeDirectories Source="$(TargetDir)Libraries" Destination="$(_ActualOutputDirectory)/Libraries" />
++	</Target>
++
++	<!-- Organize output copies of Project, NuGet, and directly referenced libraries under a single tidy folder. -->
++	<Target Name="OrganizeAllReferences" AfterTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBuildDependencyFile;CopyFilesToOutputDirectory">
++		<!-- Run the task. -->
++		<OrganizeReferenceDestinations BaseDirectory="$(LibrariesDirectory)" ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)">
++			<Output TaskParameter="ReferenceCopyLocalPaths" ItemName="ReferenceCopyLocalPaths_New" />
++		</OrganizeReferenceDestinations>
++
++		<!-- This has to be done because the Output element above can only append items, and is unable to replace them. -->
++		<ItemGroup>
++			<ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
++			<ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths_New)" />
++		</ItemGroup>
++	</Target>
++
++	<!-- Overwrites runtimeconfig.dev.json probing paths for the runtime to look only into our custom libraries directory. -->
++	<Target Name="OverwriteDevRuntimeTargets" AfterTargets="GenerateBuildRuntimeConfigurationFiles" Condition="$(GenerateRuntimeConfigDevFile) == 'true'">
++		<PropertyGroup>
 +			<DevRuntimeConfig>
 +{
 +	"runtimeOptions": {
 +		"additionalProbingPaths": [
-+			"Libraries"
++			"$(LibrariesDirectory)"
 +		]
 +	}
 +}
 +			</DevRuntimeConfig>
 +		</PropertyGroup>
++
 +		<WriteLinesToFile File="$(ProjectRuntimeConfigDevFilePath)" Lines="$(DevRuntimeConfig)" Overwrite="true" Encoding="UTF-8" />
 +	</Target>
 +

--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -130,24 +130,6 @@
 +	<UsingTask TaskName="SynchronizeDirectories" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="$(BuildTasksTaskFactory)" />
 +	<UsingTask TaskName="OrganizeReferenceDestinations" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="$(BuildTasksTaskFactory)" />
 +
-+	<!-- Installs the build's output into the relevant game folder. -->
-+	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
-+		<PropertyGroup>
-+			<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
-+		</PropertyGroup>
-+
-+		<!-- Copy files systematically to output folder -->
-+		<ItemGroup>
-+			<BinFiles Include="$(TargetDir)**" />
-+		</ItemGroup>
-+
-+		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
-+		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
-+
-+		<!-- Copy the Libraries folder, purging excessive files -->
-+		<SynchronizeDirectories Source="$(TargetDir)Libraries" Destination="$(_ActualOutputDirectory)/Libraries" />
-+	</Target>
-+
 +	<!-- Organize output copies of Project, NuGet, and directly referenced libraries under a single tidy folder. -->
 +	<Target Name="OrganizeAllReferences" AfterTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBuildDependencyFile;CopyFilesToOutputDirectory">
 +		<!-- Run the task. -->
@@ -177,6 +159,24 @@
 +		</PropertyGroup>
 +
 +		<WriteLinesToFile File="$(ProjectRuntimeConfigDevFilePath)" Lines="$(DevRuntimeConfig)" Overwrite="true" Encoding="UTF-8" />
++	</Target>
++
++	<!-- Installs the build's output into the relevant game folder. -->
++	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
++		<PropertyGroup>
++			<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
++		</PropertyGroup>
++
++		<!-- Copy files systematically to output folder -->
++		<ItemGroup>
++			<BinFiles Include="$(TargetDir)**" />
++		</ItemGroup>
++
++		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
++		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
++
++		<!-- Copy the Libraries folder, purging excessive files -->
++		<SynchronizeDirectories Source="$(TargetDir)Libraries" Destination="$(_ActualOutputDirectory)/Libraries" />
 +	</Target>
 +
  </Project>

--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/TerrariaNetCore/Terraria/Terraria.csproj
-@@ -1,90 +_,118 @@
+@@ -1,90 +_,122 @@
  <Project Sdk="Microsoft.NET.Sdk">
 +
  	<Import Project="../Configuration.targets" />
@@ -125,6 +125,10 @@
 -		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TerrariaSteamPath)\$(OutputName).exe" />
 -		<Copy SourceFiles="$(TargetDir)$(OutputName).pdb" DestinationFolder="$(TerrariaSteamPath)" />
 -	</Target>
++
++	<!-- Import tasks -->
++	<UsingTask TaskName="SynchronizeDirectories" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="$(BuildTasksTaskFactory)" />
++	<UsingTask TaskName="OrganizeReferenceDestinations" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="$(BuildTasksTaskFactory)" />
 +
 +	<!-- Installs the build's output into the relevant game folder. -->
 +	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">

--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -1,8 +1,11 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/TerrariaNetCore/Terraria/Terraria.csproj
-@@ -2,89 +_,134 @@
+@@ -1,90 +_,137 @@
+ <Project Sdk="Microsoft.NET.Sdk">
  	<Import Project="../Configuration.targets" />
  	<Import Project="../../WorkspaceInfo.targets" />
++	<Import Project="../../../tModBuildTasks/BuildTasks.targets" />
++
  	<PropertyGroup>
 -		<OutputType>WinExe</OutputType>
 +		<OutputType>Exe</OutputType>

--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/TerrariaNetCore/Terraria/Terraria.csproj
-@@ -1,90 +_,137 @@
+@@ -1,90 +_,142 @@
  <Project Sdk="Microsoft.NET.Sdk">
  	<Import Project="../Configuration.targets" />
  	<Import Project="../../WorkspaceInfo.targets" />
@@ -96,22 +96,27 @@
 +	<ItemGroup>
 +		<PackageReference Include="Steamworks.NET" Version="20.1.0" />
 +	</ItemGroup>
++
 +	<PropertyGroup>
 +		<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
 +	</PropertyGroup>
-+	<Target Name="CopyToSteamDir" AfterTargets="Build">
-+		<!-- copy files systematically to output folder -->
++
++	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
++		<!-- Copy files systematically to output folder -->
 +		<ItemGroup>
 +			<BinFiles Include="$(TargetDir)**" />
 +		</ItemGroup>
++
 +		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
 +		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
-+		<!-- todo, purge old libraries on other platforms -->
-+		<Exec Command="robocopy &quot;$(TargetDir)Libraries&quot; &quot;$(_ActualOutputDirectory)\Libraries&quot; /MIR" ContinueOnError="true" StandardOutputImportance="low" Condition="'$(OS)' == 'Windows_NT'">
-+			<Output TaskParameter="ExitCode" PropertyName="PurgeExitCode" />
-+		</Exec>
-+		<Warning Text="\Libraries file purge failed (robocopy /MIR Exit Code: $(PurgeExitCode)). Old files may not be removed." Condition="'$(PurgeExitCode)' != 2 AND '$(PurgeExitCode)' != 0" />
++
++		<!-- Copy the Libraries folder, purging excessive files -->
++		<SynchronizeDirectories
++			Source="$(TargetDir)Libraries"
++			Destination="$(_ActualOutputDirectory)/Libraries"
++		/>
 +	</Target>
++
 +	<!--See first answer in https://stackoverflow.com/questions/55946010/how-to-specify-output-folder-for-the-referenced-nuget-packages for how this was created-->
 +	<!--Dotnet Core 3.0 and later don't support subdirectory searching; so we use workaround https://github.com/dotnet/sdk/issues/10366#issuecomment-508854737 -->
 +	<Target Name="BuildRedirectNugetFilesToLib" AfterTargets="ResolveLockFileCopyLocalFiles">

--- a/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
+++ b/patches/TerrariaNetCore/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Terraria.csproj
 +++ src/TerrariaNetCore/Terraria/Terraria.csproj
-@@ -1,90 +_,142 @@
+@@ -1,90 +_,116 @@
  <Project Sdk="Microsoft.NET.Sdk">
  	<Import Project="../Configuration.targets" />
  	<Import Project="../../WorkspaceInfo.targets" />
@@ -15,7 +15,10 @@
  		<RootNamespace>Terraria</RootNamespace>
 -		<OutputName>Terraria</OutputName>
 +		<AssemblyName>Terraria</AssemblyName>
++
 +		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
++		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
++		<CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
  	</PropertyGroup>
  	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
 -		<OutputType>Exe</OutputType>
@@ -117,52 +120,22 @@
 +		/>
 +	</Target>
 +
-+	<!--See first answer in https://stackoverflow.com/questions/55946010/how-to-specify-output-folder-for-the-referenced-nuget-packages for how this was created-->
-+	<!--Dotnet Core 3.0 and later don't support subdirectory searching; so we use workaround https://github.com/dotnet/sdk/issues/10366#issuecomment-508854737 -->
-+	<Target Name="BuildRedirectNugetFilesToLib" AfterTargets="ResolveLockFileCopyLocalFiles">
++	<!-- Organizes output copies of Project, NuGet, and directly referenced libraries under a single tidy folder. -->
++	<Target Name="OrganizeAllReferences" AfterTargets="ResolveAssemblyReferences" BeforeTargets="GenerateBuildDependencyFile;CopyFilesToOutputDirectory">
++		<OrganizeReferenceDestinations
++			BaseDirectory="Libraries"
++			ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
++		>
++			<Output TaskParameter="ReferenceCopyLocalPaths" ItemName="ReferenceCopyLocalPaths_New" />
++		</OrganizeReferenceDestinations>
++
++		<!-- This has to be done because the Output element above can only append items, and is unable to replace them. -->
 +		<ItemGroup>
-+			<ReferenceCopyLocalPaths>
-+				<DirectoryInPackage>$([System.String]::Copy('%(PathInPackage)').Remove($([System.String]::Copy('%(PathInPackage)').LastIndexOf('/'))).Replace('/', '\'))</DirectoryInPackage>
-+			</ReferenceCopyLocalPaths>
-+		</ItemGroup>
-+		<ItemGroup>
-+			<ReferenceCopyLocalPaths>
-+				<DestinationSubDirectory>Libraries\$([System.String]::Copy('%(NuGetPackageID)').ToLower())\%(NuGetPackageVersion)\%(DirectoryInPackage)\</DestinationSubDirectory>
-+			</ReferenceCopyLocalPaths>
-+		</ItemGroup>
-+	</Target>
-+	<!-- In order to get pdbs/xmls while waiting for NET6, we use https://github.com/dotnet/sdk/issues/1458#issuecomment-420456386 -->
-+	<Target Name="_ResolveCopyLocalNuGetPackagePdbsAndXml" Condition="$(CopyLocalLockFileAssemblies) == true" AfterTargets="ResolveReferences">
-+		<ItemGroup>
-+			<ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdb')" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != '' and Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
-+			<ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != '' and Exists('%(RootDir)%(Directory)%(Filename).xml')" />
++			<ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
++			<ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths_New)" />
 +		</ItemGroup>
 +	</Target>
-+	<Target Name="RedirectAssemblyReferencesToLib" AfterTargets="ResolveAssemblyReferences">
-+		<ItemGroup>
-+			<!--To match deps.json for runtime resolving, paths must be of the form Libraries/<name>/<version>-->
-+			<!--Note that associated files, like pdbs/xmls won't be resolved properly here. Prefer nuget packages for that-->
-+			<ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ResolveAssemblyReference'">
-+				<DirectoryVersion>$([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').Remove($([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').IndexOf(", C"))).Substring($([System.String]::Copy('%(ReferenceCopyLocalPaths.FusionName)').IndexOf(","))).Substring(10))</DirectoryVersion>
-+			</ReferenceCopyLocalPaths>
-+			<ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ResolveAssemblyReference'">
-+				<DestinationSubDirectory>Libraries\%(ReferenceCopyLocalPaths.OriginalItemSpec)\%(ReferenceCopyLocalPaths.DirectoryVersion)\</DestinationSubDirectory>
-+			</ReferenceCopyLocalPaths>
-+		</ItemGroup>
-+	</Target>
-+	<Target Name="RedirectProjectReferencesToLib" AfterTargets="ResolveAssemblyReferences">
-+		<ItemGroup>
-+			<!--Version is bugged in deps.json for ProjectReferences, doesn't reflect AssemblyVersion for whatever reason. Uses 1.0.0-->
-+			<!--As well, FusionName isn't available, so alternate string manipulation to get Name-->
-+			<ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ProjectReference'">
-+				<VersionHack>1.0.0</VersionHack>
-+				<DllName>$([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').Remove($([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').IndexOf(".dll"))).SubString($([System.String]::Copy('%(ReferenceCopyLocalPaths.ResolvedFrom)').LastIndexOf("\"))).Substring(1))</DllName>
-+			</ReferenceCopyLocalPaths>
-+			<ReferenceCopyLocalPaths Condition="%(ReferenceCopyLocalPaths.ReferenceSourceTarget) == 'ProjectReference'">
-+				<DestinationSubDirectory>Libraries\%(ReferenceCopyLocalPaths.DllName)\%(ReferenceCopyLocalPaths.VersionHack)\</DestinationSubDirectory>
-+			</ReferenceCopyLocalPaths>
-+		</ItemGroup>
-+	</Target>
++
 +	<Target Name="OverwriteDevRuntimeTargets" AfterTargets="GenerateBuildRuntimeConfigurationFiles" Condition="$(GenerateRuntimeConfigDevFile) == 'true'">
  		<PropertyGroup>
 -			<EditBinOpts>/largeaddressaware</EditBinOpts>
@@ -180,6 +153,7 @@
 -		<Message Text="Copying $(OutputName) to Steam Dir..." Importance="high" />
 -		<Copy SourceFiles="$(TargetPath)" DestinationFiles="$(TerrariaSteamPath)\$(OutputName).exe" />
 -		<Copy SourceFiles="$(TargetDir)$(OutputName).pdb" DestinationFolder="$(TerrariaSteamPath)" />
+-	</Target>
 +			<DevRuntimeConfig>
 +{
 +	"runtimeOptions": {
@@ -191,5 +165,6 @@
 +			</DevRuntimeConfig>
 +		</PropertyGroup>
 +		<WriteLinesToFile File="$(ProjectRuntimeConfigDevFilePath)" Lines="$(DevRuntimeConfig)" Overwrite="true" Encoding="UTF-8" />
- 	</Target>
++	</Target>
++
  </Project>

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -52,7 +52,7 @@
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
  		<EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -50,24 +_,37 @@
+@@ -50,20 +_,32 @@
  		<EmbeddedResource Include="Microsoft/**" />
  	</ItemGroup>
  	<ItemGroup>
@@ -75,20 +75,23 @@
 +		<PackageReference Include="Hjson" Version="3.0.0" />
 +		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
  	</ItemGroup>
+ 
  	<PropertyGroup>
 -		<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
 +		<_ActualOutputDirectory>$(tModLoaderSteamPath)</_ActualOutputDirectory>
  	</PropertyGroup>
- 	<Target Name="CopyToSteamDir" AfterTargets="Build">
+ 
+ 	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
 +		<Delete Files="$(TargetDir)\tModPorter.runtimeconfig.json" />
 +		<Delete Files="$(TargetDir)\tModPorter.deps.json" />
- 		<!-- copy files systematically to output folder -->
+ 		<!-- Copy files systematically to output folder -->
  		<ItemGroup>
  			<BinFiles Include="$(TargetDir)**" />
- 		</ItemGroup>
+@@ -71,6 +_,7 @@
+ 
  		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
  		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
 +		<RemoveDir Directories="$(_ActualOutputDirectory)\Content" Condition="!Exists('$(TargetDir)\Content')" />
- 		<!-- todo, purge old libraries on other platforms -->
- 		<Exec Command="robocopy &quot;$(TargetDir)Libraries&quot; &quot;$(_ActualOutputDirectory)\Libraries&quot; /MIR" ContinueOnError="true" StandardOutputImportance="low" Condition="'$(OS)' == 'Windows_NT'">
- 			<Output TaskParameter="ExitCode" PropertyName="PurgeExitCode" />
+ 
+ 		<!-- Copy the Libraries folder, purging excessive files -->
+ 		<SynchronizeDirectories

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,14 +1,17 @@
 --- src/TerrariaNetCore/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -9,24 +_,27 @@
+@@ -9,27 +_,30 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
 -		<AssemblyName>Terraria</AssemblyName>
 +		<AssemblyName>tModLoader</AssemblyName>
+ 
 +		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 +		<UseAppHost>false</UseAppHost>
  		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
+ 		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+ 		<CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
  	</PropertyGroup>
 -	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
 -		<AssemblyName>$(AssemblyName)Server</AssemblyName>
@@ -39,7 +42,7 @@
  		<ProjectReference Include="../../../FNA/FNA.Core.csproj" />
  		<ProjectReference Include="../ReLogic/ReLogic.csproj" />
  		<EmbeddedResource Include="../ReLogic/bin/$(Configuration)/$(TargetFramework)/ReLogic.dll">
-@@ -40,8 +_,12 @@
+@@ -43,8 +_,12 @@
  		<Reference Include="NVorbis" />
  		<Reference Include="RailSDK.Net" />
  		<Reference Include="SteelSeriesEngineWrapper" />
@@ -52,7 +55,7 @@
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
  		<EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -50,20 +_,32 @@
+@@ -53,20 +_,32 @@
  		<EmbeddedResource Include="Microsoft/**" />
  	</ItemGroup>
  	<ItemGroup>
@@ -87,7 +90,7 @@
  		<!-- Copy files systematically to output folder -->
  		<ItemGroup>
  			<BinFiles Include="$(TargetDir)**" />
-@@ -71,6 +_,7 @@
+@@ -74,6 +_,7 @@
  
  		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
  		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,27 +1,32 @@
 --- src/TerrariaNetCore/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -9,27 +_,30 @@
+@@ -11,23 +_,34 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
 -		<AssemblyName>Terraria</AssemblyName>
 +		<AssemblyName>tModLoader</AssemblyName>
+-		<ApplicationIcon>Icon.ico</ApplicationIcon>
++		<ApplicationIcon>tModLoader.ico</ApplicationIcon>
+-
+-		<!-- Avoid overwriting Terraria.exe (if it's not Debug it's release) -->
+-		<AssemblyName Condition="$(Configuration.Contains('Debug'))">$(AssemblyName)Debug</AssemblyName>
+-		<AssemblyName Condition="!$(Configuration.Contains('Debug'))">$(AssemblyName)Release</AssemblyName>
+ 		<OutputName>$(AssemblyName)</OutputName>
+ 	</PropertyGroup>
  
-+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+ 	<!-- Build Configuration -->
+ 	<PropertyGroup>
 +		<UseAppHost>false</UseAppHost>
++		<GenerateDocumentationFile>true</GenerateDocumentationFile>
++		
+ 		<LibrariesDirectory>Libraries</LibrariesDirectory>
  		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
  		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
  		<CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
  	</PropertyGroup>
--	<PropertyGroup Condition="$(Configuration.Contains('Server'))">
--		<AssemblyName>$(AssemblyName)Server</AssemblyName>
--	</PropertyGroup>
--	<PropertyGroup Condition="$(Configuration.Contains('Debug'))">
--		<AssemblyName>$(AssemblyName)Debug</AssemblyName>
--	</PropertyGroup>
--	<!-- Avoid overwriting Terraria(Server).exe (if it's not Debug it's release) -->
--	<PropertyGroup Condition="!$(Configuration.Contains('Debug'))">
--		<AssemblyName>$(AssemblyName)Release</AssemblyName>
+ 
++	<!-- Versioning -->
 +	<PropertyGroup>
 +		<tMLVersion Condition="'$(TmlVersion)' == ''">9999.0</tMLVersion>
 +		<StableVersion Condition="'$(stableVersion)' == ''">0.0</StableVersion>
@@ -31,33 +36,49 @@
 +		<CommitSHA Condition="'$(CommitSHA)' == ''">unknown</CommitSHA>
 +		<BuildDate>$([System.DateTime]::UtcNow.ToBinary())</BuildDate>
 +		<SourceRevisionId>$(tMLVersion)|$(StableVersion)|$(BranchName)|$(BuildPurpose)|$(CommitSHA)|$(BuildDate)</SourceRevisionId>
- 	</PropertyGroup>
- 	<PropertyGroup>
- 		<OutputName>$(AssemblyName)</OutputName>
--		<ApplicationIcon>Icon.ico</ApplicationIcon>
-+		<ApplicationIcon>tModLoader.ico</ApplicationIcon>
- 	</PropertyGroup>
++	</PropertyGroup>
++
+ 	<!-- References -->
  	<ItemGroup>
-+		<Reference Include="Ionic.Zip.Reduced" />
  		<ProjectReference Include="../../../FNA/FNA.Core.csproj" />
- 		<ProjectReference Include="../ReLogic/ReLogic.csproj" />
- 		<EmbeddedResource Include="../ReLogic/bin/$(Configuration)/$(TargetFramework)/ReLogic.dll">
-@@ -43,8 +_,12 @@
+@@ -36,7 +_,9 @@
+ 			<Link>Libraries/ReLogic/ReLogic.dll</Link>
+ 			<LogicalName>Terraria.Libraries.ReLogic.ReLogic.dll</LogicalName>
+ 		</EmbeddedResource>
++		<ProjectReference Include="../../../tModPorter/tModPorter/tModPorter.csproj" />
+ 
++		<Reference Include="Ionic.Zip.Reduced" />
+ 		<Reference Include="CsvHelper" />
+ 		<Reference Include="Ionic.Zip.CF" />
+ 		<Reference Include="MP3Sharp" />
+@@ -44,12 +_,24 @@
  		<Reference Include="NVorbis" />
  		<Reference Include="RailSDK.Net" />
  		<Reference Include="SteelSeriesEngineWrapper" />
 +		<Reference Include="log4net" />
 +		<Reference Include="TerrariaHooks" />
-+		<ProjectReference Include="../../../tModPorter/tModPorter/tModPorter.csproj" />
+ 
+ 		<PackageReference Include="Steamworks.NET" Version="20.1.0" />
++		<PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.2.4" />
++		<PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2" />
++		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
++		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
++		<PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5 " />
++		<PackageReference Include="System.CodeDom" Version="6.0.0" />
++		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
++		<PackageReference Include="Hjson" Version="3.0.0" />
++		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
  	</ItemGroup>
+ 
+ 	<!-- Embedded Resources -->
  	<ItemGroup>
 +		<EmbeddedResource Include="**\*.png" />
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
  		<EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -53,20 +_,32 @@
- 		<EmbeddedResource Include="Microsoft/**" />
- 	</ItemGroup>
+@@ -60,18 +_,23 @@
+ 
+ 	<!-- Files -->
  	<ItemGroup>
 -		<None Remove="Libraries/Mono/**" />
 +		<Compile Remove="Libraries/Common/TerrariaHooks.dll" />
@@ -66,35 +87,26 @@
  		<Content Include="Libraries/Native/**" CopyToOutputDirectory="PreserveNewest" />
 +		<Content Include="release_extras/**" CopyToOutputDirectory="PreserveNewest" Link="%(RecursiveDir)%(Filename)%(Extension)" />
  	</ItemGroup>
- 	<ItemGroup>
-+		<PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.2.4" />
-+		<PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2" />
-+		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
-+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-+		<PackageReference Include="Microsoft.Win32.Registry" Version="6.0.0-preview.5.21301.5 " />
- 		<PackageReference Include="Steamworks.NET" Version="20.1.0" />
-+		<PackageReference Include="System.CodeDom" Version="6.0.0" />
-+		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
-+		<PackageReference Include="Hjson" Version="3.0.0" />
-+		<PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
- 	</ItemGroup>
  
- 	<PropertyGroup>
--		<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
-+		<_ActualOutputDirectory>$(tModLoaderSteamPath)</_ActualOutputDirectory>
- 	</PropertyGroup>
- 
+ 	<!-- Installs the build's output into the relevant game folder. -->
  	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
+ 		<PropertyGroup>
+-			<_ActualOutputDirectory>$(TerrariaSteamPath)</_ActualOutputDirectory>
++			<_ActualOutputDirectory>$(tModLoaderSteamPath)</_ActualOutputDirectory>
+ 		</PropertyGroup>
+ 
++		<!-- Exclude tModPorter's metadata. -->
 +		<Delete Files="$(TargetDir)\tModPorter.runtimeconfig.json" />
 +		<Delete Files="$(TargetDir)\tModPorter.deps.json" />
++		
  		<!-- Copy files systematically to output folder -->
  		<ItemGroup>
  			<BinFiles Include="$(TargetDir)**" />
-@@ -74,6 +_,7 @@
+@@ -79,6 +_,7 @@
  
  		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
  		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />
 +		<RemoveDir Directories="$(_ActualOutputDirectory)\Content" Condition="!Exists('$(TargetDir)\Content')" />
  
  		<!-- Copy the Libraries folder, purging excessive files -->
- 		<SynchronizeDirectories
+ 		<SynchronizeDirectories Source="$(TargetDir)Libraries" Destination="$(_ActualOutputDirectory)/Libraries" />

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Terraria.csproj
 +++ src/tModLoader/Terraria/Terraria.csproj
-@@ -7,24 +_,27 @@
+@@ -9,24 +_,27 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -39,7 +39,7 @@
  		<ProjectReference Include="../../../FNA/FNA.Core.csproj" />
  		<ProjectReference Include="../ReLogic/ReLogic.csproj" />
  		<EmbeddedResource Include="../ReLogic/bin/$(Configuration)/$(TargetFramework)/ReLogic.dll">
-@@ -38,8 +_,12 @@
+@@ -40,8 +_,12 @@
  		<Reference Include="NVorbis" />
  		<Reference Include="RailSDK.Net" />
  		<Reference Include="SteelSeriesEngineWrapper" />
@@ -52,7 +52,7 @@
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
  		<EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -48,24 +_,37 @@
+@@ -50,24 +_,37 @@
  		<EmbeddedResource Include="Microsoft/**" />
  	</ItemGroup>
  	<ItemGroup>

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -76,7 +76,7 @@
  		<EmbeddedResource Include="GameContent/Creative/Content/*" />
  		<EmbeddedResource Include="GameContent/Metadata/MaterialData/*" />
  		<EmbeddedResource Include="GameContent/WorldBuilding/*" />
-@@ -60,18 +_,23 @@
+@@ -60,10 +_,11 @@
  
  	<!-- Files -->
  	<ItemGroup>
@@ -88,6 +88,8 @@
 +		<Content Include="release_extras/**" CopyToOutputDirectory="PreserveNewest" Link="%(RecursiveDir)%(Filename)%(Extension)" />
  	</ItemGroup>
  
+ 	<!-- Import tasks -->
+@@ -73,9 +_,13 @@
  	<!-- Installs the build's output into the relevant game folder. -->
  	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
  		<PropertyGroup>
@@ -102,7 +104,7 @@
  		<!-- Copy files systematically to output folder -->
  		<ItemGroup>
  			<BinFiles Include="$(TargetDir)**" />
-@@ -79,6 +_,7 @@
+@@ -83,6 +_,7 @@
  
  		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
  		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -89,7 +89,7 @@
  	</ItemGroup>
  
  	<!-- Import tasks -->
-@@ -73,9 +_,13 @@
+@@ -104,9 +_,13 @@
  	<!-- Installs the build's output into the relevant game folder. -->
  	<Target Name="CopyToActualOutputDirectory" AfterTargets="Build">
  		<PropertyGroup>
@@ -104,7 +104,7 @@
  		<!-- Copy files systematically to output folder -->
  		<ItemGroup>
  			<BinFiles Include="$(TargetDir)**" />
-@@ -83,6 +_,7 @@
+@@ -114,6 +_,7 @@
  
  		<Message Text="Copying $(AssemblyName) to '$(_ActualOutputDirectory)'..." Importance="high" />
  		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(_ActualOutputDirectory)/%(RecursiveDir)" SkipUnchangedFiles="True" />

--- a/solutions/TerrariaNetCore.sln
+++ b/solutions/TerrariaNetCore.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "..\src\TerrariaN
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "..\FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "..\tModBuildTasks\tModLoader.BuildTasks.csproj", "{0FBF234A-8665-44FD-9B2C-88A2E43006F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,10 +29,10 @@ Global
 		{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F646F0CE-2C51-4610-B097-F16FB58CECC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F646F0CE-2C51-4610-B097-F16FB58CECC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F646F0CE-2C51-4610-B097-F16FB58CECC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F646F0CE-2C51-4610-B097-F16FB58CECC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FBF234A-8665-44FD-9B2C-88A2E43006F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FBF234A-8665-44FD-9B2C-88A2E43006F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FBF234A-8665-44FD-9B2C-88A2E43006F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FBF234A-8665-44FD-9B2C-88A2E43006F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/solutions/tModLoader.sln
+++ b/solutions/tModLoader.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter.Tests", "..\tMod
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoaderTests", "..\test\tModLoaderTests.csproj", "{D7D3267F-5E12-47C8-A853-5BA8D0F15890}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "..\tModBuildTasks\tModLoader.BuildTasks.csproj", "{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{D7D3267F-5E12-47C8-A853-5BA8D0F15890}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7D3267F-5E12-47C8-A853-5BA8D0F15890}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7D3267F-5E12-47C8-A853-5BA8D0F15890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tModBuildTasks/BuildTasks.targets
+++ b/tModBuildTasks/BuildTasks.targets
@@ -14,6 +14,7 @@
 		at the end of the build. If it's omitted, that can cause build failures
 		in subsequent builds because the task assembly can't be written by the next build.
 	-->
+	<UsingTask TaskName="SynchronizeDirectories" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="TaskHostFactory" />
 
 	<ItemGroup>
 		<!-- Add a ProjectReference to ensure that the task gets built before it needs to be called. -->

--- a/tModBuildTasks/BuildTasks.targets
+++ b/tModBuildTasks/BuildTasks.targets
@@ -15,6 +15,7 @@
 		in subsequent builds because the task assembly can't be written by the next build.
 	-->
 	<UsingTask TaskName="SynchronizeDirectories" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="TaskHostFactory" />
+	<UsingTask TaskName="OrganizeReferenceDestinations" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="TaskHostFactory" />
 
 	<ItemGroup>
 		<!-- Add a ProjectReference to ensure that the task gets built before it needs to be called. -->

--- a/tModBuildTasks/BuildTasks.targets
+++ b/tModBuildTasks/BuildTasks.targets
@@ -1,0 +1,23 @@
+<!--
+	Based on:
+	https://github.com/rainersigwald/build-task-in-solution-demo
+-->
+<Project>
+	<PropertyGroup>
+		<BuildTasksAssemblyName>tModLoader.BuildTasks</BuildTasksAssemblyName>
+		<BuildTasksAssemblyFile>$(MSBuildThisFileDirectory)\bin\$(BuildTasksAssemblyName).dll</BuildTasksAssemblyFile>
+		<BuildTasksProjectFile>$(MSBuildThisFileDirectory)\$(BuildTasksAssemblyName).csproj</BuildTasksProjectFile>
+	</PropertyGroup>
+
+	<!--
+		Using `TaskHostFactory` ensures that the task assembly will not be locked
+		at the end of the build. If it's omitted, that can cause build failures
+		in subsequent builds because the task assembly can't be written by the next build.
+	-->
+
+	<ItemGroup>
+		<!-- Add a ProjectReference to ensure that the task gets built before it needs to be called. -->
+		<ProjectReference Include="$(BuildTasksProjectFile)" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+</Project>

--- a/tModBuildTasks/BuildTasks.targets
+++ b/tModBuildTasks/BuildTasks.targets
@@ -7,15 +7,14 @@
 		<BuildTasksAssemblyName>tModLoader.BuildTasks</BuildTasksAssemblyName>
 		<BuildTasksAssemblyFile>$(MSBuildThisFileDirectory)\bin\$(BuildTasksAssemblyName).dll</BuildTasksAssemblyFile>
 		<BuildTasksProjectFile>$(MSBuildThisFileDirectory)\$(BuildTasksAssemblyName).csproj</BuildTasksProjectFile>
-	</PropertyGroup>
 
-	<!--
+		<!--
 		Using `TaskHostFactory` ensures that the task assembly will not be locked
 		at the end of the build. If it's omitted, that can cause build failures
 		in subsequent builds because the task assembly can't be written by the next build.
-	-->
-	<UsingTask TaskName="SynchronizeDirectories" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="TaskHostFactory" />
-	<UsingTask TaskName="OrganizeReferenceDestinations" AssemblyFile="$(BuildTasksAssemblyFile)" TaskFactory="TaskHostFactory" />
+		-->
+		<BuildTasksTaskFactory>TaskHostFactory</BuildTasksTaskFactory>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<!-- Add a ProjectReference to ensure that the task gets built before it needs to be called. -->

--- a/tModBuildTasks/IOUtils.cs
+++ b/tModBuildTasks/IOUtils.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Numerics;
+
+namespace tModLoader.BuildTasks;
+
+internal static class IOUtils
+{
+	/// <summary>
+	/// netstandard2.0 lacks Path.GetRelativePath. <br/>
+	/// This is a very simple replacement that assumes that 'path' derives from 'relativeTo'.
+	/// </summary>
+	public static string SubstringToRelativePath(string path, string relativeTo)
+	{
+		if (!path.StartsWith(relativeTo)) {
+			throw new ArgumentException($"Path '{path}' must derive from '{relativeTo}'.");
+		}
+
+		bool endsWithSeparator = relativeTo[relativeTo.Length - 1] is '/' or '\\';
+
+		return path.Substring(relativeTo.Length + (endsWithSeparator ? 0 : 1));
+	}
+
+	/// <summary>
+	/// Returns true if both files exist and have the same length. Does not check file contents.
+	/// </summary>
+	public static bool AreFilesSeeminglyTheSame(FileInfo fileA, FileInfo fileB)
+	{
+		return fileA.Exists && fileB.Exists
+			&& fileA.Length == fileB.Length;
+	}
+}

--- a/tModBuildTasks/IOUtils.cs
+++ b/tModBuildTasks/IOUtils.cs
@@ -23,11 +23,12 @@ internal static class IOUtils
 	}
 
 	/// <summary>
-	/// Returns true if both files exist and have the same length. Does not check file contents.
+	/// Returns true if both files exist and have the same length and write time. Does not check file contents.
 	/// </summary>
 	public static bool AreFilesSeeminglyTheSame(FileInfo fileA, FileInfo fileB)
 	{
 		return fileA.Exists && fileB.Exists
-			&& fileA.Length == fileB.Length;
+			&& fileA.Length == fileB.Length
+			&& fileA.LastWriteTimeUtc == fileB.LastWriteTimeUtc;
 	}
 }

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -60,10 +60,11 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 			else if (referenceSourceTarget == "ResolveAssemblyReference" && assemblyName != null) {
 				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, assemblyName.Version.ToString());
 			}
-			// NuGet Packages
+			// NuGet Packages - This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
 			else if (!string.IsNullOrEmpty(nugetPackageId)) {
-				// This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
-				destinationSubDirectory = Path.Combine(BaseDirectory, nugetPackageId, nugetPackageVersion, Path.GetDirectoryName(pathInPackage));
+				string? directoryInPackage = !string.IsNullOrEmpty(pathInPackage) ? Path.GetDirectoryName(pathInPackage) : string.Empty;
+
+				destinationSubDirectory = Path.Combine(BaseDirectory, nugetPackageId, nugetPackageVersion, directoryInPackage);
 			}
 			// Fallback
 			else {

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -54,21 +54,24 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 				// Version is bugged in deps.json for ProjectReferences, doesn't reflect AssemblyVersion for whatever reason. Uses 1.0.0.
 				const string VersionHack = "1.0.0";
 
-				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, VersionHack) + Path.DirectorySeparatorChar;
+				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, VersionHack);
 			}
 			// Direct Managed References
 			else if (referenceSourceTarget == "ResolveAssemblyReference" && assemblyName != null) {
-				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, assemblyName.Version.ToString()) + Path.DirectorySeparatorChar;
+				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, assemblyName.Version.ToString());
 			}
 			// NuGet Packages
 			else if (!string.IsNullOrEmpty(nugetPackageId)) {
 				// This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
-				destinationSubDirectory = Path.Combine(BaseDirectory, nugetPackageId, nugetPackageVersion, Path.GetDirectoryName(pathInPackage)) + Path.DirectorySeparatorChar;
+				destinationSubDirectory = Path.Combine(BaseDirectory, nugetPackageId, nugetPackageVersion, Path.GetDirectoryName(pathInPackage));
 			}
 			// Fallback
 			else {
 				continue;
 			}
+
+			// This MUST have a trailing slash!
+			destinationSubDirectory += Path.DirectorySeparatorChar;
 
 			// Set copying destination
 			item.SetMetadata("DestinationSubDirectory", destinationSubDirectory);

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Build.Framework;
+
+namespace tModLoader.BuildTasks;
+
+/// <summary>
+/// Organizes output copies of Project, NuGet, and directly referenced libraries under a single tidy folder.
+/// </summary>
+public sealed class OrganizeReferenceDestinations : TaskBase
+{
+	[Required]
+	public string BaseDirectory { get; set; } = null!;
+
+	//[Required]
+	//public string NativesDirectory { get; set; } = null!;
+
+	[Required, Output]
+	public ITaskItem[] ReferenceCopyLocalPaths { get; set; } = null!;
+
+	protected override void Run()
+	{
+		var items = ReferenceCopyLocalPaths;
+
+		for (int i = 0; i < items.Length; i++) {
+			var item = items[i];
+
+			string fileName = item.GetMetadata("Filename");
+			string fileExtension = item.GetMetadata("Extension");
+			string nugetPackageId = item.GetMetadata("NuGetPackageId");
+			string nugetPackageVersion = item.GetMetadata("NuGetPackageVersion");
+			string referenceSourceTarget = item.GetMetadata("ReferenceSourceTarget");
+			string runtimeIdentifier = item.GetMetadata("RuntimeIdentifier");
+			string fusionName = item.GetMetadata("FusionName");
+			string pathInPackage = item.GetMetadata("PathInPackage");
+
+			// PDBs & XMLs lack some metadata, attempt to get it from the paired .dll.
+			if (string.IsNullOrEmpty(fusionName) && !".dll".Equals(fileExtension, StringComparison.OrdinalIgnoreCase)) {
+				string dllSpec = Path.ChangeExtension(item.ItemSpec, ".dll");
+
+				if (items.FirstOrDefault(i => dllSpec.Equals(i.ItemSpec, StringComparison.OrdinalIgnoreCase)) is ITaskItem dllItem) {
+					fusionName = dllItem.GetMetadata("FusionName");
+				}
+			}
+
+			AssemblyName? assemblyName = !string.IsNullOrEmpty(fusionName) ? new AssemblyName(fusionName) : null;
+
+			string destinationSubDirectory;
+
+			// Project References
+			if (referenceSourceTarget == "ProjectReference" && assemblyName != null) {
+				// Version is bugged in deps.json for ProjectReferences, doesn't reflect AssemblyVersion for whatever reason. Uses 1.0.0.
+				const string VersionHack = "1.0.0";
+
+				destinationSubDirectory = $"{BaseDirectory}/{assemblyName.Name}/{VersionHack}/";
+			}
+			// Direct Managed References
+			else if (referenceSourceTarget == "ResolveAssemblyReference" && assemblyName != null) {
+				destinationSubDirectory = $"{BaseDirectory}/{assemblyName.Name}/{assemblyName.Version}/";
+			}
+			// NuGet Packages
+			else if (!string.IsNullOrEmpty(nugetPackageId)) {
+				// This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
+				if (!string.IsNullOrEmpty(pathInPackage)) {
+					destinationSubDirectory = $"{Path.GetDirectoryName($"{BaseDirectory}/{nugetPackageId}/{nugetPackageVersion}/{pathInPackage}").Replace('\\', '/')}/";
+				}
+				else {
+					destinationSubDirectory = $"{BaseDirectory}/{nugetPackageId}/{nugetPackageVersion}/";
+				}
+			}
+			// Fallback
+			else {
+				continue;
+			}
+
+			// Set copying destination
+			item.SetMetadata("DestinationSubDirectory", destinationSubDirectory);
+		}
+	}
+}

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -27,14 +27,14 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 		for (int i = 0; i < items.Length; i++) {
 			var item = items[i];
 
-			string fileName = item.GetMetadata("Filename");
 			string fileExtension = item.GetMetadata("Extension");
 			string nugetPackageId = item.GetMetadata("NuGetPackageId");
 			string nugetPackageVersion = item.GetMetadata("NuGetPackageVersion");
 			string referenceSourceTarget = item.GetMetadata("ReferenceSourceTarget");
-			string runtimeIdentifier = item.GetMetadata("RuntimeIdentifier");
 			string fusionName = item.GetMetadata("FusionName");
 			string pathInPackage = item.GetMetadata("PathInPackage");
+			//string fileName = item.GetMetadata("Filename");
+			//string runtimeIdentifier = item.GetMetadata("RuntimeIdentifier");
 
 			// PDBs & XMLs lack some metadata, attempt to get it from the paired .dll.
 			if (string.IsNullOrEmpty(fusionName) && !".dll".Equals(fileExtension, StringComparison.OrdinalIgnoreCase)) {
@@ -54,21 +54,16 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 				// Version is bugged in deps.json for ProjectReferences, doesn't reflect AssemblyVersion for whatever reason. Uses 1.0.0.
 				const string VersionHack = "1.0.0";
 
-				destinationSubDirectory = $"{BaseDirectory}/{assemblyName.Name}/{VersionHack}/";
+				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, VersionHack) + Path.DirectorySeparatorChar;
 			}
 			// Direct Managed References
 			else if (referenceSourceTarget == "ResolveAssemblyReference" && assemblyName != null) {
-				destinationSubDirectory = $"{BaseDirectory}/{assemblyName.Name}/{assemblyName.Version}/";
+				destinationSubDirectory = Path.Combine(BaseDirectory, assemblyName.Name, assemblyName.Version.ToString()) + Path.DirectorySeparatorChar;
 			}
 			// NuGet Packages
 			else if (!string.IsNullOrEmpty(nugetPackageId)) {
 				// This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
-				if (!string.IsNullOrEmpty(pathInPackage)) {
-					destinationSubDirectory = $"{Path.GetDirectoryName($"{BaseDirectory}/{nugetPackageId}/{nugetPackageVersion}/{pathInPackage}").Replace('\\', '/')}/";
-				}
-				else {
-					destinationSubDirectory = $"{BaseDirectory}/{nugetPackageId}/{nugetPackageVersion}/";
-				}
+				destinationSubDirectory = Path.Combine(BaseDirectory, nugetPackageId, nugetPackageVersion, Path.GetDirectoryName(pathInPackage)) + Path.DirectorySeparatorChar;
 			}
 			// Fallback
 			else {

--- a/tModBuildTasks/SynchronizeDirectories.cs
+++ b/tModBuildTasks/SynchronizeDirectories.cs
@@ -81,13 +81,13 @@ public class SynchronizeDirectories : TaskBase
 				action();
 				break;
 			}
-			catch (IOException e) {
+			catch (IOException e) when (e is not DirectoryNotFoundException or FileNotFoundException) {
 				if (attempt <= MaxAttempts) {
 					Thread.Sleep(DelayMs);
 					continue;
 				}
 
-				throw new IOException($"Failed to synchronize '{Destination}': {e.Message}", e);
+				throw new IOException($"Failed to synchronize '{Destination}' due to {e.GetType().Name}: {e.Message}", e);
 			}
 		}
 	}

--- a/tModBuildTasks/SynchronizeDirectories.cs
+++ b/tModBuildTasks/SynchronizeDirectories.cs
@@ -39,7 +39,10 @@ public class SynchronizeDirectories : TaskBase
 			string sourcePath = Path.Combine(Source, relativePath);
 
 			if (!File.Exists(sourcePath)) {
-				RunIOActionWIthRetries(file.Delete);
+				try {
+					RunIOActionWIthRetries(file.Delete);
+				}
+				catch (FileNotFoundException) { }
 			}
 		});
 

--- a/tModBuildTasks/SynchronizeDirectories.cs
+++ b/tModBuildTasks/SynchronizeDirectories.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
+
+namespace tModLoader.BuildTasks;
+
+/// <summary>
+/// Copies contents from one folder to another, additionally removing entries in the destination that aren't present in the source.
+/// </summary>
+public class SynchronizeDirectories : TaskBase
+{
+	[Required]
+	public string Source { get; set; } = string.Empty;
+
+	[Required]
+	public string Destination { get; set; } = string.Empty;
+
+	protected override void Run()
+	{
+		Source = Path.GetFullPath(Source);
+		Destination = Path.GetFullPath(Destination);
+
+		var source = new DirectoryInfo(Source);
+		var destination = new DirectoryInfo(Destination);
+
+		if (!source.Exists) {
+			Log.LogError($"Source directory '{Source}' doesn't exist!");
+			return;
+		}
+
+		destination.Create();
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+			WindowsImplementation();
+		}
+		else {
+			UnixImplementation();
+		}
+	}
+
+	private void WindowsImplementation()
+	{
+		// Robocopy is always present.
+		ExecuteAndWait(
+			"robocopy", @$"""{Source}"" ""{Destination}"" /MIR",
+			useShellExecute: true,
+			isErrorPredicate: static i => i >= 8
+		);
+	}
+
+	private static string? rsyncPath;
+
+	private void UnixImplementation()
+	{
+		// Rsync is not always present, and may need to be installed by the user.
+		rsyncPath ??= ExecuteAndWait("command", $"-v rsync", useShellExecute: false, redirectStdOutput: true)
+			.StandardOutput
+			.ReadToEnd()
+			.Trim();
+
+		if (!string.IsNullOrEmpty(rsyncPath)) {
+			ExecuteAndWait(rsyncPath, @$"-a --delete ""{Source}"" ""{Destination}""", useShellExecute: false);
+		}
+		else {
+			Log.LogMessage(MessageImportance.High, "\trsync was not found, using a slow fallback...");
+
+			// Is there a better fallback, aside for manually writing enumerations & hashchecks in C#?
+			ExecuteAndWait("rm", @$"-rf ""{Destination}""");
+			ExecuteAndWait("cp", @$"-R ""{Source}"" ""{Destination}""");
+		}
+	}
+
+	private Process ExecuteAndWait(string command, string args, bool useShellExecute = true, bool redirectStdOutput = false, Predicate<int>? isErrorPredicate = null)
+	{
+		var process = Process.Start(new ProcessStartInfo(command, args) {
+			UseShellExecute = useShellExecute,
+			RedirectStandardOutput = redirectStdOutput,
+			WindowStyle = ProcessWindowStyle.Hidden,
+		});
+
+		process.WaitForExit();
+
+		bool processErrored = (isErrorPredicate != null)
+			? isErrorPredicate.Invoke(process.ExitCode)
+			: (process.ExitCode != 0);
+
+		if (processErrored) {
+			Log.LogError($"Command '{command}{(!string.IsNullOrEmpty(args) ? $" {args}" : null)}' exited with code {process.ExitCode}.");
+		}
+
+		return process;
+	}
+}

--- a/tModBuildTasks/TaskBase.cs
+++ b/tModBuildTasks/TaskBase.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.Build.Utilities;
+
+namespace tModLoader.BuildTasks;
+
+public abstract class TaskBase : Task
+{
+	public sealed override bool Execute()
+	{
+		try {
+			Run();
+		}
+		catch (Exception e) {
+			Log.LogErrorFromException(e, true);
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+
+	protected abstract void Run();
+}

--- a/tModBuildTasks/tModLoader.BuildTasks.csproj
+++ b/tModBuildTasks/tModLoader.BuildTasks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<OutDir>bin</OutDir>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
### This PR has the following goals:
- Fix the `The expression """.Remove(-1)" cannot be evaluated.` build-time error, which has haunted TML devs & contributors for quite a while. I was going to work on a completely different PR, but couldn't, due to this hard-to-debug & random-to-resolve issue.
- Maximize readability of our main C# project file.
- Provide a simple way of introducing any other custom logic into our build pipelines for the future.

### This is all achieved by:
- Introducing a `netstandard2.0` project (currently `./tModBuildTasks/tModLoader.BuildTasks.csproj`) containing MSBuild tasks written in C#. The project is automatically built prior to `TML`/`TerrariaNetCore`.
- Rewriting contents of most of our "Targets" as C# Tasks, getting rid of XML tags that invoked .NET methods in the most unreadable way known to mankind. XML, the programming language.
- Prettifying `Terraria.csproj` with organizational & documentational comments, and a sense of space (in TerrariaNetCore & tModLoader steps).

### Checklist:
- [x] `TerrariaNetCore` builds & runs.
- [x] `tModLoader` builds & runs.
- [x] Confirmed to have no impact on the `Libraries` directory's layout.
- [x] Confirmed `TaskHostFactory`'s stability (MSBuild shouldn't keep a file handle on `tModLoader.BuildTasks.dll`).
    - [x] Works on my machine™️.
    - [x] Others' machines & IDEs.

Review one commit at a time, the sum diff isn't pretty.