### PR TITLE
The Long-Overdue Revival of Content Tags

### DIFF
--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -1,6 +1,8 @@
 --- src/TerrariaNetCore/Terraria/ID/ItemID.cs
 +++ src/tModLoader/Terraria/ID/ItemID.cs
-@@ -2,21 +_,57 @@
+@@ -1,22 +_,59 @@
++using System;
+ using System.Collections.Generic;
  using Microsoft.Xna.Framework;
  using ReLogic.Reflection;
  using Terraria.DataStructures;
@@ -96,12 +98,12 @@
  		};
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item will not burn when dropped in lava, even if it has a <see cref="Item.rare"/> of <see cref="ItemRarityID.White"/>.
-+		/// <br/> Defaults to <see langword="false"/>.
++		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item will not burn when dropped in lava, even if it has a <see cref="Item.rare"/> of <see cref="ItemRarityID.White"/>.<br/> 
++		/// Defaults to <see langword="false"/>.<br/>
++		/// Does not affect the Guide Voodoo Doll, which will always burn when tossed into lava.<br/>
++		/// <br/>
++		/// <b>Superceded by corresponding content tag:</b> <c>"lava_immune"</c>
 +		/// </summary>
-+		/// <remarks>
-+		/// This set does not affect <see cref="GuideVoodooDoll"/>, which will always burn when dropped into lava.
-+		/// </remarks>
  		public static bool[] IsLavaImmuneRegardlessOfRarity = Factory.CreateBoolSet(false, 318, 312, 173, 174, 175, 4422, 2701, 205, 206, 207, 1128, 2340, 2739, 2492, 1127, 85);
 +
 +		/// <summary>
@@ -296,12 +298,15 @@
  		public static FlowerPacketInfo[] flowerPacketInfo = Factory.CreateCustomSet<FlowerPacketInfo>(null, new object[18] {
  			(short)4041,
  			new FlowerPacketInfo {
-@@ -303,18 +_,91 @@
+@@ -303,18 +_,107 @@
  				}
  			}
  		});
 +
-+		/// <summary> Indicates that an item should show the material tooltip. Typically this means that the item is used in at least 1 recipe, but some items such as coins and void bag hide the tooltip for aesthetic reasons. </summary>
++		/// <summary>
++		/// Indicates that an item should show the material tooltip.<br/>
++		/// Typically, this means that the item is used in at least 1 recipe, but some items (such as coins and the Void Bag) hide the tooltip for aesthetic reasons.<br/>
++		/// </summary>
  		public static bool[] IsAMaterial = Factory.CreateBoolSet();
 -		public static int[] IsCrafted = Factory.CreateIntSet();
 +
@@ -314,8 +319,10 @@
 +		*/
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item will always be allowed to be picked up, even if <see cref="Player.preventAllItemPickups"/> is <see langword="true"/>.
-+		/// <br/> Defaults to <see langword="false"/>.
++		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item will always be able to be picked up, even if <see cref="Player.preventAllItemPickups"/> is <see langword="true"/>.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// <br/>
++		/// <b>Superceded by corresponding content tag:</b> <c>"bypasses_encumbering_stone"</c><br/>
 +		/// </summary>
  		public static bool[] IgnoresEncumberingStone = Factory.CreateBoolSet(58, 184, 1734, 1735, 1867, 1868, 3453, 3454, 3455, 4143);
 +
@@ -335,29 +342,35 @@
  		public static bool[] IsAPickup = Factory.CreateBoolSet(58, 184, 1734, 1735, 1867, 1868, 3453, 3454, 3455);
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is a drill.
-+		/// <br/> Drills have 40% faster use times (<see cref="Item.useTime"/>, <see cref="Item.useAnimation"/>) and 1 less tile reach (<see cref="Item.tileBoost"/>) than what are set in <see cref="Item.SetDefaults(int)"/>.
-+		/// <br/> Defaults to <see langword="false"/>.
++		/// If <see langword="true"/> for a given <b>vanilla</b> item type (<see cref="Item.type"/>), then that item is a drill.<br/>
++		/// Drills have 40% faster use times (<see cref="Item.useTime"/>, <see cref="Item.useAnimation"/>) and 1 less tile reach (<see cref="Item.tileBoost"/>) than what are set in <see cref="Item.SetDefaults(int)"/>.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// <br/>
++		/// This set <b>does not:</b><br/>
++		/// - Allow an <see cref="Item"/> to damage and destroy tiles on its own -- use <see cref="Item.pick"/> for that.<br/>
++		/// - Apply its stat modifications to modded items, as the relevant check occurs <b>before</b> any modded SetDefaults hooks.<br/>
++		/// <br/>
++		/// <b>Superceded by corresponding content tag:</b> <c>"tool/motorized/drill"</c><br/>
 +		/// </summary>
-+		/// <remarks>
-+		/// This set does <strong>not</strong> allow an <see cref="Item"/> to damage tiles -- use <see cref="Item.pick"/> for that.
-+		/// </remarks>
  		public static bool[] IsDrill = Factory.CreateBoolSet(388, 1231, 385, 386, 2779, 1196, 1189, 2784, 3464, 1203, 2774, 579);
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is a chainsaw.
-+		/// <br/> Chainsaws have 40% faster use times (<see cref="Item.useTime"/>, <see cref="Item.useAnimation"/>) and 1 less tile reach (<see cref="Item.tileBoost"/>) than what are set in <see cref="Item.SetDefaults(int)"/>.
-+		/// <br/> Defaults to <see langword="false"/>.
++		/// If <see langword="true"/> for a given <b>vanilla</b> item type (<see cref="Item.type"/>), then that item is a chainsaw.<br/>
++		/// Chainsaws have 40% faster use times (<see cref="Item.useTime"/>, <see cref="Item.useAnimation"/>) and 1 less tile reach (<see cref="Item.tileBoost"/>) than what are set in <see cref="Item.SetDefaults(int)"/>.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
++		/// <br/>
++		/// This set <b>does not:</b><br/>
++		/// - Allow an <see cref="Item"/> to cut down trees on its own -- use <see cref="Item.axe"/> for that.<br/>
++		/// - Apply its stat modifications to modded items, as the relevant check occurs <b>before</b> any modded SetDefaults hooks.<br/>
++		/// <br/>
++		/// <b>Superceded by corresponding content tag:</b> <c>"tool/motorized/chainsaw"</c><br/>
 +		/// </summary>
-+		/// <remarks>
-+		/// This set does <strong>not</strong> allow an <see cref="Item"/> to damage trees -- use <see cref="Item.axe"/> for that.
-+		/// </remarks>
  		public static bool[] IsChainsaw = Factory.CreateBoolSet(387, 3098, 1232, 383, 384, 2778, 1197, 1190, 2783, 3463, 1204, 2773, 2342, 579);
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is a paint scraper.
-+		/// <br/> Paint scrapers can scrape paint off of tiles and collect moss from <see cref="TileID.LongMoss"/>.
-+		/// <br/> Defaults to <see langword="false"/>.
++		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is a paint scraper.<br/>
++		/// Paint scrapers can scrape paint off of tiles and collect moss from <see cref="TileID.LongMoss"/>.<br/>
++		/// Defaults to <see langword="false"/>.<br/>
 +		/// </summary>
  		public static bool[] IsPaintScraper = Factory.CreateBoolSet(1100, 1545);
 +
@@ -366,17 +379,22 @@
 +		private static bool[] SummonerWeaponThatScalesWithAttackSpeed = Factory.CreateBoolSet(4672, 4679, 4680, 4678, 4913, 4912, 4911, 4914, 5074);
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is food.
-+		/// <br/> Food items can be placed onto <see cref="TileID.FoodPlatter"/>s, have a <see cref="Item.holdStyle"/> of <see cref="ItemHoldStyleID.HoldFront"/>, hide shields (<see cref="Item.shieldSlot"/>) when held,
-+		/// <br/> Food item sprites must have 3 frames. The required framing code is automatically initialized.
++		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item is food.<br/>
++		/// Food items:<br/>
++		/// - Can be placed onto <see cref="TileID.FoodPlatter"/>s.<br/>
++		/// - Have a <see cref="Item.holdStyle"/> of <see cref="ItemHoldStyleID.HoldFront"/>.<br/>
++		/// - Hide shields (<see cref="Item.shieldSlot"/>) when held.<br/>
++		/// - Must have 3 frames to their item sprite. The required framing code is automatically initialized.<br/>
++		/// <br/>
++		/// The auto-initialized animation for foods have 3 vertical frames.<br/>
++		/// 1. Inventory sprite<br/>
++		/// 2. Held sprite<br/>
++		/// 3. <see cref="TileID.FoodPlatter"/> sprite<br/>
++		/// <br/>
++		/// <see cref="Item.DefaultToFood(int, int, int, int, bool, int)"/> will set many common item values for food.<br/>
++		/// <br/>
++		/// <b>Corresponding content tag:</b> <c>"food"</c><br/>
 +		/// </summary>
-+		/// <remarks>
-+		/// The auto-initialized animation for  foods have 3 vertical frames.
-+		/// <br/> 1. Inventory sprite
-+		/// <br/> 2. Held sprite
-+		/// <br/> 3. <see cref="TileID.FoodPlatter"/> sprite
-+		/// <br/> <see cref="Item.DefaultToFood(int, int, int, int, bool, int)"/> will set many common item values for food.
-+		/// </remarks>
  		public static bool[] IsFood = Factory.CreateBoolSet(353, 357, 1787, 1911, 1912, 1919, 1920, 2266, 2267, 2268, 2425, 2426, 2427, 3195, 3532, 4009, 4010, 4011, 4012, 4013, 4014, 4015, 4016, 4017, 4018, 4019, 4020, 4021, 4022, 4023, 4024, 4025, 4026, 4027, 4028, 4029, 4030, 4031, 4032, 4033, 4034, 4035, 4036, 4037, 967, 969, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291, 4292, 4293, 4294, 4295, 4296, 4297, 4403, 4411, 4614, 4615, 4616, 4617, 4618, 4619, 4620, 4621, 4622, 4623, 4624, 4625, 5009, 5042, 5041, 5092, 5093, 5275, 5277, 5278);
 +
 +		/// <summary>

--- a/patches/tModLoader/Terraria/Item.TML.Tags.cs
+++ b/patches/tModLoader/Terraria/Item.TML.Tags.cs
@@ -1,0 +1,117 @@
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
+using Terraria.ModLoader.IO;
+
+namespace Terraria;
+
+public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
+{
+	/// <summary>
+	/// A list of all content tags that apply to this item.<br/>
+	/// Content tags are a wide variety of strings stored here, designed to help denote what an item is.<br/>
+	/// For a list of all available content tags please refer to [REDACTED].<br/>
+	/// </summary>
+	public HashSet<string> Tags { get; set; }
+
+	/// <summary>
+	/// Automagically partially populates an item's taglist BEFORE the rest of <see cref="SetDefaults(int)"/> is run.<br/>
+	/// Uses ID sets to help identify applicable tags for an item early.<br/>
+	/// </summary>
+	public void PopulateTaglistEarly()
+	{
+		Tags = [];
+
+		if (ItemID.Sets.IsFood[type])
+			Tags.Add("food");
+
+		if (ItemID.Sets.IsAKite[type])
+			Tags.Add("kite");
+
+		if (ItemID.Sets.IsFishingCrate[type]) {
+			Tags.Add("fishing_crate");
+			if (ItemID.Sets.IsFishingCrateHardmode[type])
+				Tags.Add("fishing_crate/hardmode");
+		}
+
+		if (ItemID.Sets.BossBag[type]) {
+			Tags.Add("boss_bag");
+			if (ItemID.Sets.PreHardmodeLikeBossBag[type])
+				Tags.Add("boss_bag/prehardmode");
+		}
+
+		if (ItemID.Sets.IsChainsaw[type] || ItemID.Sets.IsDrill[type]) {
+			Tags.Add("motorized_tool");
+			if (ItemID.Sets.IsChainsaw[type])
+				Tags.Add("motorized_tool/chainsaw");
+			if (ItemID.Sets.IsDrill[type])
+				Tags.Add("motorized_tool/drill");
+		}
+	}
+
+	/// <summary>
+	/// Automagically finishes population of an item's taglist AFTER <see cref="SetDefaults(int)"/> is run in full, including:<br/>
+	/// - <see cref="ModItem.SetDefaults"/>, when applicable<br/>
+	/// - All applicable <see cref="GlobalType{TEntity, TGlobal}.SetDefaults(TEntity)"/> hooks, if any<br/>
+	/// Used for tags that cannot ask ID sets for help in the early stage or at all, such as tool or weapon type tags.<br/>
+	/// </summary>
+	public void PopulateTaglistLate()
+	{
+		if (pick > 0 || axe > 0 || hammer > 0) {
+			Tags.Add("tool");
+			if (pick > 0)
+				Tags.Add("tool/pickaxe");
+			if (axe > 0)
+				Tags.Add("tool/axe");
+			if (hammer > 0)
+				Tags.Add("tool/hammer");
+		}
+
+		if (damage > 0) {
+			if (DamageType == DamageClass.Melee) {
+				if (useStyle == ItemUseStyleID.Swing && !noMelee && !noUseGraphic && !Tags.Contains("tool"))
+					Tags.Add("broadsword");
+				if (shoot > 0 && ContentSamples.ProjectilesByType[shoot].aiStyle == ProjAIStyleID.ShortSword)
+					Tags.Add("shortsword");
+				if (shoot > 0 && ContentSamples.ProjectilesByType[shoot].aiStyle == ProjAIStyleID.Flail)
+					Tags.Add("flail");
+				if (shoot > 0 && ItemID.Sets.Yoyo[type] && ContentSamples.ProjectilesByType[shoot].aiStyle == ProjAIStyleID.Yoyo)
+					Tags.Add("yoyo");
+			}
+			if (DamageType == DamageClass.Ranged) {
+				
+			}
+			if (DamageType == DamageClass.Magic) {
+				
+			}
+			if (DamageType == DamageClass.Summon) {
+				if (shoot > 0 && ContentSamples.ProjectilesByType[shoot].minionSlots > 0)
+					Tags.Add("summon/minion");
+				if (shoot > 0 && ProjectileID.Sets.IsAWhip[shoot])
+					Tags.Add("summon/sentry");
+				if (shoot > 0 && ProjectileID.Sets.IsAWhip[shoot])
+					Tags.Add("whip");
+			}
+		}
+
+		if (createTile > -1 || createWall > -1)
+		{
+			Tags.Add("placeable");
+			if (createTile > -1) {
+				Tags.Add("placeable/foreground");
+				if (ItemID.Sets.Torches[type] && TileID.Sets.Torch[createTile]) {
+					Tags.Add("placeable/foreground/torch");
+					if (ItemID.Sets.WaterTorches[type])
+						Tags.Add("placeable/foreground/torch/valid_in_water");
+				}
+			}
+			if (createWall > -1) {
+				Tags.Add("placeable/background");
+			}
+		}
+	}
+}

--- a/patches/tModLoader/Terraria/Item.TML.Tags.cs
+++ b/patches/tModLoader/Terraria/Item.TML.Tags.cs
@@ -22,7 +22,7 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	/// Automagically partially populates an item's taglist BEFORE the rest of <see cref="SetDefaults(int)"/> is run.<br/>
 	/// Uses ID sets to help identify applicable tags for an item early.<br/>
 	/// </summary>
-	public void PopulateTaglistEarly()
+	public void InitializeTags()
 	{
 		Tags = [];
 
@@ -44,13 +44,18 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 				Tags.Add("boss_bag/prehardmode");
 		}
 
-		if (ItemID.Sets.IsChainsaw[type] || ItemID.Sets.IsDrill[type]) {
-			Tags.Add("motorized_tool");
+		if (ItemID.Sets.IsChainsaw[type] || ItemID.Sets.IsDrill[type] || type == ItemID.ChlorophyteJackhammer) {
+			Tags.Add("tool/motorized");
 			if (ItemID.Sets.IsChainsaw[type])
-				Tags.Add("motorized_tool/chainsaw");
+				Tags.Add("tool/motorized/chainsaw");
 			if (ItemID.Sets.IsDrill[type])
-				Tags.Add("motorized_tool/drill");
+				Tags.Add("tool/motorized/drill");
+			if (type == ItemID.ChlorophyteJackhammer)
+				Tags.Add("tool/motorized/jackhammer");
 		}
+
+		if (ItemID.Sets.IgnoresEncumberingStone[type])
+			Tags.Add("ignores_encumbering_stone");
 	}
 
 	/// <summary>
@@ -59,7 +64,7 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 	/// - All applicable <see cref="GlobalType{TEntity, TGlobal}.SetDefaults(TEntity)"/> hooks, if any<br/>
 	/// Used for tags that cannot ask ID sets for help in the early stage or at all, such as tool or weapon type tags.<br/>
 	/// </summary>
-	public void PopulateTaglistLate()
+	public void DetermineAdditionalTags()
 	{
 		if (pick > 0 || axe > 0 || hammer > 0) {
 			Tags.Add("tool");
@@ -91,7 +96,7 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 			if (DamageType == DamageClass.Summon) {
 				if (shoot > 0 && ContentSamples.ProjectilesByType[shoot].minionSlots > 0)
 					Tags.Add("summon/minion");
-				if (shoot > 0 && ProjectileID.Sets.IsAWhip[shoot])
+				if (shoot > 0 && ContentSamples.ProjectilesByType[shoot].sentry)
 					Tags.Add("summon/sentry");
 				if (shoot > 0 && ProjectileID.Sets.IsAWhip[shoot])
 					Tags.Add("whip");
@@ -113,5 +118,8 @@ public partial class Item : TagSerializable, IEntityWithGlobals<GlobalItem>
 				Tags.Add("placeable/background");
 			}
 		}
+
+		if (rare != ItemRarityID.White || ItemID.Sets.IsLavaImmuneRegardlessOfRarity[type])
+			Tags.Add("lava_immune");
 	}
 }

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1797,16 +1797,7 @@
  	public void SetDefaults(int Type, bool noMatCheck = false, ItemVariant variant = null)
  	{
  		if (Type < 0) {
-@@ -47095,14 +_,20 @@
- 			return;
- 		}
- 
-+		// tML: ID sets are...antiquated
-+		InitializeTags();
-+
- 		if (Main.netMode == 1 || Main.netMode == 2)
- 			playerIndexTheItemIsReservedFor = 255;
- 		else
+@@ -47101,8 +_,11 @@
  			playerIndexTheItemIsReservedFor = Main.myPlayer;
  
  		ResetStats(Type);

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1797,11 +1797,12 @@
  	public void SetDefaults(int Type, bool noMatCheck = false, ItemVariant variant = null)
  	{
  		if (Type < 0) {
-@@ -47095,14 +_,19 @@
+@@ -47095,14 +_,20 @@
  			return;
  		}
  
-+		PopulateTaglistEarly();
++		// tML: ID sets are...antiquated
++		InitializeTags();
 +
  		if (Main.netMode == 1 || Main.netMode == 2)
  			playerIndexTheItemIsReservedFor = 255;
@@ -1837,7 +1838,16 @@
  		if (hairDye != 0)
  			hairDye = GameShaders.Hair.GetShaderIdFromItemId(type);
  
-@@ -47297,19 +_,29 @@
+@@ -47272,7 +_,7 @@
+ 			useAnimation = 0;
+ 		}
+ 
+-		if (ItemID.Sets.IsDrill[type] || ItemID.Sets.IsChainsaw[type] || type == 1262) {
++		if (Tags.Contains("tool/motorized")) {
+ 			useTime = (int)((double)useTime * 0.6);
+ 			if (useTime < 1)
+ 				useTime = 1;
+@@ -47297,19 +_,30 @@
  			maxStack = CommonMaxStack;
  
  		netID = type;
@@ -1847,7 +1857,8 @@
  		if (!noMatCheck)
  			material = ItemID.Sets.IsAMaterial[type];
  
-+		PopulateTaglistLate();
++		// tML: set tags which are determined by item stats
++		DetermineAdditionalTags();
 +
  		RebuildTooltip();
 -		if (type > 0 && type < ItemID.Count && ItemID.Sets.Deprecated[type]) {
@@ -2026,7 +2037,7 @@
  			NetMessage.SendData(21, -1, -1, null, i);
  		}
 -		else if (playerIndexTheItemIsReservedFor == Main.myPlayer && rare == 0 && type >= 0 && type < ItemID.Count && !ItemID.Sets.IsLavaImmuneRegardlessOfRarity[type]) {
-+		else if (playerIndexTheItemIsReservedFor == Main.myPlayer && rare == 0 && type >= 0 && !ItemID.Sets.IsLavaImmuneRegardlessOfRarity[type]) {
++		else if (playerIndexTheItemIsReservedFor == Main.myPlayer && rare == 0 && type >= 0 && !Tags.Contains("lava_immune")) {
  			active = false;
  			type = 0;
  			stack = 0;

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1797,7 +1797,15 @@
  	public void SetDefaults(int Type, bool noMatCheck = false, ItemVariant variant = null)
  	{
  		if (Type < 0) {
-@@ -47101,8 +_,11 @@
+@@ -47095,14 +_,19 @@
+ 			return;
+ 		}
+ 
++		PopulateTaglistEarly();
++
+ 		if (Main.netMode == 1 || Main.netMode == 2)
+ 			playerIndexTheItemIsReservedFor = 255;
+ 		else
  			playerIndexTheItemIsReservedFor = Main.myPlayer;
  
  		ResetStats(Type);
@@ -1829,7 +1837,7 @@
  		if (hairDye != 0)
  			hairDye = GameShaders.Hair.GetShaderIdFromItemId(type);
  
-@@ -47297,19 +_,27 @@
+@@ -47297,19 +_,29 @@
  			maxStack = CommonMaxStack;
  
  		netID = type;
@@ -1839,6 +1847,8 @@
  		if (!noMatCheck)
  			material = ItemID.Sets.IsAMaterial[type];
  
++		PopulateTaglistLate();
++
  		RebuildTooltip();
 -		if (type > 0 && type < ItemID.Count && ItemID.Sets.Deprecated[type]) {
 +		if (type > 0 && ItemID.Sets.Deprecated[type]) {

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -26,6 +26,7 @@ namespace Terraria.ModLoader;
 public static class ItemLoader
 {
 	public static int ItemCount { get; private set; } = ItemID.Count;
+	public static Dictionary<int, HashSet<string>> StaticItemTags { get; private set; }
 	private static readonly IList<ModItem> items = new List<ModItem>();
 
 	private static readonly List<HookList> hooks = new List<HookList>();
@@ -116,6 +117,8 @@ public static class ItemLoader
 			ContentSamples.ItemsByType[item.Type].RebuildTooltip();
 		}
 
+		InitializeStaticItemTags();
+
 		ValidateDropsSet();
 	}
 
@@ -125,6 +128,46 @@ public static class ItemLoader
 			hook.Update();
 		}
 	}
+
+	private static void InitializeStaticItemTags()
+	{
+		StaticItemTags = [];
+
+		for (int type = 0; type < ItemCount; type++) {
+			StaticItemTags.Add(type, []);
+			if (ItemID.Sets.IsFood[type])
+				StaticItemTags[type].Add("food");
+
+			if (ItemID.Sets.IsAKite[type])
+				StaticItemTags[type].Add("kite");
+
+			if (ItemID.Sets.IsFishingCrate[type]) {
+				StaticItemTags[type].Add("fishing_crate");
+				if (ItemID.Sets.IsFishingCrateHardmode[type])
+					StaticItemTags[type].Add("fishing_crate/hardmode");
+			}
+
+			if (ItemID.Sets.BossBag[type]) {
+				StaticItemTags[type].Add("boss_bag");
+				if (ItemID.Sets.PreHardmodeLikeBossBag[type])
+					StaticItemTags[type].Add("boss_bag/prehardmode");
+			}
+
+			if (ItemID.Sets.IsChainsaw[type] || ItemID.Sets.IsDrill[type] || type == ItemID.ChlorophyteJackhammer) {
+				StaticItemTags[type].Add("tool/motorized");
+				if (ItemID.Sets.IsChainsaw[type])
+					StaticItemTags[type].Add("tool/motorized/chainsaw");
+				if (ItemID.Sets.IsDrill[type])
+					StaticItemTags[type].Add("tool/motorized/drill");
+				if (type == ItemID.ChlorophyteJackhammer)
+					StaticItemTags[type].Add("tool/motorized/jackhammer");
+			}
+
+			if (ItemID.Sets.IgnoresEncumberingStone[type])
+				StaticItemTags[type].Add("ignores_encumbering_stone");
+		}
+	}
+
 
 	internal static void ValidateDropsSet()
 	{

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -296,14 +296,26 @@
  	public float slotsMinions;
  	public bool pygmy;
  	public bool raven;
+@@ -722,6 +_,11 @@
+ 	public bool crystalLeaf;
+ 	public int crystalLeafCooldown;
+ 	public PortableStoolUsage portableStoolInfo;
++
++	/// <summary>
++	/// Prevents all items without the <c>"ignores_encumbering_stone"</c> tag from being picked up.<br/>
++	/// As the relevant tag implies, used in vanilla solely by the Encumbering Stone.<br/>
++	/// </summary>
+ 	public bool preventAllItemPickups;
+ 	public bool dontHurtCritters;
+ 	public bool hasLucyTheAxe;
 @@ -731,6 +_,11 @@
  	public bool defendedByPaladin;
  	public bool hasPaladinShield;
  	public float[] speedSlice = new float[60];
 +
 +	/// <summary>
-+	/// The sum of the <see cref="NPC.npcSlots"/> of all town NPCs near this player.
-+	/// <br/> If <c><see cref="townNPCs"/> &gt; 2f</c>, then this player is in a town.
++	/// The sum of the <see cref="NPC.npcSlots"/> of all town NPCs near this player.<br/>
++	/// If <c><see cref="townNPCs"/> &gt; 2f</c>, then this player is in a town.<br/>
 +	/// </summary>
  	public float townNPCs;
  	public double headFrameCounter;
@@ -4782,6 +4794,15 @@
  		if (PlayerInput.UsingGamepad && cursorItemIconText.Length == 0) {
  			cursorItemIconEnabled = false;
  			cursorItemIconID = 0;
+@@ -26955,7 +_,7 @@
+ 	public bool CanAcceptItemIntoInventory(Item item)
+ 	{
+ 		if (preventAllItemPickups)
+-			return ItemID.Sets.IgnoresEncumberingStone[item.type];
++			return item.Tags.Contains("ignores_encumbering_stone");
+ 
+ 		return true;
+ 	}
 @@ -26967,11 +_,23 @@
  			if (!item.active || item.shimmerTime != 0f || item.noGrabDelay != 0 || item.playerIndexTheItemIsReservedFor != i || !CanAcceptItemIntoInventory(item) || (item.shimmered && !((double)item.velocity.Length() < 0.2)))
  				continue;


### PR DESCRIPTION
### what is this addition?
**content tags!** content tags are designed to be an easy way for tML and modders alike to mark items, NPCs, projectiles, and whatever else have you as a specific sort of thing!

### why do I care?
good question! this system is meant to intermingle with and, in a _very-long-term_ sense, eventually supercede the current ID sets system, which, while definitely very useful (as any modder worth their salt can attest), has proven time and time again to have its shortcomings --- while also simplifyin' a lot of common checks people make for items AND allowin' easier communication between mods on what should and shouldn't be a given thing

### progress checklist
- [X] basic sketch w/ item tags
- [ ] `ItemLoader.ModifyTagList(bool late)` hookset
- [ ] extend to NPCs, projectiles, maybe tiles, potentially other things as well
- [ ] add a ***ton*** of common tags
- [ ] `ModifyTagList(bool late)` hook
- [ ] **item-specific:** items inherit any tags granted by prefixes, figure out how to set this up for vanilla prefixes and add an `InheritedTags` field/property/hook? to `ModPrefix`
- [ ] make new examples for how to manually set a tag and how to check against a tag effectively, includin' when you should use tags and when you should use normal fields
- [ ] gather feedback for 6 to 9 weeks. or a few days, dependin' on how smoothly the rest goes
- [ ] get merged
- [ ] celebrate

### are there other ways to do it?
several, but I picked the string-based design due to ease of use (it is criminally easy to add a string to a hash set) and havin' the highest likelihood to not spontaneously combust with future changes

### how to check an item's tags to do things
```
if (item.Tags.Contains("a_tag"))
{
    // do things
}
```

### ExampleMod updates
to be determined! should be fairly easy to come up with something worth makin' an example for