### PR TITLE
Fix #3980 (Show class name in GetLoadableTypesException)

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -329,9 +329,9 @@ public static class AssemblyManager
 					.Select(mType => asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false))
 					.ToArray());
 		}
-		catch (Exception e) when (e is not Exceptions.GetLoadableTypesException) {
+		catch (Exception e) {
 			throw new Exceptions.GetLoadableTypesException(
-				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n" + e.Message,
+				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (e.Data["type"] is Type type ? $"The \"{type.FullName}\" class caused this error.\n\n" : "") + e.Message,
 				e
 			);
 		}
@@ -357,10 +357,8 @@ public static class AssemblyManager
 			return type.GetInterfaces().All(i => IsLoadable(mod, i));
 		}
 		catch (FileNotFoundException e) {
-			throw new Exceptions.GetLoadableTypesException(
-				$"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled.\n\nThe \"{type.FullName}\" class caused this error." + "\n\n" + e.Message,
-				e
-			);
+			e.Data["type"] = type;
+			throw;
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -328,7 +328,7 @@ public static class AssemblyManager
 					.Select(mType => asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false))
 					.ToArray());
 		}
-		catch (Exception e) {
+		catch (Exception e) when (e is not Exceptions.GetLoadableTypesException) {
 			throw new Exceptions.GetLoadableTypesException(
 				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n" + e.Message,
 				e
@@ -338,18 +338,26 @@ public static class AssemblyManager
 
 	private static bool IsLoadable(ModLoadContext mod, Type type)
 	{
-		foreach (var attr in type.GetCustomAttributesData()) {
-			if (attr.AttributeType.AssemblyQualifiedName == typeof(ExtendsFromModAttribute).AssemblyQualifiedName) {
-				var modNames = (IEnumerable<CustomAttributeTypedArgument>)attr.ConstructorArguments[0].Value;
-				if (!modNames.All(v => mod.IsModDependencyPresent((string)v.Value)))
-					return false;
+		try {
+			foreach (var attr in type.GetCustomAttributesData()) {
+				if (attr.AttributeType.AssemblyQualifiedName == typeof(ExtendsFromModAttribute).AssemblyQualifiedName) {
+					var modNames = (IEnumerable<CustomAttributeTypedArgument>)attr.ConstructorArguments[0].Value;
+					if (!modNames.All(v => mod.IsModDependencyPresent((string)v.Value)))
+						return false;
+				}
 			}
+
+			if (type.BaseType != null && !IsLoadable(mod, type.BaseType))
+				return false;
+
+			return type.GetInterfaces().All(i => IsLoadable(mod, i));
 		}
-
-		if (type.BaseType != null && !IsLoadable(mod, type.BaseType))
-			return false;
-
-		return type.GetInterfaces().All(i => IsLoadable(mod, i));
+		catch (FileNotFoundException e) {
+			throw new Exceptions.GetLoadableTypesException(
+				$"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled.\nThe \"{type.FullName}\" class caused this error." + "\n" + e.Message,
+				e
+			);
+		}
 	}
 
 	internal static void JITMod(Mod mod) => JITAssemblies(GetModAssemblies(mod.Name), mod.PreJITFilter);

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -358,7 +358,7 @@ public static class AssemblyManager
 		}
 		catch (FileNotFoundException e) {
 			throw new Exceptions.GetLoadableTypesException(
-				$"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled.\nThe \"{type.FullName}\" class caused this error." + "\n" + e.Message,
+				$"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled.\n\nThe \"{type.FullName}\" class caused this error." + "\n\n" + e.Message,
 				e
 			);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -351,6 +351,9 @@ public static class AssemblyManager
 			if (type.BaseType != null && !IsLoadable(mod, type.BaseType))
 				return false;
 
+			if (type.DeclaringType != null && !IsLoadable(mod, type.DeclaringType))
+				return false;
+
 			return type.GetInterfaces().All(i => IsLoadable(mod, i));
 		}
 		catch (FileNotFoundException e) {


### PR DESCRIPTION
~~Replicated the error by inheriting from a class in a mod that was not loaded. The stacktrace doesn't match the reported error, however, so I still need to verify if the `asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false)` should be try-catched as well.~~

A previous commit, #4033, fixed some related errors, but inheritance issues still persist.

The diff is a little hard to follow:

IsLoadable was augmented to throw an error with the classname to help modders locate the issue.

The following code was added to handle nested classes of inheriting classes. (`<>c` stuff)
```cs
if (type.DeclaringType != null && !IsLoadable(mod, type.DeclaringType))
	return false;
```
	
The following code was used to test. Variations of this code with lambdas was tested to ensure the fixes worked in tandem for their respective use-cases.
```cs
public class InheritsFromCSB : CheatSheet.CheatSheetButton
{
	public InheritsFromCSB(Asset<Texture2D> texture) : base(texture) {
			
	}
}

public class InheritsFromInheritsFromCSB : InheritsFromCSB
{
	public InheritsFromInheritsFromCSB(Asset<Texture2D> texture) : base(texture) {
		On_Player.PickTile += (On_Player.orig_PickTile orig, Player self, int x, int y, int pickPower) => {
			orig(self, x, y, pickPower);
		};
	}
}
```
A modder fixing this code only needs to annotate `InheritsFromCSB` with `[ExtendsFromMod("CheatSheet")]`. The class that inherits from `InheritsFromCSB` will not need to be annotated.

Expected Error Message:
![image](https://github.com/tModLoader/tModLoader/assets/4522492/985be8b8-1290-41e2-b896-cc90c7d8704b)
