### PR TITLE
[EM] Fix wrong order in ExampleChest unlock check

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -196,7 +196,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 				if (isLocked) {
 					// Make sure to change the code in UnlockChest if you don't want the chest to only unlock at night.
 					int key = ModContent.ItemType<ExampleChestKey>();
-					if (player.ConsumeItem(key, includeVoidBag: true) && Chest.Unlock(left, top)) {
+					if (Chest.Unlock(left, top) && player.ConsumeItem(key, includeVoidBag: true)) {
 						if (Main.netMode == NetmodeID.MultiplayerClient) {
 							NetMessage.SendData(MessageID.LockAndUnlock, -1, -1, null, player.whoAmI, 1f, left, top);
 						}

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChest.cs
@@ -196,7 +196,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 				if (isLocked) {
 					// Make sure to change the code in UnlockChest if you don't want the chest to only unlock at night.
 					int key = ModContent.ItemType<ExampleChestKey>();
-					if (Chest.Unlock(left, top) && player.ConsumeItem(key, includeVoidBag: true)) {
+					if (player.HasItemInInventoryOrOpenVoidBag(key) && Chest.Unlock(left, top) && player.ConsumeItem(key, includeVoidBag: true)) {
 						if (Main.netMode == NetmodeID.MultiplayerClient) {
 							NetMessage.SendData(MessageID.LockAndUnlock, -1, -1, null, player.whoAmI, 1f, left, top);
 						}


### PR DESCRIPTION
### What is the bug?
ExampleChest, when clicked on, would consume the key even before unlocking the chest, so if any custom conditions a modder may have in `CanUnlockChest` (such as "plantera defeated") are not fullfilled, key is consumed but chest is not opened.

### How did you fix the bug?
Swap the consume and unlock lines.

### Are there alternatives to your fix?
No, this now mirrors vanilla logic.
