### PR TITLE
Fix "is_in_docker command not found" error in manage-tModLoaderServer.sh

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -17,7 +17,7 @@ function popd {
 
 # NOTE: There is seemingly no official documentation on this file but other more "official" software does this same check.
 # See: https://github.com/moby/moby/blob/v24.0.5/libnetwork/drivers/bridge/setup_bridgenetfiltering.go#L162-L165
-function is_in_docker {
+function is_in_docker() {
 	if [[ -f /.dockerenv ]]; then
 		return 0
 	fi


### PR DESCRIPTION
### What is the bug?
A function not properly typed in the dedicated server management script.

### How did you fix the bug?
By  adding parentheses.

### Are there alternatives to your fix?
N/A
