### PR TITLE
add Player.hasGemRobe

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2029,6 +2029,16 @@
  							num110 = 5;
  							num110 -= Main.CurrentFrameFlags.ActivePlayersCount / 2;
  							if (num110 < 2)
+@@ -63451,7 +_,8 @@
+ 			else if (Main.hardMode && (Main.remixWorld || (double)num2 > (Main.rockLayer + (double)Main.maxTilesY) / 2.0) && Main.rand.Next(200) == 0) {
+ 				newNPC = NewNPC(GetSpawnSourceForNaturalSpawn(), num * 16 + 8, num2 * 16, 172);
+ 			}
+-			else if ((Main.remixWorld || (double)num2 > (Main.rockLayer + (double)Main.maxTilesY) / 2.0) && (Main.rand.Next(200) == 0 || (Main.rand.Next(50) == 0 && (Main.player[k].armor[1].type == 4256 || (Main.player[k].armor[1].type >= 1282 && Main.player[k].armor[1].type <= 1287)) && Main.player[k].armor[0].type != 238))) {
++			// Uses flag added by TML to support modded gem robes for Tim spawn rate increase.
++			else if ((Main.remixWorld || (double)num2 > (Main.rockLayer + (double)Main.maxTilesY) / 2.0) && (Main.rand.Next(200) == 0 || (Main.rand.Next(50) == 0 && Main.player[k].hasGemRobe && Main.player[k].armor[0].type != 238))) {
+ 				newNPC = NewNPC(GetSpawnSourceForNaturalSpawn(), num * 16 + 8, num2 * 16, 45);
+ 			}
+ 			else if (flag10 && Main.rand.Next(4) != 0) {
 @@ -63539,6 +_,11 @@
  				}
  			}

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -20,6 +20,11 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	public Item equippedWings = null;
 
 	/// <summary>
+	/// Set by any gem robe when worn by the player in the functional armor slot. Increases the spawn rate of <see cref="NPCID.Tim"/>.
+	/// </summary>
+	public bool hasGemRobe = false;
+
+	/// <summary>
 	/// Causes <see cref="SmartSelectLookup"/> to run the next time an item animation is finished, even if <see cref="controlUseItem"/> is held. <br/>
 	/// Used internally by tML to when a hotbar key is pressed while using an item.
 	/// </summary>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2451,7 +2451,7 @@
  		}
  
  		if (armorPiece.type == 1549) {
-@@ -10365,14 +_,17 @@
+@@ -10365,14 +_,21 @@
  			minionDamage += 0.11f;
  		}
  
@@ -2461,6 +2461,10 @@
  			maxMinions++;
  			minionDamage += 0.11f;
  		}
++
++		// Lifted from NPC.SpawnNPC for NewNPC(..., 45), which is NPCID.Tim. See usage of the flag
++		if (armorPiece.type == 4256 || (armorPiece.type >= 1282 && armorPiece.type <= 1287))
++			hasGemRobe = true;
 +
 +		ItemLoader.UpdateEquip(armorPiece, this);
  	}
@@ -3055,8 +3059,11 @@
  		calmed = false;
  		beetleOrbs = 0;
  		beetleBuff = false;
-@@ -14540,6 +_,7 @@
+@@ -14538,8 +_,10 @@
+ 		witheredWeapon = false;
+ 		parryDamageBuff = false;
  		slowOgreSpit = false;
++		hasGemRobe = false; // Added by TML.
  		wings = 0;
  		wingsLogic = 0;
 +		equippedWings = null; // Added by TML.


### PR DESCRIPTION
### What is the new feature?
`bool Player.hasGemRobe`, an equip flag set by all gem robes, causing [Tim](https://terraria.wiki.gg/wiki/Tim) to spawn more often. The name is chosen based on similar flags like `hasAngelHalo`.

This can also easily be lifted to vanilla 1.4.5.

### Why should this be part of tModLoader?
Currently you need an IL edit to make this work for modded gem robes.
A mod that makes you wear more than one set of functional armor will not cause Tim to spawn more often if the gem robe is not in the vanilla (`armor[1]`) slot.

There are also atleast 2 mods that I know of that add custom gems and want this feature.

### Are there alternative designs?
- make it a property instead of a field (and capitalize). Unlikely its get/set will ever be changed before 1.4.5 when mods will have to port anyway
- rename to `increasesTimSpawnRateBy400Percent` if naming should represent what it does
- `has*Any*GemRobe`

### Sample usage for the new feature
`override void UpdateEquip(Player player) => player.hasGemRobe = true;`

### ExampleMod updates
ExampleMod has no gem robe

