### PR TITLE
Separate DisplayName and DisplayNameClean

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/BuffDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/BuffDefinitionElement.cs
@@ -46,7 +46,7 @@ internal class BuffDefinitionElement : DefinitionElement<BuffDefinition>
 			string modname = "Terraria";
 
 			if (option.Type >= BuffID.Count) {
-				modname = BuffLoader.GetBuff(option.Type).Mod.DisplayName; // or internal name?
+				modname = BuffLoader.GetBuff(option.Type).Mod.DisplayNameClean; // or internal name?
 			}
 
 			if (modname.IndexOf(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/ItemDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/ItemDefinitionElement.cs
@@ -45,7 +45,7 @@ internal class ItemDefinitionElement : DefinitionElement<ItemDefinition>
 			string modname = "Terraria";
 
 			if (option.Type >= ItemID.Count) {
-				modname = ItemLoader.GetItem(option.Type).Mod.DisplayName; // or internal name?
+				modname = ItemLoader.GetItem(option.Type).Mod.DisplayNameClean; // or internal name?
 			}
 
 			if (modname.IndexOf(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/NPCDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/NPCDefinitionElement.cs
@@ -45,7 +45,7 @@ internal class NPCDefinitionElement : DefinitionElement<NPCDefinition>
 			string modname = option.Definition.Mod;
 
 			if (option.Type >= NPCID.Count) {
-				modname = NPCLoader.GetNPC(option.Type).Mod.DisplayName; // or internal name?
+				modname = NPCLoader.GetNPC(option.Type).Mod.DisplayNameClean; // or internal name?
 			}
 
 			if (modname.IndexOf(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/PrefixDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/PrefixDefinitionElement.cs
@@ -53,7 +53,7 @@ internal class PrefixDefinitionElement : DefinitionElement<PrefixDefinition>
 			string modname = option.Definition.Mod;
 
 			if (option.Type >= PrefixID.Count)
-				modname = PrefixLoader.GetPrefix(option.Type).Mod.DisplayName; // or internal name?
+				modname = PrefixLoader.GetPrefix(option.Type).Mod.DisplayNameClean; // or internal name?
 
 			if (modname.IndexOf(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)
 				continue;

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/ProjectileDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/ProjectileDefinitionElement.cs
@@ -44,7 +44,7 @@ internal class ProjectileDefinitionElement : DefinitionElement<ProjectileDefinit
 			string modname = option.Definition.Mod;
 
 			if (option.Type >= ProjectileID.Count) {
-				modname = ProjectileLoader.GetProjectile(option.Type).Mod.DisplayName; // or internal name?
+				modname = ProjectileLoader.GetProjectile(option.Type).Mod.DisplayNameClean; // or internal name?
 			}
 
 			if (!modname.Contains(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase))

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/TileDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/TileDefinitionElement.cs
@@ -45,7 +45,7 @@ internal class TileDefinitionElement : DefinitionElement<TileDefinition>
 			string modname = "Terraria";
 
 			if (option.Type >= TileID.Count) {
-				modname = TileLoader.GetTile(option.Type).Mod.DisplayName; // or internal name?
+				modname = TileLoader.GetTile(option.Type).Mod.DisplayNameClean; // or internal name?
 			}
 
 			if (modname.IndexOf(ChooserFilterMod.CurrentString, StringComparison.OrdinalIgnoreCase) == -1)

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -417,7 +417,7 @@ internal class UIModConfig : UIState
 
 		}
 		else {
-			throw new Exception($"There are no ModConfig for {mod.DisplayName}, how did this happen?");
+			throw new Exception($"There are no ModConfig for {mod.DisplayNameClean}, how did this happen?");
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -164,7 +164,7 @@ internal class UIModConfigList : UIState
 
 		// Have to sort by display name because normally mods are sorted by internal names
 		var mods = ModLoader.Mods.ToList();
-		mods.Sort((x, y) => CleanChatTags(x.DisplayName).CompareTo(CleanChatTags(y.DisplayName)));
+		mods.Sort((x, y) => x.DisplayNameClean.CompareTo(y.DisplayNameClean));
 
 		foreach (var mod in mods) {
 			if (ConfigManager.Configs.TryGetValue(mod, out _)) {
@@ -197,7 +197,7 @@ internal class UIModConfigList : UIState
 
 		// Have to sort by display name because normally configs are sorted by internal names
 		// TODO: Support sort by attribute or some other custom ordering then replicate logic in UIModConfig.SetMod too
-		var sortedConfigs = configs.OrderBy(x => CleanChatTags(x.DisplayName.Value)).ToList();
+		var sortedConfigs = configs.OrderBy(x => Utils.CleanChatTags(x.DisplayName.Value)).ToList();
 
 		foreach (var config in sortedConfigs) {
 			float indicatorOffset = 20;
@@ -252,13 +252,5 @@ internal class UIModConfigList : UIState
 
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 100;
 		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modsMenuID;
-	}
-
-	// TODO: this should be in utils, also add color parameter
-	private static string CleanChatTags(string text)
-	{
-		return string.Join("", ChatManager.ParseMessage(text, Color.White)
-				.Where(x => x.GetType() == typeof(TextSnippet))
-				.Select(x => x.Text));
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -202,7 +202,6 @@ public static class AssemblyManager
 			m.Logger = LogManager.GetLogger(m.Name);
 			m.Side = mod.properties.side;
 			m.DisplayName = mod.properties.displayName;
-			m.DisplayNameClean = Utils.CleanChatTags(m.DisplayName);
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null; 
 			return m;
@@ -260,7 +259,7 @@ public static class AssemblyManager
 			int i = 0;
 			foreach (var mod in modList) {
 				token.ThrowIfCancellationRequested();
-				Interface.loadMods.SetCurrentMod(i++, mod.Name, mod.properties?.displayName ?? "", Utils.CleanChatTags(mod.properties?.displayName ?? ""), mod.modFile.Version);
+				Interface.loadMods.SetCurrentMod(i++, mod.Name, mod.properties?.displayName ?? "", mod.modFile.Version);
 				mod.LoadAssemblies();
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -202,6 +202,7 @@ public static class AssemblyManager
 			m.Logger = LogManager.GetLogger(m.Name);
 			m.Side = mod.properties.side;
 			m.DisplayName = mod.properties.displayName;
+			m.DisplayNameClean = Utils.CleanChatTags(m.DisplayName);
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null; 
 			return m;
@@ -259,7 +260,7 @@ public static class AssemblyManager
 			int i = 0;
 			foreach (var mod in modList) {
 				token.ThrowIfCancellationRequested();
-				Interface.loadMods.SetCurrentMod(i++, mod.Name, mod.properties?.displayName ?? "", mod.modFile.Version);
+				Interface.loadMods.SetCurrentMod(i++, mod.Name, mod.properties?.displayName ?? "", Utils.CleanChatTags(mod.properties?.displayName ?? ""), mod.modFile.Version);
 				mod.LoadAssemblies();
 			}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
@@ -12,7 +12,7 @@ internal class LocalMod
 
 	public string Name => modFile.Name;
 	public string DisplayName => string.IsNullOrEmpty(properties.displayName) ? Name : properties.displayName;
-	internal readonly string DisplayNameClean; // Suitable for console output, chat tags stripped away.
+	public readonly string DisplayNameClean; // Suitable for console output, chat tags stripped away.
 	public Version tModLoaderVersion => properties.buildVersion;
 
 	public bool Enabled {

--- a/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
@@ -12,6 +12,7 @@ internal class LocalMod
 
 	public string Name => modFile.Name;
 	public string DisplayName => string.IsNullOrEmpty(properties.displayName) ? Name : properties.displayName;
+	internal readonly string DisplayNameClean; // Suitable for console output, chat tags stripped away.
 	public Version tModLoaderVersion => properties.buildVersion;
 
 	public bool Enabled {
@@ -25,6 +26,7 @@ internal class LocalMod
 	{
 		this.modFile = modFile;
 		this.properties = properties;
+		DisplayNameClean = Utils.CleanChatTags(DisplayName);
 	}
 
 	public LocalMod(TmodFile modFile) : this(modFile, BuildProperties.ReadModFile(modFile))

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
@@ -30,7 +30,6 @@ internal class ModLoaderMod : Mod
 	{
 		Side = ModSide.NoSync;
 		DisplayName = "tModLoader";
-		DisplayNameClean = "tModLoader";
 		Code = Assembly.GetExecutingAssembly();
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModLoaderMod.cs
@@ -30,6 +30,7 @@ internal class ModLoaderMod : Mod
 	{
 		Side = ModSide.NoSync;
 		DisplayName = "tModLoader";
+		DisplayNameClean = "tModLoader";
 		Code = Assembly.GetExecutingAssembly();
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/ModlistCommand.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/ModlistCommand.cs
@@ -42,7 +42,7 @@ internal class ModlistCommand : ModCommand
 				caller.Reply(Language.GetTextValue("tModLoader.CommandModListModlist"), Color.Yellow);
 
 			foreach (var mod in mods)
-				caller.Reply(mod.DisplayName);
+				caller.Reply(caller.CommandType == CommandType.Chat ? mod.DisplayName : mod.DisplayNameClean);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -55,7 +55,7 @@ partial class Mod
 		while (AsyncLoadQueue.Count > 0)
 			AsyncLoadQueue.Dequeue().Wait();
 
-		ModSourceBestiaryInfoElement = new GameContent.Bestiary.ModSourceBestiaryInfoElement(this, DisplayName);
+		ModSourceBestiaryInfoElement = new GameContent.Bestiary.ModSourceBestiaryInfoElement(this, DisplayName); // TODO: DisplayName is incorrect, but ModBestiaryInfoElement._displayName usage inconsistent.
 
 		if (ContentAutoloadingEnabled) {
 			var loadableTypes = AssemblyManager.GetLoadableTypes(Code)

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -75,6 +75,10 @@ public partial class Mod
 	/// The display name of this mod in the Mods menu.
 	/// </summary>
 	public string DisplayName { get; internal set; }
+	/// <summary>
+	/// Same as DisplayName, but chat tags are removed. This can be used for more readable logging and console output.
+	/// </summary>
+	public string DisplayNameClean { get; internal set; }
 
 	public AssetRepository Assets { get; private set; }
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -75,10 +75,12 @@ public partial class Mod
 	/// The display name of this mod in the Mods menu.
 	/// </summary>
 	public string DisplayName { get; internal set; }
+	
+	private string displayNameClean;
 	/// <summary>
-	/// Same as DisplayName, but chat tags are removed. This can be used for more readable logging and console output.
+	/// Same as DisplayName, but chat tags are removed. This can be used for more readable logging and console output. Also useful for searching by mod name
 	/// </summary>
-	public string DisplayNameClean { get; internal set; }
+	public string DisplayNameClean => displayNameClean ??= Utils.CleanChatTags(DisplayName);
 
 	public AssetRepository Assets { get; private set; }
 

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -78,7 +78,7 @@ public partial class Mod
 	
 	private string displayNameClean;
 	/// <summary>
-	/// Same as DisplayName, but chat tags are removed. This can be used for more readable logging and console output. Also useful for searching by mod name
+	/// Same as DisplayName, but chat tags are removed. This can be used for more readable logging and console output. It is also useful for code that searches or filters by mod name.
 	/// </summary>
 	public string DisplayNameClean => displayNameClean ??= Utils.CleanChatTags(DisplayName);
 

--- a/patches/tModLoader/Terraria/ModLoader/ModBossBarStyle.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModBossBarStyle.cs
@@ -17,7 +17,7 @@ public abstract class ModBossBarStyle : ModType
 	/// <summary>
 	/// Controls the name that shows up in the menu selection. If not overridden, it will use this mod's display name.
 	/// </summary>
-	public virtual string DisplayName => Mod.DisplayName;
+	public virtual string DisplayName => Mod.DisplayNameClean;
 
 	/// <summary>
 	/// Return true to skip update code for boss bars. Useful if you want to use your own code for finding out which NPCs to track. Returns false by default.

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -140,7 +140,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 			NPCLoader.bannerToItem[Banner] = BannerItem;
 		}
 		else if (Banner != 0 || BannerItem != 0) {
-			Logging.tML.Warn(Language.GetTextValue("tModLoader.LoadWarningBannerOrBannerItemNotSet", Mod.DisplayName, Name));
+			Logging.tML.Warn(Language.GetTextValue("tModLoader.LoadWarningBannerOrBannerItemNotSet", Mod.DisplayNameClean, Name));
 		}
 
 		if (NPC.lifeMax > 32767 || NPC.boss) {

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -140,7 +140,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 			NPCLoader.bannerToItem[Banner] = BannerItem;
 		}
 		else if (Banner != 0 || BannerItem != 0) {
-			Logging.tML.Warn(Language.GetTextValue("tModLoader.LoadWarningBannerOrBannerItemNotSet", Mod.DisplayNameClean, Name));
+			Logging.tML.Warn(Language.GetTextValue("tModLoader.LoadWarningBannerOrBannerItemNotSet", Mod.Name, Name));
 		}
 
 		if (NPC.lifeMax > 32767 || NPC.boss) {

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -107,7 +107,7 @@ public static class MonoModHooks
 
 		foreach (var asm in AssemblyManager.GetModAssemblies(mod.Name)) {
 			if (assemblyDetours.TryGetValue(asm, out var list)) {
-				Logging.tML.Debug($"Unloading {list.ilHooks.Count} IL hooks, {list.detours.Count} detours from {asm.GetName().Name} in {mod.DisplayNameClean}");
+				Logging.tML.Debug($"Unloading {list.ilHooks.Count} IL hooks, {list.detours.Count} detours from {asm.GetName().Name} in {mod.Name}");
 
 				foreach (var detour in list.detours)
 					if (detour.IsApplied)

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -107,7 +107,7 @@ public static class MonoModHooks
 
 		foreach (var asm in AssemblyManager.GetModAssemblies(mod.Name)) {
 			if (assemblyDetours.TryGetValue(asm, out var list)) {
-				Logging.tML.Debug($"Unloading {list.ilHooks.Count} IL hooks, {list.detours.Count} detours from {asm.GetName().Name} in {mod.DisplayName}");
+				Logging.tML.Debug($"Unloading {list.ilHooks.Count} IL hooks, {list.detours.Count} detours from {asm.GetName().Name} in {mod.DisplayNameClean}");
 
 				foreach (var detour in list.detours)
 					if (detour.IsApplied)

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -388,7 +388,7 @@ internal static class Interface
 			Console.WriteLine();
 			var mods = ModOrganizer.FindMods(logDuplicates: true);
 			for (int k = 0; k < mods.Length; k++) {
-				Console.Write((k + 1) + "\t\t" + mods[k].DisplayName);
+				Console.Write((k + 1) + "\t\t" + mods[k].DisplayNameClean);
 				Console.WriteLine(" (" + (mods[k].Enabled ? "enabled" : "disabled") + ")");
 			}
 			if (mods.Length == 0) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -453,7 +453,7 @@ internal static class Interface
 			EnableDepsRecursive(dep, mods, missingRefs);
 			if (!dep.Enabled) {
 				Console.ForegroundColor = ConsoleColor.Green;
-				Console.WriteLine($"Automatically enabling {dep.DisplayName} required by {mod.DisplayName}");
+				Console.WriteLine($"Automatically enabling {dep.DisplayNameClean} required by {mod.DisplayNameClean}");
 				Console.ResetColor();
 			}
 			dep.Enabled ^= true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -41,7 +41,7 @@ public class ModDownloadItem
 	{
 		ModName = name;
 		DisplayName = displayName;
-		DisplayNameClean = string.Join("", ChatManager.ParseMessage(displayName, Color.White).Where(x => x.GetType() == typeof(TextSnippet)).Select(x => x.Text));
+		DisplayNameClean = Utils.CleanChatTags(displayName);
 		PublishId = new ModPubId_t { m_ModPubId = publishId };
 		OwnerId = ownerId;
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -36,27 +36,26 @@ internal class UILoadMods : UIProgress
 	{
 		this.stageText = stageText;
 		this.modCount = modCount;
-		if (modCount < 0) SetProgressText(Language.GetTextValue(stageText), Language.GetTextValue(stageText));
+		if (modCount < 0) SetProgressText(Language.GetTextValue(stageText));
 		Progress = 0;
 		SubProgressText = "";
 	}
 
-	// uitext might have chat tags, text is the same without chat tags, logText might be unique
-	private void SetProgressText(string uitext, string text, string logText = null)
+	private void SetProgressText(string text, string logText = null)
 	{
-		Logging.tML.Info(logText ?? text);
-		if (Main.dedServ) Console.WriteLine(text);
-		else DisplayText = uitext;
+		string cleanText = Utils.CleanChatTags(text); // text might have chat tags, most notably mod display names.
+		Logging.tML.Info(logText != null ? Utils.CleanChatTags(logText) : cleanText);
+		if (Main.dedServ) Console.WriteLine(cleanText);
+		else DisplayText = text;
 	}
 
-	public void SetCurrentMod(int i, string modName, string displayName, string displayNameClean, Version version)
+	public void SetCurrentMod(int i, string modName, string displayName, Version version)
 	{
-		var displayUI = $"{displayName} v{version}";
-		var display = $"{displayNameClean} v{version}";
-		var log = $"{modName} ({displayNameClean}) v{version}";
-		SetProgressText(Language.GetTextValue(stageText, displayUI), Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
+		var display = $"{displayName} v{version}";
+		var log = $"{modName} ({displayName}) v{version}";
+		SetProgressText(Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
 		Progress = i / (float)modCount;
 	}
 
-	public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.DisplayNameClean, mod.Version);
+	public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.Version);
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UILoadMods.cs
@@ -36,25 +36,27 @@ internal class UILoadMods : UIProgress
 	{
 		this.stageText = stageText;
 		this.modCount = modCount;
-		if (modCount < 0) SetProgressText(Language.GetTextValue(stageText));
+		if (modCount < 0) SetProgressText(Language.GetTextValue(stageText), Language.GetTextValue(stageText));
 		Progress = 0;
 		SubProgressText = "";
 	}
 
-	private void SetProgressText(string text, string logText = null)
+	// uitext might have chat tags, text is the same without chat tags, logText might be unique
+	private void SetProgressText(string uitext, string text, string logText = null)
 	{
 		Logging.tML.Info(logText ?? text);
 		if (Main.dedServ) Console.WriteLine(text);
-		else DisplayText = text;
+		else DisplayText = uitext;
 	}
 
-	public void SetCurrentMod(int i, string modName, string displayName, Version version)
+	public void SetCurrentMod(int i, string modName, string displayName, string displayNameClean, Version version)
 	{
-		var display = $"{displayName} v{version}";
-		var log = $"{modName} ({displayName}) v{version}";
-		SetProgressText(Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
+		var displayUI = $"{displayName} v{version}";
+		var display = $"{displayNameClean} v{version}";
+		var log = $"{modName} ({displayNameClean}) v{version}";
+		SetProgressText(Language.GetTextValue(stageText, displayUI), Language.GetTextValue(stageText, display), Language.GetTextValue(stageText, log));
 		Progress = i / (float)modCount;
 	}
 
-	public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.Version);
+	public void SetCurrentMod(int i, Mod mod) => SetCurrentMod(i, mod.Name, mod.DisplayName, mod.DisplayNameClean, mod.Version);
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -64,7 +64,7 @@ internal class UIModItem : UIPanel
 		Height.Pixels = 90;
 		Width.Percent = 1f;
 		SetPadding(6f);
-		DisplayNameClean = string.Join("", ChatManager.ParseMessage(_mod.DisplayName, Color.White).Where(x => x.GetType() == typeof(TextSnippet)).Select(x => x.Text));
+		DisplayNameClean = _mod.DisplayNameClean;
 	}
 
 	public override void OnInitialize()

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -185,7 +185,7 @@ public partial class WorkshopHelper
 		var values = new NameValueCollection
 		{
 			{ "displayname", bp.displayName },
-			{ "displaynameclean", string.Join("", ChatManager.ParseMessage(bp.displayName, Color.White).Where(x => x.GetType() == typeof(TextSnippet)).Select(x => x.Text)) },
+			{ "displaynameclean", Utils.CleanChatTags(bp.displayName) },
 			{ "name", modFile.Name },
 			{ "version", $"{bp.version}" },
 			{ "author", bp.author },

--- a/patches/tModLoader/Terraria/Utils.TML.cs
+++ b/patches/tModLoader/Terraria/Utils.TML.cs
@@ -3,12 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Terraria.DataStructures;
 using Terraria.ModLoader;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
+using Terraria.UI.Chat;
 using Terraria.Utilities;
 
 namespace Terraria;
@@ -220,5 +222,12 @@ partial class Utils
 			Console.WriteLine("ERROR: " + message);
 			Console.ResetColor();
 		}
+	}
+
+	internal static string CleanChatTags(string text)
+	{
+		return string.Join("", ChatManager.ParseMessage(text, Color.White)
+				.Where(x => x.GetType() == typeof(TextSnippet))
+				.Select(x => x.Text));
 	}
 }


### PR DESCRIPTION
![image](https://github.com/tModLoader/tModLoader/assets/4522492/e1ac29ba-4de3-4b2a-b268-9ac316ce4542)

Some mods use chat tags to augment their displayname. We currently log displayname directly in logs and server console in various places. 

It has been suggested that we show a "clean" displayname in these situations. This seems reasonable. This PR addresses this issue