### PR TITLE
Make type 0 entities inactive in SetDefaults and TurnToAir

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1901,6 +1901,15 @@
  		placeStyle = 0;
  		buffTime = 0;
  		buffType = 0;
+@@ -47366,7 +_,7 @@
+ 		noUseGraphic = false;
+ 		lifeRegen = 0;
+ 		shootSpeed = 0f;
+-		active = true;
++		active = Type != 0;
+ 		alpha = 0;
+ 		ammo = AmmoID.None;
+ 		useAmmo = AmmoID.None;
 @@ -47426,6 +_,9 @@
  
  	public Color GetAlpha(Color newColor)
@@ -2240,10 +2249,11 @@
  	public void ClearNameOverride()
  	{
  		_nameOverride = null;
-@@ -49309,6 +_,9 @@
+@@ -49309,6 +_,10 @@
  		dye = 0;
  		shoot = 0;
  		mountType = -1;
++		active = false;
 +
 +		ModItem = null;
 +		_globals = null;

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -790,6 +790,15 @@
  		setFrameSize = false;
  		netSkip = -2;
  		realLife = -1;
+@@ -2254,7 +_,7 @@
+ 		boss = false;
+ 		noTileCollide = false;
+ 		rotation = 0f;
+-		active = true;
++		active = Type != 0;
+ 		alpha = 0;
+ 		color = default(Color);
+ 		collideX = false;
 @@ -6970,7 +_,9 @@
  			DeathSound = SoundID.NPCDeath1;
  			npcSlots = 0.1f;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -427,6 +427,15 @@
  		ownerHitCheck = false;
  		hide = false;
  		lavaWet = false;
+@@ -312,7 +_,7 @@
+ 		alpha = 0;
+ 		glowMask = -1;
+ 		type = Type;
+-		active = true;
++		active = Type != 0;
+ 		rotation = 0f;
+ 		scale = 1f;
+ 		owner = 255;
 @@ -1167,6 +_,8 @@
  			magic = true;
  		}


### PR DESCRIPTION
### What is the new feature?

Is it a new feature? Is it a bug fix? Arguably both!
`SetDefaults(0)` and `TurnToAir()` will now set `active` to `false` for `NPC`, `Projectile` and `Item`.

### Why should this be part of tModLoader?

This should reduce the incidences of iterating `Main.npc/item/projectile`, doing an `active` check, and then trying to `GetGlobal` only to get an exception because whoops, there's an `active` entity with `type == 0` and those dummy entities have no globals!

Please note that `type == 0` entities really are dummy placeholders, and not having globals is a performance feature, not a bug. Hooks already won't run on them, so making them inactive by default shouldn't hurt anyone unless they have some really bad hacks that shouldn't have worked in the first place.

Oh, this is also coming in 1.4.5, I just thought I'd forward port it because who knows when that'll be.

### Are there alternative designs?

Nope

### Sample usage for the new feature

You don't have to do anything. If you were already doing `Type != 0` checks before every `GetGlobal` or using `TryGetGlobal` the extra defensive programming won't hurt you, but it should be less necessary.

### ExampleMod updates

None