### PR TITLE
Fix Dockerfile permissions

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
@@ -20,10 +20,14 @@ ARG GID
 RUN addgroup -g $GID tml \
  && adduser tml -u $UID -G tml -h /home/tml -D
 
+# Fix permissions for tml's home directory due to the creation of `/home/tml/server/tModLoader-Logs/Natives.log`
+WORKDIR /home/tml
+RUN chown -R tml:tml /home/tml
+RUN chmod 755 /home/tml
+
 USER tml
 ENV USER tml
 ENV HOME /home/tml
-WORKDIR $HOME
 
 # Update SteamCMD and verify latest version
 RUN steamcmd +quit


### PR DESCRIPTION
Fixing the default Dockerfile.

### What is the bug?

Attempting to run the default dockerfile in `tModLoader/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile` is not possible due to an attempt to write into `/home/tml/server/tModLoader-Logs/Natives.log` as noticed by @reniivali in the following screenshot:

![image](https://github.com/tModLoader/tModLoader/assets/55662140/2074581a-f0c1-406e-a095-4f319966b9e6)

This causes the server to error and exit immediately.

This problem is most likely caused by setting the home directory path in the `adduser` command with `-h` explicitly (see [the alpine linux wiki](https://wiki.alpinelinux.org/wiki/Setting_up_a_new_user) and the [`adduser`](https://linux.die.net/man/8/adduser) manpage; specifically in the manpage (when setting the homedir path directly): "The directory HOME_DIR does not have to exist but will not be created if it is missing.").

By default, this means that `/home/tml` is owned by `root:root`, with `755`, `750`, or `700` permissions. `tml` cannot write into, or perhaps even read `/home/tml` and/or its contents.

### How did you fix the bug?

The order of operations within the Dockerfile was changed from first switching to and setting the `tml` user's environment variables, then using said variables to create `/home/tml`; to creating `/home/tml` first, and setting the ownership of `/home/tml` to `tml:tml` and setting the permission octets to `755` (`rwxr-x--x`), then proceeding with environment variable configuration. The remaining portions of the file are unchanged.

### Are there alternatives to your fix?

Yes, it would be possible to just omit `-h /home/tml` entirely, and let the alpine system defaults take over home directory creation, but I assume that it was specified directly to ensure reproducibility. My fix keeps most of the existing code, but will ensure `tml` is able to write to `/home/tml` and its subdirectories if any were created when `/home/tml` was first made (however, there shouldn't be any as it's created by `WORKDIR`, not `adduser`).
