### PR TITLE
Custom error message for building in VS while tModLoader has tmod file open

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -171,18 +171,13 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			new ModCompile(new ConsoleBuildStatus()).Build(modFolder);
 		}
 		catch (BuildException e) {
-			ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML002);
+			ErrorReporting.LogStandardDiagnosticError(e.Message, e.errorCode);
 			if (e.InnerException != null)
 				Console.Error.WriteLine(e.InnerException);
 			Environment.Exit(1);
 		}
 		catch (Exception e) {
-			if (e is IOException iOException) {
-				ErrorReporting.LogStandardDiagnosticError("Please close tModLoader or disable the mod in-game to build mods directly.", ErrorReporting.TMLErrorCode.TML003);
-			}
-			else {
-				ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML001);
-			}
+			ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML001);
 			Environment.Exit(1);
 		}
 
@@ -229,7 +224,13 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 				loadedMod.Close();
 			}
 
-			mod.modFile.Save();
+			try {
+				mod.modFile.Save();
+			}
+			catch (IOException e) {
+				throw new BuildException("Please close tModLoader or disable the mod in-game to build mods directly.", e, ErrorReporting.TMLErrorCode.TML003);
+			}
+
 			ModLoader.EnableMod(mod.Name);
 			// TODO: This should probably enable dependencies recursively as well. They will load properly, but right now the UI does not show them as loaded.
 			LocalizationLoader.HandleModBuilt(mod.Name);

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -16,6 +16,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Terraria.Localization;
+using Terraria.ModLoader.Engine;
 using Terraria.ModLoader.Exceptions;
 
 namespace Terraria.ModLoader.Core;
@@ -170,14 +171,19 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			new ModCompile(new ConsoleBuildStatus()).Build(modFolder);
 		}
 		catch (BuildException e) {
-			Console.Error.WriteLine("Error: " + e.Message);
+			ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML002);
 			if (e.InnerException != null)
 				Console.Error.WriteLine(e.InnerException);
 			Environment.Exit(1);
 		}
 		catch (Exception e) {
-			Console.Error.WriteLine(e);
-			Environment.Exit(e is IOException ? 1001 : 1); // Custom error code for tMLMod.targets custom warning.
+			if (e is IOException iOException) {
+				ErrorReporting.LogStandardDiagnosticError("Please close tModLoader or disable the mod in-game to build mods directly.", ErrorReporting.TMLErrorCode.TML001);
+			}
+			else {
+				ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML003);
+			}
+			Environment.Exit(1);
 		}
 
 		Social.Steam.WorkshopSocialModule.SteamCMDPublishPreparer(modFolder);

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -177,7 +177,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 		}
 		catch (Exception e) {
 			Console.Error.WriteLine(e);
-			Environment.Exit(1);
+			Environment.Exit(e is IOException ? 1001 : 1); // Custom error code for tMLMod.targets custom warning.
 		}
 
 		Social.Steam.WorkshopSocialModule.SteamCMDPublishPreparer(modFolder);

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -178,10 +178,10 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 		}
 		catch (Exception e) {
 			if (e is IOException iOException) {
-				ErrorReporting.LogStandardDiagnosticError("Please close tModLoader or disable the mod in-game to build mods directly.", ErrorReporting.TMLErrorCode.TML001);
+				ErrorReporting.LogStandardDiagnosticError("Please close tModLoader or disable the mod in-game to build mods directly.", ErrorReporting.TMLErrorCode.TML003);
 			}
 			else {
-				ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML003);
+				ErrorReporting.LogStandardDiagnosticError(e.Message, ErrorReporting.TMLErrorCode.TML001);
 			}
 			Environment.Exit(1);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -123,4 +123,19 @@ internal class ErrorReporting
 		}
 		return buttonID;
 	}
+
+	// Various error codes to show in Visual Studio. Mainly used to cross reference with source code. Subject to change if more granular error codes are needed.
+	internal enum TMLErrorCode
+	{
+		TML001, // tMod file in use
+		TML002, // Any BuildException
+		TML003, // Other exception
+	}
+
+	// Writes an error to stderr using the "MSBuild and Visual Studio format for diagnostic messages": https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022
+	// This means the error will show up in "Error List" in VS directly.
+	internal static void LogStandardDiagnosticError(string message, TMLErrorCode errorCode, bool error = true, string origin = "tModLoader", string subCategory = "Mod Build")
+	{
+		Console.Error.WriteLine($"{origin}: {subCategory} {(error ? "error" : "warning")} {errorCode}: {message}");
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -127,9 +127,9 @@ internal class ErrorReporting
 	/// <summary> Various error codes to show in Visual Studio. Mainly used to cross reference with source code. Subject to change if more granular error codes are needed. </summary>
 	internal enum TMLErrorCode
 	{
-		TML001, // tMod file in use
+		TML001, // Other exception
 		TML002, // Any BuildException
-		TML003, // Other exception
+		TML003, // tMod file in use
 	}
 
 	/// <summary> Writes an error to stderr using the <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022">"MSBuild and Visual Studio format for diagnostic messages"</see>.

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -124,7 +124,7 @@ internal class ErrorReporting
 		return buttonID;
 	}
 
-	// Various error codes to show in Visual Studio. Mainly used to cross reference with source code. Subject to change if more granular error codes are needed.
+	/// <summary> Various error codes to show in Visual Studio. Mainly used to cross reference with source code. Subject to change if more granular error codes are needed. </summary>
 	internal enum TMLErrorCode
 	{
 		TML001, // tMod file in use
@@ -132,8 +132,8 @@ internal class ErrorReporting
 		TML003, // Other exception
 	}
 
-	// Writes an error to stderr using the "MSBuild and Visual Studio format for diagnostic messages": https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022
-	// This means the error will show up in "Error List" in VS directly.
+	/// <summary> Writes an error to stderr using the <see href="https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022">"MSBuild and Visual Studio format for diagnostic messages"</see>.
+	/// <para/> This means the error will show up in "Error List" in VS directly. </summary>
 	internal static void LogStandardDiagnosticError(string message, TMLErrorCode errorCode, bool error = true, string origin = "tModLoader", string subCategory = "Mod Build")
 	{
 		Console.Error.WriteLine($"{origin}: {subCategory} {(error ? "error" : "warning")} {errorCode}: {message}");

--- a/patches/tModLoader/Terraria/ModLoader/Exceptions/BuildException.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Exceptions/BuildException.cs
@@ -1,13 +1,19 @@
 using System;
 using System.CodeDom.Compiler;
+using Terraria.ModLoader.Engine;
 
 namespace Terraria.ModLoader.Exceptions;
 
 internal class BuildException : Exception
 {
 	public CompilerErrorCollection compileErrors;
+	public ErrorReporting.TMLErrorCode errorCode = ErrorReporting.TMLErrorCode.TML002;
 
-	public BuildException(string message) : base(message) { }
+	public BuildException(string message, ErrorReporting.TMLErrorCode errorCode = ErrorReporting.TMLErrorCode.TML002) : base(message) {
+		this.errorCode = errorCode;
+	}
 
-	public BuildException(string message, Exception innerException) : base(message, innerException) { }
+	public BuildException(string message, Exception innerException, ErrorReporting.TMLErrorCode errorCode = ErrorReporting.TMLErrorCode.TML002) : base(message, innerException) {
+		this.errorCode = errorCode;
+	}
 }

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -40,11 +40,10 @@
 
 	<Target Name="BuildMod" AfterTargets="Build">
 		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)" ConsoleToMSBuild="true" ContinueOnError="ErrorAndContinue">
-			<Output TaskParameter="ConsoleOutput" PropertyName="ModBuildOutput"/>
 			<Output TaskParameter="ExitCode" PropertyName="ModBuildExitCode"/>
 		</Exec>
 		<Error Text="Please close tModLoader or disable the mod in-game to build mods directly" Condition=" '$(ModBuildExitCode)' == '1001' "/>
-		<Error Text="Build failed, see output panel for details" Condition=" '$(ModBuildExitCode)' == '1' "/>
+		<Error Text="Build failed, see output panel for details" Condition=" '$(ModBuildExitCode)' != '0' "/>
 	</Target>
 
 </Project>

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -39,11 +39,7 @@
 	</ItemGroup>
 
 	<Target Name="BuildMod" AfterTargets="Build">
-		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)" ConsoleToMSBuild="true" ContinueOnError="ErrorAndContinue">
-			<Output TaskParameter="ExitCode" PropertyName="ModBuildExitCode"/>
-		</Exec>
-		<Error Text="Please close tModLoader or disable the mod in-game to build mods directly" Condition=" '$(ModBuildExitCode)' == '1001' "/>
-		<Error Text="Build failed, see output panel for details" Condition=" '$(ModBuildExitCode)' != '0' "/>
+		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
 	</Target>
 
 </Project>

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -39,7 +39,12 @@
 	</ItemGroup>
 
 	<Target Name="BuildMod" AfterTargets="Build">
-		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
+		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)" ConsoleToMSBuild="true" ContinueOnError="ErrorAndContinue">
+			<Output TaskParameter="ConsoleOutput" PropertyName="ModBuildOutput"/>
+			<Output TaskParameter="ExitCode" PropertyName="ModBuildExitCode"/>
+		</Exec>
+		<Error Text="Please close tModLoader or disable the mod in-game to build mods directly" Condition=" '$(ModBuildExitCode)' == '1001' "/>
+		<Error Text="Build failed, see output panel for details" Condition=" '$(ModBuildExitCode)' == '1' "/>
 	</Target>
 
 </Project>


### PR DESCRIPTION
A common confusion for new modders is attempting to build or debug their mod through Visual Studio while tModLoader is already open. They are unaware that they need to disable the mod or close tModLoader first because the `.tmod` file is in-use and unable to be replaced.

The error is confusing and unhelpful:
![image](https://github.com/user-attachments/assets/cfcd05b3-71e4-4892-9dff-cc01edbf7af2)

The actual error is shown in the Output panel:
![image](https://github.com/user-attachments/assets/25feaa53-af28-4700-983e-fb8fc65c4d21)

This PR adds custom error messages that should hopefully instruct the modder on how to fix the issue:     
`Please close tModLoader or disable the mod in-game to build mods directly`:    
![image](https://github.com/user-attachments/assets/642d9f7c-e7ae-4310-8dba-0bddb927ad4e)

In case the error isn't caused by the usual `IOException`, a different message directing the modder to the Output panel is shown:
![image](https://github.com/user-attachments/assets/ad58efd8-b687-4f55-a1a8-9cdb236c63b4)

## Alternate solution
We could also change the `ModCompile.BuildModCommandLine` logic to save the file to a custom filename to avoid the issue, such as `ModName (1).tmod`. Assuming `build.txt` has a newer version, it will load the newer .tmod when the debugger launches or the user reloads mods in an already open tModLoader client. This might lead to more issues than it fixes, but maybe some solution avoiding the issue is better in the long run.