### PR TITLE
Fix incorrect date handling & other logging issues

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/LogArchiver.cs
@@ -123,7 +123,11 @@ internal static class LogArchiver
 		try {
 			using (var zip = new ZipFile(Path.Combine(Logging.LogArchiveDir, $"{time:yyyy-MM-dd}-{n}.zip"), Encoding.UTF8)) {
 				foreach (var logFile in logFiles) {
-					var entryName = Path.GetFileNameWithoutExtension(logFile); // Note this gives client.log from client.log.old
+					// Omit '.old', but not '.old9001', as doing the latter would result in duplicate names.
+					string entryName = Path.GetExtension(logFile) == ".old"
+						? Path.GetFileNameWithoutExtension(logFile)
+						: Path.GetFileName(logFile);
+
 					using (var stream = File.OpenRead(logFile)) {
 						if (stream.Length > 10_000_000) {
 							// Some users have enormous log files for unknown reasons. Techinically 4GB is the limit for regular zip files, but 10MB seems reasonable.

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -79,7 +79,8 @@ public static partial class Logging
 			tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
 		}
 
-		DumpEnvVars();
+		if (!Program.LaunchParameters.ContainsKey("-build"))
+			DumpEnvVars();
 
 		string stackLimit = Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize");
 

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -67,6 +67,9 @@ public static partial class Logging
 
 	internal static void LogStartup(bool dedServ)
 	{
+		if (Program.LaunchParameters.ContainsKey("-build"))
+			return;
+
 		tML.InfoFormat("Starting tModLoader {0} {1} built {2}", dedServ ? "server" : "client", BuildInfo.BuildIdentifier, $"{BuildInfo.BuildDate:g}");
 		tML.InfoFormat("Log date: {0}", DateTime.Now.ToString("d"));
 		tML.InfoFormat("Running on {0} (v{1}) {2} {3} {4}", ReLogic.OS.Platform.Current.Type, Environment.OSVersion.Version, System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture, FrameworkVersion.Framework, FrameworkVersion.Version);
@@ -81,8 +84,7 @@ public static partial class Logging
 			tML.InfoFormat("Parsed Launch Parameters: {0}", string.Join(' ', Program.LaunchParameters.Select(p => ($"{p.Key} {p.Value}").Trim())));
 		}
 
-		if (!Program.LaunchParameters.ContainsKey("-build"))
-			DumpEnvVars();
+		DumpEnvVars();
 
 		string stackLimit = Environment.GetEnvironmentVariable("COMPlus_DefaultStackSize");
 

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -47,6 +47,8 @@ public static partial class Logging
 
 	internal static void Init(LogFile logFile)
 	{
+		LegacyCleanups();
+
 		if (Program.LaunchParameters.ContainsKey("-build"))
 			return;
 
@@ -281,6 +283,25 @@ public static partial class Logging
 
 			try { File.SetCreationTime(filePath, DateTime.Now); }
 			catch { }
+		}
+	}
+
+	private static readonly string[] autoRemovedFiles = {
+		"environment-",
+	};
+
+	// Removes files that shouldn't have ever existed.
+	private static void LegacyCleanups()
+	{
+		using var _ = new QuietExceptionHandle();
+
+		foreach (string filePath in autoRemovedFiles) {
+			string fullPath = Path.Combine(LogDir, filePath);
+
+			if (File.Exists(fullPath)) {
+				try { File.Delete(fullPath); }
+				catch { }
+			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -55,6 +55,7 @@ public static partial class Logging
 		try {
 			InitLogPaths(logFile);
 			ConfigureAppenders(logFile);
+			ForceUpdateLogCreationDates();
 		}
 		catch (Exception e) {
 			ErrorReporting.FatalExit("Failed to init logging", e);
@@ -120,7 +121,7 @@ public static partial class Logging
 			File = LogPath,
 			AppendToFile = false,
 			Encoding = encoding,
-			Layout = layout
+			Layout = layout,
 		};
 
 		fileAppender.ActivateOptions();
@@ -264,6 +265,17 @@ public static partial class Logging
 		}
 		catch (Exception e) {
 			tML.Error("Failed to dump env vars", e);
+		}
+	}
+
+	private static void ForceUpdateLogCreationDates()
+	{
+		// Force-update file creation date, because log4net does not do that.
+		if (File.Exists(LogPath)) {
+			using var _ = new QuietExceptionHandle();
+
+			try { File.SetCreationTime(LogPath, DateTime.Now); }
+			catch { }
 		}
 	}
 }


### PR DESCRIPTION
Resolves #4025 by doing the following:
- [x] Force-updates creation dates of `(client|server|environment-*).log` files on startup. Log4net does not do that, and envdumps used streamed writes which especially wouldn't have done that.
- [x] Prevents `LogArchiver` from throwing silent exceptions whenever it encounters numbered `.log.old` files, halting its function.
### Additionally:
- [x] Prevents `environment-` files from being created during mod packaging:
![image](https://github.com/tModLoader/tModLoader/assets/6795251/af46136c-a295-439c-a22a-78a7739c9fd5)
(They're also deleted if found)
