### PR TITLE
Added fallbacks for assumed GOG default paths, Fix #3526

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -381,6 +381,22 @@ public partial class Main
 			if (!Directory.Exists(vanillaContentFolder)) {
 				vanillaContentFolder = Platform.IsOSX ? "../Terraria.app/Contents/Resources/Content" : "../Content"; // Nested Manual Install
 			}
+
+			// Fallback to default GOG install locations
+			if (!Directory.Exists(vanillaContentFolder)) {
+				if (Platform.IsWindows) {
+					vanillaContentFolder = Path.Combine(@"c:\", "Program Files (x86)", "GOG Galaxy", "Games", "Terraria", "Content");
+					if (!Directory.Exists(vanillaContentFolder))
+						vanillaContentFolder = Path.Combine(@"c:\", "GOG Games", "Terraria", "Content");
+				}
+				else if (Platform.IsLinux) {
+					vanillaContentFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "GOG Games", "Terraria", "Content");
+				}
+				else {
+					vanillaContentFolder = Path.Combine("/Applications", "Terraria.app", "Contents", "Resources", "Content");
+				}
+			}
+
 			Logging.tML.Info("Content folder of Terraria GOG Install Location assumed to be: " + Path.GetFullPath(vanillaContentFolder));
 		}
 

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -376,27 +376,7 @@ public partial class Main
 			vanillaContentFolder = Path.Combine(Steam.GetSteamTerrariaInstallDir(), "Content");
 		}
 		else {
-			vanillaContentFolder = Platform.IsOSX ? "../Terraria/Terraria.app/Contents/Resources/Content" : "../Terraria/Content"; // Side-by-Side Manual Install
-
-			if (!Directory.Exists(vanillaContentFolder)) {
-				vanillaContentFolder = Platform.IsOSX ? "../Terraria.app/Contents/Resources/Content" : "../Content"; // Nested Manual Install
-			}
-
-			// Fallback to default GOG install locations
-			if (!Directory.Exists(vanillaContentFolder)) {
-				if (Platform.IsWindows) {
-					vanillaContentFolder = Path.Combine(@"c:\", "Program Files (x86)", "GOG Galaxy", "Games", "Terraria", "Content");
-					if (!Directory.Exists(vanillaContentFolder))
-						vanillaContentFolder = Path.Combine(@"c:\", "GOG Games", "Terraria", "Content");
-				}
-				else if (Platform.IsLinux) {
-					vanillaContentFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "GOG Games", "Terraria", "Content");
-				}
-				else {
-					vanillaContentFolder = Path.Combine("/Applications", "Terraria.app", "Contents", "Resources", "Content");
-				}
-			}
-
+			vanillaContentFolder = Path.Combine(Path.GetDirectoryName(InstallVerifier.vanillaExePath), "Content");
 			Logging.tML.Info("Content folder of Terraria GOG Install Location assumed to be: " + Path.GetFullPath(vanillaContentFolder));
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -145,7 +145,7 @@ internal static class InstallVerifier
 		// If .exe not present, check Terraria directory (Side-by-Side Manual Install)
 		vanillaPath = Path.Combine(vanillaPath, "Terraria");
 		if (Platform.IsOSX) {
-			// GOG installs to /Applications/Terraria.app, Steam installs to /Applications/Terraria/Terraria.app
+			// GOG installs to /Applications/Terraria.app, Steam installs to /Library/Application Support/Steam/steamapps/common/Terraria/Terraria.app
 			// Vanilla .exe files are in /Contents/Resources/, not /Contents/MacOS/
 			if (Directory.Exists("../Terraria/Terraria.app/")) {
 				vanillaPath = "../Terraria/Terraria.app/Contents/Resources/";
@@ -153,6 +153,23 @@ internal static class InstallVerifier
 			else if (Directory.Exists("../Terraria.app/")) {
 				vanillaPath = "../Terraria.app/Contents/Resources/";
 			}
+		}
+
+		if (CheckForExe(vanillaPath, out exePath))
+			return true;
+
+		// Fallback to default GOG install locations
+		if (Platform.IsWindows) {
+			vanillaPath = Path.Combine(@"c:\", "Program Files (x86)", "GOG Galaxy", "Games", "Terraria");
+			if (CheckForExe(vanillaPath, out exePath))
+				return true;
+			vanillaPath = Path.Combine(@"c:\", "GOG Games", "Terraria");
+		}
+		else if (Platform.IsLinux) {
+			vanillaPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "GOG Games", "Terraria");
+		}
+		else {
+			vanillaPath = Path.Combine("/Applications", "Terraria.app", "Contents", "Resources");
 		}
 
 		return CheckForExe(vanillaPath, out exePath);

--- a/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/InstallVerifier.cs
@@ -19,7 +19,7 @@ internal static class InstallVerifier
 	private static string VanillaExe = "Terraria.exe";
 	private const string TerrariaVersion = "1.4.4.9";
 	private static string CheckExe = $"Terraria_v{TerrariaVersion}.exe"; // This should match the hashes. {Main.versionNumber}
-	private static string vanillaExePath;
+	internal static string vanillaExePath; // Only reliable for GOG installs
 
 	public static DistributionPlatform DistributionPlatform;
 


### PR DESCRIPTION
Added fallbacks to default gog install locations so gog users can install tmodloader wherever they want.

Need to verify some paths, especially the mac gog lack of a Terraria folder containing the Terraria.app app bundle folder.

