### PR TITLE
Null out `Main.dresserInterfaceDummy` on Unload

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -603,6 +603,7 @@ public static class ModContent
 			// player.whoAmI is only set for active players
 		}
 
+		Main.dresserInterfaceDummy = null;
 		Main.clientPlayer = new Player();
 		Main.ActivePlayerFileData = new Terraria.IO.PlayerFileData();
 		Main._characterSelectMenu._playerList?.Clear();


### PR DESCRIPTION
### What is the bug?

The `Player` dummy used for the dresser character styles window somehow loses its `ModPlayer`s when mods reload and never reinitializes them.

Many mods assume in `PlayerDrawLayer::GetDefaultVisibility()` and `PlayerDrawLayer::Draw()` that `Player::GetModPlayer<T>()` will always return the proper `ModPlayer` instance instead of using `Player::TryGetModPlayer<T>()`:

* https://github.com/CalamityTeam/CalamityModPublic/blob/050a908f370fec07f8d685f8021d8a3137983b7b/CalPlayer/DrawLayers/EncasementParryLayer.cs#L24
* https://github.com/GabeHasWon/SpiritMod/blob/638fa333f57498a04510c802c65de73f9a554adb/DrawLayers/BubbleLayer.cs#L20
* https://github.com/ProjectStarlight/StarlightRiver/blob/2b8934016058017d55cb7f357afa1d0c24360e24/Content/Items/Vanity/WardenVanityDrawLayer.cs#L12
* https://github.com/PotatoPersonThing/CalValEX/blob/f9143834da5cb4f16355dd47611cff039dfbd9c7/Items/Equips/PlayerLayers/Balloon.cs#L29
* https://github.com/Antirhinnum/SnekVanity/blob/c8e2944c83cac1b443b384ba1c746371b476c37f/Content/HideBodyParts/HideBodyPartsLayer.cs#L23

As a result, after reloading mods with any mod that makes this assumption enabled, interacting with a dresser will break the character styles window and all UI layers that draw after it.

https://github.com/tModLoader/tModLoader/assets/33076411/8f586a7c-3dec-4046-9ac8-b86d7a974668

```
[16:54:53.839] [Main Thread/WARN] [tML]: Silently Caught Exception: 
System.Collections.Generic.KeyNotFoundException: Instance of 'WulfrumPackPlayer' does not exist on the current player.
   at Terraria.Player.GetModPlayer[T](T baseInstance) in tModLoader\Terraria\Player.TML.cs:line 99
   at CalamityMod.ILEditing.ILChanges.CustomGrapplePostFrame(orig_PlayerFrame orig, Player self) in CalamityMod\ILEditing\MechanicILChanges.cs:line 1325
   at Hook<System.Void CalamityMod.ILEditing.ILChanges::CustomGrapplePostFrame(Terraria.On_Player+orig_PlayerFrame,Terraria.Player)>(Player )
   at SyncProxy<System.Void Terraria.Player:PlayerFrame()>(Player )
   at Terraria.Main.DrawClothesWindow() in tModLoader\Terraria\Main.cs:line 37863
   at Terraria.Main.<SetupDrawInterfaceLayers>b__1627_19() in tModLoader\Terraria\Main.cs:line 37973
   at Terraria.UI.GameInterfaceLayer.Draw() in tModLoader\Terraria\UI\GameInterfaceLayer.cs:line 25
   at Terraria.Main.DrawInterface(GameTime gameTime) in tModLoader\Terraria\Main.cs:line 38074
   at DMD<System.Void Terraria.Main:DoDraw(Microsoft.Xna.Framework.GameTime)>(Main this, GameTime gameTime)
   at SyncProxy<System.Void Terraria.Main:DoDraw(Microsoft.Xna.Framework.GameTime)>(Main , GameTime )
   at Terraria.Main.Draw_Inner(GameTime gameTime)
   at Terraria.Main.Draw(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.Game.RunLoop()
   at Microsoft.Xna.Framework.Game.Run()
   at Terraria.Program.RunGame()
   at Terraria.Program.LaunchGame_(Boolean isServer)
   at Terraria.Program.LaunchGame(String[] args, Boolean monoArgs)
   at Terraria.MonoLaunch.Main_End(String[] args)
   at Terraria.MonoLaunch.<>c__DisplayClass1_0.<Main>b__1()
```

The assumption that `Player::GetModPlayer<T>()` would work in `PlayerDrawLayer`s has never been an issue. I do not know why this has only started happening recently.

### How did you fix the bug?

Set `Main.dresserInterfaceDummy` to `null` in `ModContent::CleanupModReferences()`. The field is set back to a new `Player` instance in `Main::OpenClothesWindow()`.
### Are there alternatives to your fix?

Not that I am aware of.