### PR TITLE
More CI maintenance, update github-tag-action version to 6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           branch: ${{github.ref}}
         
         # Apply new Tag for the current commit
-      - uses: mathieudutour/github-tag-action@v6.0
+      - uses: mathieudutour/github-tag-action@v6.2
         if: ${{ steps.version.outputs.new_version != null}}
         with:
            custom_tag: ${{ steps.version.outputs.new_version }}


### PR DESCRIPTION
Updates github-tag-action to 6.2 from 6.0.

The github-tag-action changes from 6.0 to 6.2 all see like they won't break anything to me, but if someone else could look over and see if anything looks like an issue that would be good (https://github.com/mathieudutour/github-tag-action/compare/releases/v6.0...v6.2). We can't really test this without making a new tag, so we might just need to trust that it works.

Should get rid of these 4 warnings in the github actions build (https://github.com/tModLoader/tModLoader/actions/runs/10050215642):

![image](https://github.com/user-attachments/assets/0a4c0d95-2f10-4e49-8ac5-9d32c77dac96)

We might also want to update from actions/checkout@v2 and actions/cache@v2 to remove more deprecated warnings and stay ahead of any future hard deprecations. I'm not positive yet if the API for those changed anything. 