### PR TITLE
Remove IIndexed constraint from IEntityWithInstances so that HookList can be used more generally

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IEntityWithInstances.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IEntityWithInstances.cs
@@ -1,6 +1,6 @@
 namespace Terraria.ModLoader;
 
-public interface IEntityWithInstances<T> where T : IIndexed
+public interface IEntityWithInstances<T>
 {
 	RefReadOnlyArray<T> Instances { get; }
 }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -3,9 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Terraria.Graphics;
 using Terraria.IO;
 using Terraria.Localization;
@@ -13,6 +11,7 @@ using Terraria.Map;
 using Terraria.ModLoader.Core;
 using Terraria.UI;
 using Terraria.WorldBuilding;
+using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.ModSystem>;
 
 #pragma warning disable IDE0044 // Add readonly modifier
 
@@ -20,25 +19,6 @@ namespace Terraria.ModLoader;
 
 partial class SystemLoader
 {
-	internal class HookList
-	{
-		public readonly MethodInfo method;
-		private ModSystem[] arr = Array.Empty<ModSystem>();
-
-		public HookList(MethodInfo method)
-		{
-			this.method = method;
-		}
-
-		// Sadly, returning ReadOnlySpan<T>.Enumerator from a GetEnumerator() method doesn't bring the same performance
-		public ReadOnlySpan<ModSystem> Enumerate() => arr;
-
-		public void Update(IEnumerable<ModSystem> systems)
-		{
-			arr = systems.WhereMethodIsOverridden(method).ToArray();
-		}
-	}
-
 	private static readonly List<HookList> hooks = new List<HookList>();
 
 	private static HookList AddHook<F>(Expression<Func<ModSystem, F>> func) where F : Delegate


### PR DESCRIPTION
### What is the new feature?

See title. The original `IIndexed` constraint was added to because of an assumption that we needed to be able to access the `Index` of a `ModPlayer` in order to build the `int[] indices` array for iterating the separate `ModPlayer[]` arrays on different `Player`s. 

It turns out this assumption was unnecessary, and it suffices to assume that `IEntityWithInstances<T>` has instances in the same order as the `List<T> allDefaultInstances` supplied to `HookList.Update`

### Why should this be part of tModLoader?

This allows `HookList<T>` to be used with all other types, like `ModSystem`, `ModTile` etc, and it should be the foundational hook pattern going forward.

### Is this a breaking change?

To my knowledge and testing, no.
