### PR TITLE
Publicize Eye Helper

### DIFF
--- a/ExampleMod/Common/Players/ExampleBlinkingPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleBlinkingPlayer.cs
@@ -1,0 +1,31 @@
+﻿using Terraria.GameContent;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	// Showcases modifying eye state and frames under certain condition.
+	public class ExampleBlinkingPlayer : ModPlayer
+	{
+		public override void PostUpdate() {
+			// Set eye state to our custom eye state if player is in water and is in state of normal blinking.
+			if (Player.eyeHelper.CurrentEyeState == PlayerEyeHelper.EyeState.NormalBlinking && Player.wet) {
+				Player.eyeHelper.CurrentEyeFrame = PlayerEyeHelper.EyeFrame.EyeClosed;
+				Player.eyeHelper.TimeInState = 0;
+			}
+
+			// Override vanilla blind eye state with our own.
+			// It's enough to check for `Player.blind`, but that way it wouldn't replace `IsBlind` eye state set by other mods.
+			// Decide yourself whatever option fits your needs.
+			if (Player.eyeHelper.CurrentEyeState == PlayerEyeHelper.EyeState.IsBlind) {
+				// Close players eyes for 115 ticks out of 120 ticks.
+				// The remaining 5 ticks player will have half closed eyes.
+				if ((Player.eyeHelper.TimeInState % 120 - 115) < 0) {
+					Player.eyeHelper.CurrentEyeFrame = PlayerEyeHelper.EyeFrame.EyeClosed;
+				}
+				else {
+					Player.eyeHelper.CurrentEyeFrame = PlayerEyeHelper.EyeFrame.EyeHalfClosed;
+				}
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/GameContent/PlayerEyeHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/PlayerEyeHelper.cs.patch
@@ -1,0 +1,84 @@
+--- src/TerrariaNetCore/Terraria/GameContent/PlayerEyeHelper.cs
++++ src/tModLoader/Terraria/GameContent/PlayerEyeHelper.cs
+@@ -2,22 +_,48 @@
+ 
+ public struct PlayerEyeHelper
+ {
++	// TML: Made public
+-	private enum EyeFrame
++	public enum EyeFrame
+ 	{
+ 		EyeOpen,
+ 		EyeHalfClosed,
+ 		EyeClosed
+ 	}
+ 
++	// TML: Made public
+-	private enum EyeState
++	public enum EyeState
+ 	{
+ 		NormalBlinking,
++		/// <summary>
++		/// <br/> Out of 120 ticks, 5 of them will have eyes closed; otherwise eyes are half closed.
++		/// </summary>
+ 		InStorm,
++		/// <summary>
++		/// <br/> Slowly closes eyes.
++		/// <para/> If player is moderately damaged, then eyes will be half closed for first second in bed instead of open.
++		/// <br/> For the next second, eyes are half closed.
++		/// <br/> Afterwards, eyes are closed.
++		/// </summary>
+ 		InBed,
++		/// <summary>
++		/// <br/> Eyes always closed.
++		/// </summary>
+ 		JustTookDamage,
++		/// <summary>
++		/// <br/> Out of 120 ticks, 19 of them will have eyes closed; otherwise eyes are half closed.
++		/// </summary>
+ 		IsModeratelyDamaged,
++		/// <summary>
++		/// <br/> Eyes always closed.
++		/// </summary>
+ 		IsBlind,
++		/// <summary>
++		/// <br/> Out of 120 ticks, 19 of them will have eyes closed; otherwise eyes are half closed.
++		/// </summary>
+ 		IsTipsy,
++		/// <summary>
++		/// <br/> Out of 120 ticks, 19 of them will have eyes closed; otherwise eyes are half closed.
++		/// </summary>
+ 		IsPoisoned
+ 	}
+ 
+@@ -25,7 +_,20 @@
+ 	private int _timeInState;
+ 	private const int TimeToActDamaged = 20;
+ 
+-	public int EyeFrameToShow { get; private set; }
++	internal int EyeFrameToShow { get; private set; } // TML: Made internal
++
++	public EyeState CurrentEyeState { // TML
++		get => _state;
++		set => _state = value;
++	}
++	public EyeFrame CurrentEyeFrame { // TML
++		get => (EyeFrame)EyeFrameToShow;
++		set => EyeFrameToShow = (int)value;
++	}
++	public int TimeInState { // TML
++		get => _timeInState;
++		set => _timeInState = value;
++	}
+ 
+ 	public void Update(Player player)
+ 	{
+@@ -109,7 +_,7 @@
+ 		}
+ 	}
+ 
+-	private void SwitchToState(EyeState newState, bool resetStateTimerEvenIfAlreadyInState = false)
++	public void SwitchToState(EyeState newState, bool resetStateTimerEvenIfAlreadyInState = false) // TML: Made public
+ 	{
+ 		if (_state != newState || resetStateTimerEvenIfAlreadyInState) {
+ 			_state = newState;


### PR DESCRIPTION
Closes #2350 

### What is the new feature?
Publicizes `PlayerEyeHelper` to give modders control over player eyes.

### Why should this be part of tModLoader?
There's no (good) way of interacting with player eyes (excluding reflection which is slow and will box eye helper struct)

### Are there alternative designs?
.

### Sample usage for the new feature
```cs
Player.eyeHelper.CurrentEyeFrame = PlayerEyeHelper.EyeFrame.EyeOpen;
```

### ExampleMod updates
Added `ExampleBlinkingPlayer` to showcase new possibilities.

### Porting Notes
`Player.eyeHelper.EyeFrameToShow` => `Player.eyeHelper.CurrentEyeFrame` (return type was also changed from `int` to `PlayerEyeHelper.EyeFrame`)