### PR TITLE
Changes LocalizationLoader.LoadModTranslations signature to include LanguageManager

### DIFF
--- a/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
+++ b/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
@@ -76,7 +76,7 @@
  			}
  		}
 +
-+		LocalizationLoader.LoadModTranslations(culture);
++		LocalizationLoader.LoadModTranslations(this, culture);
  	}
  
 +	// Replaced by ProcessCopyCommandsInTexts implementation in LanguageManager.tML.cs

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -28,9 +28,12 @@ public static class LocalizationLoader
 		}
 	}
 
+	[Obsolete("Use LoadModTranslations(LanguageManager, GameCulture) instead")]
 	public static void LoadModTranslations(GameCulture culture)
+		=> LoadModTranslations(LanguageManager.Instance, culture)
+
+	public static void LoadModTranslations(LanguageManager lang, GameCulture culture)
 	{
-		var lang = LanguageManager.Instance;
 		foreach (var mod in ModLoader.Mods) {
 			foreach (var (key, value) in LoadTranslations(mod, culture)) {
 				lang.GetText(key).SetValue(value); // can only set the value of existing keys. Cannot register new keys.


### PR DESCRIPTION
### What is the new feature?
Changes `LocalizationLoader.LoadModTranslations` signature to include `LanguageManager`.

```diff
-public static void LoadModTranslations(GameCulture culture)
+public static void LoadModTranslations(LanguageManager lang, GameCulture culture)
```

### Why should this be part of tModLoader?
`LanguageManager.Instance` is often used (and hardcoded) instead of passing an instance, making it really difficult to implement specific culture orientated language manager (e.g. english language manager).

### Are there alternative designs?
... no.

### Sample usage for the new feature
```cs
public sealed class SpecificCultureOrientatedLanguageManager {
  private readonly LanguageManager _languageManager;
  private readonly GameCulture _culture;
  
  public SpecificCultureOrientatedLanguageManager(GameCulture culture) {
    _languageManager = LanguageManager__ctor();
    _culture = culture;
    
    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
    static extern LanguageManager LanguageManager__ctor();
  }
  
  public void LoadLanguage() {
    // From this abomination:
    void LoadVanillaTranslations() {
      string[] languageFilesForCulture = GetLanguageFilesForCulture(_languageManager, _culture);
      foreach (string languageFile in languageFilesForCulture) {
	try {
	  string text = Utils.ReadEmbeddedResource(languageFile);
	  if (text is null or { Length: < 2 })
	    throw new FormatException();
	  _languageManager.LoadLanguageFromFileTextJson(text, true);
	}
	catch {
	  Console.WriteLine("Failed to load language file: " + text);
	  break;
	}
      }
      
      //LocalizationLoader.LoadModTranslations(_culture);
    }
    void LoadModTranslations() {
      var loadTranslationsMethod = typeof(LocalizationLoader)
        .GetRuntimeMethod("LoadTranslations")
        .CreateDelegate<Func<Mod, GameCulture, List<(string, string)>>>();
    
      foreach (var mod in ModLoader.Mods) {
        foreach (var (key, value) in loadTranslationsMethod(mod, _culture)) {
          SetValue(_languageManager.GetText(key), value);
        }
      }
      
      [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(SetValue))]
      static extern void SetValue(LocalizedText @this, string text);
    }
    LoadVanillaTranslations();
    LoadModTranslations();
    // To one simple method call:
    LoadFilesForCulture(_languageManager, _culture);
    
    ProcessCopyCommandsInTexts(_languageManager);
  }
  
  [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(GetLanguageFilesForCulture))]
  private static extern string[] GetLanguageFilesForCulture(LanguageManager @this, GameCulture culture);
  
  [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(LoadFilesForCulture))]
  private static extern void LoadFilesForCulture(LanguageManager @this, GameCulture culture);
  
  [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(ProcessCopyCommandsInTexts))]
  private static extern void ProcessCopyCommandsInTexts(LanguageManager @this);
}