### PR TITLE
Minor performance improvement

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -184,7 +184,7 @@
 +					tileStyle = sandType + 1;
 +					break;
 +				}
-+					
++
 +				if (tile.frameX == 204 || tile.frameX == 202) {
 +					var asset = PlantLoader.GetCactusFruitTexture(sandType);
 +					if (asset != null)
@@ -250,12 +250,13 @@
  		return num;
  	}
  
-@@ -2877,7 +_,7 @@
+@@ -2877,7 +_,8 @@
  		vertices.TopRightColor *= num7;
  		bool flag7 = false;
  		if (flag6) {
++			int totalCount = LoaderManager.Get<WaterStylesLoader>().TotalCount;
 -			for (int i = 0; i < 15; i++) {
-+			for (int i = 0; i < LoaderManager.Get<WaterStylesLoader>().TotalCount; i++) {
++			for (int i = 0; i < totalCount; i++) {
  				if (Main.IsLiquidStyleWater(i) && Main.liquidAlpha[i] > 0f && i != num2) {
  					DrawPartialLiquid(!solidLayer, tileCache, ref position, ref liquidSize, i, ref vertices);
  					flag7 = true;
@@ -548,7 +549,7 @@
 +
  			texture2D = TextureAssets.TreeTop[treeTextureIndex].Value;
 +		}
-+			
++
  
  		return texture2D;
  	}


### PR DESCRIPTION
### What is the bug?
Not a bug by definition, but this is the closest template to what I could find.
![performance](https://github.com/tModLoader/tModLoader/assets/51512085/cb54212e-a709-44a1-869f-7c7d45355a82)

From profiling, the call to `LoaderManager.Get` can use up to 1.65% of the frame time while running.

### How did you fix the bug?
Extracting the condition out of the for-loop condition will reduce the amount of calls to only once per invocation.

### Are there alternatives to your fix?
As this is minor edit, I don't believe there's anything else that should be done.

