### PR TITLE
Add new MethodOverrideQuery for faster HasOverride checks

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/Cloning.cs
@@ -56,19 +56,17 @@ public static class Cloning
 	public static bool IsCloneable<T, F>(T t, Expression<Func<T, F>> cloneMethod) where F : Delegate
 	{
 		var type = t.GetType();
-		return typeInfos.TryGetValue(type, out var typeInfo) ? typeInfo.IsCloneable : ComputeInfo(t.GetType(), cloneMethod.ToMethodInfo()).IsCloneable;
+		if (!typeInfos.TryGetValue(type, out var typeInfo))
+			typeInfo = ComputeInfo(type, cloneMethod.ToOverrideQuery().Binder(t).Method.DeclaringType);
+
+		return typeInfo.IsCloneable;
 	}
 
-	public static bool IsCloneable(Type type, MethodInfo cloneMethod) => GetOrComputeInfo(type, cloneMethod).IsCloneable;
-
-	private static TypeCloningInfo GetOrComputeInfo(Type type, MethodInfo cloneMethod) =>
-		typeInfos.TryGetValue(type, out var typeInfo) ? typeInfo : ComputeInfo(type, cloneMethod);
-
-	private static TypeCloningInfo ComputeInfo(Type type, MethodInfo cloneMethod)
+	private static TypeCloningInfo ComputeInfo(Type type, Type cloneableAncestor)
 	{
 		var info = new TypeCloningInfo {
 			type = type,
-			overridesClone = LoaderUtils.GetDerivedDefinition(type, cloneMethod).DeclaringType == type
+			overridesClone = type == cloneableAncestor
 		};
 
 		if (!info.overridesClone) {
@@ -76,7 +74,7 @@ public static class Cloning
 					type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
 					.Where(f => f.DeclaringType == type && !IsCloneByReference(f))
 					.ToArray();
-			info.baseTypeInfo = GetOrComputeInfo(type.BaseType, cloneMethod);
+			info.baseTypeInfo = typeInfos.TryGetValue(type.BaseType, out var typeInfo) ? typeInfo : ComputeInfo(type.BaseType, cloneableAncestor);
 		}
 
 		typeInfos[type] = info;

--- a/patches/tModLoader/Terraria/ModLoader/Core/GlobalHookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/GlobalHookList.cs
@@ -7,15 +7,20 @@ namespace Terraria.ModLoader.Core;
 
 public class GlobalHookList<TGlobal> where TGlobal : GlobalType<TGlobal>
 {
-	public readonly MethodInfo method;
+	public LoaderUtils.MethodOverrideQuery<TGlobal> HookOverrideQuery { get; }
+	public MethodInfo Method => HookOverrideQuery.Method;
+
 	private TGlobal[] hookGlobals;
 	private TGlobal[][] hookGlobalsByType;
 
-	public GlobalHookList(MethodInfo method)
+	public GlobalHookList(LoaderUtils.MethodOverrideQuery<TGlobal> hook)
 	{
-		this.method = method;
+		HookOverrideQuery = hook;
 		Update();
 	}
+
+	[Obsolete("Use HookList.Create instead", error: true)]
+	public GlobalHookList(MethodInfo method) : this(method.ToBindingExpression<TGlobal>().ToOverrideQuery()) { }
 
 	public ReadOnlySpan<TGlobal> Enumerate() => hookGlobals;
 	public ReadOnlySpan<TGlobal> Enumerate(int type) => ForType(type);
@@ -28,11 +33,11 @@ public class GlobalHookList<TGlobal> where TGlobal : GlobalType<TGlobal>
 
 	public void Update()
 	{
-		hookGlobals = GlobalList<TGlobal>.Globals.WhereMethodIsOverridden(method).ToArray();
+		hookGlobals = GlobalList<TGlobal>.Globals.Where(HookOverrideQuery.HasOverride).ToArray();
 		hookGlobalsByType = GlobalTypeLookups<TGlobal>.Initialized ? GlobalTypeLookups<TGlobal>.BuildPerTypeGlobalLists(hookGlobals) : null;
 	}
 
 	public static GlobalHookList<TGlobal> Create(Expression<Func<TGlobal, Delegate>> expr) => Create<Delegate>(expr);
 	public static GlobalHookList<TGlobal> Create<F>(Expression<Func<TGlobal, F>> expr) where F : Delegate
-		=> new(expr.ToMethodInfo());
+		=> new(expr.ToOverrideQuery());
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/GlobalHookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/GlobalHookList.cs
@@ -37,7 +37,14 @@ public class GlobalHookList<TGlobal> where TGlobal : GlobalType<TGlobal>
 		hookGlobalsByType = GlobalTypeLookups<TGlobal>.Initialized ? GlobalTypeLookups<TGlobal>.BuildPerTypeGlobalLists(hookGlobals) : null;
 	}
 
+	/// <summary>
+	/// <inheritdoc cref="LoaderUtils.ToOverrideQuery"/>
+	/// </summary>
 	public static GlobalHookList<TGlobal> Create(Expression<Func<TGlobal, Delegate>> expr) => Create<Delegate>(expr);
+
+	/// <summary>
+	/// <inheritdoc cref="LoaderUtils.ToOverrideQuery"/>
+	/// </summary>
 	public static GlobalHookList<TGlobal> Create<F>(Expression<Func<TGlobal, F>> expr) where F : Delegate
 		=> new(expr.ToOverrideQuery());
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/GlobalLoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/GlobalLoaderUtils.cs
@@ -113,7 +113,7 @@ public static class GlobalLoaderUtils<TGlobal, TEntity> where TGlobal : GlobalTy
 	public static void BuildTypeLookups(Action<int> setDefaults)
 	{
 		try {
-			var hookSetDefaults = Globals.WhereMethodIsOverridden(g => (Action<TEntity>)g.SetDefaults).ToArray();
+			var hookSetDefaults = Globals.WhereMethodIsOverridden(g => g.SetDefaults).ToArray();
 
 			int typeCount = GlobalList<TGlobal>.EntityTypeCount;
 			Array.Fill(HookSetDefaultsEarly = new TGlobal[typeCount][], Array.Empty<TGlobal>());

--- a/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/HookList.cs
@@ -67,7 +67,14 @@ public class HookList<T> where T : class
 		return true;
 	}
 
+	/// <summary>
+	/// <inheritdoc cref="LoaderUtils.ToOverrideQuery"/>
+	/// </summary>
 	public static HookList<T> Create(Expression<Func<T, Delegate>> expr) => Create<Delegate>(expr);
+
+	/// <summary>
+	/// <inheritdoc cref="LoaderUtils.ToOverrideQuery"/>
+	/// </summary>
 	public static HookList<T> Create<F>(Expression<Func<T, F>> expr) where F : Delegate
 		=> new(expr.ToOverrideQuery());
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LoaderUtils.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,6 +13,30 @@ namespace Terraria.ModLoader.Core;
 
 public static class LoaderUtils
 {
+	public class MethodOverrideQuery<T>
+	{
+		public MethodInfo Method { get; }
+		public Func<T, Delegate> Binder { get; }
+
+		private MethodOverrideQuery(MethodInfo method, Func<T, Delegate> binder)
+		{
+			Method = method;
+			Binder = binder;
+		}
+
+		public bool HasOverride(T t) => Binder(t).Method != Method;
+
+
+		private static readonly ConcurrentDictionary<MethodInfo, MethodOverrideQuery<T>> _cache = new();
+		public static MethodOverrideQuery<T> Create(Expression<Func<T, Delegate>> expr) => Create<Delegate>(expr);
+
+		public static MethodOverrideQuery<T> Create<F>(Expression<Func<T, F>> expr) where F : Delegate
+		{
+			var method = expr.ToMethodInfo();
+			return _cache.GetOrAdd(method, _ => new MethodOverrideQuery<T>(method, expr.Compile()));
+		}
+	}
+
 	/// <summary> Calls static constructors on the provided type and, optionally, its nested types. </summary>
 	public static void ResetStaticMembers(Type type, bool recursive = true)
 	{
@@ -65,6 +89,7 @@ public static class LoaderUtils
 			throw new MultipleException(exceptions);
 	}
 
+	[Obsolete("Poor performance. Use HasOverride instead", error: true)]
 	public static bool HasMethod(Type type, Type declaringType, string method, params Type[] args)
 	{
 		var methodInfo = type.GetMethod(method, args);
@@ -96,16 +121,52 @@ public static class LoaderUtils
 		return method;
 	}
 
+	private static Type[] _actions = new Type[] { typeof(Action), typeof(Action<>), typeof(Action<,>), typeof(Action<,,>), typeof(Action<,,,>), typeof(Action<,,,,>) };
+	private static Type[] _funcs = new Type[] { typeof(Func<>), typeof(Func<,>), typeof(Func<,,>), typeof(Func<,,,>), typeof(Func<,,,,>), typeof(Func<,,,,,>) };
+	[Obsolete("Exists to support other obsolete methods", error: true)]
+	internal static Expression<Func<T, Delegate>> ToBindingExpression<T>(this MethodInfo method)
+	{
+		var paramTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
+		var delType = method.ReturnType == typeof(void) ? _actions[paramTypes.Length] : _funcs[paramTypes.Length];
+		if (method.ReturnType != typeof(void))
+			paramTypes = paramTypes.Concat(new Type[] { method.ReturnType }).ToArray();
+
+		if (paramTypes.Length != 0)
+			delType = delType.MakeGenericType(paramTypes);
+
+		var retType = typeof(Func<T, Delegate>);
+		var createDelegate = new Func<Type, object, Delegate>(method.CreateDelegate).Method;
+		var param = Expression.Parameter(typeof(T), "t");
+		return Expression.Lambda<Func<T, Delegate>>(
+			Expression.Convert(
+				Expression.Call(
+					Expression.Constant(method),
+					createDelegate,
+					Expression.Constant(delType),
+					param
+				),
+				delType
+			),
+			param
+		);
+	}
+
+	public static MethodOverrideQuery<T> ToOverrideQuery<T, F>(this Expression<Func<T, F>> expr) where F : Delegate
+		=> MethodOverrideQuery<T>.Create(expr);
+
+	[Obsolete("Poor performance. Use MethodOverrideQuery instead", error: true)]
 	public static MethodInfo GetDerivedDefinition(Type t, MethodInfo baseMethod)
 		=> t.GetMethods().Single(m => m.GetBaseDefinition() == baseMethod);
 
+	[Obsolete("Poor performance. Use the delegate expression version instead", error: true)]
 	public static bool HasOverride(Type t, MethodInfo baseMethod)
 		=> baseMethod.DeclaringType!.IsInterface ? t.IsAssignableTo(baseMethod.DeclaringType) : GetDerivedDefinition(t, baseMethod).DeclaringType != baseMethod.DeclaringType;
 
 	public static bool HasOverride<T>(T t, Expression<Func<T, Delegate>> expr) => HasOverride<T, Delegate>(t, expr);
 	public static bool HasOverride<T, F>(T t, Expression<Func<T, F>> expr) where F : Delegate
-		=> HasOverride(t!.GetType(), expr.ToMethodInfo());
+		=> expr.ToOverrideQuery().HasOverride(t);
 
+	[Obsolete("Poor performance. Use the delegate expression version instead", error: true)]
 	public static IEnumerable<T> WhereMethodIsOverridden<T>(this IEnumerable<T> providers, MethodInfo method)
 	{
 		if (!method.IsVirtual)
@@ -116,17 +177,13 @@ public static class LoaderUtils
 
 	public static IEnumerable<T> WhereMethodIsOverridden<T>(this IEnumerable<T> providers, Expression<Func<T, Delegate>> expr) => WhereMethodIsOverridden<T, Delegate>(providers, expr);
 	public static IEnumerable<T> WhereMethodIsOverridden<T, F>(this IEnumerable<T> providers, Expression<Func<T, F>> expr) where F : Delegate
-		=> WhereMethodIsOverridden(providers, expr.ToMethodInfo());
+		=> providers.Where(expr.ToOverrideQuery().HasOverride);
 
 	public static void MustOverrideTogether<T>(T t, params Expression<Func<T, Delegate>>[] methods)
-		=> MustOverrideTogether(t!.GetType(), methods.Select(m => m.ToMethodInfo()).ToArray());
-
-	private static void MustOverrideTogether(Type type, params MethodInfo[] methods)
 	{
-		int c = methods.Count(m => HasOverride(type, m));
-		
+		int c = methods.Count(m => HasOverride(t, m));
 		if (c > 0 && c < methods.Length)
-			throw new Exception($"{type} must override all of ({string.Join('/', methods.Select(m => m.Name))}) or none");
+			throw new Exception($"{t!.GetType()} must override all of ({string.Join('/', methods.Select(m => m.Name))}) or none");
 	}
 
 	private static readonly HashSet<Type> validatedTypes = new();

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -400,11 +400,7 @@ public static class ModLoader
 	/// </summary>
 	internal static void BuildGlobalHook<T, F>(ref F[] list, IList<T> providers, Expression<Func<T, F>> expr) where F : Delegate
 	{
-		list = BuildGlobalHook(providers, expr).Select(expr.Compile()).ToArray();
-	}
-
-	internal static T[] BuildGlobalHook<T, F>(IList<T> providers, Expression<Func<T, F>> expr) where F : Delegate
-	{
-		return providers.WhereMethodIsOverridden(expr).ToArray();
+		var query = expr.ToOverrideQuery();
+		list = providers.Where(query.HasOverride).Select(t => (F)query.Binder(t)).ToArray();
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -23,7 +23,7 @@ partial class SystemLoader
 
 	private static HookList AddHook<F>(Expression<Func<ModSystem, F>> func) where F : Delegate
 	{
-		var hook = new HookList(func.ToMethodInfo());
+		var hook = new HookList(func.ToOverrideQuery());
 		hooks.Add(hook);
 		return hook;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -23,7 +23,7 @@ partial class SystemLoader
 
 	private static HookList AddHook<F>(Expression<Func<ModSystem, F>> func) where F : Delegate
 	{
-		var hook = new HookList(func.ToOverrideQuery());
+		var hook = HookList.Create(func);
 		hooks.Add(hook);
 		return hook;
 	}


### PR DESCRIPTION
### What is the new feature?

Significantly faster implementation of checking whether an instance has an override for a method. This takes advantage of the fact that bound delegate creation performs a v-table lookup and returns the most derived `MethodInfo`. 

A downside is that we can't perform fast override queries based on just the `Type`, we need an instance, but in all cases used in tModLoader an instance was helpfully already available.

### Why should this be part of tModLoader?

Addresses #4054

### Are there alternative designs?

It does suffice to run `MethodInfo.CreateDelegate` rather than `Expression.Compile` as the `Binder`, but it's unlikely to be significantly faster than this impl, and there's the hope that compiling the `Binder` will allow the JIT to optimize it.

### Is this a breaking change

Yes, but best efforts have been made to maintain backwards compatibility, and it has been tested with popular mods. 

The breaking changes are;
- `[Global]HookList.method` has been replaced with the `Method` property.
- `[Global]HookList(MethodInfo)` constructors use a hacky `ToBindingExpression` helper method which doesn't support hooks containing `ref` params or more than 6 arguments. 
  - Modders are advised to use `[Global]HookList.Create` instead.
