### PR TITLE
Implement error message for 32 bit Windows users rather than black window quickly closing

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/busybox-sh.bat
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/busybox-sh.bat
@@ -3,4 +3,8 @@ for /f "tokens=4-5 delims=. " %%i in ('ver') do (
 	set WINDOWS_MINOR=%%j
 )
 
+:: busybox64.exe won't launch on 32 bit OS, so we need to do this check here so we have at least some output other than the window closing immediately. Adapted from https://stackoverflow.com/a/24590583
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
+if %OS%==32BIT echo This is a 32 bit operating system, tModLoader requires a 64 bit operating system to launch && pause && Exit /b
+
 start "" "LaunchUtils/busybox64.exe" bash %*


### PR DESCRIPTION
32 bit Windows users attempting to launch the game will only see a black command prompt appear for a split second and then close. This can be difficult to diagnose, as they also don't have a Logs folder. If they manually open a command prompt and run `start-tModLoaderServer.bat`, they'll see the actual error, `busybox64.exe is not compatible with the version of Windows you are running`.

This PR adds a check for 32 bit OS and will show a message to the user, clarifying the situation and avoiding confusing troubleshooting.