### PR TITLE
Fix documentation references for nuget packages

### DIFF
--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -37,6 +37,7 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 			string pathInPackage = item.GetMetadata("PathInPackage");
 			//string fileName = item.GetMetadata("Filename");
 			//string runtimeIdentifier = item.GetMetadata("RuntimeIdentifier");
+			string dllDirectoryInPackage = null;
 
 			// PDBs & XMLs lack some metadata, attempt to get it from the paired .dll.
 			if (string.IsNullOrEmpty(fusionName) && !".dll".Equals(fileExtension, StringComparison.OrdinalIgnoreCase)) {
@@ -44,6 +45,8 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 
 				if (items.FirstOrDefault(i => dllSpec.Equals(i.ItemSpec, StringComparison.OrdinalIgnoreCase)) is ITaskItem dllItem) {
 					fusionName = dllItem.GetMetadata("FusionName");
+					string dllPathInPackage = dllItem.GetMetadata("PathInPackage");
+					dllDirectoryInPackage = !string.IsNullOrEmpty(dllPathInPackage) ? Path.GetDirectoryName(dllPathInPackage) : string.Empty;
 				}
 			}
 
@@ -65,6 +68,10 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 			// NuGet Packages - This is used for all NuGet libraries, whether native or managed, whether rid-specific or agnostic.
 			else if (!string.IsNullOrEmpty(nugetPackageId)) {
 				string? directoryInPackage = !string.IsNullOrEmpty(pathInPackage) ? Path.GetDirectoryName(pathInPackage) : string.Empty;
+
+				if (string.IsNullOrEmpty(directoryInPackage) && !string.IsNullOrEmpty(dllDirectoryInPackage)) {
+					directoryInPackage = dllDirectoryInPackage;
+				}
 
 				// NuGet package IDs are lowercased in folder repositories.
 				string? nugetPackageIdLower = nugetPackageId.ToLower();

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -43,7 +43,7 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 
 			// PDBs & XMLs lack some metadata, attempt to get it from the paired .dll.
 			if (string.IsNullOrEmpty(fusionName) && !".dll".Equals(fileExtension, StringComparison.OrdinalIgnoreCase)) {
-				string libSpec = item.ItemSpec.Replace($"{sep}{nugetPackageVersion}{sep}ref{sep}", $"{sep}{nugetPackageVersion}{sep}lib{sep}");
+				string libSpec = ReplaceLast(item.ItemSpec, $"{sep}{nugetPackageVersion}{sep}ref{sep}", $"{sep}{nugetPackageVersion}{sep}lib{sep}");
 				string dllSpec = Path.ChangeExtension(libSpec, ".dll");
 
 				if (items.FirstOrDefault(i => dllSpec.Equals(i.ItemSpec, StringComparison.OrdinalIgnoreCase)) is ITaskItem dllItem) {
@@ -103,4 +103,7 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 			item.SetMetadata("DestinationSubDirectory", destinationSubDirectory);
 		}
 	}
+
+	private static string ReplaceLast(string str, string match, string replacement)
+		=> str.LastIndexOf(match) is int index and not -1 ? str.Remove(index, match.Length).Insert(index, replacement) : str;
 }

--- a/tModBuildTasks/OrganizeReferenceDestinations.cs
+++ b/tModBuildTasks/OrganizeReferenceDestinations.cs
@@ -28,6 +28,8 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 
 	private void ProcessItems(ITaskItem[] items)
 	{
+		char sep = Path.DirectorySeparatorChar;
+
 		foreach (var item in items) {
 			string fileExtension = item.GetMetadata("Extension");
 			string nugetPackageId = item.GetMetadata("NuGetPackageId");
@@ -37,11 +39,12 @@ public sealed class OrganizeReferenceDestinations : TaskBase
 			string pathInPackage = item.GetMetadata("PathInPackage");
 			//string fileName = item.GetMetadata("Filename");
 			//string runtimeIdentifier = item.GetMetadata("RuntimeIdentifier");
-			string dllDirectoryInPackage = null;
+			string? dllDirectoryInPackage = null;
 
 			// PDBs & XMLs lack some metadata, attempt to get it from the paired .dll.
 			if (string.IsNullOrEmpty(fusionName) && !".dll".Equals(fileExtension, StringComparison.OrdinalIgnoreCase)) {
-				string dllSpec = Path.ChangeExtension(item.ItemSpec, ".dll");
+				string libSpec = item.ItemSpec.Replace($"{sep}{nugetPackageVersion}{sep}ref{sep}", $"{sep}{nugetPackageVersion}{sep}lib{sep}");
+				string dllSpec = Path.ChangeExtension(libSpec, ".dll");
 
 				if (items.FirstOrDefault(i => dllSpec.Equals(i.ItemSpec, StringComparison.OrdinalIgnoreCase)) is ITaskItem dllItem) {
 					fusionName = dllItem.GetMetadata("FusionName");


### PR DESCRIPTION
When modding, there are a few libraries with documentation that would be useful to have automatically show up. Currently they do not because they are in a different location from the .dll file:

```
tModLoader\Libraries\Newtonsoft.Json\13.0.3\Newtonsoft.Json.xml
tModLoader\Libraries\Newtonsoft.Json\13.0.3\lib\net6.0\Newtonsoft.Json.dll
```

This PR fixes that. I'm not sure why we need that much nesting in the first place, but I seem to remember it causing issues during the initial dotnet core migration.

This PR does not fix `MonoMod.RuntimeDetour.xml`, which was the main motivator for this fix in the first place. For some reason the .xml file is not copied anywhere despite being in the `.nupkg`. Updating to `25.1.1` from `25.1.0` fixes this somehow, but I'm not sure what other changes `25.1.1` might bring. 