### PR TITLE
Initial Implementation of Global for Prefix Benefits

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -616,6 +616,13 @@ public abstract class GlobalItem : GlobalType<Item, GlobalItem>
 	}
 
 	/// <summary>
+	/// Allows you to modify the effects of prefixes after all modded prefixes & vanilla prefixes have been applied. 
+	/// </summary>
+	public virtual void PostUpdatePrefixBenefits(Item equippedItem, Player player)
+	{
+	}
+
+	/// <summary>
 	/// Allows you to determine whether the player is wearing an armor set, and return a name for this set.
 	/// If there is no armor set, return the empty string.
 	/// Returns the empty string by default.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1312,6 +1312,19 @@ public static class ItemLoader
 		}
 	}
 
+	private static HookList HookPostUpdatePrefixBenefits = AddHook<Action<Item, Player>>(g => g.PostUpdatePrefixBenefits);
+
+	/// <summary>
+	/// Runs at the end of UpdatePrefixBenefits for each equipped Item.
+	/// Acts like a Global for ModPrefix without going to length of implementing a GlobalPrefix 
+	/// </summary>
+	public static void PostUpdatePrefixBenefits(Player player, Item equippedItem)
+	{
+		foreach (var g in HookPostUpdatePrefixBenefits.Enumerate()) {
+			g.PostUpdatePrefixBenefits(equippedItem, player);
+		}
+	}
+
 	private static HookList HookArmorSetShadows = AddHook<Action<Player, string>>(g => g.ArmorSetShadows);
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
@@ -155,6 +155,8 @@ public static class PrefixLoader
 			prefix.ApplyAccessoryEffects(player);
 		}
 
+		ItemLoader.PostUpdatePrefixBenefits(player, item);
+
 		// Should there be more here for tooltips? Not entirely sure how that's handled in tML. - Mutant
 	}
 }


### PR DESCRIPTION
### What is the new feature?
#4184 

### Why should this be part of tModLoader?
To increase cross-mod compatibility and 'vanilla'-like behavior.

### Are there alternative designs?
Could implement new GlobalPrefix  instead of adding another hook to GlobalItem class

For one hook, I'm not sure it adds significant value to break out a net new global.  There isn't exactly a 'Prefix' entity to apply this to in 'normal' fashion. And all the other 'Update Accessory' logic is already in GlobalItem.
On the flip side, it would be significantly more consistent with other hook usage & I assume more performant.

### Sample usage for the new feature

```if (item.prefix == PrefixID.Hard)
              {
                  /* Prehardmode = 1
                   * Hardmode = 2
                   * Post-Moon Lord = 3
                   * Post-DoG = 4
                   */
  
                  if (DownedBossSystem.downedDoG)
                      self.statDefense += 3;
                  else if (NPC.downedMoonlord)
                      self.statDefense += 2;
                  else if (Main.hardMode)
                      self.statDefense += 1;
  
                  self.endurance += 0.0025f;
              }```

### ExampleMod updates