### PR TITLE
Improve speed of AssetRequestMode.ImmediateLoad during mod loading

### DIFF
--- a/patches/tModLoader/ReLogic/Content/AssetRepository.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/AssetRepository.cs.patch
@@ -188,7 +188,7 @@
  			if (_assets.TryGetValue(assetName, out var value))
  				asset = value as Asset<T>;
  
-@@ -66,20 +_,39 @@
+@@ -66,21 +_,45 @@
  				asset = new Asset<T>(assetName);
  				_assets[assetName] = asset;
  			}
@@ -223,18 +223,24 @@
 +		}
 +	}
 +
-+	public void TransferCompletedAssets() // todo, allow partial transfers
++	public bool TransferCompletedAssets() // todo, allow partial transfers
  	{
  		ThrowIfDisposed();
 +		ThrowIfNotMainThread();
 +
++		bool transferredAnything = false;
  		lock (_requestLock) {
 -			_asyncLoader.TransferCompleted();
-+			while (_assetTransferQueue.TryDequeue(out var action))
++			while (_assetTransferQueue.TryDequeue(out var action)) {
 +				action();
++				transferredAnything = true;
++			}
  		}
++
++		return transferredAnything;
  	}
  
+ 	private void ReloadAssetsIfSourceChanged(AssetRequestMode mode)
 @@ -90,7 +_,7 @@
  			if (contentSource == null)
  				ForceReloadAsset(item, AssetRequestMode.DoNotLoad);
@@ -244,7 +250,7 @@
  		}
  	}
  
-@@ -99,81 +_,149 @@
+@@ -99,81 +_,148 @@
  		if (mode == AssetRequestMode.DoNotLoad)
  			return;
  
@@ -404,9 +410,8 @@
 +			// rather than running the whole transfer queue, and potentially inducing stuttering, we run the continuation directly from the asset
 +
 +			// wait for a continuation to be scheduled (all async loads will schedule one)
-+			while (asset.Continuation == null) {
-+				Thread.Yield();
-+			}
++			if (asset.Continuation == null)
++				SpinWait.SpinUntil(() => asset.Continuation != null);
 +
 +			// running continuations requires the main thread (MainThreadAwaitable)
 +			if (tracked) {

--- a/patches/tModLoader/ReLogic/Content/IAssetRepository.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/IAssetRepository.cs.patch
@@ -8,7 +8,7 @@
  using ReLogic.Content.Sources;
  
  namespace ReLogic.Content;
-@@ -16,7 +_,30 @@
+@@ -16,7 +_,31 @@
  
  	void SetSources(IEnumerable<IContentSource> sources, AssetRequestMode mode = AssetRequestMode.ImmediateLoad);
  
@@ -30,11 +30,13 @@
 +	/// <returns></returns>
 -	Asset<T> Request<T>(string assetName, AssetRequestMode mode = AssetRequestMode.ImmediateLoad) where T : class;
 +	Asset<T> Request<T>(string assetName, AssetRequestMode mode = AssetRequestMode.AsyncLoad) where T : class;
-+
+ 
+-	void TransferCompletedAssets();
 +	// Added by TML.
 +	Asset<T> CreateUntracked<T>(Stream stream, string name, AssetRequestMode mode = AssetRequestMode.ImmediateLoad) where T : class;
- 
- 	void TransferCompletedAssets();
++
++	// Return type changed to bool to indicate if any assets were transferred
++	bool TransferCompletedAssets();
 +
 +	// Exists to change the default parameter of 'mode' (from Immediate to Async) for modders, but not the base game.
 +	internal Asset<T> Request<T>(string assetName) where T : class

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -626,9 +626,26 @@ public static class ModContent
 
 	internal static void TransferCompletedAssets()
 	{
-		foreach (var mod in ModLoader.Mods)
+		if (!ModLoader.isLoading) {
+			DoTransferCompletedAssets();
+			return;
+		}
+
+		// During mod loading, spin wait for assets to transfer. Note that SpinWait.SpinUntil uses a low resolution timer (~15ms on windows) so it may spin for up to that long.
+		// If any assets are queued we will continue to spend main thread time to transfer assets. We accept some frame stutter to hopefully sync up with repeated ImmediateLoad calls and get better throughput
+		var sw = Stopwatch.StartNew();
+		while (sw.ElapsedMilliseconds < 15 && SpinWait.SpinUntil(DoTransferCompletedAssets, millisecondsTimeout: 1)) { }
+	}
+
+	private static bool DoTransferCompletedAssets()
+	{
+		bool transferredAnything = false;
+		foreach (var mod in ModLoader.Mods) {
 			if (mod.Assets is AssetRepository assetRepo && !assetRepo.IsDisposed)
-				assetRepo.TransferCompletedAssets();
+				transferredAnything |= assetRepo.TransferCompletedAssets();
+		}
+
+		return false;
 	}
 
 	private class AssetWaitTracker : IDisposable

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -68,7 +68,7 @@ public static class ModLoader
 	internal static bool skipLoad;
 	internal static Action OnSuccessfulLoad;
 
-	private static bool isLoading;
+	internal static bool isLoading;
 
 	public static Mod[] Mods { get; private set; } = new Mod[0];
 


### PR DESCRIPTION
### What is the new feature?

During mod loading, the main thread will now devote more CPU time to spin waiting for assets to load. Can decrease FPS to ~50 when mods are actually doing lots of immediate loads.

### Why should this be part of tModLoader?

Since mod loading runs on another thread, and assets can only finish loading on the main thread, using `AssetRequestMode.ImmediateLoad` limits mods to loading only a single asset each frame. This change means the main thread spends some time after loading an asset, waiting for another one to be queued and processing it immediately. There's no actual way to perfectly sync up the threads, but it is an improvement.

Improves the speed of `AssetRequestMode.ImmediateLoad` by ~30%. This will improve mod loading times for mods which haven't moved to `AsyncLoad` yet. Note that `ImmediateLoad` is still not recommended, it's just, slightly faster than it was.

### Are there alternative designs?

I experimented with a bunch, but avoiding starvation of cores and confusing the windows scheduler was harder than I expected. This 'works on my machine' and shouldn't be a performance problem for others.