### PR TITLE
Preserve prefixes for unloaded items and unloaded prefixes

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "Entladen",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "Aprilscherz",
 		"ModLoader.Items.StartBag.DisplayName": "Starterpaket",
 		"ModLoader.Items.StartBag.Tooltip": "Einige Starter-Items haben nicht in dein Inventar gepasst",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "Unloaded",
+		"ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		"ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		"ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		// "ModLoader.Unloaded": "Unloaded",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "Chiste del Día de los Inocentes",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa de partida",
 		"ModLoader.Items.StartBag.Tooltip": "Algunos objetos de partida no cabían en tu inventario",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		// "ModLoader.Unloaded": "Unloaded",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "La Blague du Poisson D'Avril",
 		"ModLoader.Items.StartBag.DisplayName": "Sac de Départ",
 		"ModLoader.Items.StartBag.Tooltip": "Votre inventaire ne contenait pas assez de place pour certains objets de départ",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -979,6 +979,7 @@
 	},
 	"Mods": {
 		// "ModLoader.Unloaded": "Unloaded",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		// "ModLoader.Items.AprilFools.DisplayName": "April Fools Joke",
 		// "ModLoader.Items.StartBag.DisplayName": "Starting Bag",
 		// "ModLoader.Items.StartBag.Tooltip": "Some starting items couldn't fit in your inventory\n{$CommonItemTooltip.RightClickToOpen}",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "Niezaładowane",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "Prima Aprilis",
 		"ModLoader.Items.StartBag.DisplayName": "Początkowy ekwipunek",
 		"ModLoader.Items.StartBag.Tooltip": "Niektóre początkowe przedmioty nie zmieściły się w twoim ekwipunku.",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "Descarregado",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "Piada de 1° de Abril",
 		"ModLoader.Items.StartBag.DisplayName": "Bolsa Iniciante",
 		"ModLoader.Items.StartBag.Tooltip": "Alguns itens iniciais não cabem em seu inventário",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -977,6 +977,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "Выгружено",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "Первоапрельская шутка",
 		"ModLoader.Items.StartBag.DisplayName": "Стартовая сумка",
 		"ModLoader.Items.StartBag.Tooltip": "Некоторые стартовые предметы не поместились в ваш инвентарь",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -979,6 +979,7 @@
 	},
 	"Mods": {
 		"ModLoader.Unloaded": "卸载",
+		// "ModLoader.Prefixes.UnloadedPrefix.Tooltip": "Prefix from unloaded mod: {0}",
 		"ModLoader.Items.AprilFools.DisplayName": "愚人节玩笑",
 		"ModLoader.Items.StartBag.DisplayName": "起始包",
 		"ModLoader.Items.StartBag.Tooltip": "部分起始物品无法正常放入背包",

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2890,7 +2890,7 @@
  					if (diff == 1)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num4), (byte)((float)(int)mcColor.G * num4), (byte)((float)(int)mcColor.B * num4), a);
  
-@@ -16311,47 +_,92 @@
+@@ -16311,47 +_,93 @@
  
  					if (hoverItem.expert || rare == -12)
  						black = new Microsoft.Xna.Framework.Color((byte)((float)DiscoR * num4), (byte)((float)DiscoG * num4), (byte)((float)DiscoB * num4), a);
@@ -2922,6 +2922,7 @@
 +				Color realLineColor = black;
 +
 +				if (overrideColor[k].HasValue) {
++					// TODO: Some way for mods to bypass mouseTextColor pulsing for a TooltipLine. Apply to UnloadedPrefix once implemented.
 +					realLineColor = overrideColor[k].Value * num4;
 +					drawableLines[k].OverrideColor = realLineColor;
 +				}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -10,9 +10,9 @@ public class UnloadedGlobalItem : GlobalItem
 	internal IList<TagCompound> data = new List<TagCompound>();
 
 	[CloneByReference]
-	internal string modPrefixMod = null;
+	public string ModPrefixMod { get; internal set; } = null;
 	[CloneByReference]
-	internal string modPrefixName = null;
+	public string ModPrefixName { get; internal set; } = null;
 
 	public override bool InstancePerEntity => true;
 

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -9,9 +9,9 @@ public class UnloadedGlobalItem : GlobalItem
 	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 	internal IList<TagCompound> data = new List<TagCompound>();
 
-	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
+	[CloneByReference]
 	internal string modPrefixMod = null;
-	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
+	[CloneByReference]
 	internal string modPrefixName = null;
 
 	public override bool InstancePerEntity => true;

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedGlobalItem.cs
@@ -9,6 +9,11 @@ public class UnloadedGlobalItem : GlobalItem
 	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
 	internal IList<TagCompound> data = new List<TagCompound>();
 
+	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
+	internal string modPrefixMod = null;
+	[CloneByReference] // safe to share between clones, because it cannot be changed after creation/load
+	internal string modPrefixName = null;
+
 	public override bool InstancePerEntity => true;
 
 	public override void SaveData(Item item, TagCompound tag)

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedItem.cs
@@ -79,6 +79,8 @@ public sealed class UnloadedItem : ModLoaderModItem
 
 		Item.SetDefaults(modItem.Type);
 
+		ItemIO.LoadModdedPrefix(Item, tag);
+
 		if (modData?.Count > 0) {
 			Item.ModItem.LoadData(modData);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
@@ -8,7 +8,7 @@ public sealed class UnloadedPrefix : ModPrefix
 	public override IEnumerable<TooltipLine> GetTooltipLines(Item item)
 	{
 		UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
-		yield return new TooltipLine("UnloadedPrefix", this.GetLocalization("Tooltip").Format($"{unloadedGlobalItem.modPrefixMod}/{unloadedGlobalItem.modPrefixName}")) {
+		yield return new TooltipLine("UnloadedPrefix", this.GetLocalization("Tooltip").Format($"{unloadedGlobalItem.ModPrefixMod}/{unloadedGlobalItem.ModPrefixName}")) {
 			IsModifier = true,
 			OverrideColor = new(215, 123, 186)
 		};

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
@@ -10,7 +10,7 @@ public sealed class UnloadedPrefix : ModPrefix
 		UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
 		yield return new TooltipLine("UnloadedPrefix", this.GetLocalization("Tooltip").Format($"{unloadedGlobalItem.ModPrefixMod}/{unloadedGlobalItem.ModPrefixName}")) {
 			IsModifier = true,
-			OverrideColor = new(215, 123, 186)
+			OverrideColor = new(215, 123, 186) // This is the color used in our unloaded textures
 		};
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
@@ -4,11 +4,11 @@ using Terraria.Localization;
 namespace Terraria.ModLoader.Default;
 public sealed class UnloadedPrefix : ModPrefix
 {
-	public override LocalizedText DisplayName => Language.GetText("Mods.ModLoader.Unloaded");
+	public override LocalizedText DisplayName => LocalizedText.Empty;
 	public override IEnumerable<TooltipLine> GetTooltipLines(Item item)
 	{
 		UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
-		yield return new TooltipLine("UnloadedPrefix", $"{unloadedGlobalItem.modPrefixMod}/{unloadedGlobalItem.modPrefixName}") {
+		yield return new TooltipLine("UnloadedPrefix", this.GetLocalization("Tooltip").Format($"{unloadedGlobalItem.modPrefixMod}/{unloadedGlobalItem.modPrefixName}")) {
 			IsModifier = true,
 			OverrideColor = new(215, 123, 186)
 		};

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Terraria.Localization;
+
+namespace Terraria.ModLoader.Default;
+public sealed class UnloadedPrefix : ModPrefix
+{
+	public override LocalizedText DisplayName => Language.GetText("Mods.ModLoader.Unloaded");
+	public override IEnumerable<TooltipLine> GetTooltipLines(Item item)
+	{
+		UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
+		yield return new TooltipLine("UnloadedPrefix", $"{unloadedGlobalItem.modPrefixMod}/{unloadedGlobalItem.modPrefixName}") {
+			IsModifier = true,
+			OverrideColor = new(215, 123, 186)
+		};
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -106,6 +106,17 @@ public static class ItemIO
 			}
 		}
 
+		LoadModdedPrefix(item, tag);
+
+		item.stack = tag.Get<int?>("stack") ?? 1;
+		item.favorited = tag.GetBool("fav");
+
+		if (item.ModItem is not UnloadedItem)
+			LoadGlobals(item, tag.GetList<TagCompound>("globalData"));
+	}
+
+	internal static void LoadModdedPrefix(Item item, TagCompound tag)
+	{
 		if (tag.ContainsKey("modPrefixMod") && tag.ContainsKey("modPrefixName")) {
 			string modPrefixMod = tag.GetString("modPrefixMod");
 			string modPrefixName = tag.GetString("modPrefixName");
@@ -122,12 +133,6 @@ public static class ItemIO
 		else if (tag.ContainsKey("prefix")) {
 			item.Prefix(tag.GetByte("prefix"));
 		}
-
-		item.stack = tag.Get<int?>("stack") ?? 1;
-		item.favorited = tag.GetBool("fav");
-
-		if (item.ModItem is not UnloadedItem)
-			LoadGlobals(item, tag.GetList<TagCompound>("globalData"));
 	}
 
 	public static Item Load(TagCompound tag)

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -59,8 +59,15 @@ public static class ItemIO
 
 
 		if (PrefixLoader.GetPrefix(item.prefix) is ModPrefix modPrefix) {
-			tag.Set("modPrefixMod", modPrefix.Mod.Name);
-			tag.Set("modPrefixName", modPrefix.Name);
+			if (modPrefix is UnloadedPrefix) {
+				UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
+				tag.Set("modPrefixMod", unloadedGlobalItem.modPrefixMod);
+				tag.Set("modPrefixName", unloadedGlobalItem.modPrefixName);
+			}
+			else {
+				tag.Set("modPrefixMod", modPrefix.Mod.Name);
+				tag.Set("modPrefixName", modPrefix.Name);
+			}
 		}
 		else if (item.prefix != 0 && item.prefix < PrefixID.Count) {
 			tag.Set("prefix", (byte)item.prefix);
@@ -100,7 +107,17 @@ public static class ItemIO
 		}
 
 		if (tag.ContainsKey("modPrefixMod") && tag.ContainsKey("modPrefixName")) {
-			item.Prefix(ModContent.TryFind(tag.GetString("modPrefixMod"), tag.GetString("modPrefixName"), out ModPrefix prefix) ? prefix.Type : 0);
+			string modPrefixMod = tag.GetString("modPrefixMod");
+			string modPrefixName = tag.GetString("modPrefixName");
+			if (ModContent.TryFind(modPrefixMod, modPrefixName, out ModPrefix prefix)) {
+				item.Prefix(prefix.Type);
+			}
+			else {
+				item.Prefix(ModContent.PrefixType<UnloadedPrefix>());
+				UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
+				unloadedGlobalItem.modPrefixMod = modPrefixMod;
+				unloadedGlobalItem.modPrefixName = modPrefixName;
+			}
 		}
 		else if (tag.ContainsKey("prefix")) {
 			item.Prefix(tag.GetByte("prefix"));

--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -61,8 +61,8 @@ public static class ItemIO
 		if (PrefixLoader.GetPrefix(item.prefix) is ModPrefix modPrefix) {
 			if (modPrefix is UnloadedPrefix) {
 				UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
-				tag.Set("modPrefixMod", unloadedGlobalItem.modPrefixMod);
-				tag.Set("modPrefixName", unloadedGlobalItem.modPrefixName);
+				tag.Set("modPrefixMod", unloadedGlobalItem.ModPrefixMod);
+				tag.Set("modPrefixName", unloadedGlobalItem.ModPrefixName);
 			}
 			else {
 				tag.Set("modPrefixMod", modPrefix.Mod.Name);
@@ -126,8 +126,8 @@ public static class ItemIO
 			else {
 				item.Prefix(ModContent.PrefixType<UnloadedPrefix>());
 				UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
-				unloadedGlobalItem.modPrefixMod = modPrefixMod;
-				unloadedGlobalItem.modPrefixName = modPrefixName;
+				unloadedGlobalItem.ModPrefixMod = modPrefixMod;
+				unloadedGlobalItem.ModPrefixName = modPrefixName;
 			}
 		}
 		else if (tag.ContainsKey("prefix")) {

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 4
-ru-RU 5
-pt-BR 46
-pl-PL 41
-it-IT 940
-fr-FR 555
-es-ES 364
-de-DE 365
+zh-Hans 5
+ru-RU 6
+pt-BR 47
+pl-PL 42
+it-IT 941
+fr-FR 556
+es-ES 365
+de-DE 366


### PR DESCRIPTION
The benefits of this addition are listed in #3250, the details of its implementation are roughly as described in [this comment](https://github.com/tModLoader/tModLoader/issues/3250#issuecomment-1428491828_) by @Chicken-Bones
![1281930_20240822014928_1](https://github.com/user-attachments/assets/05841b27-df1a-463e-96e6-5f80da85d603)
