### PR TITLE
Automatically switch to x86 architecture when Rosetta is present

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/BashUtils.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/BashUtils.sh
@@ -5,6 +5,7 @@ root_dir="$(dirname "$(pwd -P)")"
 
 # Read uname into a variable used in various places
 _uname=$(uname)
+_arch=$(uname -m)
 
 # Sourced from dotnet-install.sh
 # Check if a program is present or not

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -8,9 +8,10 @@ cd "$(dirname "$0")"
 
 echo "You are on platform: \"$_uname\" arch: \"$_arch\""
 
-# Detect arm64 launches and the presence of rosetta (stolen from the dotnet official install script)
+# Detect arm64 launches and the presence of Rosetta (oahd running on the system is how the dotnet official install script does it)
 if [ "$_arch" = "arm64" ] && [ "$(/usr/bin/pgrep oahd >/dev/null 2>&1;echo $?)" -eq 0 ]; then
-	echo "arm64 detected, restarting under arch -x86_64"
+	echo "arm64 environment with Rosetta detected, restarting under arch -x86_64"
+	# Note this only changes the environment, so that dotnet install scripts download an x86 version. Launching an x86 process from an arm shell or vice versa does not require using arch, or otherwise intentionally invoking Rosetta.
 	exec arch -x86_64 ./ScriptCaller.sh "$@"
 fi
 
@@ -72,7 +73,7 @@ else
 		echo "A Windows dotnet executable was detected, possibly from a previous Proton launch. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
 		mkdir "$dotnet_dir"
-	elif [[ "$(file "$install_dir/dotnet")" == *"arm64"* ]]; then
+	elif [[ "$_arch" != "arm64" ]] && [[ "$(file "$install_dir/dotnet")" == *"arm64"* ]]; then
 		echo "An arm64 install of dotnet was detected. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
 		mkdir "$dotnet_dir"

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -6,7 +6,13 @@
 cd "$(dirname "$0")"
 . ./BashUtils.sh
 
-echo "You are on platform: \"$_uname\""
+echo "You are on platform: \"$_uname\" arch: \"$_arch\""
+
+# Detect arm64 launches and the presence of rosetta (stolen from the dotnet official install script)
+if [ "$_arch" = "arm64" ] && [ "$(/usr/bin/pgrep oahd >/dev/null 2>&1;echo $?)" -eq 0 ]; then
+	echo "arm64 detected, restarting under arch -x86_64"
+	exec arch -x86_64 ./ScriptCaller.sh "$@"
+fi
 
 LaunchLogs="$root_dir/tModLoader-Logs"
 
@@ -64,6 +70,10 @@ if [[ "$_uname" == *"_NT"* ]]; then
 else
 	if [[ -f "$install_dir/dotnet.exe" ]]; then
 		echo "A Windows dotnet executable was detected, possibly from a previous Proton launch. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
+		rm -rf "$dotnet_dir"
+		mkdir "$dotnet_dir"
+	elif [[ "$(file "$install_dir/dotnet")" == *"arm64"* ]]; then
+		echo "An arm64 install of dotnet was detected. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
 		mkdir "$dotnet_dir"
 	fi


### PR DESCRIPTION
### What is the new feature?

On M1 Macs, when `./start-tModLoader.sh` is launched via terminal or otherwise outside of steam, the start scripts will automatically detect the `arm64` architecture and restart under `x86_64`

### Why should this be part of tModLoader?

- #3986 
- #3998
- Developers needing custom start scripts

### Are there alternative designs?

Not that I can think of

### Sample usage for the new feature

`./start-tModLoader.sh` in a terminal where `arch` reports `arm64` on an M1 Mac

