### PR TITLE
Make Mod Publish Button Dynamic - QoL UI Improvement

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -268,12 +268,13 @@
  		uIText.IsWrapped = true;
  		uISlicedImage.Append(uIText);
  		_descriptionText = uIText;
-@@ -593,7 +_,7 @@
+@@ -593,7 +_,8 @@
  
  	private void AddPublishButton(int backButtonYLift, UIElement outerContainer)
  	{
 -		UITextPanel<LocalizedText> uITextPanel = new UITextPanel<LocalizedText>(Language.GetText("Workshop.Publish"), 0.7f, large: true);
-+		UITextPanel<LocalizedText> uITextPanel = new UITextPanel<LocalizedText>(Language.GetText(_isUpdate ? "tModLoader.PublishUpdateButton" : "Workshop.Publish"), 0.7f, large: true);
++		UITextPanel<LocalizedText> uITextPanel = new UITextPanel<LocalizedText>(Language.GetText(_isUpdate ? "tModLoader.PublishUpdateButton" : "tModLoader.PublishNewButton"), 0.7f, large: true);
++		uITextPanel.TextColor = _isUpdate ? Color.White : Color.Orange;
  		uITextPanel.Width.Set(-10f, 0.5f);
  		uITextPanel.Height.Set(50f, 0f);
  		uITextPanel.VAlign = 1f;

--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -8,7 +8,7 @@
  using Terraria.Social;
  using Terraria.Social.Base;
  using Terraria.UI;
-@@ -34,20 +_,36 @@
+@@ -34,20 +_,37 @@
  	private UIElement _publishButton;
  	private WorkshopItemPublicSettingId _optionPublicity = WorkshopItemPublicSettingId.Public;
  	private GroupOptionButton<WorkshopItemPublicSettingId>[] _publicityOptions;
@@ -30,6 +30,7 @@
 +	protected UIElement _tMLDisclaimerButton;
 +
 +	private bool _isMod;
++	private bool _isUpdate;
 +
 +	public UIState PreviousUIState {
 +		get => _previousUIState;
@@ -48,7 +49,22 @@
  	}
  
  	public override void OnInitialize()
-@@ -80,13 +_,23 @@
+@@ -66,8 +_,7 @@
+ 		uIPanel.Width.Set(0f, 1f);
+ 		uIPanel.Height.Set(-num3, 1f);
+ 		uIPanel.BackgroundColor = new Color(33, 43, 79) * 0.8f;
+-		AddBackButton(num, uIElement);
++		AddBackButton(num, uIElement);	
+-		AddPublishButton(num, uIElement);
+ 		int num5 = 6 + num4;
+ 		UIList uiList = AddUIList(uIPanel, num5);
+ 		FillUIList(uiList);
+@@ -76,17 +_,28 @@
+ 		uIElement.Append(uIPanel);
+ 		Append(uIElement);
+ 		SetDefaultOptions();
++		AddPublishButton(num, uIElement);
+ 	}
  
  	private void SetDefaultOptions()
  	{
@@ -108,6 +124,15 @@
  		_previewImageUIElement = uIImage;
  		UICharacterNameButton uICharacterNameButton = new UICharacterNameButton(Language.GetText("Workshop.PreviewImagePathTitle"), Language.GetText("Workshop.PreviewImagePathEmpty"), Language.GetText("Workshop.PreviewImagePathDescription")) {
  			Width = StyleDimension.FromPixelsAndPercent(0f - num, 1f),
+@@ -161,6 +_,8 @@
+ 		if (!TryFindingTags(out var info))
+ 			return;
+ 
++		_isUpdate = true;
++
+ 		if (info.tags != null) {
+ 			foreach (GroupOptionButton<WorkshopTagOption> tagOption in _tagOptions) {
+ 				bool flag = info.tags.Contains(tagOption.OptionValue.InternalNameForAPIs);
 @@ -169,10 +_,14 @@
  			}
  		}
@@ -243,6 +268,15 @@
  		uIText.IsWrapped = true;
  		uISlicedImage.Append(uIText);
  		_descriptionText = uIText;
+@@ -593,7 +_,7 @@
+ 
+ 	private void AddPublishButton(int backButtonYLift, UIElement outerContainer)
+ 	{
+-		UITextPanel<LocalizedText> uITextPanel = new UITextPanel<LocalizedText>(Language.GetText("Workshop.Publish"), 0.7f, large: true);
++		UITextPanel<LocalizedText> uITextPanel = new UITextPanel<LocalizedText>(Language.GetText(_isUpdate ? "tModLoader.PublishUpdateButton" : "Workshop.Publish"), 0.7f, large: true);
+ 		uITextPanel.Width.Set(-10f, 0.5f);
+ 		uITextPanel.Height.Set(50f, 0f);
+ 		uITextPanel.VAlign = 1f;
 @@ -643,7 +_,9 @@
  			UsedTags = (from x in _tagOptions
  						where x.IsSelected

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Gegenstand {0} aktualisieren",
 		"PublishItem": "Versuche Gegenstand {0} zu veröffentlichen",
 		"SteamDownloader": "Download wird in die Warteschleife des Steam-Download-Managers gestellt...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Zu {0}% heruntergeladen",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Gegenstand {0} aktualisieren",
 		"PublishItem": "Versuche Gegenstand {0} zu veröffentlichen",
 		"SteamDownloader": "Download wird in die Warteschleife des Steam-Download-Managers gestellt...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Zu {0}% heruntergeladen",
 

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Gegenstand {0} aktualisieren",
 		"PublishItem": "Versuche Gegenstand {0} zu veröffentlichen",
 		"SteamDownloader": "Download wird in die Warteschleife des Steam-Download-Managers gestellt...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Zu {0}% heruntergeladen",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Updating Item {0}",
 		"PublishItem": "Attempting Publishing Item {0}",
 		"SteamDownloader": "Queuing download with Steam download manager...",
-		"PublishUpdateButton": "Update",
+		"PublishUpdateButton": "Push Update",
+		"PublishNewButton": "Publish New",
 		"DownloadProgress": "Download {0}% Complete",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Updating Item {0}",
 		"PublishItem": "Attempting Publishing Item {0}",
 		"SteamDownloader": "Queuing download with Steam download manager...",
+		"PublishUpdateButton": "Update",
 		"DownloadProgress": "Download {0}% Complete",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Updating Item {0}",
 		"PublishItem": "Attempting Publishing Item {0}",
 		"SteamDownloader": "Queuing download with Steam download manager...",
-		"PublishUpdateButton": "Push Update",
+		"PublishUpdateButton": "Update Existing",
 		"PublishNewButton": "Publish New",
 		"DownloadProgress": "Download {0}% Complete",
 

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Actualizando el elemento {0}",
 		"PublishItem": "Publicando el elemento {0}",
 		"SteamDownloader": "Poner en cola la descarga mediante el gestor de Steam...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Progreso de descarga: {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Actualizando el elemento {0}",
 		"PublishItem": "Publicando el elemento {0}",
 		"SteamDownloader": "Poner en cola la descarga mediante el gestor de Steam...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Progreso de descarga: {0}%",
 

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Actualizando el elemento {0}",
 		"PublishItem": "Publicando el elemento {0}",
 		"SteamDownloader": "Poner en cola la descarga mediante el gestor de Steam...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Progreso de descarga: {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Mise à jour d'un Élément {0}",
 		"PublishItem": "Tentative d'Élément de Publication {0}",
 		"SteamDownloader": "Téléchargement en file d'attente avec le gestionnaire de téléchargement Steam...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Téléchargement {0}% Terminé",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Mise à jour d'un Élément {0}",
 		"PublishItem": "Tentative d'Élément de Publication {0}",
 		"SteamDownloader": "Téléchargement en file d'attente avec le gestionnaire de téléchargement Steam...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Téléchargement {0}% Terminé",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Mise à jour d'un Élément {0}",
 		"PublishItem": "Tentative d'Élément de Publication {0}",
 		"SteamDownloader": "Téléchargement en file d'attente avec le gestionnaire de téléchargement Steam...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Téléchargement {0}% Terminé",
 

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -170,7 +170,7 @@
 		// "UpdateItem": "Updating Item {0}",
 		// "PublishItem": "Attempting Publishing Item {0}",
 		// "SteamDownloader": "Queuing download with Steam download manager...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		// "DownloadProgress": "Download {0}% Complete",
 

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -170,7 +170,8 @@
 		// "UpdateItem": "Updating Item {0}",
 		// "PublishItem": "Attempting Publishing Item {0}",
 		// "SteamDownloader": "Queuing download with Steam download manager...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		// "DownloadProgress": "Download {0}% Complete",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -170,6 +170,7 @@
 		// "UpdateItem": "Updating Item {0}",
 		// "PublishItem": "Attempting Publishing Item {0}",
 		// "SteamDownloader": "Queuing download with Steam download manager...",
+		// "PublishUpdateButton": "Update",
 		// "DownloadProgress": "Download {0}% Complete",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Zaktualizuj pozycję {0}",
 		"PublishItem": "Próba opublikowania pozycji {0}",
 		"SteamDownloader": "Pobieranie jest w kolejce przez menedżera pobierania Steam...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Pobrano {0}%",
 

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Zaktualizuj pozycję {0}",
 		"PublishItem": "Próba opublikowania pozycji {0}",
 		"SteamDownloader": "Pobieranie jest w kolejce przez menedżera pobierania Steam...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Pobrano {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Zaktualizuj pozycję {0}",
 		"PublishItem": "Próba opublikowania pozycji {0}",
 		"SteamDownloader": "Pobieranie jest w kolejce przez menedżera pobierania Steam...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Pobrano {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Atualizando item {0}",
 		"PublishItem": "Tentando publicar item {0}",
 		"SteamDownloader": "Enfileirando o download com o gerenciador de downloads do Steam...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Download {0}% concluído",
 

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Atualizando item {0}",
 		"PublishItem": "Tentando publicar item {0}",
 		"SteamDownloader": "Enfileirando o download com o gerenciador de downloads do Steam...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Download {0}% concluído",
 
 		// Mod Errors
@@ -594,7 +595,7 @@
 		"TagsCategoryModSide": "Lado do mod",
 		"TagsCategoryTModLoaderVersion": "Versão do tModLoader",
 		"TagsCategoryLanguage": "{$LegacyMenu.103}",
-		// Tag descriptions by Webmilio, Tomat, Solxan, and Setnour6. Translations by Pixelnando.
+		// Tag descriptions by Webmilio, Tomat, Solxan, and Setnour6.
 		"TagsContent": "Conteúdo Novo",
 		"TagsContentDescription": "Adiciona conteúdo novo (por exemplo, itens, armas, npcs etc.) ao jogo",
 		"TagsUtility": "Utilidades",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Atualizando item {0}",
 		"PublishItem": "Tentando publicar item {0}",
 		"SteamDownloader": "Enfileirando o download com o gerenciador de downloads do Steam...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Download {0}% concluído",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -168,7 +168,7 @@
 		"UpdateItem": "Обновление {0}",
 		"PublishItem": "Попытка публикации {0}",
 		"SteamDownloader": "Постановка скачивания в очередь менеджера загрузок Steam...",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Скачано {0}%",
 

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -168,6 +168,7 @@
 		"UpdateItem": "Обновление {0}",
 		"PublishItem": "Попытка публикации {0}",
 		"SteamDownloader": "Постановка скачивания в очередь менеджера загрузок Steam...",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "Скачано {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -168,7 +168,8 @@
 		"UpdateItem": "Обновление {0}",
 		"PublishItem": "Попытка публикации {0}",
 		"SteamDownloader": "Постановка скачивания в очередь менеджера загрузок Steam...",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "Скачано {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -172,7 +172,8 @@
 		"UpdateItem": "正在更新模组 {0}",
 		"PublishItem": "尝试发布模组 {0}",
 		"SteamDownloader": "正在使用 Steam 下载管理器排队下载……",
-		// "PublishUpdateButton": "Update",
+		// "PublishUpdateButton": "Push Update",
+		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "下载完成 {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -172,7 +172,7 @@
 		"UpdateItem": "正在更新模组 {0}",
 		"PublishItem": "尝试发布模组 {0}",
 		"SteamDownloader": "正在使用 Steam 下载管理器排队下载……",
-		// "PublishUpdateButton": "Push Update",
+		// "PublishUpdateButton": "Update Existing",
 		// "PublishNewButton": "Publish New",
 		"DownloadProgress": "下载完成 {0}%",
 

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -172,6 +172,7 @@
 		"UpdateItem": "正在更新模组 {0}",
 		"PublishItem": "尝试发布模组 {0}",
 		"SteamDownloader": "正在使用 Steam 下载管理器排队下载……",
+		// "PublishUpdateButton": "Update",
 		"DownloadProgress": "下载完成 {0}%",
 
 		// Mod Errors

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.cs.patch
@@ -145,15 +145,12 @@
  				ulong? num = null;
  				if (AWorkshopEntry.TryReadingManifest(contentFolderPath + Path.DirectorySeparatorChar + "workshop.json", out var info))
  					num = info.workshopEntryId;
-@@ -185,9 +_,26 @@
+@@ -185,9 +_,23 @@
  				if (num.HasValue && finder.HasItemOfId(num.Value)) {
  					_publishedFileID = new PublishedFileId_t(num.Value);
  					PreventUpdatingCertainThings();
 +				*/
 +				_publishedFileID = new PublishedFileId_t(existingID);
-+
-+				if (existingID == 0 && AWorkshopEntry.TryReadingManifest(contentFolderPath + Path.DirectorySeparatorChar + "workshop.json", out var info))
-+					_publishedFileID = new PublishedFileId_t(info.workshopEntryId);
 +
 +				// Verify can write to the manifest before running creating any items.
 +				if (!WrappedWriteManifest())

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -16,7 +16,6 @@ public partial class WorkshopSocialModule
 {
 	public override List<string> GetListOfMods() => _downloader.ModPaths;
 	private ulong currPublishID = 0;
-	private ulong existingAuthorID = 0;
 
 	public override bool TryGetInfoForMod(TmodFile modFile, out FoundWorkshopEntryInfo info)
 	{
@@ -33,11 +32,20 @@ public partial class WorkshopSocialModule
 
 		currPublishID = 0;
 
-		if (!mods.Any() || mods[0] == null)
+		if (!mods.Any() || mods[0] == null) {
+			// This logic is for using a local copy of Workshop.json to figure out what the publish ID is. 
+			// It is currently unused and would need modifications to get the 'mod download item' for later.
+			/*
+			if (!AWorkshopEntry.TryReadingManifest(  <GET PATH> + Path.DirectorySeparatorChar + "workshop.json", out info))
+				return false;
+
+			currPublishID = info.workshopEntryId;
+			mods[0] = Get Mod From Publish ID ()
+			*/
 			return false;
+		}
 
 		currPublishID = ulong.Parse(mods[0].PublishId.m_ModPubId);
-		existingAuthorID = ulong.Parse(mods[0].OwnerId);
 
 		// Update the subscribed mod to be the latest version published, so keeps all versions (stable, preview) together
 		WorkshopBrowserModule.Instance.DownloadItem(mods[0], uiProgress: null);
@@ -83,14 +91,6 @@ public partial class WorkshopSocialModule
 		buildData["trueversion"] = buildData["version"];
 
 		if (currPublishID != 0) {
-			var currID = Steamworks.SteamUser.GetSteamID();
-
-			// Reject posting the mod if you don't 'own' the mod copy. NOTE: Steam doesn't support updating via contributor role anyways.
-			if (DateTime.Today < new DateTime(2023, 11, 21) && existingAuthorID != currID.m_SteamID) {
-				IssueReporter.ReportInstantUploadProblem("tModLoader.ModAlreadyUploaded");
-				return false;
-			}
-
 			// Publish by updating the files available on the current published version
 			workshopFolderPath = Path.Combine(Directory.GetParent(ModOrganizer.WorkshopFileFinder.ModPaths[0]).ToString(), $"{currPublishID}");
 

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 23
-ru-RU 7
-pt-BR 8
-pl-PL 156
-it-IT 902
-fr-FR 517
-es-ES 326
-de-DE 327
+zh-Hans 24
+ru-RU 8
+pt-BR 9
+pl-PL 157
+it-IT 903
+fr-FR 518
+es-ES 327
+de-DE 328

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 22
-ru-RU 11
-pt-BR 12
-pl-PL 155
-it-IT 901
-fr-FR 516
-es-ES 325
-de-DE 326
+zh-Hans 23
+ru-RU 7
+pt-BR 8
+pl-PL 156
+it-IT 902
+fr-FR 517
+es-ES 326
+de-DE 327


### PR DESCRIPTION
The Publish Button on the Publishing UI has been updated to be 'Update' instead of 'publish' when it is an update.
Also moved around some code for consistency
 
![image](https://github.com/tModLoader/tModLoader/assets/59670736/6e989c49-addc-4f79-add9-b783239b2b7e)
