### PR TITLE
Added checks, filtering, and logging for local mods with non-standard filenames. Fixes #4338

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/LocalMod.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("tModLoaderTests")]
@@ -26,7 +27,7 @@ internal class LocalMod
 
 	public override string ToString() => Name;
 
-	public string DetailedInfo => $"{Name} {Version} for tML {tModLoaderVersion} from {location}";
+	public string DetailedInfo => $"{Name} {Version} for tML {tModLoaderVersion} from {location}" + (Path.GetFileNameWithoutExtension(modFile.path) != Name ? $" ({Path.GetFileName(modFile.path)})": "");
 
 	public LocalMod(ModLocation location, TmodFile modFile, BuildProperties properties)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -136,7 +136,7 @@ internal static class ModOrganizer
 		OrderByDescending(m => m.tModLoaderVersion, "a matching version for a newer tModLoader exists");
 		FilterOut(m => m.location != ModLocation.Workshop && list.Any(m2 => m2.location == ModLocation.Workshop && m2.modFile.Hash == m.modFile.Hash), "an identical copy exists in the workshop folder");
 		OrderByDescending(m => m.location == ModLocation.Local, "a local copy with the same version (but different hash) exists");
-		FilterOut(m => m.location == ModLocation.Local && Path.GetFileNameWithoutExtension(m.modFile.path) != m.Name && list.Any(m2 => m2.location == ModLocation.Local && Path.GetFileNameWithoutExtension(m2.modFile.path) == m.Name), "this is a renamed duplicate of another .tmod file in the local mods folder");
+		OrderByDescending(m => Path.GetFileNameWithoutExtension(m.modFile.path) == m.Name, "this .tmod has been renamed");
 
 		var selected = list.FirstOrDefault();
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -136,6 +136,7 @@ internal static class ModOrganizer
 		OrderByDescending(m => m.tModLoaderVersion, "a matching version for a newer tModLoader exists");
 		FilterOut(m => m.location != ModLocation.Workshop && list.Any(m2 => m2.location == ModLocation.Workshop && m2.modFile.Hash == m.modFile.Hash), "an identical copy exists in the workshop folder");
 		OrderByDescending(m => m.location == ModLocation.Local, "a local copy with the same version (but different hash) exists");
+		FilterOut(m => m.location == ModLocation.Local && Path.GetFileNameWithoutExtension(m.modFile.path) != m.Name && list.Any(m2 => m2.location == ModLocation.Local && Path.GetFileNameWithoutExtension(m2.modFile.path) == m.Name), "this is a renamed duplicate of another .tmod file in the local mods folder");
 
 		var selected = list.FirstOrDefault();
 
@@ -460,7 +461,7 @@ internal static class ModOrganizer
 	{
 		// If a mod maker attempts to debug a mod with a lower version, it won't be selected so we catch that here. We throw an error because this is definitely not desired.
 		foreach (var mod in mods) {
-			var localMod = AllFoundMods.SingleOrDefault(x => x.Name == mod.Name && x.location == ModLocation.Local);
+			var localMod = AllFoundMods.SingleOrDefault(x => x.Name == mod.Name && x.location == ModLocation.Local && Path.GetFileNameWithoutExtension(x.modFile.path) == mod.Name);
 
 			// If Local mod is newer than selected Workshop/Modpack mod...
 			if (localMod == null || localMod == mod || localMod.lastModified.CompareTo(mod.lastModified) <= 0) {


### PR DESCRIPTION
Fixes #4338 . It is intended that this be cherrypicked to preview and stable once merged since it is affecting a good number of users.

1. Adds the filename to `LocalMod.DetailedInfo` when it doesn't match the mod name. Will help to diagnose the issue and lets users know which file is the duplicate.
2. EnsureRecentlyBuildModsAreLoading now specifically checks for a local mod with the correct filename, as a recently built mod would be.
3. ModOrganizer.SelectVersionToLoad filters out local mods with non-standard names. This happens last so the highest version if present should still load.