### PR TITLE
Remove redundant and erroneous PPID reassignment in launch script

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
@@ -2,5 +2,4 @@
 cd "$(dirname "$0")"
 
 chmod a+x ./LaunchUtils/ScriptCaller.sh
-# forward our parent process id to the child in case ScriptCaller needs to kill the parent to break free of steam's process lifetime tracker (reaper)
-PPID=$PPID ./LaunchUtils/ScriptCaller.sh "$@" &
+./LaunchUtils/ScriptCaller.sh "$@" &


### PR DESCRIPTION
### What is the bug?

`PPID` is a readonly variable, and cannot be reassigned. Our attempt to do so was erroneous. Most of the time bash carries on anyway, but this creates a misleading error in the logs.

```
/home/cb/.local/share/Steam/steamapps/common/tModLoader/start-tModLoader.sh: line 6: PPID: readonly variable
```

The bug has been present since the initial implementation in https://github.com/tModLoader/tModLoader/pull/2380/commits/c06e4338b9f592be63e6165e521de2a207febbf3#diff-e97dbf4a5db5bcbb88768f7ee813b288259c7947f7ca24a468d1104942f991b9

Somehow @covers1624 and I missed the error message (and the fact it didn't do anything and wasn't needed) in our testing

### How did you fix the bug?

Removed the offending code. I validated that steam playtime tracking for Terraria continues to work as expected on both Mac and Linux, and that `$PPID` is still the same without the explicit pass-through (because `./` execution runs in the same shell process).

### Are there alternatives to your fix?

No