### PR TITLE
Fix world corruption when changing frameImportant for modded tiles

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -57,12 +57,13 @@ internal static partial class TileIO
 
 				// Check saved entries
 				foreach (var entry in savedEntryList) {
+					savedEntryLookup[entry.type] = entry;
+
 					// If the saved entry can be found among the loaded blocks, then use the entry created for the loaded block
 					if (ModContent.TryFind(entry.modName, entry.name, out TBlock block)) {
-						savedEntryLookup[entry.type] = entries[block.Type];
+						entry.loadedType = block.Type;
 					}
 					else { // If it can't be found, then add entry to the end of the entries list and set the loadedType to the unloaded placeholder
-						savedEntryLookup[entry.type] = entry;
 						entry.type = (ushort)entries.Count;
 						entry.loadedType = canPurgeOldData ? entry.vanillaReplacementType : ModContent.Find<TBlock>(string.IsNullOrEmpty(entry.unloadedType) ? entry.DefaultUnloadedType : entry.unloadedType).Type;
 						entries.Add(entry);

--- a/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/TileIO_Basic.cs
@@ -59,9 +59,9 @@ internal static partial class TileIO
 				foreach (var entry in savedEntryList) {
 					savedEntryLookup[entry.type] = entry;
 
-					// If the saved entry can be found among the loaded blocks, then use the entry created for the loaded block
+					// If the saved entry can be found among the loaded blocks, then use its loadedType
 					if (ModContent.TryFind(entry.modName, entry.name, out TBlock block)) {
-						entry.loadedType = block.Type;
+						entry.type = entry.loadedType = block.Type;
 					}
 					else { // If it can't be found, then add entry to the end of the entries list and set the loadedType to the unloaded placeholder
 						entry.type = (ushort)entries.Count;


### PR DESCRIPTION
When a modded tile is `frameImportant` then we save the `frameX` and `frameY`. We also save the value of `frameImportant` in an entry for that tile in the file. 

A bug in the tile loading code was discarding the saved value of `frameImportant` and using the current value for the mod. This causes an over/underread error, offsetting or corrupting the remainder of modded tile data.

The fix is to use the saved entry for deserialization, and just update the `loadedType` field to the current runtime `Type` of the tile