### PR TITLE
Add podman support

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -24,7 +24,7 @@ function try_make_link {
 # NOTE: There is seemingly no official documentation on this file but other more "official" software does this same check.
 # See: https://github.com/moby/moby/blob/v24.0.5/libnetwork/drivers/bridge/setup_bridgenetfiltering.go#L162-L165
 function is_in_docker {
-	if [[ -f /.dockerenv ]]; then
+	if ([[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]]); then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
### What is the new feature?

Now the "docker way" of starting server also works on podman.

### Why should this be part of tModLoader?

Podman is a popular container runtime, and right now you can support it with minimal changes.

### Are there alternative designs?

There are probably other ways to recognize containerized environment, but looking at comments in the code they were already considered.

### Sample usage for the new feature

```
podman-compose up -d
```