### PR TITLE
Enhance Mod pack Capabilities, and fix bugs.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
@@ -366,6 +366,13 @@ internal class UIModPackItem : UIPanel
 			Interface.infoMessage.Show(Language.GetTextValue("tModLoader.ModPackModsMissing", string.Join("\n", modListItem._missing)), Interface.modPacksMenuID);
 		}
 
+		string configsPath = Path.Combine(modListItem._filepath, "ModConfigs");
+		var configFilesFromPack = Directory.EnumerateFiles(configsPath);
+		foreach (string configFile in configFilesFromPack) {
+			string configName = Path.GetFileName(configFile);
+			File.Copy(configFile, Path.Combine(Config.ConfigManager.ModConfigPath, configName), true);
+		}
+
 		Logging.tML.Info($"Enabled Collection of mods defined in  Mod Pack {modListItem._filename}");
 		ModLoader.OnSuccessfulLoad += () => Main.menuMode = Interface.modPacksMenuID;
 		ModLoader.Reload();

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
@@ -208,14 +208,6 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 	public UIModPackItem LoadModernModPack(string folderPath)
 	{
 		string enabledJson = Path.Combine(folderPath, "Mods", "enabled.json");
-		string configsPath = Path.Combine(folderPath, "ModConfigs");
-
-		var configFilesFromPack = Directory.EnumerateFiles(configsPath);
-		foreach (string configFile in configFilesFromPack) {
-			string configName = Path.GetFileName(configFile);
-			File.Copy(configFile, Path.Combine(Config.ConfigManager.ModConfigPath, configName), true);
-		}
-
 		string[] modPackMods = JsonConvert.DeserializeObject<string[]>(File.ReadAllText(enabledJson));
 		if (modPackMods == null) {
 			Utils.LogAndConsoleInfoMessage($"No contents in enabled.json at: {folderPath}. Is this correct?");


### PR DESCRIPTION
### What is the bug?

The bug is about mod packs not syncing mod configurations. I've also found some issues when updating the mod pack with enabled. The files aren't really updating, copying and deleting properly, making mod packs very confusing to work with.

#### Related issues

- #4228 - Directly addresses the issue.
- #4258 - Mod configuration loss can be mitigated if mod pack feature can synchronize mod configurations.

### How did you fix the bug?

I uncommented an existing line that copies mod configurations in their proper folder. (If this was intended to be commented temporarily, please explain to me so I have more context.)

I also added code that copies mod config files into the real mod configs folder.

~~I noticed that updating the mod pack with Enabled button inconsistently copies the `.tmod` files into the mod pack folder. Sometimes, it doesn't work. Spamming the button sometimes makes the copying successful. What is the real intention of the button? Should it only copy enabled.json? Or should it also copy `.tmod` files?~~

I also included a fix where Update Mod pack with Enabled does not correctly update the mod pack files. Now, they copy `.tmod` files correctly alongside the mod configs.