### PR TITLE
Log which native dll is throwing a native exception

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using Terraria.Utilities;
 
 namespace Terraria.ModLoader.Engine;
 
@@ -45,6 +47,17 @@ internal static class NativeExceptionHandling
 		}
 		else {
 			Logging.tML.Fatal("Failed to retrieve module information.");
+		}
+
+		// Delete old .dmp.zip files
+		Logging.tML.Fatal("Attempting to save minidump...");
+		string minidumpPath = CrashDump.WriteExceptionAsZipAndClearOld(CrashDump.Options.Normal);
+		if (minidumpPath == null) {
+			Logging.tML.Fatal($"Minidump saving failed, either this isn't Windows or the logs folder could not be created."); // Shouldn't be possible with current code.
+		}
+		else {
+			Logging.tML.Fatal($"Minidump saved to: \'{Path.GetFullPath(minidumpPath)}\'");
+			Logging.tML.Fatal("This file can be provided to tModLoader developers to help diagnose the issue.");
 		}
 
 		// Return EXCEPTION_EXECUTE_HANDLER to let the OS handle the exception

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Terraria.ModLoader.Engine;
+
+internal static class NativeExceptionHandling
+{
+	internal static void Init(){
+		if (!OperatingSystem.IsWindows())
+			return;
+
+		// Note: Only called when not being debugged!
+		SetUnhandledExceptionFilter(OurUnhandledExceptionFilter);
+	}
+
+	// Unhandled exception filter callback
+	static IntPtr OurUnhandledExceptionFilter(IntPtr exceptionInfo)
+	{
+		Logging.tML.Fatal("Native exception has occurred, attempting to determine erroring module...");
+
+		// System.Diagnostics.Debugger.Launch(); // To debug this code, uncomment this line and start tModLoader without debugging.
+
+		// Cast the pointer to EXCEPTION_POINTERS
+		var exPointers = Marshal.PtrToStructure<EXCEPTION_POINTERS>(exceptionInfo);
+
+		// Get the exception address
+		var ExceptionRecord = Marshal.PtrToStructure<EXCEPTION_RECORD>(exPointers.ExceptionRecord);
+		IntPtr exceptionAddress = ExceptionRecord.ExceptionAddress;
+
+		// Try to get the module handle
+		IntPtr moduleHandle;
+		bool success = GetModuleHandleEx(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			exceptionAddress, out moduleHandle);
+
+		if (success && moduleHandle != IntPtr.Zero) {
+			// Get the module file name
+			StringBuilder moduleName = new StringBuilder(260);
+			GetModuleFileName(moduleHandle, moduleName, moduleName.Capacity);
+
+			// Log the module file path
+			Logging.tML.Fatal("Exception occurred in module: " + moduleName.ToString());
+			// These end up in the console or also natives.log if launched through launch script
+		}
+		else {
+			Logging.tML.Fatal("Failed to retrieve module information.");
+		}
+
+		// Return EXCEPTION_EXECUTE_HANDLER to let the OS handle the exception
+		return (IntPtr)1;
+	}
+
+	// P/Invoke declarations
+	[DllImport("kernel32.dll")]
+	static extern IntPtr SetUnhandledExceptionFilter(UnhandledExceptionFilter filter);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+	static extern bool GetModuleHandleEx(uint dwFlags, IntPtr lpModuleName, out IntPtr phModule);
+
+	[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+	static extern uint GetModuleFileName(IntPtr hModule, StringBuilder lpFilename, int nSize);
+	
+
+	// Constants for GetModuleHandleEx
+	const uint GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS = 0x00000004;
+	const uint GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT = 0x00000002;
+
+	// Structure definitions
+	[StructLayout(LayoutKind.Sequential)]
+	struct EXCEPTION_RECORD
+	{
+		public uint ExceptionCode;
+		public uint ExceptionFlags;
+		public IntPtr ExceptionRecord;
+		public IntPtr ExceptionAddress;
+		public uint NumberParameters;
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+		public IntPtr[] ExceptionInformation;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	struct EXCEPTION_POINTERS
+	{
+		public IntPtr ExceptionRecord;
+		public IntPtr ContextRecord;
+	}
+
+	// Delegate for the unhandled exception filter
+	delegate IntPtr UnhandledExceptionFilter(IntPtr exceptionInfo);
+}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
@@ -51,7 +51,7 @@ internal static class NativeExceptionHandling
 
 		// Delete old .dmp.zip files
 		Logging.tML.Fatal("Attempting to save minidump...");
-		string minidumpPath = CrashDump.WriteExceptionAsZipAndClearOld(CrashDump.Options.Normal);
+		string minidumpPath = CrashDump.WriteExceptionAsZipAndClearOld(CrashDump.Options.Normal, exceptionInfo);
 		if (minidumpPath == null) {
 			Logging.tML.Fatal($"Minidump saving failed, either this isn't Windows or the logs folder could not be created."); // Shouldn't be possible with current code.
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/NativeExceptionHandling.cs
@@ -51,7 +51,11 @@ internal static class NativeExceptionHandling
 
 		// Delete old .dmp.zip files
 		Logging.tML.Fatal("Attempting to save minidump...");
-		string minidumpPath = CrashDump.WriteExceptionAsZipAndClearOld(CrashDump.Options.Normal, exceptionInfo);
+		var dumpOptions = CrashDump.Options.Normal | CrashDump.Options.WithThreadInfo; // There might be more to add here.
+		if (Main.instance?.LaunchParameters?.ContainsKey("-fulldump") == true)
+			dumpOptions = CrashDump.Options.WithFullMemory;
+
+		string minidumpPath = CrashDump.WriteExceptionAsZipAndClearOld(dumpOptions, exceptionInfo);
 		if (minidumpPath == null) {
 			Logging.tML.Fatal($"Minidump saving failed, either this isn't Windows or the logs folder could not be created."); // Shouldn't be possible with current code.
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -102,6 +102,7 @@ public static partial class Logging
 		AssemblyResolving.Init();
 		LoggingHooks.Init();
 		LogArchiver.ArchiveLogs();
+		NativeExceptionHandling.Init();
 	}
 
 	private static void ConfigureAppenders(LogFile logFile)

--- a/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
@@ -20,7 +20,7 @@
 +	/// <summary>
 +	/// Writes a dump to the logs folder, zips it, and deletes old dumps. Intended to preserve a single dump for client and server to not waste harddrive space.
 +	/// </summary>
-+	public static string WriteExceptionAsZipAndClearOld(Options options)
++	public static string WriteExceptionAsZipAndClearOld(Options options, IntPtr exceptionPointers)
 +	{
 +		if (!Platform.IsWindows)
 +			return null;
@@ -42,7 +42,7 @@
 +		}
 +
 +		using (FileStream fileStream = File.Create(path)) {
-+			Write(fileStream.SafeFileHandle, options, ExceptionInfo.Present);
++			Write(fileStream.SafeFileHandle, options, ExceptionInfo.None, exceptionPointers);
 +		}
 +
 +		string zipFilename = Path.ChangeExtension(path, ".dmp.zip");
@@ -65,3 +65,25 @@
  	}
  
  	private static bool Write(Options options, ExceptionInfo exceptionInfo, string outputDirectory)
+@@ -72,11 +_,10 @@
+ 		return Write(fileStream.SafeFileHandle, options, exceptionInfo);
+ 	}
+ 
+-	private static bool Write(SafeHandle fileHandle, Options options, ExceptionInfo exceptionInfo)
++	private static bool Write(SafeHandle fileHandle, Options options, ExceptionInfo exceptionInfo, IntPtr exceptionPointers = 0)
+ 	{
+ 		if (!Platform.IsWindows)
+ 			return false;
+-
+ 		Process currentProcess = Process.GetCurrentProcess();
+ 		IntPtr handle = currentProcess.Handle;
+ 		uint id = (uint)currentProcess.Id;
+@@ -86,6 +_,8 @@
+ 		expParam.ExceptionPointers = IntPtr.Zero;
+ 		if (exceptionInfo == ExceptionInfo.Present)
+ 			expParam.ExceptionPointers = Marshal.GetExceptionPointers();
++		if(exceptionPointers != IntPtr.Zero)
++			expParam.ExceptionPointers = exceptionPointers;
+ 
+ 		bool flag = false;
+ 		if (expParam.ExceptionPointers == IntPtr.Zero)

--- a/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
@@ -1,0 +1,67 @@
+--- src/TerrariaNetCore/Terraria/Utilities/CrashDump.cs
++++ src/tModLoader/Terraria/Utilities/CrashDump.cs
+@@ -3,8 +_,12 @@
+ using System.Globalization;
+ using System.IO;
+ using System.Runtime.InteropServices;
++using System.Text;
+ using System.Threading;
+ using ReLogic.OS;
++using Terraria.ModLoader;
++using Ionic.Zip;
++using System.Linq;
+ 
+ namespace Terraria.Utilities;
+ 
+@@ -53,10 +_,51 @@
+ 	public static bool WriteException(Options options, string outputDirectory = ".") => Write(options, ExceptionInfo.Present, outputDirectory);
+ 	public static bool Write(Options options, string outputDirectory = ".") => Write(options, ExceptionInfo.None, outputDirectory);
+ 
++	/// <summary>
++	/// Writes a dump to the logs folder, zips it, and deletes old dumps. Intended to preserve a single dump for client and server to not waste harddrive space.
++	/// </summary>
++	public static string WriteExceptionAsZipAndClearOld(Options options)
++	{
++		if (!Platform.IsWindows)
++			return null;
++
++		string fileName = CreateDumpName();
++		string path = Path.Combine(Logging.LogDir, fileName);
++
++		if (!Utils.TryCreatingDirectory(Logging.LogDir))
++			return null;
++
++		string prefix = fileName.Split('_')[0];
++		var extensions = new[] { ".dmp.zip", ".dmp" }; // Note: All zip files are deleted on launch anyway by LogArchiver.MoveZipsToArchiveDir
++		foreach (FileInfo file in new DirectoryInfo(Logging.LogDir).GetFiles()) {
++			// Preserve one "server..." and "client..." dump
++			if (extensions.Any(ext => file.Extension == ext) && file.Name.StartsWith(prefix)) {
++				Logging.tML.Info($"Deleting old dump file: {file.Name}");
++				file.Delete();
++			}
++		}
++
++		using (FileStream fileStream = File.Create(path)) {
++			Write(fileStream.SafeFileHandle, options, ExceptionInfo.Present);
++		}
++
++		string zipFilename = Path.ChangeExtension(path, ".dmp.zip");
++		using (var zip = new ZipFile(zipFilename, Encoding.UTF8)) {
++			zip.AddFile(path, "");
++			zip.Save();
++			File.Delete(path);
++		}
++
++		return zipFilename;
++	}
++
+ 	private static string CreateDumpName()
+ 	{
+ 		DateTime dateTime = DateTime.Now.ToLocalTime();
++		return string.Format("{0}_{1}_{2}_{3}.dmp", Main.dedServ ? "server" : "client", BuildInfo.versionTag, dateTime.ToString("MM-dd-yy_HH-mm-ss-ffff", CultureInfo.InvariantCulture), Thread.CurrentThread.ManagedThreadId);
++		/*
+ 		return string.Format("{0}_{1}_{2}_{3}.dmp", Main.dedServ ? "TerrariaServer" : "Terraria", Main.versionNumber, dateTime.ToString("MM-dd-yy_HH-mm-ss-ffff", CultureInfo.InvariantCulture), Thread.CurrentThread.ManagedThreadId);
++		*/
+ 	}
+ 
+ 	private static bool Write(Options options, ExceptionInfo exceptionInfo, string outputDirectory)

--- a/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
@@ -65,7 +65,7 @@
  	}
  
  	private static bool Write(Options options, ExceptionInfo exceptionInfo, string outputDirectory)
-@@ -72,11 +_,10 @@
+@@ -72,7 +_,7 @@
  		return Write(fileStream.SafeFileHandle, options, exceptionInfo);
  	}
  
@@ -74,10 +74,6 @@
  	{
  		if (!Platform.IsWindows)
  			return false;
--
- 		Process currentProcess = Process.GetCurrentProcess();
- 		IntPtr handle = currentProcess.Handle;
- 		uint id = (uint)currentProcess.Id;
 @@ -86,6 +_,8 @@
  		expParam.ExceptionPointers = IntPtr.Zero;
  		if (exceptionInfo == ExceptionInfo.Present)

--- a/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
+++ b/patches/tModLoader/Terraria/Utilities/CrashDump.cs.patch
@@ -32,7 +32,7 @@
 +			return null;
 +
 +		string prefix = fileName.Split('_')[0];
-+		var extensions = new[] { ".dmp.zip", ".dmp" }; // Note: All zip files are deleted on launch anyway by LogArchiver.MoveZipsToArchiveDir
++		var extensions = new[] { ".dmp.zip", ".dmp" }; // Note: All zip files are deleted on launch anyway by LogArchiver.MoveZipsToArchiveDir, so this code doesn't usually do anything
 +		foreach (FileInfo file in new DirectoryInfo(Logging.LogDir).GetFiles()) {
 +			// Preserve one "server..." and "client..." dump
 +			if (extensions.Any(ext => file.Extension == ext) && file.Name.StartsWith(prefix)) {


### PR DESCRIPTION
Information about native exceptions sometimes don't appear anywhere and currently we need to instruct users to make a minidump to diagnose the issue. This PR adds logging to help remedy the situation. 

Sample output:
```
[15:51:14.707] [Main Thread/INFO] [tML]: Distribution Platform: Steam. Detection method: CWD is /steamapps/
[15:51:14.717] [Main Thread/DEBUG] [TerrariaSteamClient]: Disabled. Launched outside steam client.
[15:51:14.880] [Main Thread/INFO] [FNA]: SDL.SDL_Init(SDL.SDL_INIT_VIDEO)...
[15:51:14.883] [Main Thread/INFO] [FNA]: Success
[15:51:14.883] [Main Thread/INFO] [FNA]: SDL.SDL_InitSubSystem(SDL.SDL_INIT_GAMECONTROLLER)...
[15:51:14.955] [Main Thread/INFO] [FNA]: Success
[15:51:14.958] [Main Thread/WARN] [FNA]: Intentionally Crashing
[15:51:14.959] [5/FATAL] [tML]: Native exception has occurred, attempting to determine erroring library...
[15:51:14.960] [5/FATAL] [tML]: Exception occurred in module: C:\Program Files (x86)\Steam\steamapps\common\tModLoaderDev\Libraries\Native\Windows\FNA3D.DLL
```