### PR TITLE
feat: journeys end menu persist on restart

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -73,17 +73,11 @@ public static class MenuLoader
 			Main.instance.playOldTile = true; // If the previous menu was the 1.3.5.3 one, automatically reactivate it.
 		}
 
-		// We can skip searching for ModMenus when JourneysEnd Menu was last loaded menu
-		if (LastSelectedModMenu != MenuJourneysEnd.FullName)
-			switchToMenu = MenutML;
-		else {
-			switchToMenu = MenuJourneysEnd;
-			loading = false;
-			return;
-		}
-
+		switchToMenu = MenutML;
 		if (ModContent.TryFind(LastSelectedModMenu, out ModMenu value) && value.IsAvailable)
 			switchToMenu = value;
+		if (LastSelectedModMenu == MenuJourneysEnd.FullName)
+			switchToMenu = MenuJourneysEnd;
 
 		loading = false;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -73,7 +73,15 @@ public static class MenuLoader
 			Main.instance.playOldTile = true; // If the previous menu was the 1.3.5.3 one, automatically reactivate it.
 		}
 
-		switchToMenu = MenutML;
+		// We can skip searching for ModMenus when JourneysEnd Menu was last loaded menu
+		if (LastSelectedModMenu != MenuJourneysEnd.FullName)
+			switchToMenu = MenutML;
+		else {
+			switchToMenu = MenuJourneysEnd;
+			loading = false;
+			return;
+		}
+
 		if (ModContent.TryFind(LastSelectedModMenu, out ModMenu value) && value.IsAvailable)
 			switchToMenu = value;
 


### PR DESCRIPTION
### What is the new feature?
When last selected menu was journeys end it also get loaded on startup

### Why should this be part of tModLoader?
To complete the menu saving we already handle + requested in #4015 

### Are there alternative designs?
Open for suggestions

### Sample usage for the new feature
1. Open Terraria
2. Switch to Journeys End menu theme
3. Close Terraria
4. Open again
5. Voilà 

Tested also with skip loading mods (holding shift while start)
Close #4015