### PR TITLE
Reimplement `DrawSunAndMoon` Patch for Custom ModMenu Sun and Moon Textures

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6164,27 +6164,17 @@
  		screenPosition.X = (int)screenPosition.X;
  		screenPosition.Y = (int)screenPosition.Y;
  		ClampScreenPositionToWorld();
-@@ -51877,12 +_,21 @@
- 
- 	private void DrawSunAndMoon(SceneArea sceneArea, Microsoft.Xna.Framework.Color moonColor, Microsoft.Xna.Framework.Color sunColor, float tempMushroomInfluence)
- 	{
-+		Texture2D value;
-+		Texture2D value2;
-+		ModMenu menu = MenuLoader.CurrentMenu;
--		Texture2D value = TextureAssets.Sun.Value;
-+		value = TextureAssets.Sun.Value;
- 		int num = moonType;
-+		if (gameMenu) {
-+			value = menu.SunTexture?.Value ?? TextureAssets.Sun.Value;
-+			value2 = menu.MoonTexture?.Value ?? TextureAssets.Moon[Utils.Clamp(num, 0, 8)].Value;
-+			goto SkipVanillaTextures;
-+		}
- 		if (!TextureAssets.Moon.IndexInRange(num))
+@@ -51883,6 +_,13 @@
  			num = Utils.Clamp(num, 0, 8);
  
--		Texture2D value2 = TextureAssets.Moon[num].Value;
-+		value2 = TextureAssets.Moon[num].Value;
-+		SkipVanillaTextures:
+ 		Texture2D value2 = TextureAssets.Moon[num].Value;
++
++		if (gameMenu) {
++			ModMenu menu = MenuLoader.CurrentMenu;
++			value = menu.SunTexture?.Value ?? value;
++			value2 = menu.MoonTexture?.Value ?? value2;
++		}
++
  		int num2 = sceneArea.bgTopY;
  		int num3 = (int)(time / 54000.0 * (double)(sceneArea.totalWidth + (float)(value.Width * 2))) - value.Width;
  		int num4 = 0;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6164,6 +6164,30 @@
  		screenPosition.X = (int)screenPosition.X;
  		screenPosition.Y = (int)screenPosition.Y;
  		ClampScreenPositionToWorld();
+@@ -51877,12 +_,21 @@
+ 
+ 	private void DrawSunAndMoon(SceneArea sceneArea, Microsoft.Xna.Framework.Color moonColor, Microsoft.Xna.Framework.Color sunColor, float tempMushroomInfluence)
+ 	{
++		Texture2D value;
++		Texture2D value2;
++		ModMenu menu = MenuLoader.CurrentMenu;
+-		Texture2D value = TextureAssets.Sun.Value;
++		value = TextureAssets.Sun.Value;
+ 		int num = moonType;
++		if (gameMenu) {
++			value = menu.SunTexture?.Value ?? TextureAssets.Sun.Value;
++			value2 = menu.MoonTexture?.Value ?? TextureAssets.Moon[Utils.Clamp(num, 0, 8)].Value;
++			goto SkipVanillaTextures;
++		}
+ 		if (!TextureAssets.Moon.IndexInRange(num))
+ 			num = Utils.Clamp(num, 0, 8);
+ 
+-		Texture2D value2 = TextureAssets.Moon[num].Value;
++		value2 = TextureAssets.Moon[num].Value;
++		SkipVanillaTextures:
+ 		int num2 = sceneArea.bgTopY;
+ 		int num3 = (int)(time / 54000.0 * (double)(sceneArea.totalWidth + (float)(value.Width * 2))) - value.Width;
+ 		int num4 = 0;
 @@ -51988,6 +_,8 @@
  				spriteBatch.Draw(TextureAssets.PumpkinMoon.Value, position2, new Microsoft.Xna.Framework.Rectangle(0, TextureAssets.PumpkinMoon.Width() * moonPhase, TextureAssets.PumpkinMoon.Width(), TextureAssets.PumpkinMoon.Width()), moonColor, num9, new Vector2(TextureAssets.PumpkinMoon.Width() / 2, TextureAssets.PumpkinMoon.Width() / 2), num8, SpriteEffects.None, 0f);
  			else if (snowMoon)


### PR DESCRIPTION
*Resolves #3971.*

### What is the bug?

 #3971

### How did you fix the bug?

Add back logic for overriding the sun and moon textures based on the current ModMenu (lost in the process of updating to 1.4.4.2).

### Are there alternatives to your fix?

Nothing important, just other ways to add the logic (e.g. setting value and value2 after vanilla sets them, but I decided to stick with the original patch).