### PR TITLE
Modernization: Load error display message

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -234,7 +234,8 @@ public static class ModLoader
 		// Getting Real Technical Section
 
 		sb.AppendLine($"For Support, Include Files at \"Open Logs\" and Information Below");
-		sb.AppendLine($"   Error(s)::\n{exception.Message}");
+		string exceptionDetails = exception.Data.Contains("hideStackTrace") ? exception.Message : exception.ToString();
+		sb.AppendLine($"   Error(s)::\n{exceptionDetails}");
 
 		if (exception is Exceptions.JITException)
 			sb.AppendLine($"The mod will need to be updated to match the current tModLoader version, or may be incompatible with the version of some of your other mods. Click the '{Language.GetTextValue("tModLoader.OpenWebHelp")}' button to learn more.");
@@ -290,6 +291,10 @@ public static class ModLoader
 			if (e.Data.Contains("mod"))
 				msg += "\n" + Language.GetTextValue("tModLoader.DefensiveUnload", e.Data["mod"]);
 
+			msg += $"For Support, Include Files at \"Open Logs\" and Information Below";
+			string exceptionDetails = e.Data.Contains("hideStackTrace") ? e.Message : e.ToString();
+			msg += $"\n   Error(s)::\n{exceptionDetails}";
+
 			DisplayLoadError(msg, e, true);
 
 			return false;
@@ -333,9 +338,9 @@ public static class ModLoader
 	private static void DisplayLoadError(string msg, Exception e, bool fatal, bool continueIsRetry = false)
 	{
 		if (fatal)
-			Logging.tML.Fatal(msg, e);
+			Logging.tML.Fatal(msg);
 		else
-			Logging.tML.Error(msg, e);
+			Logging.tML.Error(msg);
 
 		if (Main.dedServ) {
 			Console.ForegroundColor = ConsoleColor.Red;

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -214,9 +214,9 @@ public static class ModLoader
 		sb.AppendLine("Possible load issue causes are:");
 
 		(bool relevant, string desc)[] commonIssues = {
-			(false, "A dependency mod has updated and this mod is out of date with the dependency"),
+			(false, "A dependency mod may have updated and this mod is out of date with the dependency"),
 			(false, $"You attempted to load a Stable mod on {BuildInfo.Purpose} tModLoader"),
-			(false, "You attempted to load a 1.3/1.4.3 Mod on 1.4.4"),
+			(false, $"You attempted to load a {"1.3/1.4.3"} mod on {SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion)}"),
 			(false, "You are using a different tML version than the 'Frozen' modpack"),
 		};
 
@@ -224,12 +224,7 @@ public static class ModLoader
 			commonIssues[0].relevant |= item.properties.modReferences.Length > 0;
 			commonIssues[1].relevant |= !BuildInfo.IsStable && item.tModLoaderVersion.MajorMinor() != BuildInfo.tMLVersion.MajorMinor();
 			commonIssues[2].relevant |= SocialBrowserModule.GetBrowserVersionNumber(item.tModLoaderVersion) != SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
-
-			if (item.location == ModLocation.Modpack) {
-				var ss = File.ReadLines(Path.Combine(ModOrganizer.ModPackActive, "Mods", "tmlversion.txt")).FirstOrDefault();
-				commonIssues[3].relevant |= item.location == ModLocation.Modpack && new Version(ss).MajorMinor() != BuildInfo.tMLVersion.MajorMinor();
-			}
-			
+			commonIssues[3].relevant |= item.location == ModLocation.Modpack && new Version(File.ReadLines(Path.Combine(ModOrganizer.ModPackActive, "Mods", "tmlversion.txt")).FirstOrDefault()).MajorMinor() != BuildInfo.tMLVersion.MajorMinor();
 		}
 
 		foreach (var item in commonIssues.Where(item => item.relevant)) {


### PR DESCRIPTION
### What is the new feature?
A rewrite of the Text contents of the Load Error message during Mod Loading.

### Why should this be part of tModLoader?
This rewrite is to simplify the information for a player, and make it easier to see.
As well as change the 'advice' to be more accurate and meaningful to a player.

### Are there alternative designs?
Yes, UI has many alternative designs. 
We could go so far as a whole new UI menu to try to split out information and exception trace.
But it would be easier to keep the same backing UI and refine the text.

### Sample usage for the new feature
![image](https://github.com/tModLoader/tModLoader/assets/59670736/ca227a11-4ec8-4b63-9fa7-f915d9a9a2f3)
