### PR TITLE
Fix incorrect fishing line offset with vanilla bobbers on modded rods.

### DIFF
--- a/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
@@ -48,6 +48,15 @@ namespace ExampleMod.Content.Items.Tools
 			return false;
 		}
 
+		public override void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor) {
+			// Change these two values in order to change the origin of where the line is being drawn.
+			// This will make it draw 47 pixels right and 31 pixels up from the player's center, while they are looking right and in normal gravity.
+			lineOriginOffset = new Vector2(47, -31);
+
+			// Sets the fishing line's color. Note that this will be overridden by the colored string accessories.
+			lineColor = Main.DiscoColor;
+		}
+
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
 		public override void AddRecipes() {
 			CreateRecipe()

--- a/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleFishingRod.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ExampleMod.Content.Projectiles;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
 using Terraria.ID;
@@ -6,6 +7,9 @@ using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items.Tools
 {
+	// ExampleFishingRod is a fishing rod item.
+	// The code in SetDefaults and the code setting lineOriginOffset in ModifyFishingLine is all the would be needed for a typical working fishing rod item.
+	// All of the rest of the code showcases other additional capabilities, such as multiple bobbers, custom line colors, and fishing in lava.
 	public class ExampleFishingRod : ModItem
 	{
 		public override void SetStaticDefaults() {
@@ -24,7 +28,7 @@ namespace ExampleMod.Content.Items.Tools
 
 			Item.fishingPole = 30; // Sets the poles fishing power
 			Item.shootSpeed = 12f; // Sets the speed in which the bobbers are launched. Wooden Fishing Pole is 9f and Golden Fishing Rod is 17f.
-			Item.shoot = ModContent.ProjectileType<Projectiles.ExampleBobber>(); // The Bobber projectile.
+			Item.shoot = ModContent.ProjectileType<Projectiles.ExampleBobber>(); // The bobber projectile. Note that this will be overridden by Fishing Bobber accessories if present, so don't assume the bobber spawned is the specified projectile. https://terraria.wiki.gg/wiki/Fishing_Bobbers
 		}
 
 		// Grants the High Test Fishing Line bool if holding the item.
@@ -48,13 +52,20 @@ namespace ExampleMod.Content.Items.Tools
 			return false;
 		}
 
-		public override void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor) {
+		public override void ModifyFishingLine(Projectile bobber, ref Vector2 lineOriginOffset, ref Color lineColor) {
 			// Change these two values in order to change the origin of where the line is being drawn.
-			// This will make it draw 47 pixels right and 31 pixels up from the player's center, while they are looking right and in normal gravity.
-			lineOriginOffset = new Vector2(47, -31);
+			// This will make it draw 43 pixels right and 30 pixels up from the player's center, while they are looking right and in normal gravity.
+			lineOriginOffset = new Vector2(43, -30);
 
 			// Sets the fishing line's color. Note that this will be overridden by the colored string accessories.
-			lineColor = Main.DiscoColor;
+			if (bobber.ModProjectile is ExampleBobber exampleBobber) {
+				// ExampleBobber has custom code to decide on a line color.
+				lineColor = exampleBobber.FishingLineColor;
+			}
+			else {
+				// If the bobber isn't ExampleBobber, a Fishing Bobber accessory is in effect and we use DiscoColor instead.
+				lineColor = Main.DiscoColor;
+			}
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Content/Projectiles/ExampleBobber.cs
+++ b/ExampleMod/Content/Projectiles/ExampleBobber.cs
@@ -1,11 +1,27 @@
-﻿using Terraria;
+﻿using Microsoft.Xna.Framework;
+using System.IO;
+using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Projectiles
 {
+	// ExampleBobber is a fishing bobber spawned by ExampleFishingRod.
+	// Aside from the code in SetDefaults, everything else should be ignored when making a typical bobber projectile.
+	// Typically the fishing rod item decides the line color, but this bobber decides its own line color and serves as an example of using OnSpawn, SendExtraAI, and ReceiveExtraAI to sync a random value determined when spawned.
 	public class ExampleBobber : ModProjectile
 	{
+		public static readonly Color[] PossibleLineColors = new Color[] {
+			new Color(255, 215, 0), // A gold color
+			new Color(0, 191, 255) // A blue color
+		};
+
+		// This holds the index of the fishing line color in the PossibleLineColors array.
+		private int fishingLineColorIndex;
+
+		public Color FishingLineColor => PossibleLineColors[fishingLineColorIndex];
+
 		public override void SetDefaults() {
 			// These are copied through the CloneDefaults method
 			// Projectile.width = 14;
@@ -19,12 +35,26 @@ namespace ExampleMod.Content.Projectiles
 			DrawOriginOffsetY = -8; // Adjusts the draw position
 		}
 
+		public override void OnSpawn(IEntitySource source) {
+			// Decide color of the pole by getting the index of a random entry from the PossibleLineColors array.
+			fishingLineColorIndex = (byte)Main.rand.Next(PossibleLineColors.Length);
+		}
+
 		public override void AI() {
 			// Always ensure that graphics-related code doesn't run on dedicated servers via this check.
 			if (!Main.dedServ) {
-				// Create some light.
-				Lighting.AddLight(Projectile.Center, Main.DiscoColor.ToVector3());
+				// Create some light based on the color of the line.
+				Lighting.AddLight(Projectile.Center, FishingLineColor.ToVector3());
 			}
+		}
+
+		// These last two methods are required so the line color is properly synced in multiplayer.
+		public override void SendExtraAI(BinaryWriter writer) {
+			writer.Write((byte)fishingLineColorIndex);
+		}
+
+		public override void ReceiveExtraAI(BinaryReader reader) {
+			fishingLineColorIndex = reader.ReadByte();
 		}
 	}
 }

--- a/ExampleMod/Content/Projectiles/ExampleBobber.cs
+++ b/ExampleMod/Content/Projectiles/ExampleBobber.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.Xna.Framework;
-using System.IO;
-using Terraria;
-using Terraria.DataStructures;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -9,16 +6,6 @@ namespace ExampleMod.Content.Projectiles
 {
 	public class ExampleBobber : ModProjectile
 	{
-		public static readonly Color[] PossibleLineColors = new Color[] {
-			new Color(255, 215, 0), // A gold color
-			new Color(0, 191, 255) // A blue color
-		};
-
-		// This holds the index of the fishing line color in the PossibleLineColors array.
-		private int fishingLineColorIndex;
-
-		private Color FishingLineColor => PossibleLineColors[fishingLineColorIndex];
-
 		public override void SetDefaults() {
 			// These are copied through the CloneDefaults method
 			// Projectile.width = 14;
@@ -32,35 +19,12 @@ namespace ExampleMod.Content.Projectiles
 			DrawOriginOffsetY = -8; // Adjusts the draw position
 		}
 
-		public override void OnSpawn(IEntitySource source) {
-			// Decide color of the pole by getting the index of a random entry from the PossibleLineColors array.
-			fishingLineColorIndex = (byte)Main.rand.Next(PossibleLineColors.Length);
-		}
-
-		// What if we want to randomize the line color
 		public override void AI() {
 			// Always ensure that graphics-related code doesn't run on dedicated servers via this check.
 			if (!Main.dedServ) {
-				// Create some light based on the color of the line.
-				Lighting.AddLight(Projectile.Center, FishingLineColor.ToVector3());
+				// Create some light.
+				Lighting.AddLight(Projectile.Center, Main.DiscoColor.ToVector3());
 			}
-		}
-
-		public override void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor) {
-			// Change these two values in order to change the origin of where the line is being drawn.
-			// This will make it draw 47 pixels right and 31 pixels up from the player's center, while they are looking right and in normal gravity.
-			lineOriginOffset = new Vector2(47, -31);
-			// Sets the fishing line's color. Note that this will be overridden by the colored string accessories.
-			lineColor = FishingLineColor;
-		}
-
-		// These last two methods are required so the line color is properly synced in multiplayer.
-		public override void SendExtraAI(BinaryWriter writer) {
-			writer.Write((byte)fishingLineColorIndex);
-		}
-
-		public override void ReceiveExtraAI(BinaryReader reader) {
-			fishingLineColorIndex = reader.ReadByte();
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3717,7 +3717,7 @@
  		if (type == 4442)
  			stringColor = new Microsoft.Xna.Framework.Color(100, 100, 200, 100);
  
-+		ProjectileLoader.ModifyFishingLine(proj, ref polePosX, ref polePosY, ref stringColor);
++		ProjectileLoader.ModifyFishingLine(player, ref polePosX, ref polePosY, ref stringColor);
 +
  		stringColor = TryApplyingPlayerStringColor(Main.player[proj.owner].stringColor, stringColor);
  		float gravDir = Main.player[proj.owner].gravDir;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3713,10 +3713,11 @@
  				if (proj.type == 312) {
  					ulong seed3 = TileFrameSeed;
  					for (int num439 = 0; num439 < 4; num439++) {
-@@ -28416,6 +_,8 @@
+@@ -28416,6 +_,9 @@
  		if (type == 4442)
  			stringColor = new Microsoft.Xna.Framework.Color(100, 100, 200, 100);
  
++		ProjectileLoader.ModifyFishingLine(proj, ref polePosX, ref polePosY, ref stringColor);
 +		ItemLoader.ModifyFishingLine(proj, ref polePosX, ref polePosY, ref stringColor);
 +
  		stringColor = TryApplyingPlayerStringColor(Main.player[proj.owner].stringColor, stringColor);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3717,7 +3717,7 @@
  		if (type == 4442)
  			stringColor = new Microsoft.Xna.Framework.Color(100, 100, 200, 100);
  
-+		ProjectileLoader.ModifyFishingLine(player, ref polePosX, ref polePosY, ref stringColor);
++		ItemLoader.ModifyFishingLine(proj, ref polePosX, ref polePosY, ref stringColor);
 +
  		stringColor = TryApplyingPlayerStringColor(Main.player[proj.owner].stringColor, stringColor);
  		float gravDir = Main.player[proj.owner].gravDir;

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2216,6 +2216,26 @@ public static class ItemLoader
 		return tooltips;
 	}
 
+	public static void ModifyFishingLine(Projectile projectile, ref float polePosX, ref float polePosY, ref Color lineColor)
+	{
+		Player player = Main.player[projectile.owner];
+		Item item = player.inventory[player.selectedItem];
+
+		if (item.ModItem == null)
+			return;
+
+		ProjectileLoader.ModifyFishingLine(projectile, ref polePosX, ref polePosY, ref lineColor);
+
+		Vector2 lineOriginOffset = Vector2.Zero;
+
+		item.ModItem.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
+
+		polePosX += lineOriginOffset.X * player.direction;
+		if (player.direction < 0)
+			polePosX -= 13f;
+		polePosY += lineOriginOffset.Y * player.gravDir;
+	}
+
 	internal static HookList HookSaveData = AddHook<Action<Item, TagCompound>>(g => g.SaveData);
 	internal static HookList HookNetSend = AddHook<Action<Item, BinaryWriter>>(g => g.NetSend);
 	internal static HookList HookNetReceive = AddHook<Action<Item, BinaryReader>>(g => g.NetReceive);

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2224,11 +2224,9 @@ public static class ItemLoader
 		if (item.ModItem == null)
 			return;
 
-		ProjectileLoader.ModifyFishingLine(projectile, ref polePosX, ref polePosY, ref lineColor);
-
 		Vector2 lineOriginOffset = Vector2.Zero;
 
-		item.ModItem.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
+		item.ModItem.ModifyFishingLine(projectile, ref lineOriginOffset, ref lineColor);
 
 		polePosX += lineOriginOffset.X * player.direction;
 		if (player.direction < 0)

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -1191,9 +1191,10 @@ ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float const
 	/// <summary>
 	/// If this item is a fishing pole, allows you to modify the origin and color of its fishing line.
 	/// </summary>
+	/// <param name="bobber">The bobber projectile</param>
 	/// <param name="lineOriginOffset"> The offset of the fishing line's origin from the player's center. </param>
 	/// <param name="lineColor"> The fishing line's color, before being overridden by string color accessories. </param>
-	public virtual void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)
+	public virtual void ModifyFishingLine(Projectile bobber, ref Vector2 lineOriginOffset, ref Color lineColor)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -1189,6 +1189,15 @@ ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float const
 	}
 
 	/// <summary>
+	/// If this item is a fishing pole, allows you to modify the origin and color of its fishing line.
+	/// </summary>
+	/// <param name="lineOriginOffset"> The offset of the fishing line's origin from the player's center. </param>
+	/// <param name="lineColor"> The fishing line's color, before being overridden by string color accessories. </param>
+	public virtual void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)
+	{
+	}
+
+	/// <summary>
 	/// Allows you to determine how many of this item a player obtains when the player fishes this item.
 	/// </summary>
 	/// <param name="stack">The stack.</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -312,12 +312,10 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 		return null;
 	}
 
-	/// <summary>
-	/// If this projectile is a bobber, allows you to modify the origin of the fishing line that's connecting to the fishing pole, as well as the fishing line's color.
-	/// </summary>
-	/// <param name="lineOriginOffset"> The offset of the fishing line's origin from the player's center. </param>
-	/// <param name="lineColor"> The fishing line's color, before being overridden by string color accessories. </param>
-	[Obsolete("Moved to ModItem. Fishing line position and color are now tied to the used pole.")]
+	[Obsolete]
+	internal void ModifyFishingLine_Obsolete(ref Vector2 lineOriginOffset, ref Color lineColor) => ModifyFishingLine(ref lineOriginOffset, ref lineColor);
+
+	[Obsolete($"Moved to ModItem. Fishing line position and color are now tied to the used pole.", error: true)]
 	public virtual void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)
 	{
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -317,6 +317,7 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	/// </summary>
 	/// <param name="lineOriginOffset"> The offset of the fishing line's origin from the player's center. </param>
 	/// <param name="lineColor"> The fishing line's color, before being overridden by string color accessories. </param>
+	[Obsolete("Moved to ModItem. Fishing line position and color are now tied to the used pole.")]
 	public virtual void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)
 	{
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -312,10 +312,7 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 		return null;
 	}
 
-	[Obsolete]
-	internal void ModifyFishingLine_Obsolete(ref Vector2 lineOriginOffset, ref Color lineColor) => ModifyFishingLine(ref lineOriginOffset, ref lineColor);
-
-	[Obsolete($"Moved to ModItem. Fishing line position and color are now tied to the used pole.", error: true)]
+	[Obsolete($"Moved to ModItem. Fishing line position and color are now set by the pole used.", error: true)]
 	public virtual void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)
 	{
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -572,20 +572,17 @@ public static class ProjectileLoader
 		}
 	}
 
-	public static void ModifyFishingLine(Player player, ref float polePosX, ref float polePosY, ref Color lineColor)
+	public static void ModifyFishingLine(Projectile projectile , ref float polePosX, ref float polePosY, ref Color lineColor)
 	{
-		Item item = player.inventory[player.selectedItem];
-
-		if (item.ModItem == null)
+		if (projectile.ModProjectile == null)
 			return;
 
 		Vector2 lineOriginOffset = Vector2.Zero;
+		Player player = Main.player[projectile.owner];
 
-		item.ModItem.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
+		projectile.ModProjectile.ModifyFishingLine_Obsolete(ref lineOriginOffset, ref lineColor);
 
 		polePosX += lineOriginOffset.X * player.direction;
-		if (player.direction < 0)
-			polePosX -= 13f;
 		polePosY += lineOriginOffset.Y * player.gravDir;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -572,15 +572,16 @@ public static class ProjectileLoader
 		}
 	}
 
-	public static void ModifyFishingLine(Projectile projectile, ref float polePosX, ref float polePosY, ref Color lineColor)
+	public static void ModifyFishingLine(Player player, ref float polePosX, ref float polePosY, ref Color lineColor)
 	{
-		if (projectile.ModProjectile == null)
+		Item item = player.inventory[player.selectedItem];
+
+		if (item.ModItem == null)
 			return;
 
 		Vector2 lineOriginOffset = Vector2.Zero;
-		Player player = Main.player[projectile.owner];
 
-		projectile.ModProjectile?.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
+		item.ModItem.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
 
 		polePosX += lineOriginOffset.X * player.direction;
 		if (player.direction < 0)

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -572,7 +572,8 @@ public static class ProjectileLoader
 		}
 	}
 
-	public static void ModifyFishingLine(Projectile projectile , ref float polePosX, ref float polePosY, ref Color lineColor)
+	[Obsolete($"Moved to ItemLoader. Fishing line position and color are now set by the pole used.")]
+	public static void ModifyFishingLine(Projectile projectile, ref float polePosX, ref float polePosY, ref Color lineColor)
 	{
 		if (projectile.ModProjectile == null)
 			return;
@@ -580,7 +581,7 @@ public static class ProjectileLoader
 		Vector2 lineOriginOffset = Vector2.Zero;
 		Player player = Main.player[projectile.owner];
 
-		projectile.ModProjectile.ModifyFishingLine_Obsolete(ref lineOriginOffset, ref lineColor);
+		projectile.ModProjectile?.ModifyFishingLine(ref lineOriginOffset, ref lineColor);
 
 		polePosX += lineOriginOffset.X * player.direction;
 		polePosY += lineOriginOffset.Y * player.gravDir;

--- a/tModPorter/tModPorter.Tests/TestData/ModProjectileTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModProjectileTest.Expected.cs
@@ -59,4 +59,8 @@ public class ModProjectileTest : ModProjectile
 	public override void OnHitPvp(Player target, int damage, bool crit)/* tModPorter Note: Removed. Use OnHitPlayer and check info.PvP */ { }
 #endif
 	public override void OnKill(int timeLeft) { }
+
+#if COMPILE_ERROR
+	public override void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor)/* tModPorter Note: Removed. Use ModItem.ModifyFishingLine */ { }
+#endif
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModProjectileTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModProjectileTest.cs
@@ -44,4 +44,6 @@ public class ModProjectileTest : ModProjectile
 	public override void ModifyHitPvp(Player target, ref int damage, ref bool crit) { }
 	public override void OnHitPvp(Player target, int damage, bool crit) { }
 	public override void Kill(int timeLeft) { }
+
+	public override void ModifyFishingLine(ref Vector2 lineOriginOffset, ref Color lineColor) { }
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -320,6 +320,8 @@ public static partial class Config
 		HookRemoved("Terraria.ModLoader.ModPrefix",		"AutoStaticDefaults", "Nothing to override anymore. Use hjson files to adjust localization");
 		HookRemoved("Terraria.ModLoader.ModSystem",		"SetLanguage", "Use OnLocalizationsLoaded. New hook is called at slightly different times, so read the documentation");
 
+		HookRemoved("Terraria.ModLoader.ModProjectile", "ModifyFishingLine", "Use ModItem.ModifyFishingLine");
+
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Load",		to: "LoadData");
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Save",		to: "SaveData");
 		RenameMethod("Terraria.ModLoader.GlobalItem",	from: "Load",		to: "LoadData");

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -320,8 +320,6 @@ public static partial class Config
 		HookRemoved("Terraria.ModLoader.ModPrefix",		"AutoStaticDefaults", "Nothing to override anymore. Use hjson files to adjust localization");
 		HookRemoved("Terraria.ModLoader.ModSystem",		"SetLanguage", "Use OnLocalizationsLoaded. New hook is called at slightly different times, so read the documentation");
 
-		HookRemoved("Terraria.ModLoader.ModProjectile", "ModifyFishingLine", "Use ModItem.ModifyFishingLine");
-
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Load",		to: "LoadData");
 		RenameMethod("Terraria.ModLoader.ModItem",		from: "Save",		to: "SaveData");
 		RenameMethod("Terraria.ModLoader.GlobalItem",	from: "Load",		to: "LoadData");
@@ -545,5 +543,6 @@ public static partial class Config
 		RenameMethod("Terraria.ModLoader.ProjectileLoader", from: "Kill", to: "OnKill");
 		RenameMethod("Terraria.ModLoader.ModProjectile", from: "Kill", to: "OnKill");
 		RenameMethod("Terraria.ModLoader.GlobalProjectile", from: "Kill", to: "OnKill");
+		HookRemoved("Terraria.ModLoader.ModProjectile", "ModifyFishingLine", "Use ModItem.ModifyFishingLine");
 	}
 }


### PR DESCRIPTION
### What is the bug?
[#3906]
Since the fishing line offset of modded rods was bound to bobbers, vanilla bobber accessories that replaced the original projectile of modded rods were causing incorrect offset.

Vanilla rods:
![image](https://github.com/tModLoader/tModLoader/assets/90686797/dc718cb0-965a-4ab6-8b39-f3b145331247)

Modded rods:
![image](https://github.com/tModLoader/tModLoader/assets/90686797/9bdc595e-6abd-44fc-ada3-85d03281099b)

Fixed modded rods:
![image](https://github.com/tModLoader/tModLoader/assets/90686797/39be6581-9bb2-4d5e-93a5-ec878f9a1d59)

### How did you fix the bug?
Move ModifyFishingLine() hook to the ModItem class. This, alas, has no backward compatibility.

### Are there alternatives to your fix?
Since vanilla bobber projectiles completely replace modded ones, there probably aren't any.
Additionally, ExampleFishingRod and ExampleBobber should also be updated.
