### PR TITLE
Assert executability of manage-tModLoaderServer.sh

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
@@ -34,6 +34,9 @@ ADD --chown=tml:tml https://raw.githubusercontent.com/tModLoader/tModLoader/1.4.
 # directory as this file, comment out the above line and uncomment this line:
 # COPY --chown=tml:tml manage-tModLoaderServer.sh .
 
+# Make management script executable. Fixes "Permission Denied" error on some systems.
+RUN chmod +x manage-tModLoaderServer.sh
+
 RUN ./manage-tModLoaderServer.sh install-tml --github --tml-version $TML_VERSION
 
 EXPOSE 7777


### PR DESCRIPTION
Building this dockerfile failed on my machine, as manage-tModLoaderServer.sh was not set to be executable. This was causing a "Permission Denied" error. This change fixes that.

### What is the bug?
`manage-tModLoaderServer.sh` was not executable, throwing exit code 126 and a "Permission Denied" error.

```
 => ERROR [tml 8/8] RUN ./manage-tModLoaderServer.sh install-tml --github --tml-version $TML_VERSION                            5.1s
------
 > [tml 8/8] RUN ./manage-tModLoaderServer.sh install-tml --github --tml-version $TML_VERSION:
3.554 /bin/sh: ./manage-tModLoaderServer.sh: Permission denied
------
failed to solve: process "/bin/sh -c ./manage-tModLoaderServer.sh install-tml --github --tml-version $TML_VERSION" did not complete successfully: exit code: 126
```

### How did you fix the bug?
Use `chmod` to make the script executable.

### Are there alternatives to your fix?
Most likely, but this is a straightforward fix.
