### PR TITLE
Fix #4283

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
@@ -172,11 +172,11 @@ public class WorkshopPublishInfoStateForMods : AWorkshopPublishInfoState<TmodFil
 			queryType = QueryType.SearchDirect
 		};
 
-		if (!WorkshopHelper.TryGetModDownloadItemsByInternalName(query, out List<ModDownloadItem> mods) || mods.Count != 1 || mods[0] == null) {
+		if (!WorkshopHelper.TryGetModDownloadItem(_dataObject.Name, out var mod) || mod == null) {
 			return;
 		}
 
-		ulong existingAuthorID = ulong.Parse(mods[0].OwnerId);
+		ulong existingAuthorID = ulong.Parse(mod.OwnerId);
 		if (existingAuthorID == 0 || existingAuthorID == Steamworks.SteamUser.GetSteamID().m_SteamID) {
 			return;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
@@ -379,7 +379,7 @@ internal class UIModPackItem : UIPanel
 		}
 
 		var query = new QueryParameters() { searchModSlugs = _mods };
-		if (!WorkshopHelper.TryGetPublishIdByInternalName(query, out var modIds))
+		if (!WorkshopHelper.TryGetGroupPublishIdsByInternalName(query, out var modIds))
 			return new List<ModPubId_t>(); // query failed. TODO, actually show an error UI instead
 
 		var output = new List<ModPubId_t>();

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -160,5 +160,6 @@ public struct QueryParameters
 public enum QueryType
 {
 	SearchAll,
-	SearchDirect
+	SearchDirect,
+	SearchUserPublishedOnly
 }

--- a/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/SteamedWraps.cs
@@ -244,24 +244,38 @@ public static class SteamedWraps
 
 	public static SteamAPICall_t GenerateAndSubmitModBrowserQuery(uint page, QueryParameters qP, string internalName = null)
 	{
-		if (SteamClient) {
-			UGCQueryHandle_t qHandle = SteamUGC.CreateQueryAllUGCRequest(CalculateQuerySort(qP), EUGCMatchingUGCType.k_EUGCMatchingUGCType_Items, new AppId_t(thisApp), new AppId_t(thisApp), page);
+		var qHandle = GetQueryHandle(page, qP);
+		if (qHandle == default)
+			return new();
 
+		if (SteamClient) {
 			ModifyQueryHandle(ref qHandle, qP);
 			FilterByInternalName(ref qHandle, internalName);
 
 			return SteamUGC.SendQueryUGCRequest(qHandle);
 		}
-		else if (SteamAvailable) {
-			UGCQueryHandle_t qHandle = SteamGameServerUGC.CreateQueryAllUGCRequest(CalculateQuerySort(qP), EUGCMatchingUGCType.k_EUGCMatchingUGCType_Items, new AppId_t(thisApp), new AppId_t(thisApp), page);
-
+		else { // assumes SteamAvailable as GetQueryHandle already checks this and is a required pre-req
 			ModifyQueryHandle(ref qHandle, qP);
 			FilterByInternalName(ref qHandle, internalName);
 			
 			return SteamGameServerUGC.SendQueryUGCRequest(qHandle);
 		}
+	}
 
-		return new();
+	public static UGCQueryHandle_t GetQueryHandle(uint page, QueryParameters qP)
+	{
+		// To find unlisted / private / friends only mods on Steam Workshop that user can see but QueryAll does not, we have to side step to a custom query. - Solxan, July 30 2024
+		if (SteamClient && qP.queryType == QueryType.SearchUserPublishedOnly) {
+			return SteamUGC.CreateQueryUserUGCRequest(SteamUser.GetSteamID().GetAccountID(), EUserUGCList.k_EUserUGCList_Published, EUGCMatchingUGCType.k_EUGCMatchingUGCType_Items, EUserUGCListSortOrder.k_EUserUGCListSortOrder_CreationOrderDesc, new AppId_t(thisApp), new AppId_t(thisApp), page);
+		}
+
+		// These will only return visibility = public - Solxan, July 30 2024
+		if (SteamClient)
+			return SteamUGC.CreateQueryAllUGCRequest(CalculateQuerySort(qP), EUGCMatchingUGCType.k_EUGCMatchingUGCType_Items, new AppId_t(thisApp), new AppId_t(thisApp), page);
+		else if (SteamAvailable)
+			return SteamGameServerUGC.CreateQueryAllUGCRequest(CalculateQuerySort(qP), EUGCMatchingUGCType.k_EUGCMatchingUGCType_Items, new AppId_t(thisApp), new AppId_t(thisApp), page);
+
+		return default;
 	}
 
 	public static void FetchPlayTimeStats(UGCQueryHandle_t handle, uint index, out ulong hot, out ulong downloads)

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -74,12 +74,19 @@ public partial class WorkshopHelper
 	{
 		item = null;
 
-		var query = new QueryHelper.AQueryInstance(new QueryParameters() { searchModSlugs = new string[] { modSlug } });
-		if (!query.TrySearchByInternalName(out var items))
+		var query = new QueryHelper.AQueryInstance(new QueryParameters() { queryType = QueryType.SearchDirect });
+		if (!query.TrySearchByInternalName(modSlug, out item))
 			return false;
 
-		item = items[0];
-		return item != null; // TODO, return value is ambiguous between a connection error and the mod not existing on workshop, currently both are logged as an error and the item is skipped
+		if (item == null) {
+			// search of all mods that were published by this user - Does not work with co-published/non-owner
+			// this should catch private / friends-only visibility
+			query.queryParameters.queryType = QueryType.SearchUserPublishedOnly;
+			if (!query.TrySearchByInternalName(modSlug, out item))
+				return false;
+		}
+
+		return true;
 	}
 
 	// Should this be in SteamedWraps or here?
@@ -94,11 +101,13 @@ public partial class WorkshopHelper
 	}
 
 	/////// Used for Publishing ////////////////////
-	internal static bool TryGetPublishIdByInternalName(QueryParameters query, out List<string> modIds)
+	internal static bool TryGetGroupPublishIdsByInternalName(QueryParameters query, out List<string> modIds)
 	{
 		modIds = new List<string>();
 
-		if (!TryGetModDownloadItemsByInternalName(query, out List<ModDownloadItem> items))
+		var queryHandle = new QueryHelper.AQueryInstance(query);
+		// default search of all public mods. If fails, returns false
+		if (!queryHandle.TryGroupSearchByInternalName(out var items))
 			return false;
 
 		for (int i = 0; i < query.searchModSlugs.Length; i++) {
@@ -109,15 +118,6 @@ public partial class WorkshopHelper
 			else
 				modIds.Add(items[i].PublishId.m_ModPubId);
 		}
-
-		return true;
-	}
-
-	internal static bool TryGetModDownloadItemsByInternalName(QueryParameters query, out List<ModDownloadItem> mods)
-	{
-		var queryHandle = new QueryHelper.AQueryInstance(query);
-		if (!queryHandle.TrySearchByInternalName(out mods))
-			return false;
 
 		return true;
 	}
@@ -383,32 +383,42 @@ public partial class WorkshopHelper
 			/// Outputs a List of ModDownloadItems of equal length to QueryParameters.SearchModSlugs
 			/// Uses null entries to fill gaps to ensure length consistency
 			/// </summary>
-			internal bool TrySearchByInternalName(out List<ModDownloadItem> items)
+			internal bool TryGroupSearchByInternalName(out List<ModDownloadItem> items)
 			{
 				items = new List<ModDownloadItem>();
 
 				foreach (var slug in queryParameters.searchModSlugs) {
-					try {
-						WaitForQueryResult(SteamedWraps.GenerateAndSubmitModBrowserQuery(page: 1, queryParameters, internalName: slug));
-
-						if (_queryReturnCount == 0) {
-							Logging.tML.Info($"No Mod on Workshop with internal name: {slug}");
-							items.Add(null);
-							continue;
-						}
-
-						items.Add(GenerateModDownloadItemFromQuery(0));
-					}
-					catch {
-						// If Query Fails, we can't publish
+					if (!TrySearchByInternalName(slug, out var item))
 						return false;
-					}
-					finally {
-						ReleaseWorkshopQuery();
-					}
+
+					items.Add(item);
 				}
 
 				return true;
+			}
+
+			internal bool TrySearchByInternalName(string slug, out ModDownloadItem item)
+			{
+				item = null;
+
+				try {
+					WaitForQueryResult(SteamedWraps.GenerateAndSubmitModBrowserQuery(page: 1, queryParameters, internalName: slug));
+
+					if (_queryReturnCount == 0) {
+						Logging.tML.Info($"No Mod on Workshop with internal name: {slug}");
+						return true;
+					}
+
+					item = GenerateModDownloadItemFromQuery(0);
+					return true;
+				}
+				catch {
+					// If Query Fails, we can't publish
+					return false;
+				}
+				finally {
+					ReleaseWorkshopQuery();
+				}
 			}
 
 			/////// Run Queries ////////////////////
@@ -451,10 +461,6 @@ public partial class WorkshopHelper
 				SteamUGCDetails_t pDetails = SteamedWraps.FetchItemDetails(_primaryUGCHandle, i);
 
 				PublishedFileId_t id = pDetails.m_nPublishedFileId;
-
-				if (pDetails.m_eVisibility != ERemoteStoragePublishedFileVisibility.k_ERemoteStoragePublishedFileVisibilityPublic) {
-					return null;
-				}
 
 				if (pDetails.m_eResult != EResult.k_EResultOK) {
 					Logging.tML.Warn("Unable to fetch mod PublishId#" + id + " information. " + pDetails.m_eResult);

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopSocialModule.TML.cs
@@ -22,34 +22,24 @@ public partial class WorkshopSocialModule
 	{
 		info = null;
 		var query = new QueryParameters() {
-			searchModSlugs = new string[] { modFile.Name },
 			queryType = QueryType.SearchDirect
 		};
 
-		if (!WorkshopHelper.TryGetModDownloadItemsByInternalName(query, out List<ModDownloadItem> mods)) {
+		if (!WorkshopHelper.TryGetModDownloadItem(modFile.Name, out var mod)) {
 			IssueReporter.ReportInstantUploadProblem("tModLoader.NoWorkshopAccess");
 			return false;
 		}
 
 		currPublishID = 0;
 
-		if (!mods.Any() || mods[0] == null) {
-			// This logic is for using a local copy of Workshop.json to figure out what the publish ID is. 
-			// It is currently unused and would need modifications to get the 'mod download item' for later.
-			/*
-			if (!AWorkshopEntry.TryReadingManifest(  <GET PATH> + Path.DirectorySeparatorChar + "workshop.json", out info))
-				return false;
-
-			currPublishID = info.workshopEntryId;
-			mods[0] = Get Mod From Publish ID ()
-			*/
+		if (mod == null) {
 			return false;
 		}
 
-		currPublishID = ulong.Parse(mods[0].PublishId.m_ModPubId);
+		currPublishID = ulong.Parse(mod.PublishId.m_ModPubId);
 
 		// Update the subscribed mod to be the latest version published, so keeps all versions (stable, preview) together
-		WorkshopBrowserModule.Instance.DownloadItem(mods[0], uiProgress: null);
+		WorkshopBrowserModule.Instance.DownloadItem(mod, uiProgress: null);
 
 		// Grab the tags from workshop.json
 		ModOrganizer.WorkshopFileFinder.Refresh(new WorkshopIssueReporter()); // Force detection in case mod wasn't installed
@@ -206,7 +196,7 @@ public partial class WorkshopSocialModule
 
 		if (buildData["modreferences"].Length > 0) {
 			var query = new QueryParameters() { searchModSlugs = buildData["modreferences"].Split(",") };
-			if (!WorkshopHelper.TryGetPublishIdByInternalName(query, out var modIds))
+			if (!WorkshopHelper.TryGetGroupPublishIdsByInternalName(query, out var modIds))
 				return false;
 
 			foreach (string modRef in modIds) {


### PR DESCRIPTION
Adds a check against published mods by the user to determine if they have a non-public mod that general queries don't see. 

This fixes #4283, however:
This fix only works for the owner of the mod. A co-publisher/maintainer working via friends-only won't be able to see it. 

That said, that is highly unlikely and could be solved with some other more unstable tertiary attempts if absolutely needed. 

Also refactors more of the code to scale slight better and make code paths easier to identify
