### PR TITLE
Clear ReflectionHelper cache

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -3,6 +3,7 @@ using MonoMod.RuntimeDetour;
 using MonoMod.RuntimeDetour.HookGen;
 using MonoMod.Utils;
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -125,6 +126,16 @@ public static class MonoModHooks
 		HookEndpointManager.Clear();
 		assemblyDetours.Clear();
 		_hookCache.Clear();
+
+		var type = typeof(ReflectionHelper);
+		FieldInfo[] caches = [
+			type.GetField("AssemblyCache", BindingFlags.NonPublic | BindingFlags.Static),
+			type.GetField("AssembliesCache", BindingFlags.NonPublic | BindingFlags.Static),
+			type.GetField("ResolveReflectionCache", BindingFlags.NonPublic | BindingFlags.Static),
+		];
+		foreach(var cache in caches) {
+			((IDictionary)cache.GetValue(null)).Clear();
+		}
 	}
 
 	#region Obsolete HookEndpointManager method replacement

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -127,13 +127,14 @@ public static class MonoModHooks
 		assemblyDetours.Clear();
 		_hookCache.Clear();
 
+		// #4220 - Mitigation for bugs in reflection cache with mod reloads, and helps with assembly unloading
 		var type = typeof(ReflectionHelper);
 		FieldInfo[] caches = [
 			type.GetField("AssemblyCache", BindingFlags.NonPublic | BindingFlags.Static),
 			type.GetField("AssembliesCache", BindingFlags.NonPublic | BindingFlags.Static),
 			type.GetField("ResolveReflectionCache", BindingFlags.NonPublic | BindingFlags.Static),
 		];
-		foreach(var cache in caches) {
+		foreach (var cache in caches) {
 			((IDictionary)cache.GetValue(null)).Clear();
 		}
 	}


### PR DESCRIPTION
### What is the bug?

When a mod is not fully unloaded (quite common), `MonoMod.Utils.ReflectionHelper` retains the previously loaded mod assembly. After force reloading the mod, MonoMod incorrectly uses the cached data to generate dynamic methods. This can result in generic methods like `GetInstance<T>` or `GetGlobalPlayer<T>` returning null where T is a type from mod assembly

These often occur when you want to patch another mod or avoiding `EmitDelegate` for performance

Example:

```cs
public class TestSystem : ModSystem
{
	public record JsonData(string Name);

	public override void Load()
	{
		IL_Main.Update += IL_Main_Update;
		JsonConvert.SerializeObject(new JsonData("Prevent fully unloaded"));
	}

	private void IL_Main_Update(ILContext il)
	{
		var cursor = new ILCursor(il);
		var method = ModContent.GetInstance<TestSystem>;
		cursor.Emit(OpCodes.Call, method.Method);
		cursor.EmitDelegate((TestSystem system) =>
		{
			Mod.Logger.Info($"Emit Call return is null: {system is null}");
			system = ModContent.GetInstance<TestSystem>();
			Mod.Logger.Info($"Emit Delegate return is null: {system is null}");
		});
	}
}

```

Expected output

- Before Reload: (false, false)
- After Reload: (true, false)

### How did you fix the bug?

Clear the cache dictionary

### Are there alternatives to your fix?

Replace emitting calling a generic method info with `EmitDelegate`

Remove generic method calling while patching another mod, which is troublesome

