### PR TITLE
Localized MagicSummonHybrid Tooltip and Fixed Missing Space at the Beginning

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -533,6 +533,7 @@
 		"SpecialAttackSpeedScaling": "{0}% benefit from attack speed boosts",
 		"ModifiedByModsHoldSHIFT": "Is modified (hold SHIFT for more info)",
 		"ModifiedByMods": "Is modified by ",
+		"MagicSummonHybridDamageClass": " magic or summon damage",
 
 		// Memory bar
 		"LastLoadRamUsage": "Estimated last load RAM usage: {0}",

--- a/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
+++ b/patches/tModLoader/Terraria/ModLoader/VanillaDamageClasses.cs
@@ -92,7 +92,7 @@ public class SummonMeleeSpeedDamageClass : VanillaDamageClass
 
 public class MagicSummonHybridDamageClass : VanillaDamageClass
 {
-	protected override string LangKey => "magic or summon damage";
+	protected override string LangKey => "tModLoader.MagicSummonHybridDamageClass";
 
 	public override StatInheritanceData GetModifierInheritance(DamageClass damageClass)
 	{


### PR DESCRIPTION
### What is the bug?

The tooltip for `DamageClass.MagicSummonHybrid` was not localized and was missing a space at the beginning of the text.

![image](https://github.com/tModLoader/tModLoader/assets/11262234/c3069a34-2688-4511-821c-c3a33e32ba39)

### How did you fix the bug?

Added a key in the tModLoader localization file and added a space at the front.

![image](https://github.com/tModLoader/tModLoader/assets/11262234/d553ba9b-9ca0-4ddb-8b66-34ba92e6bf3d)

### Are there alternatives to your fix?

The name of the localization key could be different. The actual tooltip text could be reworded, too.

I don't know if the other languages need a commented out key added to their file.
