### PR TITLE
correct a spelling error in EnvironmentFix.sh which causes tModLoader to crash when launch with Vulkan on Mac

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/EnvironmentFix.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/EnvironmentFix.sh
@@ -26,7 +26,7 @@ fi
 if [ "$_uname" = Darwin ]; then
 	library_dir="$root_dir/Libraries/Native/OSX"
 	export DYLD_LIBRARY_PATH="$library_dir"
-	export VK_ICD_FILENAMES="$libary_dir/MoltenVK_icd.json"
+	export VK_ICD_FILENAMES="$library_dir/MoltenVK_icd.json"
 	ln -sf "$library_dir/libSDL2-2.0.0.dylib" "$library_dir/libSDL2.dylib"
 
 	# El Capitan is a total idiot and wipes this variable out, making the


### PR DESCRIPTION
### What is the bug?

tModLoader crashes when launch with Vulkan on Mac due to a spelling error in EnvironmentFix.sh.

### How did you fix the bug?

Correct the spelling error.

### Are there alternatives to your fix?

No.