### PR TITLE
Error message for mac users on outdated macOS (less than v10.15)

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -337,6 +337,9 @@ public static partial class Program
 					Console.WriteLine("Warning: Building mods requires the 64 bit dotnet SDK to be installed, but the 32 bit dotnet SDK appears to be running. It is likely that you accidentally installed the 32 bit dotnet SDK and it is taking priority. To fix this, follow the instructions at https://github.com/tModLoader/tModLoader/wiki/tModLoader-guide-for-developers#net-sdk"); // MessageBoxShow called below will also error when attempting to load 32 bit SDL2.
 				ErrorReporting.FatalExit("The current Windows Architecture of your System is CURRENTLY unsupported. Aborting...");
 			}
+			if (Platform.Current.Type == PlatformType.OSX && Environment.OSVersion.Version < new Version(10, 15)) {
+				ErrorReporting.FatalExit("tModLoader requires macOS v10.15 (Catalina) or higher to run as of tModLoader v2024.03+. Please update macOS.\nIf updating is not possible, manually downgrading (https://github.com/tModLoader/tModLoader/wiki/tModLoader-guide-for-players#manual-installation) to tModLoader v2024.02.3.0 (https://github.com/tModLoader/tModLoader/releases/tag/v2024.02.3.0) is an option to keep playing.\nAborting...");
+			}
 
 			Logging.LogStartup(isServer); // Should run as early as is possible. Want as complete a log file as possible
 


### PR DESCRIPTION
In the weeks since v2024.03 has been in stable, we've noticed that macOS users below v10.15 (Catalina) can't successfully launch tModLoader. The .NET 8 release notes (https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#macos) say macOS 12+ is needed, but that doesn't seem to be the case.

Supported devices for v10.15 (https://support.apple.com/en-us/118458) seem to be anything in the last 10 years, so we are fine with this new limitation:
```
MacBook (Early 2015 or newer)
MacBook Air (Mid 2012 or newer)
MacBook Pro (Mid 2012 or newer)
Mac mini (Late 2012 or newer)
iMac (Late 2012 or newer)
iMac Pro (2017)
Mac Pro (Late 2013 or newer)
```

This PR adds an error message to inform the user. This is better than the game appearing to start in Steam and then suddenly closing.

**TODO: Screenshot of new error message window here. Code is not tested yet:**

Sample of errors seen by pre 10.15 users:
[Natives (27).log](https://github.com/tModLoader/tModLoader/files/15325199/Natives.27.log)
[Natives (28).log](https://github.com/tModLoader/tModLoader/files/15325234/Natives.28.log)