### PR TITLE
Fix item variants not being shown in NPC shops (#4280)

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -484,7 +484,7 @@
  	public sbyte handOnSlot = -1;
  	public sbyte handOffSlot = -1;
  	public sbyte backSlot = -1;
-@@ -121,49 +_,247 @@
+@@ -121,49 +_,248 @@
  	public sbyte faceSlot = -1;
  	public sbyte balloonSlot = -1;
  	public sbyte beardSlot = -1;
@@ -580,6 +580,7 @@
 +	/// <summary>
 +	/// The number of copper coins this item is worth (aka, cost to buy from a merchant). Setting it to <c>10462</c> would mean the item cost 1 gold, 4 silver, and 62 copper. The sell price of an item is one fifth of its value. Value also influences reforge costs with the goblin tinkerer.
 +	/// <br/> For convenience, you can also use the <see cref="Item.buyPrice(int, int, int, int)"/> method for setting values: <c>Item.value = Item.buyPrice(0, 1, 4, 62);</c> You can also use the <see cref="Item.sellPrice(int, int, int, int)"/> method if you would rather think about an item's value the other way. Both <c>Item.buyPrice(0, 0, 10, 55)</c> and <c>Item.sellPrice(0, 0, 2, 11)</c> would set the value to <c>1055</c>.
++	/// <para/> If custom purchase prices disconnected from the item value are needed, <see cref="shopCustomPrice"/> should be set for the item instance added to a shop entry.
 +	/// </summary>
  	public int value;
  	public bool buy;
@@ -778,7 +779,7 @@
  	public bool PaintOrCoating {
  		get {
  			if (paint <= 0)
-@@ -196,11 +_,19 @@
+@@ -196,12 +_,24 @@
  
  	public bool FitsAccessoryVanitySlot => true;
  
@@ -789,15 +790,20 @@
  
  	public int OriginalDefense => ContentSamples.ItemsByType[type].defense;
 +	*/
-+
+ 
 +	public int OriginalRarity => ContentSamples.ItemsByType.TryGetValue(type, out Item item) ? item.rare : 0;
 +
 +	public int OriginalDamage => ContentSamples.ItemsByType.TryGetValue(type, out Item item) ? item.damage : 0;
 +
 +	public int OriginalDefense => ContentSamples.ItemsByType.TryGetValue(type, out Item item) ? item.defense : 0;
- 
++
++	/// <summary>
++	/// If not null, indicates that this item has a special seed variant active.
++	/// <para/> Item variants are not supported for modded items.
++	/// </summary>
  	public ItemVariant Variant { get; private set; }
  
+ 	public bool IsACoin {
 @@ -254,12 +_,27 @@
  		}
  	}
@@ -2296,7 +2302,15 @@
  			TurnToAir();
  	}
  
-@@ -49359,6 +_,7 @@
+@@ -49356,9 +_,15 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Resets the stats of this item while preserving modded data, prefix, stack, and favorited. Used to update the stats of this item to facilitate <see cref="ItemVariants"/>. This is called on most items when a player enters a world to ensure that their stats match the variant expected for the world seed.
++	/// <para/> If <paramref name="onlyIfVariantChanged"/> is true (it usually is), then the item is only refreshed if <see cref="Item.Variant"/> and <see cref="ItemVariants.SelectVariant(int)"/> differ.
++	/// </summary>
++	/// <param name="onlyIfVariantChanged"></param>
  	public void Refresh(bool onlyIfVariantChanged = true)
  	{
  		if (!IsAir && (!onlyIfVariantChanged || ItemVariants.SelectVariant(type) != Variant)) {

--- a/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using System;
+using Terraria.GameContent.Items;
 
 namespace Terraria.ModLoader;
 
@@ -8,9 +9,23 @@ public sealed partial class NPCShop
 {
 	public new sealed class Entry : AbstractNPCShop.Entry
 	{
-		public Item Item { get; }
-
+		private readonly Item item;
 		private readonly List<Condition> conditions;
+
+		public Item Item {
+			get {
+				Item actualItem = item;
+
+				ItemVariant itemVariant = ItemVariants.SelectVariant(item.type);
+				if (itemVariant != null) {
+					actualItem = new Item();
+					actualItem.SetDefaults(item.type, variant: itemVariant);
+				}
+
+				return actualItem;
+			}
+		}
+
 		public IEnumerable<Condition> Conditions => conditions;
 
 		private Action<Item, NPC> shopOpenedHooks;
@@ -27,7 +42,7 @@ public sealed partial class NPCShop
 		public Entry(Item item, params Condition[] condition)
 		{
 			Disabled = false;
-			Item = item;
+			this.item = item;
 			conditions = condition.ToList();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
@@ -9,23 +9,9 @@ public sealed partial class NPCShop
 {
 	public new sealed class Entry : AbstractNPCShop.Entry
 	{
-		private readonly Item item;
+		public Item Item { get; }
+
 		private readonly List<Condition> conditions;
-
-		public Item Item {
-			get {
-				Item actualItem = item;
-
-				ItemVariant itemVariant = ItemVariants.SelectVariant(item.type);
-				if (itemVariant != null) {
-					actualItem = new Item();
-					actualItem.SetDefaults(item.type, variant: itemVariant);
-				}
-
-				return actualItem;
-			}
-		}
-
 		public IEnumerable<Condition> Conditions => conditions;
 
 		private Action<Item, NPC> shopOpenedHooks;
@@ -42,7 +28,7 @@ public sealed partial class NPCShop
 		public Entry(Item item, params Condition[] condition)
 		{
 			Disabled = false;
-			this.item = item;
+			Item = item;
 			conditions = condition.ToList();
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCShop.Entry.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Terraria.GameContent.Items;
+using System;
 
 namespace Terraria.ModLoader;
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCShop.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCShop.cs
@@ -88,8 +88,19 @@ public sealed partial class NPCShop : AbstractNPCShop
 		return this;
 	}
 
+	/// <summary>
+	/// <inheritdoc cref="Add(int, Condition[])"/>
+	/// <para/> This overload takes an <see cref="Item"/> instance instead of just an item type. This Item can be customized prior to being registered. This is commonly used to provide a custom shop price or currency for this shop entry:
+	/// <code>npcShop.Add(new Item(ItemID.MagicDagger) {
+	///		shopCustomPrice = 2,
+	///		shopSpecialCurrency = ExampleMod.ExampleCustomCurrencyId
+	///	}, Condition.RemixWorld);
+	/// </code>
+	/// </summary>
 	public NPCShop Add(Item item, params Condition[] condition) => Add(new Entry(item, condition));
-	public NPCShop Add(int item, params Condition[] condition) => Add(ContentSamples.ItemsByType[item], condition);
+	/// <summary> Adds the specified item with the provided conditions to this shop. If all of the conditions are satisfied, the item will be available in the shop. </summary>
+	public NPCShop Add(int item, params Condition[] condition) => Add(new Entry(item, condition));
+	/// <inheritdoc cref="Add(int, Condition[])"/>
 	public NPCShop Add<T>(params Condition[] condition) where T : ModItem => Add(ModContent.ItemType<T>(), condition);
 
 	private NPCShop InsertAt(Entry targetEntry, bool after, Item item, params Condition[] condition) => Add(new Entry(item, condition).SetOrdering(targetEntry, after));

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4871,6 +4871,17 @@
  		return num;
  	}
  
+@@ -27301,6 +_,10 @@
+ 		RefreshItems(bank3.item, onlyIfVariantChanged);
+ 		RefreshItems(bank4.item, onlyIfVariantChanged);
+ 		RefreshItems(_temporaryItemSlots, onlyIfVariantChanged);
++
++		foreach (Item item in NPCShopDatabase.AllShops.SelectMany(x => x.ActiveEntries).Select(x => x.Item)) {
++			item.Refresh(onlyIfVariantChanged);
++		}
+ 	}
+ 
+ 	private void RefreshItems(Item[] array, bool onlyIfVariantChanged)
 @@ -27344,11 +_,29 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4871,13 +4871,29 @@
  		return num;
  	}
  
-@@ -27301,6 +_,10 @@
+@@ -27286,6 +_,10 @@
+ 		return true;
+ 	}
+ 
++	/// <summary>
++	/// Calls <see cref="Item.Refresh(bool)"/> on all player-owned storage (inventory, banks, equipment). Also refreshes recipe and shop entries.
++	/// <para/> This is called when entering a world and serves to ensure that items with <see cref="ItemVariants"/> have the correct stats.
++	/// </summary>
+ 	public void RefreshItems(bool onlyIfVariantChanged = true)
+ 	{
+ 		if (onlyIfVariantChanged && whoAmI == Main.myPlayer)
+@@ -27301,6 +_,15 @@
  		RefreshItems(bank3.item, onlyIfVariantChanged);
  		RefreshItems(bank4.item, onlyIfVariantChanged);
  		RefreshItems(_temporaryItemSlots, onlyIfVariantChanged);
 +
 +		foreach (Item item in NPCShopDatabase.AllShops.SelectMany(x => x.ActiveEntries).Select(x => x.Item)) {
++			// Don't adjust custom prices, modders would need to add multiple shop entries to account for variants with custom prices anyway. 
++			var originalCustomPrice = item.shopCustomPrice;
++			var originalSpecialCurrency = item.shopSpecialCurrency;
 +			item.Refresh(onlyIfVariantChanged);
++			item.shopCustomPrice = originalCustomPrice;
++			item.shopSpecialCurrency = originalSpecialCurrency;
 +		}
  	}
  


### PR DESCRIPTION
### What is the bug?
NPC shops only list the base items, not item variants if any are active. Fixes #4280 

### How did you fix the bug?
I edited the NPC shop entry class to always return a matching item variant if an active variant exists.
Since item variants are always registered with conditions which must be met, this is probably feasible. On the other hand this behavior might be a bit unexpected if an item is added to the shop using the `Add(Item item, params Condition[] condition)` method instead of `Add(int item, params Condition[] condition)`.

### Are there alternatives to your fix?
The NPC shop database is build on game startup, so selecting the item variant cannot be done at this stage. The only alternative I see, is the `NPCShop.FillShop` method where the items are currently read from the shop entries.

