### PR TITLE
AllowVanillaClients removal

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
@@ -104,24 +104,22 @@
  
  		return playerDeathReason;
  	}
-@@ -140,10 +_,16 @@
+@@ -140,10 +_,14 @@
  			writer.Write((short)_sourceProjectileType);
  
  		if (bitsByte[5])
 +			ItemIO.Send(_sourceItem, writer);
-+
-+		goto SkipVanillaItemWrite;
-+
++		/*
 +		if (bitsByte[5])
  			writer.Write((short)_sourceItemType);
  
  		if (bitsByte[6])
  			writer.Write((byte)_sourceItemPrefix);
-+		SkipVanillaItemWrite:
++		*/
  
  		if (bitsByte[7])
  			writer.Write(_sourceCustomReason);
-@@ -168,11 +_,20 @@
+@@ -168,11 +_,15 @@
  		if (bitsByte[4])
  			playerDeathReason._sourceProjectileType = reader.ReadInt16();
  
@@ -132,12 +130,7 @@
  		if (bitsByte[6])
  			playerDeathReason._sourceItemPrefix = reader.ReadByte();
 +		*/
-+		if (false) {
-+			int itemType = bitsByte[5] ? reader.ReadInt16() : 0;
-+			int prefix = bitsByte[6] ? reader.ReadByte() : 0;
-+			playerDeathReason._sourceItem = itemType == 0 ? null : new Item(itemType, prefix: prefix);
-+		}
-+		else if (bitsByte[5])
++		if (bitsByte[5])
 +			playerDeathReason._sourceItem = ItemIO.Receive(reader);
  
  		if (bitsByte[7])

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
@@ -104,18 +104,15 @@
  
  		return playerDeathReason;
  	}
-@@ -139,11 +_,19 @@
- 		if (bitsByte[4])
+@@ -140,10 +_,16 @@
  			writer.Write((short)_sourceProjectileType);
  
-+		if (!ModNet.AllowVanillaClients) {
-+			if (bitsByte[5])
-+				ItemIO.Send(_sourceItem, writer);
-+
-+			goto SkipVanillaItemWrite;
-+		}
-+
  		if (bitsByte[5])
++			ItemIO.Send(_sourceItem, writer);
++
++		goto SkipVanillaItemWrite;
++
++		if (bitsByte[5])
  			writer.Write((short)_sourceItemType);
  
  		if (bitsByte[6])
@@ -135,7 +132,7 @@
  		if (bitsByte[6])
  			playerDeathReason._sourceItemPrefix = reader.ReadByte();
 +		*/
-+		if (ModNet.AllowVanillaClients) {
++		if (false) {
 +			int itemType = bitsByte[5] ? reader.ReadInt16() : 0;
 +			int prefix = bitsByte[6] ? reader.ReadByte() : 0;
 +			playerDeathReason._sourceItem = itemType == 0 ? null : new Item(itemType, prefix: prefix);

--- a/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/TileEntity.cs.patch
@@ -74,7 +74,7 @@
  		writer.Write(Position.Y);
 +
 +		//Call NetSend instead of the vanilla method when in modded contexts.
-+		if (networkSend && !ModNet.AllowVanillaClients) {
++		if (networkSend) {
 +			NetSend(writer);
 +
 +			return;
@@ -94,7 +94,7 @@
  		Position = new Point16(reader.ReadInt16(), reader.ReadInt16());
 +
 +		//Call NetReceive instead of the vanilla method when in modded contexts.
-+		if (networkSend && !ModNet.AllowVanillaClients) {
++		if (networkSend) {
 +			NetReceive(reader);
 +
 +			return;

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.cs.patch
@@ -52,28 +52,24 @@
  		WorldGen.destroyObject = true;
  		for (int k = num; k < num + 2; k++) {
  			for (int l = num2; l < num2 + 3; l++) {
-@@ -468,6 +_,11 @@
+@@ -468,6 +_,9 @@
  		if (dye)
  			item = _dyes[itemIndex];
  
-+		if (!ModNet.AllowVanillaClients) {
-+			ItemIO.Send(item, writer, writeStack: true);
-+			return;
-+		}
++		ItemIO.Send(item, writer, writeStack: true);
++		return;
 +
  		writer.Write((ushort)item.netID);
  		writer.Write((ushort)item.stack);
  		writer.Write(item.prefix);
-@@ -475,12 +_,21 @@
+@@ -475,12 +_,19 @@
  
  	public void ReadItem(int itemIndex, BinaryReader reader, bool dye)
  	{
 +		Item item = (dye ? _dyes : _items)[itemIndex];
 +
-+		if (!ModNet.AllowVanillaClients) {
-+			ItemIO.Receive(item, reader, readStack: true);
-+			return;
-+		}
++		ItemIO.Receive(item, reader, readStack: true);
++		return;
 +
  		int defaults = reader.ReadUInt16();
  		int stack = reader.ReadUInt16();

--- a/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/EmoteBubble.cs.patch
@@ -33,7 +33,7 @@
  	public int frameCounter;
  	public int frame;
  	public const int EMOTE_SHEET_HORIZONTAL_FRAMES = 8;
-@@ -64,7 +_,23 @@
+@@ -64,7 +_,21 @@
  			else if (anch.entity is Projectile)
  				item = 2;
  
@@ -46,11 +46,9 @@
 +			// This adds an overhead of a byte to the message 91 (SyncEmoteBubble) in case of Projectile.
 +			// tl;dr: byte type -> ushort packedOwnerType [owner << 8 | type] (only if it's a projectile)
 +			int whoAmI = anch.entity.whoAmI;
-+			if (!ModNet.AllowVanillaClients) {
-+				if (anch.entity is Projectile projectile) {
-+					whoAmI = projectile.identity; // This is the meta parameter in DeserializeNetAnchor
-+					item = projectile.owner << 8 | item;
-+				}
++			if (anch.entity is Projectile projectile) {
++				whoAmI = projectile.identity; // This is the meta parameter in DeserializeNetAnchor
++				item = projectile.owner << 8 | item;
 +			}
 +
 -			return Tuple.Create(item, anch.entity.whoAmI);
@@ -58,7 +56,7 @@
  		}
  
  		return Tuple.Create(0, 0);
-@@ -72,12 +_,33 @@
+@@ -72,13 +_,31 @@
  
  	public static WorldUIAnchor DeserializeNetAnchor(int type, int meta)
  	{
@@ -73,25 +71,24 @@
  			case 1:
  				return new WorldUIAnchor(Main.player[meta]);
  			case 2:
-+				if (!ModNet.AllowVanillaClients) {
-+					// meta represents the identity here
-+					int owner = packedOwnerType >> 8;
++				// meta represents the identity here
++				int owner = packedOwnerType >> 8;
 +
-+					// identity matching code taken from MessageBuffer.GetData case 27
-+					int whoAmI = Main.maxProjectiles;
-+					for (int i = 0; i < Main.maxProjectiles; i++) {
-+						Projectile projectile = Main.projectile[i];
-+						if (projectile.owner == owner && projectile.identity == meta && projectile.active) {
-+							whoAmI = i;
-+							break;
-+						}
++				// identity matching code taken from MessageBuffer.GetData case 27
++				int whoAmI = Main.maxProjectiles;
++				for (int i = 0; i < Main.maxProjectiles; i++) {
++					Projectile projectile = Main.projectile[i];
++					if (projectile.owner == owner && projectile.identity == meta && projectile.active) {
++						whoAmI = i;
++						break;
 +					}
-+
-+					return new WorldUIAnchor(Main.projectile[whoAmI]);
 +				}
- 				return new WorldUIAnchor(Main.projectile[meta]);
++
+-				return new WorldUIAnchor(Main.projectile[meta]);
++				return new WorldUIAnchor(Main.projectile[whoAmI]);
  			default:
  				throw new Exception("How did you end up getting this?");
+ 		}
 @@ -86,6 +_,13 @@
  
  	public static int AssignNewID() => NextID++;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1250,13 +1250,12 @@
  					Console.WriteLine("");
  					Console.Write(Language.GetTextValue("CLI.EnterServerPassword"));
  					Netplay.ServerPassword = ReadLineInput();
-@@ -4563,6 +_,11 @@
+@@ -4563,6 +_,10 @@
  		catch {
  		}
  
 +		// Run one tick to JIT all the game content now rather than when a player connects
 +		Logging.ServerConsoleLine("Running one update...");
-+		Logging.tML.Info($"Server starting with AllowVanillaClients set to {ModNet.AllowVanillaClients}");
 +		Update(new GameTime());
 +
  		if (WorldGen.loadFailed || !WorldGen.loadSuccess) {

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -137,18 +137,17 @@
  					Item[] array3 = null;
  					Item[] array4 = null;
  					int num261 = 0;
-@@ -411,20 +_,31 @@
+@@ -411,20 +_,29 @@
  					}
  
  					if (flag16) {
 +						player17.trashItem = ItemIO.Receive(reader, readStack: true);
-+						goto SkipVanillaRead;
-+
++						/*
  						player17.trashItem = new Item();
  						player17.trashItem.netDefaults(type16);
  						player17.trashItem.stack = stack7;
  						player17.trashItem.Prefix(num260);
-+						SkipVanillaRead:
++						*/
 +
  						if (num258 == Main.myPlayer && !Main.ServerSideCharacter)
  							clientPlayer.trashItem = player17.trashItem.Clone();
@@ -158,29 +157,27 @@
  						int stack8 = array3[num261].stack;
 +
 +						array3[num261] = ItemIO.Receive(reader, readStack: true);
-+						goto SkipVanillaRead;
-+
++						/*
  						array3[num261] = new Item();
  						array3[num261].netDefaults(type16);
  						array3[num261].stack = stack7;
  						array3[num261].Prefix(num260);
-+						SkipVanillaRead:
++						*/
 +
  						if (num258 == Main.myPlayer && !Main.ServerSideCharacter)
  							array4[num261] = array3[num261].Clone();
  
-@@ -438,10 +_,15 @@
+@@ -438,10 +_,14 @@
  						}
  					}
  					else {
 +						array3[num261] = ItemIO.Receive(reader, readStack: true);
-+						goto SkipVanillaRead;
-+
++						/*
  						array3[num261] = new Item();
  						array3[num261].netDefaults(type16);
  						array3[num261].stack = stack7;
  						array3[num261].Prefix(num260);
-+						SkipVanillaRead:
++						*/
 +
  						if (num258 == Main.myPlayer && !Main.ServerSideCharacter)
  							array4[num261] = array3[num261].Clone();
@@ -618,7 +615,7 @@
  					tileEntity.ID = num67;
  					TileEntity.ByID[tileEntity.ID] = tileEntity;
  					TileEntity.ByPosition[tileEntity.Position] = tileEntity;
-@@ -2819,10 +_,22 @@
+@@ -2819,10 +_,21 @@
  				if (Main.netMode == 2) {
  					short x12 = reader.ReadInt16();
  					int y12 = reader.ReadInt16();
@@ -626,13 +623,12 @@
 +					Item item;
 +					item = ItemIO.Receive(reader);
 +					item.stack = reader.Read7BitEncodedInt();
-+					goto SkipVanillaRead;
-+
++					/*
  					int netid3 = reader.ReadInt16();
  					int prefix3 = reader.ReadByte();
  					int stack6 = reader.ReadInt16();
 +					item = new Item(netid3, stack6, prefix3);
-+					SkipVanillaRead:
++					*/
 +
 +					/*
  					TEItemFrame.TryPlacing(x12, y12, netid3, prefix3, stack6);
@@ -716,20 +712,19 @@
  					EmoteBubble.NewBubble(num214, new WorldUIAnchor(Main.player[num213]), 360);
  					EmoteBubble.CheckForNPCsToReactToEmoteBubble(num214, Main.player[num213]);
  				}
-@@ -3293,10 +_,21 @@
+@@ -3293,10 +_,20 @@
  				if (Main.netMode == 2) {
  					short x10 = reader.ReadInt16();
  					int y10 = reader.ReadInt16();
 +
 +					Item item;
 +					item = ItemIO.Receive(reader, readStack: true);
-+					goto SkipVanillaRead;
-+
++					/*
  					int netid2 = reader.ReadInt16();
  					int prefix2 = reader.ReadByte();
  					int stack4 = reader.ReadInt16();
 +					item = new Item(netid2, stack4, prefix2);
-+					SkipVanillaRead:
++					*/
 +
 +					/*
  					TEWeaponsRack.TryPlacing(x10, y10, netid2, prefix2, stack4);
@@ -738,7 +733,7 @@
  				}
  				break;
  			case 124: {
-@@ -3431,20 +_,44 @@
+@@ -3431,20 +_,43 @@
  					ushort key = reader.ReadUInt16();
  					LegacySoundStyle legacySoundStyle = SoundID.SoundByIndex[key];
  					BitsByte bitsByte4 = reader.ReadByte();
@@ -768,13 +763,12 @@
 +
 +					Item item;
 +					item = ItemIO.Receive(reader, readStack: true);
-+					goto SkipVanillaRead;
-+
++					/*
  					int netid = reader.ReadInt16();
  					int prefix = reader.ReadByte();
  					int stack = reader.ReadInt16();
 +					item = new Item(netid, stack, prefix);
-+					SkipVanillaRead:
++					*/
 +
 +					/*
  					TEFoodPlatter.TryPlacing(x5, y5, netid, prefix, stack);

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -124,13 +124,15 @@
  				ReadAccessoryVisibility(reader, player14.hideVisibleAccessory);
  				player14.hideMisc = reader.ReadByte();
  				player14.hairColor = reader.ReadRGB();
-@@ -319,9 +_,9 @@
+@@ -319,9 +_,14 @@
  				Player player17 = Main.player[num258];
  				lock (player17) {
  					int num259 = reader.ReadInt16();
--					int stack7 = reader.ReadInt16();
--					int num260 = reader.ReadByte();
--					int type16 = reader.ReadInt16();
++					/*
+ 					int stack7 = reader.ReadInt16();
+ 					int num260 = reader.ReadByte();
+ 					int type16 = reader.ReadInt16();
++					*/
 +					int stack7 = -1;
 +					int num260 = -1;
 +					int type16 = -1;
@@ -356,13 +358,15 @@
  				if (Main.npc[num190].life <= 0)
  					NetMessage.TrySendData(23, -1, -1, null, num190);
  				else
-@@ -1625,9 +_,9 @@
+@@ -1625,9 +_,14 @@
  			case 32: {
  				int num164 = reader.ReadInt16();
  				int num165 = reader.ReadByte();
--				int stack5 = reader.ReadInt16();
--				int prefixWeWant3 = reader.ReadByte();
--				int type8 = reader.ReadInt16();
++				/*
+ 				int stack5 = reader.ReadInt16();
+ 				int prefixWeWant3 = reader.ReadByte();
+ 				int type8 = reader.ReadInt16();
++				*/
 +				int stack5 = -1;
 +				int prefixWeWant3 = -1;
 +				int type8 = -1;

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -120,7 +120,7 @@
  
  				player14.name = reader.ReadString().Trim().Trim();
 -				player14.hairDye = reader.ReadByte();
-+				player14.hairDye = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt();
++				player14.hairDye = reader.Read7BitEncodedInt();
  				ReadAccessoryVisibility(reader, player14.hideVisibleAccessory);
  				player14.hideMisc = reader.ReadByte();
  				player14.hairColor = reader.ReadRGB();
@@ -131,20 +131,18 @@
 -					int stack7 = reader.ReadInt16();
 -					int num260 = reader.ReadByte();
 -					int type16 = reader.ReadInt16();
-+					int stack7 = ModNet.AllowVanillaClients ? reader.ReadInt16() : -1;
-+					int num260 = ModNet.AllowVanillaClients ? reader.ReadByte() : -1;
-+					int type16 = ModNet.AllowVanillaClients ? reader.ReadInt16() : -1;
++					int stack7 = -1;
++					int num260 = -1;
++					int type16 = -1;
  					Item[] array3 = null;
  					Item[] array4 = null;
  					int num261 = 0;
-@@ -411,20 +_,35 @@
+@@ -411,20 +_,31 @@
  					}
  
  					if (flag16) {
-+						if (!ModNet.AllowVanillaClients) {
-+							player17.trashItem = ItemIO.Receive(reader, readStack: true);
-+							goto SkipVanillaRead;
-+						}
++						player17.trashItem = ItemIO.Receive(reader, readStack: true);
++						goto SkipVanillaRead;
 +
  						player17.trashItem = new Item();
  						player17.trashItem.netDefaults(type16);
@@ -159,10 +157,8 @@
  						int type17 = array3[num261].type;
  						int stack8 = array3[num261].stack;
 +
-+						if (!ModNet.AllowVanillaClients) {
-+							array3[num261] = ItemIO.Receive(reader, readStack: true);
-+							goto SkipVanillaRead;
-+						}
++						array3[num261] = ItemIO.Receive(reader, readStack: true);
++						goto SkipVanillaRead;
 +
  						array3[num261] = new Item();
  						array3[num261].netDefaults(type16);
@@ -173,14 +169,12 @@
  						if (num258 == Main.myPlayer && !Main.ServerSideCharacter)
  							array4[num261] = array3[num261].Clone();
  
-@@ -438,10 +_,17 @@
+@@ -438,10 +_,15 @@
  						}
  					}
  					else {
-+						if (!ModNet.AllowVanillaClients) {
-+							array3[num261] = ItemIO.Receive(reader, readStack: true);
-+							goto SkipVanillaRead;
-+						}
++						array3[num261] = ItemIO.Receive(reader, readStack: true);
++						goto SkipVanillaRead;
 +
  						array3[num261] = new Item();
  						array3[num261].netDefaults(type16);
@@ -196,7 +190,7 @@
  					Main.LobbyId = reader.ReadUInt64();
  					Sandstorm.IntendedSeverity = reader.ReadSingle();
 +
-+					if (!ModNet.AllowVanillaClients && Netplay.Connection.State > 4)
++					if (Netplay.Connection.State > 4)
 +						WorldIO.ReceiveModData(reader);
 +
  					if (Netplay.Connection.State == 3) {
@@ -239,9 +233,9 @@
  				Vector2 position3 = reader.ReadVector2();
  				Vector2 velocity3 = reader.ReadVector2();
 -				int stack3 = reader.ReadInt16();
++				int stack3 = reader.Read7BitEncodedInt();
 -				int prefixWeWant2 = reader.ReadByte();
-+				int stack3 = ModNet.AllowVanillaClients ? reader.ReadInt16() : reader.Read7BitEncodedInt();
-+				int prefixWeWant2 = ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt();
++				int prefixWeWant2 = reader.Read7BitEncodedInt();
  				int num106 = reader.ReadByte();
  				int num107 = reader.ReadInt16();
  				bool shimmered = false;
@@ -267,7 +261,7 @@
  					item4.position = position3;
  					item4.velocity = velocity3;
  					item4.active = true;
-@@ -1419,11 +_,16 @@
+@@ -1419,11 +_,15 @@
  				if (num158 == 668)
  					NPC.deerclopsBoss = num155;
  
@@ -276,8 +270,7 @@
  					nPC5.releaseOwner = reader.ReadByte();
  
 +				// Extra AI is read into a temporary buffer for parity with ProjectileLoader code, and to avoid exceptions causing underreads.
-+				if (!ModNet.AllowVanillaClients)
-+					NPCLoader.ReceiveExtraAI(nPC5, NPCLoader.ReadExtraAI(reader));
++				NPCLoader.ReceiveExtraAI(nPC5, NPCLoader.ReadExtraAI(reader));
 +
  				break;
  			}
@@ -373,20 +366,18 @@
 -				int stack5 = reader.ReadInt16();
 -				int prefixWeWant3 = reader.ReadByte();
 -				int type8 = reader.ReadInt16();
-+				int stack5 = ModNet.AllowVanillaClients ? reader.ReadInt16() : -1;
-+				int prefixWeWant3 = ModNet.AllowVanillaClients ? reader.ReadByte() : -1;
-+				int type8 = ModNet.AllowVanillaClients ? reader.ReadInt16() : -1;
++				int stack5 = -1;
++				int prefixWeWant3 = -1;
++				int type8 = -1;
  				if (num164 >= 0 && num164 < 8000) {
  					if (Main.chest[num164] == null)
  						Main.chest[num164] = new Chest();
-@@ -1635,9 +_,16 @@
+@@ -1635,9 +_,14 @@
  					if (Main.chest[num164].item[num165] == null)
  						Main.chest[num164].item[num165] = new Item();
  
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Receive(Main.chest[num164].item[num165], reader, readStack: true);
-+						goto SkipVanillaItemSetup;
-+					}
++					ItemIO.Receive(Main.chest[num164].item[num165], reader, readStack: true);
++					goto SkipVanillaItemSetup;
 +
  					Main.chest[num164].item[num165].netDefaults(type8);
  					Main.chest[num164].item[num165].Prefix(prefixWeWant3);
@@ -535,13 +526,12 @@
  						break;
  					case 4:
  						if (num206 == -1) {
-@@ -1860,6 +_,13 @@
+@@ -1860,6 +_,12 @@
  				player7.zone3 = reader.ReadByte();
  				player7.zone4 = reader.ReadByte();
  				player7.zone5 = reader.ReadByte();
 +
-+				if (!ModNet.AllowVanillaClients)
-+					BiomeLoader.ReceiveCustomBiomes(player7, reader);
++				BiomeLoader.ReceiveCustomBiomes(player7, reader);
 +
 +				//TML: Recalculate the 'not in any biome' value.
 +				player7.ZonePurity = player7.InZonePurity();
@@ -628,17 +618,15 @@
  					tileEntity.ID = num67;
  					TileEntity.ByID[tileEntity.ID] = tileEntity;
  					TileEntity.ByPosition[tileEntity.Position] = tileEntity;
-@@ -2819,10 +_,24 @@
+@@ -2819,10 +_,22 @@
  				if (Main.netMode == 2) {
  					short x12 = reader.ReadInt16();
  					int y12 = reader.ReadInt16();
 +
 +					Item item;
-+					if (!ModNet.AllowVanillaClients) {
-+						item = ItemIO.Receive(reader);
-+						item.stack = reader.Read7BitEncodedInt();
-+						goto SkipVanillaRead;
-+					}
++					item = ItemIO.Receive(reader);
++					item.stack = reader.Read7BitEncodedInt();
++					goto SkipVanillaRead;
 +
  					int netid3 = reader.ReadInt16();
  					int prefix3 = reader.ReadByte();
@@ -659,7 +647,7 @@
  				int num186 = reader.ReadByte();
 +
 +				// If type corresponds to projectile (magic number 2), read another byte for owner #WorldUIAnchorProjectileSyncFix
-+				if (!ModNet.AllowVanillaClients && num186 == 2) {
++				if (num186 == 2) {
 +					int owner = reader.ReadByte();
 +					num186 |= owner << 8; // Reassign num186 for use in DeserializeNetAnchor - this is now "packedOwnerType"
 +				}
@@ -728,16 +716,14 @@
  					EmoteBubble.NewBubble(num214, new WorldUIAnchor(Main.player[num213]), 360);
  					EmoteBubble.CheckForNPCsToReactToEmoteBubble(num214, Main.player[num213]);
  				}
-@@ -3293,10 +_,23 @@
+@@ -3293,10 +_,21 @@
  				if (Main.netMode == 2) {
  					short x10 = reader.ReadInt16();
  					int y10 = reader.ReadInt16();
 +
 +					Item item;
-+					if (!ModNet.AllowVanillaClients) {
-+						item = ItemIO.Receive(reader, readStack: true);
-+						goto SkipVanillaRead;
-+					}
++					item = ItemIO.Receive(reader, readStack: true);
++					goto SkipVanillaRead;
 +
  					int netid2 = reader.ReadInt16();
  					int prefix2 = reader.ReadByte();
@@ -752,7 +738,7 @@
  				}
  				break;
  			case 124: {
-@@ -3431,20 +_,46 @@
+@@ -3431,20 +_,44 @@
  					ushort key = reader.ReadUInt16();
  					LegacySoundStyle legacySoundStyle = SoundID.SoundByIndex[key];
  					BitsByte bitsByte4 = reader.ReadByte();
@@ -781,10 +767,8 @@
  					int y5 = reader.ReadInt16();
 +
 +					Item item;
-+					if (!ModNet.AllowVanillaClients) {
-+						item = ItemIO.Receive(reader, readStack: true);
-+						goto SkipVanillaRead;
-+					}
++					item = ItemIO.Receive(reader, readStack: true);
++					goto SkipVanillaRead;
 +
  					int netid = reader.ReadInt16();
  					int prefix = reader.ReadByte();

--- a/patches/tModLoader/Terraria/ModLoader/BuffLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BuffLoader.cs
@@ -40,8 +40,6 @@ public static class BuffLoader
 
 	internal static int ReserveBuffID()
 	{
-		if (ModNet.AllowVanillaClients) throw new Exception("Adding buffs breaks vanilla client compatibility");
-
 		int reserveID = nextBuff;
 		nextBuff++;
 		return reserveID;

--- a/patches/tModLoader/Terraria/ModLoader/EmoteBubbleLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/EmoteBubbleLoader.cs
@@ -21,9 +21,6 @@ public static class EmoteBubbleLoader
 
 	internal static int Add(ModEmoteBubble emoteBubble)
 	{
-		if (ModNet.AllowVanillaClients)
-			throw new Exception("Adding emote bubbles breaks vanilla client compatibility");
-
 		emoteBubbles.Add(emoteBubble);
 		return EmoteBubbleCount - 1;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -185,7 +185,7 @@ public static class ItemIO
 	public static void Receive(Item item, BinaryReader reader, bool readStack = false, bool readFavorite = false)
 	{
 		item.netDefaults(reader.Read7BitEncodedInt());
-		item.Prefix(ModNet.AllowVanillaClients ? reader.ReadByte() : reader.Read7BitEncodedInt());
+		item.Prefix(reader.Read7BitEncodedInt());
 
 		if (readStack)
 			item.stack = reader.Read7BitEncodedInt();

--- a/patches/tModLoader/Terraria/ModLoader/ModNet.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNet.cs
@@ -95,8 +95,6 @@ public static class ModNet
 	{
 		kickMsg = null;
 		isModded = clientVersion.StartsWith("tModLoader");
-		if (AllowVanillaClients && clientVersion == "Terraria" + Main.curRelease)
-			return true;
 
 		if (clientVersion == NetVersionString)
 			return true;
@@ -127,15 +125,12 @@ public static class ModNet
 	internal static void Unload()
 	{
 		netMods = null;
-		if (!Main.dedServ && Main.netMode != 1) //disable vanilla client compatibility restrictions when reloading on a client
-			AllowVanillaClients = false;
 		ModNet.SetModNetDiagnosticsUI(ModLoader.Mods);
 	}
 
 	internal static void SyncMods(int clientIndex)
 	{
 		var p = new ModPacket(MessageID.SyncMods);
-		p.Write(AllowVanillaClients);
 
 		var syncMods = ModLoader.Mods.Where(mod => mod.Side == ModSide.Both).ToList();
 		AddNoSyncDeps(syncMods);
@@ -196,9 +191,6 @@ public static class ModNet
 	// This method is split so that the local variables aren't held by the GC when reloading
 	internal static bool SyncClientMods(BinaryReader reader, out bool needsReload)
 	{
-		AllowVanillaClients = reader.ReadBoolean();
-		Logging.tML.Info($"Server reports AllowVanillaClients set to {AllowVanillaClients}");
-
 		Main.statusText = Language.GetTextValue("tModLoader.MPSyncingMods");
 		Mod[] clientMods = ModLoader.Mods;
 		LocalMod[] modFiles = ModOrganizer.FindAllMods();

--- a/patches/tModLoader/Terraria/ModLoader/MountLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MountLoader.cs
@@ -32,9 +32,6 @@ public static class MountLoader
 
 	internal static int ReserveMountID()
 	{
-		if (ModNet.AllowVanillaClients)
-			throw new Exception("Adding mounts breaks vanilla client compatibility");
-
 		return MountCount++;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PrefixLoader.cs
@@ -33,9 +33,6 @@ public static class PrefixLoader
 
 	internal static int ReservePrefixID()
 	{
-		if (ModNet.AllowVanillaClients)
-			throw new Exception("Adding items breaks vanilla client compatibility");
-
 		return PrefixCount++;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/RarityLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/RarityLoader.cs
@@ -12,9 +12,6 @@ public static class RarityLoader
 
 	internal static int Add(ModRarity rarity)
 	{
-		if (ModNet.AllowVanillaClients)
-			throw new Exception("Adding rarities breaks vanilla client compatibility");
-
 		rarities.Add(rarity);
 		return RarityCount - 1;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -99,9 +99,6 @@ public static class TileLoader
 
 	internal static int ReserveTileID()
 	{
-		if (ModNet.AllowVanillaClients)
-			throw new Exception("Adding tiles breaks vanilla client compatibility");
-
 		int reserveID = nextTile;
 		nextTile++;
 		return reserveID;

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -45,8 +45,6 @@ public static class WallLoader
 
 	internal static int ReserveWallID()
 	{
-		if (ModNet.AllowVanillaClients) throw new Exception("Adding walls breaks vanilla client compatibility");
-
 		int reserveID = nextWall;
 		nextWall++;
 		return reserveID;

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -67,7 +67,7 @@
  					WriteAccessoryVisibility(writer, player4.hideVisibleAccessory);
  					writer.Write(player4.hideMisc);
  					writer.WriteRGB(player4.hairColor);
-@@ -166,12 +_,19 @@
+@@ -166,12 +_,17 @@
  
  					num11 = item6.stack;
  					num12 = item6.netID;
@@ -75,10 +75,8 @@
  					if (num11 < 0)
  						num11 = 0;
  
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Send(item6, writer, writeStack: true);
-+						goto SkipVanillaWrite;
-+					}
++					ItemIO.Send(item6, writer, writeStack: true);
++					goto SkipVanillaWrite;
 +
  					writer.Write((short)num11);
  					writer.Write((byte)number3);
@@ -87,7 +85,7 @@
  					break;
  				}
  				case 7: {
-@@ -340,8 +_,13 @@
+@@ -340,8 +_,12 @@
  						writer.Write(SocialAPI.Network.GetLobbyId());
  					else
  						writer.Write(0uL);
@@ -95,22 +93,19 @@
  
  					writer.Write(Sandstorm.IntendedSeverity);
 +
-+					if (!ModNet.AllowVanillaClients)
-+						WorldIO.SendModData(writer);
++					WorldIO.SendModData(writer);
 +
  					break;
  				}
  				case 8:
-@@ -551,8 +_,17 @@
+@@ -551,8 +_,15 @@
  					writer.Write((short)number);
  					writer.WriteVector2(item3.position);
  					writer.WriteVector2(item3.velocity);
 +
-+					if (!ModNet.AllowVanillaClients) {
-+						writer.Write7BitEncodedInt(item3.stack);
-+						writer.Write7BitEncodedInt(item3.prefix);
-+						goto SkipVanillaWrite;
-+					}
++					writer.Write7BitEncodedInt(item3.stack);
++					writer.Write7BitEncodedInt(item3.prefix);
++					goto SkipVanillaWrite;
 +
  					writer.Write((short)item3.stack);
 -					writer.Write(item3.prefix);
@@ -128,7 +123,7 @@
  					break;
  				}
  				case 22:
-@@ -636,9 +_,12 @@
+@@ -636,9 +_,11 @@
  						}
  					}
  
@@ -136,8 +131,7 @@
 +					if (nPC2.type >= 0 && Main.npcCatchable[nPC2.type])
  						writer.Write((byte)nPC2.releaseOwner);
  
-+					if (!ModNet.AllowVanillaClients)
-+						NPCLoader.SendExtraAI(writer, NPCLoader.WriteExtraAI(nPC2));
++					NPCLoader.SendExtraAI(writer, NPCLoader.WriteExtraAI(nPC2));
 +
  					break;
  				}
@@ -153,7 +147,7 @@
  					if (projectile.originalDamage != 0)
  						bitsByte23[6] = true;
  
-+					byte[] extraAI = !ModNet.AllowVanillaClients ? ProjectileLoader.WriteExtraAI(projectile) : null;
++					byte[] extraAI = ProjectileLoader.WriteExtraAI(projectile);
 +					bool hasExtraAI = extraAI?.Length > 0;
 +					bitsByte24[1] = hasExtraAI; // This bit is unused by vanilla
 +
@@ -199,15 +193,13 @@
  					break;
  				case 29:
  					writer.Write((short)number);
-@@ -735,13 +_,21 @@
+@@ -735,13 +_,19 @@
  					Item item7 = Main.chest[number].item[(byte)number2];
  					writer.Write((short)number);
  					writer.Write((byte)number2);
 +
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Send(item7, writer, writeStack: true);
-+						goto SkipVanillaWrite;
-+					}
++					ItemIO.Send(item7, writer, writeStack: true);
++					goto SkipVanillaWrite;
 +
  					short value4 = (short)item7.netID;
  					if (item7.Name == null)
@@ -234,13 +226,12 @@
  					break;
  				case 35:
  					writer.Write((byte)number);
-@@ -798,6 +_,10 @@
+@@ -798,6 +_,9 @@
  					writer.Write(player3.zone3);
  					writer.Write(player3.zone4);
  					writer.Write(player3.zone5);
 +
-+					if (!ModNet.AllowVanillaClients)
-+						BiomeLoader.SendCustomBiomes(player3, writer);
++					BiomeLoader.SendCustomBiomes(player3, writer);
 +
  					break;
  				}
@@ -254,16 +245,14 @@
  
  					break;
  				}
-@@ -1121,14 +_,27 @@
+@@ -1121,14 +_,25 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item4 = Main.player[(int)number4].inventory[(int)number3];
 +
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Send(item4, writer);
-+						writer.Write7BitEncodedInt(number5);
-+						goto SkipVanillaWrite;
-+					}
++					ItemIO.Send(item4, writer);
++					writer.Write7BitEncodedInt(number5);
++					goto SkipVanillaWrite;
 +
  					writer.Write((short)item4.netID);
 -					writer.Write(item4.prefix);
@@ -277,7 +266,7 @@
  					writer.Write((byte)number2);
 +
 +					// Send byte for owner if type corresponds to projectile (magic number 2) #WorldUIAnchorProjectileSyncFix
-+					if (!ModNet.AllowVanillaClients && (byte)number2 == 2)
++					if ((byte)number2 == 2)
 +						writer.Write((byte)((int)number2 >> 8));
 +
  					if (number2 != 255f) {
@@ -315,15 +304,13 @@
  				case 118:
  					writer.Write((byte)number);
  					_currentPlayerDeathReason.WriteSelfTo(writer);
-@@ -1291,9 +_,16 @@
+@@ -1291,9 +_,14 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item2 = Main.player[(int)number4].inventory[(int)number3];
 +
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Send(item2, writer, writeStack: true);
-+						goto SkipVanillaWrite;
-+					}
++					ItemIO.Send(item2, writer, writeStack: true);
++					goto SkipVanillaWrite;
 +
  					writer.Write((short)item2.netID);
 -					writer.Write(item2.prefix);
@@ -333,16 +320,13 @@
  					break;
  				}
  				case 124: {
-@@ -1356,9 +_,17 @@
+@@ -1356,9 +_,14 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item = Main.player[(int)number4].inventory[(int)number3];
 +
-+
-+					if (!ModNet.AllowVanillaClients) {
-+						ItemIO.Send(item, writer, writeStack: true);
-+						goto SkipVanillaWrite;
-+					}
++					ItemIO.Send(item, writer, writeStack: true);
++					goto SkipVanillaWrite;
 +
  					writer.Write((short)item.netID);
 -					writer.Write(item.prefix);

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -50,16 +50,14 @@
  					break;
  				case 3:
  					writer.Write((byte)remoteClient);
-@@ -115,7 +_,15 @@
+@@ -115,7 +_,13 @@
  					writer.Write((byte)player4.skinVariant);
  					writer.Write((byte)player4.hair);
  					writer.Write(player4.name);
 +
-+					if (ModNet.AllowVanillaClients) {
 -					writer.Write(player4.hairDye);
-+						writer.Write7BitEncodedInt(player4.hairDye);
-+						goto SkipVanillaWrite;
-+					}
++					writer.Write7BitEncodedInt(player4.hairDye);
++					goto SkipVanillaWrite;
 +
 +					writer.Write((byte)player4.hairDye);
 +					SkipVanillaWrite:

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -50,22 +50,16 @@
  					break;
  				case 3:
  					writer.Write((byte)remoteClient);
-@@ -115,7 +_,13 @@
+@@ -115,7 +_,7 @@
  					writer.Write((byte)player4.skinVariant);
  					writer.Write((byte)player4.hair);
  					writer.Write(player4.name);
-+
 -					writer.Write(player4.hairDye);
 +					writer.Write7BitEncodedInt(player4.hairDye);
-+					goto SkipVanillaWrite;
-+
-+					writer.Write((byte)player4.hairDye);
-+					SkipVanillaWrite:
-+
  					WriteAccessoryVisibility(writer, player4.hideVisibleAccessory);
  					writer.Write(player4.hideMisc);
  					writer.WriteRGB(player4.hairColor);
-@@ -166,12 +_,17 @@
+@@ -166,12 +_,16 @@
  
  					num11 = item6.stack;
  					num12 = item6.netID;
@@ -74,12 +68,11 @@
  						num11 = 0;
  
 +					ItemIO.Send(item6, writer, writeStack: true);
-+					goto SkipVanillaWrite;
-+
++					/*
  					writer.Write((short)num11);
  					writer.Write((byte)number3);
  					writer.Write((short)num12);
-+					SkipVanillaWrite:
++					*/
  					break;
  				}
  				case 7: {
@@ -96,20 +89,17 @@
  					break;
  				}
  				case 8:
-@@ -551,8 +_,15 @@
+@@ -551,8 +_,12 @@
  					writer.Write((short)number);
  					writer.WriteVector2(item3.position);
  					writer.WriteVector2(item3.velocity);
-+
 +					writer.Write7BitEncodedInt(item3.stack);
 +					writer.Write7BitEncodedInt(item3.prefix);
-+					goto SkipVanillaWrite;
-+
++					/*
  					writer.Write((short)item3.stack);
 -					writer.Write(item3.prefix);
 +					writer.Write((byte)item3.prefix);
-+					SkipVanillaWrite:
-+
++					*/
  					writer.Write((byte)number2);
  					short value2 = 0;
  					if (item3.active && item3.stack > 0)
@@ -191,14 +181,13 @@
  					break;
  				case 29:
  					writer.Write((short)number);
-@@ -735,13 +_,19 @@
+@@ -735,13 +_,18 @@
  					Item item7 = Main.chest[number].item[(byte)number2];
  					writer.Write((short)number);
  					writer.Write((byte)number2);
 +
 +					ItemIO.Send(item7, writer, writeStack: true);
-+					goto SkipVanillaWrite;
-+
++					/*
  					short value4 = (short)item7.netID;
  					if (item7.Name == null)
  						value4 = 0;
@@ -208,7 +197,7 @@
 -					writer.Write(item7.prefix);
 +					writer.Write((byte)item7.prefix);
  					writer.Write(value4);
-+					SkipVanillaWrite:
++					*/
  					break;
  				}
  				case 33: {
@@ -243,20 +232,19 @@
  
  					break;
  				}
-@@ -1121,14 +_,25 @@
+@@ -1121,14 +_,24 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item4 = Main.player[(int)number4].inventory[(int)number3];
 +
 +					ItemIO.Send(item4, writer);
 +					writer.Write7BitEncodedInt(number5);
-+					goto SkipVanillaWrite;
-+
++					/*
  					writer.Write((short)item4.netID);
 -					writer.Write(item4.prefix);
 +					writer.Write((byte)item4.prefix);
  					writer.Write((short)number5);
-+					SkipVanillaWrite:
++					*/
  					break;
  				}
  				case 91:
@@ -302,35 +290,33 @@
  				case 118:
  					writer.Write((byte)number);
  					_currentPlayerDeathReason.WriteSelfTo(writer);
-@@ -1291,9 +_,14 @@
+@@ -1291,9 +_,13 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item2 = Main.player[(int)number4].inventory[(int)number3];
 +
 +					ItemIO.Send(item2, writer, writeStack: true);
-+					goto SkipVanillaWrite;
-+
++					/*
  					writer.Write((short)item2.netID);
 -					writer.Write(item2.prefix);
 +					writer.Write((byte)item2.prefix);
  					writer.Write((short)number5);
-+					SkipVanillaWrite:
++					*/
  					break;
  				}
  				case 124: {
-@@ -1356,9 +_,14 @@
+@@ -1356,9 +_,13 @@
  					writer.Write((short)number);
  					writer.Write((short)number2);
  					Item item = Main.player[(int)number4].inventory[(int)number3];
 +
 +					ItemIO.Send(item, writer, writeStack: true);
-+					goto SkipVanillaWrite;
-+
++					/*
  					writer.Write((short)item.netID);
 -					writer.Write(item.prefix);
 +					writer.Write((byte)item.prefix);
  					writer.Write((short)number5);
-+					SkipVanillaWrite:
++					*/
  					break;
  				}
  				case 134: {


### PR DESCRIPTION
We retired AllowVanillaClients, but it is still in the codebase. Removing it should help clean up patches and make following the code flow easier. Many labels that skip over now unreachable code are also removed in favor of being commented out.

There is also an incidental fix for syncing `player.hairDye`, it seems that the logic was accidentally flipped a couple years back. It is likely unreported since it would require a lot of modded hair dyes to be added to actually cause sync issues. (This is assuming Write(byte) and Write7BitEncodedInt behave the same for values under 128, which I think is true. There are only 12 vanilla hair dye.)

Brought up by and fixes #4232