### PR TITLE
Updated OneDrive opening logic in Program.TML.cs to open in background w/ no pop-ups

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -142,14 +142,25 @@ public static partial class Program
 			try {
 				var oneDrivePath1 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft\\OneDrive\\OneDrive.exe");
 				var oneDrivePath2 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft OneDrive\\OneDrive.exe");
-				if (File.Exists(oneDrivePath1))
-					System.Diagnostics.Process.Start(oneDrivePath1);
-				else if (File.Exists(oneDrivePath2))
-					System.Diagnostics.Process.Start(oneDrivePath2);
 
+				// passing /background to onedrive starts it with neither a tooltip popup nor a file explorer window
+				System.Diagnostics.ProcessStartInfo oneDriveInfo = new System.Diagnostics.ProcessStartInfo {
+					Arguments = "/background",
+					UseShellExecute = false
+				};
+
+				if (File.Exists(oneDrivePath1)) {
+					oneDriveInfo.FileName = oneDrivePath1;
+					System.Diagnostics.Process.Start(oneDriveInfo);
+				}
+				else if (File.Exists(oneDrivePath2)) {
+					oneDriveInfo.FileName = oneDrivePath2;
+					System.Diagnostics.Process.Start(oneDriveInfo);
+				}
 				Thread.Sleep(3000);
 			}
 			catch { }
+
 		}
 
 		// Verify that we are moving maxVersionOfSource player data to destination folder. Do so by checking for version <= maxVersionOfSource

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -160,7 +160,6 @@ public static partial class Program
 				Thread.Sleep(3000);
 			}
 			catch { }
-
 		}
 
 		// Verify that we are moving maxVersionOfSource player data to destination folder. Do so by checking for version <= maxVersionOfSource


### PR DESCRIPTION
### What is the new feature?
Changed logic in `Program.TML.cs` to open OneDrive in the background with no pop-ups instead of opening a new File Explorer window that must be manually closed. Passes `/background` as a cmd-line argument using `ProcessStartInfo` from `System.Diagnostics`.

### Why should this be part of tModLoader?
A small QOL change. Based on [this Reddit post](https://www.reddit.com/r/Terraria/comments/15lev8t/tmodloader_opens_onedrive_in_file_explorer_every/?rdt=61396) from 8 months ago, there are still recent replies (as recent as 1 day ago) requesting a fix.

### Are there alternative designs?
NA.

### Sample usage for the new feature
Upon running tModLoader, OneDrive now opens and appears in the system tray. Tested locally and on a couple of different Windows systems with no issues.
