### PR TITLE
Config List Fixes

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -425,6 +425,7 @@ internal class UIModConfig : UIState
 
 	public override void OnActivate()
 	{
+		Interface.modConfigList.ModToSelectOnOpen = mod;
 		filterTextField.SetText("");
 
 		updateNeeded = false;

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
@@ -6,6 +7,7 @@ using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
+using Terraria.UI.Chat;
 using Terraria.UI.Gamepad;
 
 namespace Terraria.ModLoader.Config.UI;
@@ -162,7 +164,7 @@ internal class UIModConfigList : UIState
 
 		// Have to sort by display name because normally mods are sorted by internal names
 		var mods = ModLoader.Mods.ToList();
-		mods.Sort((x, y) => x.DisplayName.CompareTo(y.DisplayName));
+		mods.Sort((x, y) => CleanChatTags(x.DisplayName).CompareTo(CleanChatTags(y.DisplayName)));
 
 		foreach (var mod in mods) {
 			if (ConfigManager.Configs.TryGetValue(mod, out _)) {
@@ -195,7 +197,7 @@ internal class UIModConfigList : UIState
 
 		// Have to sort by display name because normally configs are sorted by internal names
 		// TODO: Support sort by attribute or some other custom ordering then replicate logic in UIModConfig.SetMod too
-		var sortedConfigs = configs.OrderBy(x => x.DisplayName.Value).ToList();
+		var sortedConfigs = configs.OrderBy(x => CleanChatTags(x.DisplayName.Value)).ToList();
 
 		foreach (var config in sortedConfigs) {
 			float indicatorOffset = 20;
@@ -250,5 +252,13 @@ internal class UIModConfigList : UIState
 
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 100;
 		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modsMenuID;
+	}
+
+	// TODO: this should be in utils, also add color parameter
+	private static string CleanChatTags(string text)
+	{
+		return string.Join("", ChatManager.ParseMessage(text, Color.White)
+				.Where(x => x.GetType() == typeof(TextSnippet))
+				.Select(x => x.Text));
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -12,8 +12,9 @@ namespace Terraria.ModLoader.Config.UI;
 
 internal class UIModConfigList : UIState
 {
-	public Mod SelectedMod;
+	public Mod ModToSelectOnOpen;
 
+	private Mod selectedMod;
 	private UIElement uIElement;
 	private UIPanel uIPanel;
 	private UITextPanel<LocalizedText> backButton;
@@ -119,7 +120,6 @@ internal class UIModConfigList : UIState
 		}.WithFadedMouseOver();
 		backButton.OnLeftClick += (_, _) => {
 			SoundEngine.PlaySound(SoundID.MenuClose);
-			SelectedMod = null;
 
 			if (Main.gameMenu)
 				Main.menuMode = Interface.modsMenuID;
@@ -134,16 +134,25 @@ internal class UIModConfigList : UIState
 	{
 		modList?.Clear();
 		configList?.Clear();
-		SelectedMod = null;
+		selectedMod = null;
+		ModToSelectOnOpen = null;
 	}
 
 	public override void OnActivate()
 	{
 		modList?.Clear();
 		configList?.Clear();
-		PopulateMods();
 
-		if (SelectedMod != null)
+		// Select the mod that we clicked on, otherwise don't select anything
+		selectedMod = null;
+		if (ModToSelectOnOpen != null) {
+			selectedMod = ModToSelectOnOpen;
+			ModToSelectOnOpen = null;
+		}
+
+		// Populate UI
+		PopulateMods();
+		if (selectedMod != null)
 			PopulateConfigs();
 	}
 
@@ -163,12 +172,12 @@ internal class UIModConfigList : UIState
 					ScalePanel = true,
 					AltPanelColor = UICommon.MainPanelBackground,
 					AltHoverPanelColor = UICommon.MainPanelBackground * (1 / 0.8f),
-					UseAltColors = () => SelectedMod != mod,
+					UseAltColors = () => selectedMod != mod,
 					ClickSound = SoundID.MenuTick,
 				};
 
 				modPanel.OnLeftClick += delegate (UIMouseEvent evt, UIElement listeningElement) {
-					SelectedMod = mod;
+					selectedMod = mod;
 					PopulateConfigs();
 				};
 
@@ -181,7 +190,7 @@ internal class UIModConfigList : UIState
 	{
 		configList?.Clear();
 
-		if (SelectedMod == null || !ConfigManager.Configs.TryGetValue(SelectedMod, out var configs))
+		if (selectedMod == null || !ConfigManager.Configs.TryGetValue(selectedMod, out var configs))
 			return;
 
 		// Have to sort by display name because normally configs are sorted by internal names
@@ -201,7 +210,7 @@ internal class UIModConfigList : UIState
 			configPanel.PaddingRight += indicatorOffset;
 
 			configPanel.OnLeftClick += delegate (UIMouseEvent evt, UIElement listeningElement) {
-				Interface.modConfig.SetMod(SelectedMod, config);
+				Interface.modConfig.SetMod(selectedMod, config);
 				if (Main.gameMenu)
 					Main.menuMode = Interface.modConfigID;
 				else

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -454,7 +454,7 @@ internal class UIModItem : UIPanel
 	internal void OpenConfig(UIMouseEvent evt, UIElement listeningElement)
 	{
 		SoundEngine.PlaySound(SoundID.MenuOpen);
-		Interface.modConfigList.SelectedMod = ModLoader.GetMod(ModName);
+		Interface.modConfigList.ModToSelectOnOpen = ModLoader.GetMod(ModName);
 		Main.menuMode = Interface.modConfigListID;
 	}
 


### PR DESCRIPTION
### What is the bug?
- Selected mod in the config list isn't consistent between closing and reopening config list, opening then closing a config, and using escape and the back button to close the config or config list
- Mod and config names with chat tags at the beginning are sorted to the top because the name starts with a bracket

### How did you fix the bug?
- By handling mod selection differently (instead of deselecting mod on back, it is deselected on open with an option to set a selected mod)
- Cleaning mod and config names of chat tags

### Are there alternatives to your fix?
No.
