### PR TITLE
Prevent config.json corruption and workaround existing corruption.

### DIFF
--- a/patches/tModLoader/Terraria/IO/Preferences.cs.patch
+++ b/patches/tModLoader/Terraria/IO/Preferences.cs.patch
@@ -1,0 +1,17 @@
+--- src/TerrariaNetCore/Terraria/IO/Preferences.cs
++++ src/tModLoader/Terraria/IO/Preferences.cs
+@@ -93,7 +_,14 @@
+ 					if (this.OnProcessText != null)
+ 						this.OnProcessText(ref text);
+ 
++					// tML: Due to corrupted config.json, we save to .bak file then atomically File.Move in an attempt to avoid corruption.
++					string bakPath = _path + ".bak";
++					File.WriteAllText(bakPath, text);
++					File.Move(bakPath, _path, overwrite: true);
++					File.Delete(bakPath);
++					/*
+ 					File.WriteAllText(_path, text);
++					*/
+ 					File.SetAttributes(_path, FileAttributes.Normal);
+ 				}
+ 				else {

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -90,4 +90,37 @@ internal class ErrorReporting
 
 		FatalExit(message);
 	}
+
+	/// <summary>
+	/// Shows an OS-provided modal message box displaying a message and a number of buttons and returns the button index of the user-selected option. The first option will be mapped to return key and the last option to escape key. The options are displayed from right to left in order.
+	/// </summary>
+	/// <returns></returns>
+	internal static int ShowMessageBoxWithChoices(string title, string message, string[] buttonLabels)
+	{
+		SDL2.SDL.SDL_MessageBoxButtonData[] buttons = new SDL2.SDL.SDL_MessageBoxButtonData[buttonLabels.Length];
+		for (int i = 0; i < buttonLabels.Length; i++) {
+			buttons[i] = new SDL2.SDL.SDL_MessageBoxButtonData() { flags = 0, buttonid = i, text = buttonLabels[i] };
+			if (i == 0)
+				buttons[i].flags = SDL2.SDL.SDL_MessageBoxButtonFlags.SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT;
+			else if (i == buttonLabels.Length - 1)
+				buttons[i].flags = SDL2.SDL.SDL_MessageBoxButtonFlags.SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT;
+		}
+		SDL2.SDL.SDL_MessageBoxData messageBoxData = new SDL2.SDL.SDL_MessageBoxData() {
+			flags = SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_INFORMATION,
+			window = IntPtr.Zero,
+			title = title,
+			message = message,
+			numbuttons = buttons.Length,
+			buttons = buttons,
+			colorScheme = null
+		};
+		int buttonID;
+		if (SDL2.SDL.SDL_ShowMessageBox(ref messageBoxData, out buttonID) < 0) {
+			Logging.tML.Info("ShowMessageBoxWithChoices: Error displaying message box");
+		}
+		if (buttonID == -1) {
+			Logging.tML.Info("ShowMessageBoxWithChoices: No selection");
+		}
+		return buttonID;
+	}
 }

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -160,7 +160,7 @@ public static partial class Program
 		if (!File.Exists(sourceFolderConfig)) {
 			Logging.tML.Info($"No config.json found at {sourceFolderConfig}\nAssuming nothing to port");
 			return;
-		}	
+		}
 
 		string lastLaunchedTml = null;
 		try {
@@ -174,24 +174,16 @@ public static partial class Program
 				lastLaunchedTml = BuildInfo.tMLVersion.ToString();
 			}
 			else {
-				e.HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#configjson-corrupted";
-				ErrorReporting.FatalExit($"Attempt to Port from \"{oldFolderPath}\" to \"{newFolderPath}\" aborted, the \"{sourceFolderConfig}\" file is corrupted.", e);
+				PromptUserForNewestTMLVersionLaunched(ref lastLaunchedTml);
+
+				if (string.IsNullOrEmpty(lastLaunchedTml)) {
+					e.HelpLink = "https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Usage-FAQ#configjson-corrupted";
+					ErrorReporting.FatalExit($"Attempt to Port from \"{oldFolderPath}\" to \"{newFolderPath}\" aborted, the \"{sourceFolderConfig}\" file is corrupted.", e);
+				}
 			}
 		}
 
-		if (string.IsNullOrEmpty(lastLaunchedTml)) {
-			// If the config.json is missing LastLaunchedTModLoaderVersion entry, we can ask the user. (Most likely the user copied Terraria/config.json over)
-			int result = ErrorReporting.ShowMessageBoxWithChoices(
-				title: "Failed to read config.json configuration file",
-				message: "Your config.json file is incomplete.\n\nPlease select one of the following options and the game will resume loading:\n\nWhat is the highest version of tModLoader that you have launched?",
-				buttonLabels: new string[] { "1.4.4", "1.4.3", "Cancel" }
-			);
-			if (result == 0)
-				lastLaunchedTml = BuildInfo.tMLVersion.ToString();
-			if (result == 1)
-				lastLaunchedTml = "2022.09";
-			// If the user presses escape or presses cancel, lastLaunchedTml will still be NullOrEmpty.
-		}
+		PromptUserForNewestTMLVersionLaunched(ref lastLaunchedTml);
 
 		if (string.IsNullOrEmpty(lastLaunchedTml)) {
 			// It's unclear what we should do in this situation. Leave it up to the user.
@@ -237,6 +229,24 @@ public static partial class Program
 		}
 
 		Logging.tML.Info($"Porting {cloudName} finished");
+
+		static void PromptUserForNewestTMLVersionLaunched(ref string lastLaunchedTml)
+		{
+			if (string.IsNullOrEmpty(lastLaunchedTml)) {
+				// If the config.json is missing LastLaunchedTModLoaderVersion entry, we can ask the user. (Most likely the user copied Terraria/config.json over)
+				// We can't localized these the normal way because localization isn't loaded at this point.
+				int result = ErrorReporting.ShowMessageBoxWithChoices(
+					title: "Failed to read config.json configuration file",
+					message: "Your config.json file is incomplete.\n\nPlease select one of the following options and the game will resume loading:\n\nWhat is the highest version of tModLoader that you have launched?",
+					buttonLabels: new string[] { "1.4.4", "1.4.3", "Cancel" }
+				);
+				if (result == 0)
+					lastLaunchedTml = BuildInfo.tMLVersion.ToString();
+				if (result == 1)
+					lastLaunchedTml = "2022.09";
+				// If the user presses escape or presses cancel, lastLaunchedTml will still be NullOrEmpty.
+			}
+		}
 	}
 
 	internal static void PortFilesMaster(string savePath, bool isCloud)


### PR DESCRIPTION
Implements various workarounds for config.json corruption issues that prevent version migration from processing correctly.

config.json should now no longer be corrupted due to computer crashes while saving.

config.json file write timestamp is used to make assumptions about the status of porting. A recent edit suggest that a tModLoader version with the porting logic has already been executed.

A final fallback is a prompt for the user to select which version has been launched, allowing the logic to proceed. 