### PR TITLE
Add ProjectileID.Sets.FiresFewerFromDaedalusStormbow

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
@@ -11,8 +11,8 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override void SetStaticDefaults()
 		{
-			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire less projectiles from Daedalus Stormbow like this:
-			//ProjectileID.Sets.FiresLessFromDaedalusStormbow[Projectile.type] = true;
+			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire fewer projectiles from Daedalus Stormbow for game balance considerations like this:
+			//ProjectileID.Sets.FiresFewerFromDaedalusStormbow[Type] = true;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
@@ -11,7 +11,7 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override void SetStaticDefaults()
 		{
-			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile like this:
+			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile  from Daedalus Stormbow like this:
 			//ProjectileID.Sets.FiresLessFromDaedalusStormbow[Projectile.type] = true;
 		}
 

--- a/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
@@ -9,6 +9,12 @@ namespace ExampleMod.Content.Projectiles
 	// This example is similar to the Wooden Arrow projectile
 	public class ExampleArrowProjectile : ModProjectile
 	{
+		public override void SetStaticDefaults()
+		{
+			//If this arrow had strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile like this:
+			//ProjectileID.Sets.FiresLessFromDaedalusStormbow[Projectile.type] = true;
+		}
+
 		public override void SetDefaults() {
 			Projectile.width = 10; // The width of projectile hitbox
 			Projectile.height = 10; // The height of projectile hitbox

--- a/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
@@ -11,7 +11,7 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override void SetStaticDefaults()
 		{
-			//If this arrow had strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile like this:
+			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile like this:
 			//ProjectileID.Sets.FiresLessFromDaedalusStormbow[Projectile.type] = true;
 		}
 

--- a/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleArrowProjectile.cs
@@ -11,7 +11,7 @@ namespace ExampleMod.Content.Projectiles
 	{
 		public override void SetStaticDefaults()
 		{
-			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire 1 less projectile  from Daedalus Stormbow like this:
+			// If this arrow would have strong effects (like Holy Arrow pierce), we can make it fire less projectiles from Daedalus Stormbow like this:
 			//ProjectileID.Sets.FiresLessFromDaedalusStormbow[Projectile.type] = true;
 		}
 

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -9,6 +9,12 @@ partial class ProjectileID
 		/// </summary>
 		public static bool[] SingleGrappleHook = Factory.CreateBoolSet(false, 13, 315, 230, 231, 232, 233, 234, 235, 331, 753, 865, 935);
 
+		// Values taken from Player.ItemCheck_Shoot type == 3029 check
+		/// <summary>
+		/// Set of Projectile IDs that will fire 1 less from <see cref="ItemID.DaedalusStormbow"/>
+		/// </summary>
+		public static bool[] FiresLessFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
+
 		/// <summary>
 		/// Used to scale down summon tag damage for fast hitting minions and sentries. 
 		/// </summary>

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -11,9 +11,9 @@ partial class ProjectileID
 
 		// Values taken from Player.ItemCheck_Shoot type == 3029 check
 		/// <summary>
-		/// Set of Projectile IDs that will fire less from <see cref="ItemID.DaedalusStormbow"/>
+		/// Set of Projectile IDs that have a chance to fire fewer projectiles from <see cref="ItemID.DaedalusStormbow"/>
 		/// </summary>
-		public static bool[] FiresLessFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
+		public static bool[] FiresFewerFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
 
 		/// <summary>
 		/// Used to scale down summon tag damage for fast hitting minions and sentries. 

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -11,7 +11,7 @@ partial class ProjectileID
 
 		// Values taken from Player.ItemCheck_Shoot type == 3029 check
 		/// <summary>
-		/// Set of Projectile IDs that will fire 1 less from <see cref="ItemID.DaedalusStormbow"/>
+		/// Set of Projectile IDs that will fire less from <see cref="ItemID.DaedalusStormbow"/>
 		/// </summary>
 		public static bool[] FiresLessFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
 

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7099,7 +7099,7 @@
  			int num11 = 3;
 -			if (projToShoot == 91 || projToShoot == 4 || projToShoot == 5 || projToShoot == 41) {
 +			//if (projToShoot == 91 || projToShoot == 4 || projToShoot == 5 || projToShoot == 41)
-+			if (ProjectileID.Sets.FiresLessFromDaedalusStormbow[projToShoot])
++			if (ProjectileID.Sets.FiresFewerFromDaedalusStormbow[projToShoot])
 +			{
  				if (Main.rand.Next(3) == 0)
  					num11--;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7093,6 +7093,17 @@
  		if (projToShoot == 76) {
  			projToShoot += Main.rand.Next(3);
  			float num7 = (float)Main.screenHeight / Main.GameViewMatrix.Zoom.Y;
+@@ -36895,7 +_,9 @@
+ 		}
+ 		else if (sItem.type == 3029) {
+ 			int num11 = 3;
+-			if (projToShoot == 91 || projToShoot == 4 || projToShoot == 5 || projToShoot == 41) {
++			//if (projToShoot == 91 || projToShoot == 4 || projToShoot == 5 || projToShoot == 41)
++			if (ProjectileID.Sets.FiresLessFromDaedalusStormbow[projToShoot])
++			{
+ 				if (Main.rand.Next(3) == 0)
+ 					num11--;
+ 			}
 @@ -38410,10 +_,14 @@
  		projType = 721;
  		Item item = inventory[selectedItem];


### PR DESCRIPTION
### What is the new feature?
`ProjectileID.Sets.FiresFewerFromDaedalusStormbow` which contains "overpowered" arrows so the [Daedalus Stormbow](https://terraria.wiki.gg/wiki/Daedalus_Stormbow) fires 1 fewer projectile occasionally (instead of 1 more), as per its spec: `Each shot fires three arrows with an additional 1/3 (33.33%) chance to spawn one extra arrow (one fewer arrow while using Holy, Unholy, Hellfire, or Jester's Arrows)`

### Why should this be part of tModLoader?
Requires an IL edit otherwise, helps balancing stronger arrows with the Daedalus Stormbow.

### Are there alternative designs?
No

### Sample usage for the new feature
See ExampleArrowProjectile

### ExampleMod updates
See ExampleArrowProjectile

