### PR TITLE
fix celebrationmk10 treasure bag 1.4.4 regression

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1395,7 +1395,7 @@
  	{
 +		DropFromItem(type);
 +
-+		if ((!ItemID.Sets.PreHardmodeLikeBossBag[type] || Main.tenthAnniversaryWorld)) {
++		if (!ItemID.Sets.PreHardmodeLikeBossBag[type]) {
 +			TryGettingDevArmor(GetItemSource_OpenItem(type));
 +		}
 +


### PR DESCRIPTION
### What is the bug?
As per https://terraria.wiki.gg/wiki/Celebrationmk10#History, in 1.4.4 the prehm treasure bags no longer drop dev sets on the celebrationmk10 seed.

### How did you fix the bug?
Remove the check tml added during refactoring of grab bag code. This now mirrors vanilla behavior because the tml-added set PreHardmodeLikeBossBag also contains Queen Slime.

### Are there alternatives to your fix?
Remove the {} aswell since it's a single line if statement (this however changes a patch line indicator further up, so I didn't do it)