### PR TITLE
Description Parameter Interpolation

### DIFF
--- a/ExampleMod/description.txt
+++ b/ExampleMod/description.txt
@@ -1,3 +1,9 @@
 Learn how to mod with tModLoader by exploring the source code for this mod.
 
 You can find the source code at https://github.com/tModLoader/tModLoader/tree/1.4.4/ExampleMod
+
+You can interpolate these values into a mod description:
+- ModVersion: {ModVersion}
+- ModHomepage: {ModHomepage}
+- tMLVersion: {tMLVersion}
+- tMLBuildPurpose: {tMLBuildPurpose}

--- a/ExampleMod/description_workshop.txt
+++ b/ExampleMod/description_workshop.txt
@@ -1,3 +1,9 @@
 Learn how to mod with tModLoader by exploring the source code for this mod.
 
 You can find the source code at https://github.com/tModLoader/tModLoader/tree/1.4.4/ExampleMod
+
+You can interpolate these values into a mod description:
+- ModVersion: {ModVersion}
+- ModHomepage: {ModHomepage}
+- tMLVersion: {tMLVersion}
+- tMLBuildPurpose: {tMLBuildPurpose}

--- a/patches/tModLoader/Terraria/ModLoader/Core/BuildProperties.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/BuildProperties.cs
@@ -178,6 +178,9 @@ internal class BuildProperties
 		properties.sortAfter = properties.RefNames(true).Where(dep => !properties.sortBefore.Contains(dep))
 			.Concat(properties.sortAfter).Distinct().ToArray();
 
+		// Interpolate description values
+		ModCompile.UpdateSubstitutedDescriptionValues(ref properties.description, properties.version.ToString(), properties.homepage);
+
 		return properties;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -479,5 +479,17 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 		pdb = pdbStream.ToArray();
 		return results.Diagnostics.Where(d => d.Severity >= DiagnosticSeverity.Warning).ToArray();
 	}
+
+	internal static void UpdateSubstitutedDescriptionValues(ref string description, string modVersion, string homepage)
+	{
+		// Language.GetText returns the given key if it can't be found, this way we can use LocalizedText.FormatWith
+		// This allows us to use substitution keys such as {ModVersion}
+		description = Language.GetText(description).FormatWith(new {
+			ModVersion = modVersion,
+			ModHomepage = homepage,
+			tMLVersion = BuildInfo.tMLVersion.MajorMinor().ToString(),
+			tMLBuildPurpose = BuildInfo.Purpose.ToString(),
+		});
+	}
 }
 #endif

--- a/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
@@ -635,8 +635,6 @@ public static class SteamedWraps
 				patchNotes += ", learn more at the [url={ModHomepage}]homepage[/url]";
 		}
 
-		// Interpolate workshop description and changenotes values
-		ModCompile.UpdateSubstitutedDescriptionValues(ref _entryData.Description, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
 		ModCompile.UpdateSubstitutedDescriptionValues(ref patchNotes, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
 
 		string refs = _entryData.BuildData["workshopdeps"];

--- a/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.UI.DownloadManager;
 using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.Social.Base;
@@ -634,7 +635,10 @@ public static class SteamedWraps
 				patchNotes += ", learn more at the [url={ModHomepage}]homepage[/url]";
 		}
 
-		UpdatePatchNotesWithModData(ref patchNotes, _entryData.BuildData);	
+		// Interpolate workshop description and changenotes values
+		ModCompile.UpdateSubstitutedDescriptionValues(ref _entryData.Description, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
+		ModCompile.UpdateSubstitutedDescriptionValues(ref patchNotes, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
+
 		string refs = _entryData.BuildData["workshopdeps"];
 
 		if (!string.IsNullOrWhiteSpace(refs)) {
@@ -651,17 +655,5 @@ public static class SteamedWraps
 				}
 			}
 		}
-	}
-
-	internal static void UpdatePatchNotesWithModData(ref string patchNotes, NameValueCollection buildData)
-	{
-		// Language.GetText returns the given key if it can't be found, this way we can use LocalizedText.FormatWith
-		// This allows us to use substitution keys such as {ModVersion}
-		patchNotes = Language.GetText(patchNotes).FormatWith(new {
-			ModVersion = buildData["trueversion"],
-			ModHomepage = buildData["homepage"],
-			tMLVersion = BuildInfo.tMLVersion.MajorMinor().ToString(),
-			tMLBuildPurpose = BuildInfo.Purpose.ToString(),
-		});
 	}
 }

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Social/Steam/WorkshopHelper.cs
 +++ src/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs
-@@ -1,14 +_,20 @@
+@@ -1,14 +_,19 @@
  using System;
  using System.Collections.Generic;
 +using System.Collections.Specialized;
@@ -11,7 +11,6 @@
  using Terraria.IO;
 +using Terraria.Localization;
 +using Terraria.ModLoader;
-+using Terraria.ModLoader.Core;
  using Terraria.Social.Base;
  using Terraria.Utilities;
  

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -263,14 +263,11 @@
  				UGCUpdateHandle_t uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
  				if (_entryData.Title != null)
  					SteamUGC.SetItemTitle(uGCUpdateHandle_t, _entryData.Title);
-@@ -261,23 +_,66 @@
+@@ -261,23 +_,63 @@
  
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
 +				*/
-+
-+				// Can't interpolate the parameters at the same time as the change notes, since the change notes are handled after the description is already published
-+				ModCompile.UpdateSubstitutedDescriptionValues(ref _entryData.Description, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
 +
 +				var uGCUpdateHandle_t = GenerateUgcUpdateHandle(out var patchNotes);
 +				_updateCallback = EResult.k_EResultNone;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Social/Steam/WorkshopHelper.cs
 +++ src/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs
-@@ -1,14 +_,19 @@
+@@ -1,14 +_,20 @@
  using System;
  using System.Collections.Generic;
 +using System.Collections.Specialized;
@@ -11,6 +11,7 @@
  using Terraria.IO;
 +using Terraria.Localization;
 +using Terraria.ModLoader;
++using Terraria.ModLoader.Core;
  using Terraria.Social.Base;
  using Terraria.Utilities;
  
@@ -262,11 +263,14 @@
  				UGCUpdateHandle_t uGCUpdateHandle_t = SteamUGC.StartItemUpdate(SteamUtils.GetAppID(), _publishedFileID);
  				if (_entryData.Title != null)
  					SteamUGC.SetItemTitle(uGCUpdateHandle_t, _entryData.Title);
-@@ -261,23 +_,63 @@
+@@ -261,23 +_,66 @@
  
  				if (_entryData.Visibility.HasValue)
  					SteamUGC.SetItemVisibility(uGCUpdateHandle_t, _entryData.Visibility.Value);
 +				*/
++
++				// Can't interpolate the parameters at the same time as the change notes, since the change notes are handled after the description is already published
++				ModCompile.UpdateSubstitutedDescriptionValues(ref _entryData.Description, _entryData.BuildData["trueversion"], _entryData.BuildData["homepage"]);
 +
 +				var uGCUpdateHandle_t = GenerateUgcUpdateHandle(out var patchNotes);
 +				_updateCallback = EResult.k_EResultNone;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -283,7 +283,7 @@ public partial class WorkshopSocialModule
 		string descriptionFinal = $"[quote=GithubActions(Don't Modify)]Version Summary {buildData["versionsummary"]}\nDeveloped By {buildData["author"]}[/quote]" +
 			$"{workshopDesc}";
 
-		SteamedWraps.UpdatePatchNotesWithModData(ref changeNotes, buildData);
+		ModCompile.UpdateSubstitutedDescriptionValues(ref changeNotes, buildData["trueversion"], buildData["homepage"]);
 
 		// Make the publish.vdf file
 		string manifest = Path.Combine(publishedModFiles, "workshop.json");

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -106,6 +106,7 @@ public partial class WorkshopSocialModule
 		}
 
 		string description = buildData["description"] + $"\n[quote=tModLoader]Developed By {buildData["author"]}[/quote]";
+		ModCompile.UpdateSubstitutedDescriptionValues(ref description, buildData["trueversion"],buildData["homepage"]);
 		if (description.Length >= Steamworks.Constants.k_cchPublishedDocumentDescriptionMax) {
 			IssueReporter.ReportInstantUploadProblem("tModLoader.DescriptionLengthExceedLimit");
 			return false;

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -106,7 +106,7 @@ public partial class WorkshopSocialModule
 		}
 
 		string description = buildData["description"] + $"\n[quote=tModLoader]Developed By {buildData["author"]}[/quote]";
-		ModCompile.UpdateSubstitutedDescriptionValues(ref description, buildData["trueversion"],buildData["homepage"]);
+		ModCompile.UpdateSubstitutedDescriptionValues(ref description, buildData["trueversion"], buildData["homepage"]);
 		if (description.Length >= Steamworks.Constants.k_cchPublishedDocumentDescriptionMax) {
 			IssueReporter.ReportInstantUploadProblem("tModLoader.DescriptionLengthExceedLimit");
 			return false;


### PR DESCRIPTION
### What is the new feature?
https://github.com/tModLoader/tModLoader/issues/3807

Since this is very hard to test, add the following log function calls and disable the following checks in the shown functions and attempt to publish ExampleMod.

`WorkshopSocialModule.TML.cs`
![image](https://github.com/tModLoader/tModLoader/assets/62684035/fd3fe9ee-bdff-4946-9957-2e6e25ad3d50)
(same method just scroll down)
![image](https://github.com/tModLoader/tModLoader/assets/62684035/7c15b76c-f968-4ce9-a4e4-455c45acea8e)

`WorkshopHelper.cs`
`APublisherInstance`
`private void UpdateItem(bool creatingItem = false)`
![image](https://github.com/tModLoader/tModLoader/assets/62684035/77579b91-ec31-4b8e-83f8-55dc19e71633)

### Why should this be part of tModLoader?
https://github.com/tModLoader/tModLoader/issues/3807

### Are there alternative designs?
Overhauling the publishing system, which is very messy at the moment and doesn't give much freedom to modders.

### Sample usage for the new feature
In either `description.txt` or `description_workshop.txt`:
```
You can interpolate these values into a mod description:
- ModVersion: {ModVersion}
- ModHomepage: {ModHomepage}
- tMLVersion: {tMLVersion}
- tMLBuildPurpose: {tMLBuildPurpose}
```

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
Added test values to the descriptions (I'm not sure if these will be interpolated because of how ExampleMod is published).

