### PR TITLE
Modded Toilet Fishing Fix

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5877,7 +5877,14 @@
  		if (result.BaitItemType == 2673)
  			return result;
  
-@@ -32894,12 +_,15 @@
+@@ -32890,16 +_,22 @@
+ 		if (canFloatInWater && wet)
+ 			num += 5;
+ 
++		/*
+ 		if (sitting.TryGetSittingBlock(this, out var tile) && ((tile.type == 15 && tile.frameY / 40 == 1) || tile.type == 497))
++		*/
++		if (sitting.TryGetSittingBlock(this, out var _) && sitting.details.IsAToilet) // Make modded toilets give the fishing boost as well
  			num += 5;
  
  		int num2 = result.BaitPower + result.PolePower + fishingSkill + num;


### PR DESCRIPTION
### What is the bug?
Modded toilets did not automatically grant the +5 fishing power bonus that vanilla toilets do.

### How did you fix the bug?
Changed the check to check `PlayerSittingHelper.details.IsToilet` instead of the hardcoded tile checks.

### Are there alternatives to your fix?
- An additional field could be added to `ExtraInfo`, allowing modders to control the fishing bonus and Poo creation separately.
- This change could be discarded entirely in favor of making modders manually add the fishing bonus, though I'm unsure which hook would be best off the top of my head.