### PR TITLE
Fix #4242

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -398,7 +398,7 @@ internal class UIModItem : UIPanel
 
 		// TODO: These should just be UITexts
 		if (_mod.properties.side != ModSide.Server && (_mod.Enabled != _loaded || _configChangesRequireReload)) {
-			drawPos += new Vector2(_uiModStateText.Width.Pixels + left2ndLine, 0f);
+			drawPos += new Vector2((_uiModStateText?.Width.Pixels ?? 0) + left2ndLine, 0f);
 			Utils.DrawBorderString(spriteBatch, _configChangesRequireReload ? Language.GetTextValue("tModLoader.ModReloadForced") : Language.GetTextValue("tModLoader.ModReloadRequired"), drawPos, Color.White, 1f, 0f, 0f, -1);
 		}
 		if (_mod.properties.side == ModSide.Server) {


### PR DESCRIPTION
### What is the bug?
#4242

### How did you fix the bug?
Add a null check to the offending line.

### Are there alternatives to your fix?
There's almost certainly an underlying reason for why this bug only starting to happen now (or at least went unreported this long), but I don't watch tModLoader development closely enough to have an idea what it could be, and `UIModItem` hasn't been changed recently.