### PR TITLE
Make HitInfo and HurtInfo read/init only

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleSwingingEnergySwordProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleSwingingEnergySwordProjectile.cs
@@ -160,6 +160,11 @@ namespace ExampleMod.Content.Projectiles
 			Utils.PlotTileLine(Projectile.Center + starting, Projectile.Center + ending, width, DelegateMethods.CutTiles);
 		}
 
+		public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers) {
+			// Set the target's hit direction to away from the player so the knockback is in the correct direction.
+			modifiers.HitDirectionOverride = (Main.player[Projectile.owner].Center.X < target.Center.X) ? 1 : (-1);
+		}
+
 		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone) {
 			// Vanilla has several particles that can easily be used anywhere.
 			// The particles from the Particle Orchestra are predefined by vanilla and most can not be customized that much.
@@ -171,17 +176,16 @@ namespace ExampleMod.Content.Projectiles
 
 			// You could also spawn dusts at the enemy position. Here is simple an example:
 			// Dust.NewDust(Main.rand.NextVector2FromRectangle(target.Hitbox), 0, 0, ModContent.DustType<Content.Dusts.Sparkle>());
+		}
 
-			// Set the target's hit direction to away from the player so the knockback is in the correct direction.
-			hit.HitDirection = (Main.player[Projectile.owner].Center.X < target.Center.X) ? 1 : (-1);
+		public override void ModifyHitPlayer(Player target, ref Player.HurtModifiers modifiers) {
+			modifiers.HitDirectionOverride = (Main.player[Projectile.owner].Center.X < target.Center.X) ? 1 : (-1);
 		}
 
 		public override void OnHitPlayer(Player target, Player.HurtInfo info) {
 			ParticleOrchestrator.RequestParticleSpawn(clientOnly: false, ParticleOrchestraType.Excalibur,
 				new ParticleOrchestraSettings { PositionInWorld = Main.rand.NextVector2FromRectangle(target.Hitbox) },
 				Projectile.owner);
-
-			info.HitDirection = (Main.player[Projectile.owner].Center.X < target.Center.X) ? 1 : (-1);
 		}
 
 		// Taken from Main.DrawProj_Excalibur()

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -283,7 +283,7 @@
  				projectile.ProjectileFixDesperation();
  				if (Main.netMode == 2)
  					NetMessage.TrySendData(27, -1, whoAmI, null, num230);
-@@ -1538,10 +_,29 @@
+@@ -1538,10 +_,33 @@
  			}
  			case 28: {
  				int num211 = reader.ReadInt16();
@@ -297,17 +297,21 @@
 +				var num212 = reader.Read7BitEncodedInt();
 +				NPC.HitInfo hit = default;
 +				if (num212 >= 0) {
++					var sourceDamage = reader.Read7BitEncodedInt();
++					var damageType = DamageClassLoader.DamageClasses[reader.Read7BitEncodedInt()];
++					var hitDirection = reader.ReadSByte();
++					var knockBack = reader.ReadSingle();
++					BitsByte flags = reader.ReadByte();
 +					hit = new NPC.HitInfo {
 +						Damage = num212,
-+						SourceDamage = reader.Read7BitEncodedInt(),
-+						DamageType = DamageClassLoader.DamageClasses[reader.Read7BitEncodedInt()],
-+						HitDirection = reader.ReadSByte(),
-+						Knockback = reader.ReadSingle()
++						SourceDamage = sourceDamage,
++						DamageType = damageType,
++						HitDirection = hitDirection,
++						Knockback = knockBack,
++						Crit = flags[0],
++						InstantKill = flags[1],
++						HideCombatText = flags[2],
 +					};
-+					BitsByte flags = reader.ReadByte();
-+					hit.Crit = flags[0];
-+					hit.InstantKill = flags[1];
-+					hit.HideCombatText = flags[2];
 +				}
 +
  				if (Main.netMode == 2) {

--- a/patches/tModLoader/Terraria/NPC.TML.Hit.cs
+++ b/patches/tModLoader/Terraria/NPC.TML.Hit.cs
@@ -255,14 +255,14 @@ public partial class NPC
 	/// <summary>
 	/// Represents a finalized damage calculation for damage about to be applied to an NPC. This is the result of all modifications done previously in a <see cref="HitModifiers"/> provided to the ModifyHit hooks.
 	/// </summary>
-	public struct HitInfo
+	public readonly struct HitInfo
 	{
 		/// <summary>
 		/// The DamageType of the hit.
 		/// </summary>
-		public DamageClass DamageType = DamageClass.Default;
+		public DamageClass DamageType { get; init; } = DamageClass.Default;
 
-		private int _sourceDamage = 1;
+		private readonly int _sourceDamage = 1;
 		/// <summary>
 		/// The amount of damage 'dealt' to the NPC, before incoming damage multipliers, armor, critical strikes etc.<br/>
 		/// Use this to trigger effects which scale based on damage dealt, and also deal damage.<br/>
@@ -273,11 +273,11 @@ public partial class NPC
 		/// Used by vanilla for dryad ward retaliation, and many sword on-hit projectiles like volcano and beekeeper
 		/// </summary>
 		public int SourceDamage {
-			readonly get => _sourceDamage;
-			set => _sourceDamage = Math.Max(value, 1);
+			get => _sourceDamage;
+			init => _sourceDamage = Math.Max(value, 1);
 		}
 
-		private int _damage = 1;
+		private readonly int _damage = 1;
 		/// <summary>
 		/// The amount of damage received by the NPC. How much life the NPC will lose. <br/>
 		/// Is NOT capped at the NPC's current life. <br/>
@@ -285,36 +285,36 @@ public partial class NPC
 		/// Cannot be set to less than 1.
 		/// </summary>
 		public int Damage {
-			readonly get => _damage;
-			set => _damage = Math.Max(value, 1);
+			get => _damage;
+			init => _damage = Math.Max(value, 1);
 		}
 
 		/// <summary>
 		/// Whether or not the hit is a crit
 		/// </summary>
-		public bool Crit = false;
+		public bool Crit { get; init; } = false;
 
 		/// <summary>
 		/// The direction to apply knockback in.
 		/// </summary>
-		public int HitDirection = 0;
+		public int HitDirection { get; init; } = 0;
 
 		/// <summary>
 		/// The amount of knockback to apply. Should always be >= 0. <br/>
 		/// Note that <see cref="NPC.StrikeNPC(HitInfo, bool, bool)"/> has a staggered knockback falloff, and that critical strikes automatically get extra 40% knockback in excess of this value.
 		/// </summary>
-		public float Knockback = 0;
+		public float Knockback { get; init; } = 0;
 
 		/// <summary>
 		/// If true, as much damage as necessary will be dealt, and damage number popups will not be shown for this hit. <br/>
 		/// Has no effect if the NPC is <see cref="NPC.immortal"/>
 		/// </summary>
-		public bool InstantKill = false;
+		public bool InstantKill { get; init; } = false;
 
 		/// <summary>
 		/// If true, damage number popups will not be shown for this hit.
 		/// </summary>
-		public bool HideCombatText = false;
+		public bool HideCombatText { get; init; } = false;
 
 		public HitInfo() { }
 	}

--- a/patches/tModLoader/Terraria/Player.TML.Hurt.cs
+++ b/patches/tModLoader/Terraria/Player.TML.Hurt.cs
@@ -187,29 +187,29 @@ public partial class Player
 	/// <summary>
 	/// Represents a finalized damage calculation for damage about to be applied to a Player. This is the result of all modifications done previously in a <see cref="HurtModifiers"/> provided to various hooks.
 	/// </summary>
-	public struct HurtInfo
+	public readonly struct HurtInfo
 	{
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.DamageSource"/>
 		/// </summary>
-		public PlayerDeathReason DamageSource = null;
+		public PlayerDeathReason DamageSource { get; init; } = null;
 
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.PvP"/>
 		/// </summary>
-		public bool PvP = false;
+		public bool PvP { get; init; } = false;
 
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.CooldownCounter"/>
 		/// </summary>
-		public int CooldownCounter = -1;
+		public int CooldownCounter { get; init; } = -1;
 
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.Dodgeable"/>
 		/// </summary>
-		public bool Dodgeable = true;
+		public bool Dodgeable { get; init; } = true;
 
-		private int _sourceDamage = 1;
+		private readonly int _sourceDamage = 1;
 		/// <summary>
 		/// The amount of damage 'dealt' to the player, before incoming damage multipliers, armor, damage reduction.<br/>
 		/// Use this to trigger effects which scale based on how 'hard' the player was hit rather than how much life was lost.<br/>
@@ -218,45 +218,45 @@ public partial class Player
 		/// Using this instead of <see cref="Damage"/> can prevent diminishing returns damage mitigation, when adding beneficial effects like retaliatory damage.
 		/// </summary>
 		public int SourceDamage {
-			readonly get => _sourceDamage;
-			set => _sourceDamage = Math.Max(value, 1);
+			get => _sourceDamage;
+			init => _sourceDamage = Math.Max(value, 1);
 		}
 
-		private int _damage = 1;
+		private readonly int _damage = 1;
 		/// <summary>
 		/// The amount of damage received by the player. How much life the player will lose. <br/>
 		/// Is NOT capped at the player's current life.<br/>
 		/// Cannot be set to less than 1.
 		/// </summary>
 		public int Damage {
-			readonly get => _damage;
-			set => _damage = Math.Max(value, 1);
+			get => _damage;
+			init => _damage = Math.Max(value, 1);
 		}
 
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.HitDirection"/>
 		/// </summary>
-		public int HitDirection = 0;
+		public int HitDirection { get; init; } = 0;
 
 		/// <summary>
 		/// The amount of knockback to apply. Should always be >= 0.
 		/// </summary>
-		public float Knockback = 0;
+		public float Knockback { get; init; } = 0;
 
 		/// <summary>
 		/// <inheritdoc cref="HurtModifiers.Cancel"/>
 		/// </summary>
-		public bool Cancelled = false;
+		public bool Cancelled { get; init; } = false;
 
 		/// <summary>
 		/// If true, dust will not spawn
 		/// </summary>
-		public bool DustDisabled = false;
+		public bool DustDisabled { get; init; } = false;
 
 		/// <summary>
 		/// If true, sound will not play
 		/// </summary>
-		public bool SoundDisabled = false;
+		public bool SoundDisabled { get; init; } = false;
 
 		public HurtInfo() { }
 	}


### PR DESCRIPTION
### What is the new feature?

`NPC.HitInfo` and `Player.HurtInfo` are now `readonly` and have `get; init` properties.

### Why should this be part of tModLoader?

> I see people trying to do 
> `hit.Crit = false`, which compiles but doesn't do anything

### Are there alternative designs?

Make the hook parameters `in` instead. This would be just as breaking, and not carry through to user's own non-hook methods. The dotnet guidelines also recommend making a struct `readonly` if it's going to be used with `in` where possible (though this is a performance detail that isn't too relevant to us).

### Sample usage for the new feature

![image](https://github.com/tModLoader/tModLoader/assets/388233/dde3d6fe-8bbe-4763-8363-b594ded0daf3)

### Porting notes

The `Hit/HurtModifiers.ModifyHit/HurtInfo` backdoors are now a little bit harder to use. Modders will have to create a new `Hit/HurtInfo` (preferably via the `with` syntax) instead of setting fields directly. Eg:

```cs
public override void ModifyHitNPC(NPC target, ref NPC.HitModifiers modifiers) {
	modifiers.ModifyHitInfo += (ref info) => {
		// no longer works
		info.Damage *= 2;

		// instead make a new HitInfo
		info = info with { Damage = info.Damage * 2 };
	};
}
```

### ExampleMod updates
None required

