### PR TITLE
Implement Caching for Mod.GetContent() Results

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -10,7 +10,7 @@ namespace Terraria.ModLoader;
 /// </summary>
 internal class ContentCache
 {
-	private static Dictionary<Type, IList> _cachedContentForAllMods = new();
+	private static readonly Dictionary<Type, IList> _cachedContentForAllMods = new();
 
 	internal static bool contentLoadingFinished;
 

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -67,8 +67,8 @@ internal class ContentCache
 
 	private static event Action OnUnload;
 
-	internal ContentCache(Mod source) {
-		_mod = source;
+	internal ContentCache(Mod mod) {
+		_mod = mod;
 	}
 
 	internal void Add(ILoadable loadable) {

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -20,16 +20,16 @@ internal class ContentCache
 	}
 
 	public static IEnumerable<T> GetContentForAllMods<T>() where T : ILoadable {
+		// Check of the cache already exists
+		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
+		if (_cachedContentForAllMods.TryGetValue(typeof(T), out IList cachedContent))
+			return (IReadOnlyList<T>)cachedContent;
+
 		if (!contentLoadingFinished) {
 			// Content has not fully loaded yet, so we can't rely on the cache.
 			// Return a lazy enumerable instead.
 			return ModLoader.Mods.SelectMany(static m => m.GetContent<T>());
 		}
-
-		// Check of the cache already exists
-		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
-		if (_cachedContentForAllMods.TryGetValue(typeof(T), out IList cachedContent))
-			return (IReadOnlyList<T>)cachedContent;
 
 		// Construct the cache
 		IReadOnlyList<T> content = ModLoader.Mods.SelectMany(static m => m.GetContent<T>()).ToList().AsReadOnly();
@@ -52,6 +52,11 @@ internal class ContentCache
 	public IEnumerable<ILoadable> GetContent() => _content.AsReadOnly();  // Prevent exposing the list via hard cast
 
 	public IEnumerable<T> GetContent<T>() where T : ILoadable {
+		// Check of the cache already exists
+		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
+		if (_cachedContent.TryGetValue(typeof(T), out IList cachedContent))
+			return (IReadOnlyList<T>)cachedContent;
+
 		if (_content.Count == 0) {
 			// Mod has not loaded yet
 			return Enumerable.Empty<T>();
@@ -62,11 +67,6 @@ internal class ContentCache
 			// Return a lazy enumerable instead.
 			return _content.OfType<T>();
 		}
-
-		// Check of the cache already exists
-		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
-		if (_cachedContent.TryGetValue(typeof(T), out IList cachedContent))
-			return (IReadOnlyList<T>)cachedContent;
 
 		// Construct the cache
 		IReadOnlyList<T> content = _content.OfType<T>().ToList().AsReadOnly();

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -39,7 +39,6 @@ internal class ContentCache
 
 	private readonly Mod _mod;
 	private readonly List<ILoadable> _content = new List<ILoadable>();
-	// nint is used instead of Type because it will have no collisions, and is faster to compare
 	private readonly Dictionary<Type, IList> _cachedContent = new();
 
 	internal ContentCache(Mod mod) {

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Terraria.ModLoader;
+
+/// <summary>
+/// Container object for <see cref="ILoadable"/> instances added for a <see cref="Mod"/>
+/// </summary>
+internal class ContentCache
+{
+	private class Cache<T> where T : ILoadable {
+		private static Dictionary<string, Cache<T>> _instancesPerMod;
+
+		public static Cache<T> FindOrCreate(ContentCache cache) {
+			_instancesPerMod ??= new();
+
+			string key = cache._mod.Name;
+
+			if (!_instancesPerMod.TryGetValue(key, out Cache<T> instance))
+				_instancesPerMod[key] = instance = new Cache<T>(cache);
+
+			return instance;
+		}
+
+		private readonly ContentCache _source;
+		private IReadOnlyList<T> _cache;
+
+		private Cache(ContentCache source) {
+			_source = source;
+		}
+
+		public IEnumerable<T> GetOrCacheContent() {
+			IEnumerable<T> lazyContent = _source._content.OfType<T>();
+
+			if (_source._mod.loading) {
+				// Content may not have fully loaded yet, so we can't rely on the cache.
+				// Return a lazy enumerable instead.
+				return lazyContent;
+			}
+
+			// Populate the cache if it's not already populated
+			if (_cache is null) {
+				_cache = lazyContent.ToList().AsReadOnly();
+				_source.OnClear += Clear;
+			}
+
+			return _cache;
+		}
+
+		private void Clear() {
+			_cache = null;
+		}
+	}
+
+	private readonly Mod _mod;
+	private readonly IList<ILoadable> _content = new List<ILoadable>();
+	private event Action OnClear;
+
+	internal ContentCache(Mod source) {
+		_mod = source;
+	}
+
+	internal void Add(ILoadable loadable) {
+		_content.Add(loadable);
+	}
+
+	internal void Clear() {
+		_content.Clear();
+		Interlocked.Exchange(ref OnClear, null)?.Invoke();
+	}
+
+	public IEnumerable<ILoadable> GetContent() => _content;
+
+	public IEnumerable<T> GetContent<T>() where T : ILoadable => Cache<T>.FindOrCreate(this).GetOrCacheContent();
+
+	public IEnumerable<ILoadable> Reverse() => _content.Reverse();
+}

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -80,7 +80,7 @@ internal class ContentCache
 	}
 
 	private readonly Mod _mod;
-	private readonly IList<ILoadable> _content = new List<ILoadable>();
+	private readonly List<ILoadable> _content = new List<ILoadable>();
 	private event Action OnClear;
 
 	private ContentCache(Mod mod) {
@@ -96,9 +96,9 @@ internal class ContentCache
 		Interlocked.Exchange(ref OnClear, null)?.Invoke();
 	}
 
-	public IEnumerable<ILoadable> GetContent() => _content;
+	public IEnumerable<ILoadable> GetContent() => _content.AsReadOnly();  // Prevent exposing the list via hard cast
 
 	public IEnumerable<T> GetContent<T>() where T : ILoadable => Cache<T>.GetOrCreate(this).GetOrCacheContent();
 
-	public IEnumerable<ILoadable> Reverse() => _content.Reverse();
+	public IEnumerable<ILoadable> Reverse() => Enumerable.Reverse(_content);
 }

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Terraria.ModLoader;
 
@@ -11,22 +10,17 @@ namespace Terraria.ModLoader;
 /// </summary>
 internal class ContentCache
 {
-	private static event Action OnUnload;
-	private static Dictionary<nint, IList> _cachedContentForAllMods = new();
+	private static Dictionary<Type, IList> _cachedContentForAllMods = new();
 
-	internal static bool hasLoadingStarted;
-	internal static bool loadingContent;
+	internal static bool contentLoadingFinished;
 
 	internal static void Unload() {
-		Interlocked.Exchange(ref OnUnload, null)?.Invoke();
-	}
-
-	private static void UnloadStaticCache() {
+		contentLoadingFinished = false;
 		_cachedContentForAllMods.Clear();
 	}
 
 	public static IEnumerable<T> GetContentForAllMods<T>() where T : ILoadable {
-		if (!hasLoadingStarted || loadingContent) {
+		if (!contentLoadingFinished) {
 			// Content has not fully loaded yet, so we can't rely on the cache.
 			// Return a lazy enumerable instead.
 			return ModLoader.Mods.SelectMany(static m => m.GetContent<T>());
@@ -34,25 +28,19 @@ internal class ContentCache
 
 		// Check of the cache already exists
 		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
-		nint handle = typeof(T).TypeHandle.Value;
-		if (_cachedContentForAllMods.TryGetValue(handle, out IList cachedContent))
+		if (_cachedContentForAllMods.TryGetValue(typeof(T), out IList cachedContent))
 			return (IReadOnlyList<T>)cachedContent;
 
 		// Construct the cache
-		if (_cachedContentForAllMods.Count == 0)
-			OnUnload += UnloadStaticCache;
-
 		IReadOnlyList<T> content = ModLoader.Mods.SelectMany(static m => m.GetContent<T>()).ToList().AsReadOnly();
-		_cachedContentForAllMods[handle] = (IList)content;
+		_cachedContentForAllMods[typeof(T)] = (IList)content;
 		return content;
 	}
 
 	private readonly Mod _mod;
 	private readonly List<ILoadable> _content = new List<ILoadable>();
 	// nint is used instead of Type because it will have no collisions, and is faster to compare
-	private readonly Dictionary<nint, IList> _cachedContent = new();
-
-	internal bool hasModLoadedYet;
+	private readonly Dictionary<Type, IList> _cachedContent = new();
 
 	internal ContentCache(Mod mod) {
 		_mod = mod;
@@ -65,7 +53,12 @@ internal class ContentCache
 	public IEnumerable<ILoadable> GetContent() => _content.AsReadOnly();  // Prevent exposing the list via hard cast
 
 	public IEnumerable<T> GetContent<T>() where T : ILoadable {
-		if (!hasModLoadedYet || _mod.loading) {
+		if (_content.Count == 0) {
+			// Mod has not loaded yet
+			return Enumerable.Empty<T>();
+		}
+
+		if (_mod.loading) {
 			// Content may not have fully loaded yet, so we can't rely on the cache.
 			// Return a lazy enumerable instead.
 			return _content.OfType<T>();
@@ -73,20 +66,16 @@ internal class ContentCache
 
 		// Check of the cache already exists
 		// It will already be a ReadOnlyList<T>, so it just needs to be cast back to it
-		nint handle = typeof(T).TypeHandle.Value;
-		if (_cachedContent.TryGetValue(handle, out IList cachedContent))
+		if (_cachedContent.TryGetValue(typeof(T), out IList cachedContent))
 			return (IReadOnlyList<T>)cachedContent;
 
 		// Construct the cache
-		if (_cachedContent.Count == 0)
-			OnUnload += UnloadInstanceCache;
-
 		IReadOnlyList<T> content = _content.OfType<T>().ToList().AsReadOnly();
-		_cachedContent[handle] = (IList)content;
+		_cachedContent[typeof(T)] = (IList)content;
 		return content;
 	}
 
-	private void UnloadInstanceCache() {
+	internal void Clear() {
 		_content.Clear();
 		_cachedContent.Clear();
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -25,14 +25,16 @@ internal class ContentCache
 		if (_cachedContentForAllMods.TryGetValue(typeof(T), out IList cachedContent))
 			return (IReadOnlyList<T>)cachedContent;
 
+		var query = ModLoader.Mods.SelectMany(static m => m.GetContent<T>());
+
 		if (!contentLoadingFinished) {
 			// Content has not fully loaded yet, so we can't rely on the cache.
 			// Return a lazy enumerable instead.
-			return ModLoader.Mods.SelectMany(static m => m.GetContent<T>());
+			return query;
 		}
 
 		// Construct the cache
-		IReadOnlyList<T> content = ModLoader.Mods.SelectMany(static m => m.GetContent<T>()).ToList().AsReadOnly();
+		IReadOnlyList<T> content = query.ToList().AsReadOnly();
 		_cachedContentForAllMods[typeof(T)] = (IList)content;
 		return content;
 	}
@@ -62,14 +64,16 @@ internal class ContentCache
 			return Enumerable.Empty<T>();
 		}
 
+		var query = _content.OfType<T>();
+
 		if (_mod.loading) {
 			// Content may not have fully loaded yet, so we can't rely on the cache.
 			// Return a lazy enumerable instead.
-			return _content.OfType<T>();
+			return query;
 		}
 
 		// Construct the cache
-		IReadOnlyList<T> content = _content.OfType<T>().ToList().AsReadOnly();
+		IReadOnlyList<T> content = query.ToList().AsReadOnly();
 		_cachedContent[typeof(T)] = (IList)content;
 		return content;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ContentCache.cs
@@ -13,7 +13,7 @@ internal class ContentCache
 	private class Cache<T> where T : ILoadable {
 		private static Dictionary<string, Cache<T>> _instancesPerMod;
 
-		public static Cache<T> FindOrCreate(ContentCache cache) {
+		public static Cache<T> GetOrCreate(ContentCache cache) {
 			if (_instancesPerMod is null) {
 				_instancesPerMod = new();
 				OnUnload += Unload;
@@ -98,7 +98,7 @@ internal class ContentCache
 
 	public IEnumerable<ILoadable> GetContent() => _content;
 
-	public IEnumerable<T> GetContent<T>() where T : ILoadable => Cache<T>.FindOrCreate(this).GetOrCacheContent();
+	public IEnumerable<T> GetContent<T>() where T : ILoadable => Cache<T>.GetOrCreate(this).GetOrCacheContent();
 
 	public IEnumerable<ILoadable> Reverse() => _content.Reverse();
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -203,7 +203,7 @@ public static class AssemblyManager
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
-			m.content = new ContentCache(m);
+			m.content = ContentCache.GetOrCreate(m);
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -202,7 +202,8 @@ public static class AssemblyManager
 			m.Side = mod.properties.side;
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
-			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null; 
+			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
+			m.content = new ContentCache(m);
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -203,7 +203,6 @@ public static class AssemblyManager
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
-			m.content = ContentCache.GetOrCreate(m);
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -202,7 +202,7 @@ public static class AssemblyManager
 			m.Side = mod.properties.side;
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
-			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
+			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null; 
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -36,7 +36,6 @@ partial class Mod
 		foreach (var loadable in Content.GetContent().Reverse()) {
 			loadable.Unload();
 		}
-
 		Content.Clear();
 
 		equipTextures.Clear();

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -33,7 +33,7 @@ partial class Mod
 
 		Unload();
 
-		foreach (var loadable in Content.GetContent().Reverse()) {
+		foreach (var loadable in GetContent().Reverse()) {
 			loadable.Unload();
 		}
 		Content.Clear();

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -20,7 +20,7 @@ partial class Mod
 
 	//Entities
 	internal readonly IDictionary<Tuple<string, EquipType>, EquipTexture> equipTextures = new Dictionary<Tuple<string, EquipType>, EquipTexture>();
-	internal readonly IList<ILoadable> content = new List<ILoadable>();
+	internal ContentCache content { get; set; }
 
 	internal void SetupContent()
 	{

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -20,7 +20,7 @@ partial class Mod
 
 	//Entities
 	internal readonly IDictionary<Tuple<string, EquipType>, EquipTexture> equipTextures = new Dictionary<Tuple<string, EquipType>, EquipTexture>();
-	internal ContentCache Content { get; set; }
+	internal ContentCache Content { get; private set; }
 
 	internal void SetupContent()
 	{
@@ -37,6 +37,7 @@ partial class Mod
 			loadable.Unload();
 		}
 		Content.Clear();
+		Content = null;
 
 		equipTextures.Clear();
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -37,6 +37,8 @@ partial class Mod
 			loadable.Unload();
 		}
 
+		Content.Clear();
+
 		equipTextures.Clear();
 
 		Assets?.Dispose();

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -20,7 +20,7 @@ partial class Mod
 
 	//Entities
 	internal readonly IDictionary<Tuple<string, EquipType>, EquipTexture> equipTextures = new Dictionary<Tuple<string, EquipType>, EquipTexture>();
-	internal ContentCache content { get; set; }
+	internal ContentCache Content { get; set; }
 
 	internal void SetupContent()
 	{
@@ -33,10 +33,9 @@ partial class Mod
 
 		Unload();
 
-		foreach (var loadable in content.Reverse()) {
+		foreach (var loadable in Content.GetContent().Reverse()) {
 			loadable.Unload();
 		}
-		content.Clear();
 
 		equipTextures.Clear();
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -151,13 +151,13 @@ public partial class Mod
 	/// Returns all registered content instances that are added by this mod.
 	/// <br/>This only includes the 'template' instance for each piece of content, not all the clones/new instances which get added to Items/Players/NPCs etc. as the game is played
 	/// </summary>
-	public IEnumerable<ILoadable> GetContent() => content;
+	public IEnumerable<ILoadable> GetContent() => content.GetContent();
 
 	/// <summary>
 	/// Returns all registered content instances that derive from the provided type that are added by this mod.
 	/// <br/>This only includes the 'template' instance for each piece of content, not all the clones/new instances which get added to Items/Players/NPCs etc. as the game is played
 	/// </summary>
-	public IEnumerable<T> GetContent<T>() where T : ILoadable => content.OfType<T>();
+	public IEnumerable<T> GetContent<T>() where T : ILoadable => content.GetContent<T>();
 
 	/// <summary> Attempts to find the template instance from this mod with the specified name (not the clone/new instance which gets added to Items/Players/NPCs etc. as the game is played). Caching the result is recommended.<para/>This will throw exceptions on failure. </summary>
 	/// <exception cref="KeyNotFoundException"/>

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -90,6 +90,10 @@ public partial class Mod
 
 	public PreJITFilter PreJITFilter { get; protected set; } = new PreJITFilter();
 
+	public Mod() {
+		Content = new ContentCache(this);
+	}
+
 	internal void AutoloadConfig()
 	{
 		if (Code == null)
@@ -142,7 +146,7 @@ public partial class Mod
 			return false;
 
 		instance.Load(this);
-		content.Add(instance);
+		Content.Add(instance);
 		ContentInstance.Register(instance);
 		return true;
 	}
@@ -151,13 +155,13 @@ public partial class Mod
 	/// Returns all registered content instances that are added by this mod.
 	/// <br/>This only includes the 'template' instance for each piece of content, not all the clones/new instances which get added to Items/Players/NPCs etc. as the game is played
 	/// </summary>
-	public IEnumerable<ILoadable> GetContent() => content.GetContent();
+	public IEnumerable<ILoadable> GetContent() => Content.GetContent();
 
 	/// <summary>
 	/// Returns all registered content instances that derive from the provided type that are added by this mod.
 	/// <br/>This only includes the 'template' instance for each piece of content, not all the clones/new instances which get added to Items/Players/NPCs etc. as the game is played
 	/// </summary>
-	public IEnumerable<T> GetContent<T>() where T : ILoadable => content.GetContent<T>();
+	public IEnumerable<T> GetContent<T>() where T : ILoadable => Content.GetContent<T>();
 
 	/// <summary> Attempts to find the template instance from this mod with the specified name (not the clone/new instance which gets added to Items/Players/NPCs etc. as the game is played). Caching the result is recommended.<para/>This will throw exceptions on failure. </summary>
 	/// <exception cref="KeyNotFoundException"/>

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -278,15 +278,11 @@ public static class ModContent
 	{
 		CacheVanillaState();
 
-		ContentCache.hasLoadingStarted = true;
-		ContentCache.loadingContent = true;
-
 		Interface.loadMods.SetLoadStage("tModLoader.MSLoading", ModLoader.Mods.Length);
 		LoadModContent(token, mod => {
 			if (mod.Code != Assembly.GetExecutingAssembly()) AssemblyManager.JITMod(mod);
 			ContentInstance.Register(mod);
 			mod.loading = true;
-			mod.Content.hasModLoadedYet = true;
 			mod.AutoloadConfig();
 			mod.PrepareAssets();
 			mod.Autoload();
@@ -295,7 +291,7 @@ public static class ModContent
 			mod.loading = false;
 		});
 
-		ContentCache.loadingContent = false;
+		ContentCache.contentLoadingFinished = true;
 
 		Interface.loadMods.SetLoadStage("tModLoader.MSResizing");
 		ResizeArrays();
@@ -437,10 +433,6 @@ public static class ModContent
 	internal static void UnloadModContent()
 	{
 		MenuLoader.Unload(); //do this early, so modded menus won't be active when unloaded
-
-		// Copied here in case mod loading is cancelled early
-		ContentCache.hasLoadingStarted = false;
-		ContentCache.loadingContent = false;
 
 		int i = 0;
 		foreach (var mod in ModLoader.Mods.Reverse()) {

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -453,6 +453,7 @@ public static class ModContent
 	{
 		MonoModHooks.Clear();
 		TypeCaching.Clear();
+		ContentCache.Unload();
 		ItemLoader.Unload();
 		EquipLoader.Unload();
 		PrefixLoader.Unload();


### PR DESCRIPTION
### What is the new feature?
This pull request implements an internal `Terraria.ModLoader.ContentCache` type that changes how `Mod` adds and gets its `ILoadable`s.

### Why should this be part of tModLoader?
`Mod.GetContent<T>()` has been reported to be [causing lag when used frequently](https://discord.com/channels/103110554649894912/445276626352209920/1191938315620991046).  These changes to `Mod` hope to make this a non-issue.

### Are there alternative designs?
A simple dictionary in a generic class could be an alternative design, however the code present in this pull request is the only thing that I could come up with.

### Sample usage for the new feature
N/A, internal API change

### ExampleMod updates
N/A, internal API change