### PR TITLE
Fix Legacy Splash Sound for Shimmer

### DIFF
--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -661,7 +661,14 @@ partial class SoundID
 		LegacySoundIDs.DoubleJump => DoubleJump,
 		LegacySoundIDs.Run => Run,
 		LegacySoundIDs.Coins => Coins,
-		LegacySoundIDs.Splash => style switch { 1 => SplashWeak, _ => Splash },
+		LegacySoundIDs.Splash => style switch {
+			1 => SplashWeak,
+			2 => Shimmer1,
+			3 => Shimmer2,
+			4 => ShimmerWeak1,
+			5 => ShimmerWeak2,
+			_ => Splash
+		},
 		LegacySoundIDs.FemaleHit => FemaleHit,
 		LegacySoundIDs.Tink => Tink,
 		LegacySoundIDs.Unlock => Unlock,


### PR DESCRIPTION
### What is the bug?

Fixes #4111 

The legacy Splash sound was missing the cases for the shimmer sounds, so it defaulted to the regular splash sound.

### How did you fix the bug?

Updated the `LegacySoundIDs.Splash` switch statement in `SoundID.TML.GetLegacyStyle()` with the shimmer styles.

### Are there alternatives to your fix?

Probably not.
