### PR TITLE
Add hook for armor set bonus activation

### DIFF
--- a/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
@@ -1,0 +1,49 @@
+﻿using Terraria;
+using Terraria.ModLoader;
+
+namespace ExampleMod.Common.Players
+{
+	// This ModPlayer facilitates a set bonus effect. This example shows how either ArmorSetBonusActivated or ArmorSetBonusHeld can be used depending on how you want the player to interact with the set bonus effect. 
+	public class ExampleArmorSetBonusPlayer : ModPlayer
+	{
+		public bool ExampleSetHood; // Indicates if the ExampleSet with ExampleHood is the active armor set.
+		public int ShadowStyle = 0; // This is the shadow to use. Note that ExampleHood.ArmorSetShadows will only be called if the full armor set is visible.
+
+		public override void ResetEffects() {
+			ExampleSetHood = false;
+		}
+
+		public override void ArmorSetBonusActivated() {
+			if (!ExampleSetHood) {
+				return;
+			}
+
+			if (ShadowStyle == 3) {
+				ShadowStyle = 0;
+			}
+			ShadowStyle = (ShadowStyle + 1) % 3;
+			ShowMessageForShadowStyle();
+		}
+
+		public override void ArmorSetBonusHeld(int holdTime) {
+			if (!ExampleSetHood) {
+				return;
+			}
+
+			if (holdTime == 60) {
+				ShadowStyle = ShadowStyle == 3 ? 0 : 3;
+				ShowMessageForShadowStyle();
+			}
+		}
+
+		private void ShowMessageForShadowStyle() {
+			string styleName = ShadowStyle switch {
+				1 => "armorEffectDrawShadow",
+				2 => "armorEffectDrawOutlines",
+				3 => "armorEffectDrawOutlinesForbidden",
+				_ => "None",
+			};
+			Main.NewText("Current shadow style: " + styleName);
+		}
+	}
+}

--- a/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleKeybindPlayer.cs
@@ -1,4 +1,5 @@
 using ExampleMod.Common.Systems;
+using System;
 using Terraria;
 using Terraria.GameInput;
 using Terraria.ID;
@@ -9,11 +10,40 @@ namespace ExampleMod.Common.Players
 	// See Common/Systems/KeybindSystem for keybind registration.
 	public class ExampleKeybindPlayer : ModPlayer
 	{
+		private int LearningExampleKeybindHeldTimer;
+		private int LearningExampleKeybindDoubleTapTimer;
+
 		public override void ProcessTriggers(TriggersSet triggersSet) {
+			// The most common way to use keybinds is to use JustPressed to run code whenever the keybind is pressed
 			if (KeybindSystem.RandomBuffKeybind.JustPressed) {
 				int buff = Main.rand.Next(BuffID.Count);
 				Player.AddBuff(buff, 600);
 				Main.NewText($"ExampleMod's ModKeybind was just pressed. The {Lang.GetBuffName(buff)} buff was given to the player.");
+			}
+
+			// These examples show other potential behaviors of keybinds, such as a double tap and being held down.
+			
+			// We can use Current and a timer to run code after the keybind has been held for some time
+			if (KeybindSystem.LearningExampleKeybind.Current) {
+				LearningExampleKeybindHeldTimer++;
+				if (LearningExampleKeybindHeldTimer == 30) {
+					Main.NewText("LearningExampleKeybind held for half a second");
+				}
+			}
+			else {
+				LearningExampleKeybindHeldTimer = 0;
+			}
+
+			// We can use JustPressed and a timer to implement a double tap behavior as well.
+			LearningExampleKeybindDoubleTapTimer = Math.Max(0, LearningExampleKeybindDoubleTapTimer - 1);
+			if (KeybindSystem.LearningExampleKeybind.JustPressed) {
+				if (LearningExampleKeybindDoubleTapTimer > 0) {
+					Main.NewText("LearningExampleKeybind double tapped within a quarter of a a second");
+				}
+				else {
+					// On 1st press, set timer for 15, if a 2nd press happens before it reaches 0, it will be a double tap.
+					LearningExampleKeybindDoubleTapTimer = 15;
+				}
 			}
 		}
 	}

--- a/ExampleMod/Common/Systems/KeybindSystem.cs
+++ b/ExampleMod/Common/Systems/KeybindSystem.cs
@@ -7,17 +7,20 @@ namespace ExampleMod.Common.Systems
 	public class KeybindSystem : ModSystem
 	{
 		public static ModKeybind RandomBuffKeybind { get; private set; }
+		public static ModKeybind LearningExampleKeybind { get; private set; }
 
 		public override void Load() {
 			// Registers a new keybind
 			// We localize keybinds by adding a Mods.{ModName}.Keybind.{KeybindName} entry to our localization files. The actual text displayed to English users is in en-US.hjson
 			RandomBuffKeybind = KeybindLoader.RegisterKeybind(Mod, "RandomBuff", "P");
+			LearningExampleKeybind = KeybindLoader.RegisterKeybind(Mod, "LearningExample", "O");
 		}
 
 		// Please see ExampleMod.cs' Unload() method for a detailed explanation of the unloading process.
 		public override void Unload() {
 			// Not required if your AssemblyLoadContext is unloading properly, but nulling out static fields can help you figure out what's keeping it loaded.
 			RandomBuffKeybind = null;
+			LearningExampleKeybind = null;
 		}
 	}
 }

--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -70,10 +70,10 @@ namespace ExampleMod.Content.Items.Accessories
 			else if (Player.controlUp && Player.releaseUp && Player.doubleTapCardinalTimer[DashUp] < 15) {
 				DashDir = DashUp;
 			}
-			else if (Player.controlRight && Player.releaseRight && Player.doubleTapCardinalTimer[DashRight] < 15) {
+			else if (Player.controlRight && Player.releaseRight && Player.doubleTapCardinalTimer[DashRight] < 15 && Player.doubleTapCardinalTimer[DashLeft] == 0) {
 				DashDir = DashRight;
 			}
-			else if (Player.controlLeft && Player.releaseLeft && Player.doubleTapCardinalTimer[DashLeft] < 15) {
+			else if (Player.controlLeft && Player.releaseLeft && Player.doubleTapCardinalTimer[DashLeft] < 15 && Player.doubleTapCardinalTimer[DashRight] == 0) {
 				DashDir = DashLeft;
 			}
 			else {

--- a/ExampleMod/Content/Items/Armor/ExampleHood.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHood.cs
@@ -1,4 +1,5 @@
-﻿using Terraria;
+﻿using ExampleMod.Common.Players;
+using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -15,7 +16,8 @@ namespace ExampleMod.Content.Items.Armor
 		public static LocalizedText SetBonusText { get; private set; }
 
 		public override void SetStaticDefaults() {
-			SetBonusText = this.GetLocalization("SetBonus").WithFormatArgs(ManaCostReductionPercent);
+			// We are passing in "{0}" into WithFormatArgs to replace "{0}" with itself because we do the final formatting for this LocalizedText in UpdateArmorSet itself according to the players current ReversedUpDownArmorSetBonuses setting.
+			SetBonusText = this.GetLocalization("SetBonus").WithFormatArgs("{0}", ManaCostReductionPercent);
 		}
 
 		public override void SetDefaults() {
@@ -33,8 +35,25 @@ namespace ExampleMod.Content.Items.Armor
 
 		// UpdateArmorSet allows you to give set bonuses to the armor.
 		public override void UpdateArmorSet(Player player) {
-			player.setBonus = SetBonusText.Value; // This is the setbonus tooltip: "10% reduced mana cost"
+			// This is the setbonus tooltip:
+			//   Double tap or hold DOWN/UP to toggle various armor shadow effects
+			//   10% reduced mana cost
+			player.setBonus = SetBonusText.Format(Language.GetTextValue(Main.ReversedUpDownArmorSetBonuses ? "Key.UP" : "Key.DOWN"));
 			player.manaCost -= ManaCostReductionPercent / 100f; // Reduces mana cost by 10%
+			player.GetModPlayer<ExampleArmorSetBonusPlayer>().ExampleSetHood = true;
+		}
+
+		public override void ArmorSetShadows(Player player) {
+			var exampleArmorSetBonusPlayer = player.GetModPlayer<ExampleArmorSetBonusPlayer>();
+			if(exampleArmorSetBonusPlayer.ShadowStyle == 1) {
+				player.armorEffectDrawShadow = true;
+			}
+			else if(exampleArmorSetBonusPlayer.ShadowStyle == 2) {
+				player.armorEffectDrawOutlines = true;
+			}
+			else if (exampleArmorSetBonusPlayer.ShadowStyle == 3) {
+				player.armorEffectDrawOutlinesForbidden = true;
+			}
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 578/578, 100%, missing 0
-ru-RU, 7/578, 1%, missing 571
-zh-Hans, 2/578, 0%, missing 576
+en-US, 580/580, 100%, missing 0
+ru-RU, 7/580, 1%, missing 573
+zh-Hans, 2/580, 0%, missing 578

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -23,7 +23,11 @@ Mods: {
 
 		Currencies.ExampleCustomCurrency: example items
 		DamageClasses.ExampleDamageClass.DisplayName: example damage
-		Keybinds.RandomBuff.DisplayName: Random Buff
+
+		Keybinds: {
+			RandomBuff.DisplayName: Random Buff
+			LearningExample.DisplayName: Learning Example
+		}
 
 		NPCs: {
 			ExampleCustomAISlimeNPC.DisplayName: Flutter Slime
@@ -273,7 +277,11 @@ Mods: {
 			ExampleHood: {
 				DisplayName: Example Hood
 				Tooltip: This is a modded hood.
-				SetBonus: "{$CommonItemTooltip.PercentReducedManaCost}"
+				SetBonus:
+					'''
+					Double tap or hold {0} to toggle various armor shadow effects
+					{$CommonItemTooltip.PercentReducedManaCost@1}
+					'''
 			}
 
 			ExampleLeggings: {

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -23,7 +23,11 @@ Mods: {
 
 		// Currencies.ExampleCustomCurrency: example items
 		// DamageClasses.ExampleDamageClass.DisplayName: example damage
-		// Keybinds.RandomBuff.DisplayName: Random Buff
+
+		Keybinds: {
+			// RandomBuff.DisplayName: Random Buff
+			// LearningExample.DisplayName: Learning Example
+		}
 
 		NPCs: {
 			ExampleCustomAISlimeNPC.DisplayName: Порхающий слизень
@@ -273,7 +277,11 @@ Mods: {
 			ExampleHood: {
 				// DisplayName: Example Hood
 				// Tooltip: This is a modded hood.
-				// SetBonus: "{$CommonItemTooltip.PercentReducedManaCost}"
+				/* SetBonus:
+					'''
+					Double tap or hold {0} to toggle various armor shadow effects
+					{$CommonItemTooltip.PercentReducedManaCost@1}
+					''' */
 			}
 
 			ExampleLeggings: {

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -23,7 +23,11 @@ Mods: {
 
 		// Currencies.ExampleCustomCurrency: example items
 		// DamageClasses.ExampleDamageClass.DisplayName: example damage
-		Keybinds.RandomBuff.DisplayName: 随机增益
+
+		Keybinds: {
+			RandomBuff.DisplayName: 随机增益
+			// LearningExample.DisplayName: Learning Example
+		}
 
 		NPCs: {
 			// ExampleCustomAISlimeNPC.DisplayName: Flutter Slime
@@ -273,7 +277,11 @@ Mods: {
 			ExampleHood: {
 				// DisplayName: Example Hood
 				// Tooltip: This is a modded hood.
-				// SetBonus: "{$CommonItemTooltip.PercentReducedManaCost}"
+				/* SetBonus:
+					'''
+					Double tap or hold {0} to toggle various armor shadow effects
+					{$CommonItemTooltip.PercentReducedManaCost@1}
+					''' */
 			}
 
 			ExampleLeggings: {

--- a/patches/tModLoader/Terraria/CommonDocs.xml
+++ b/patches/tModLoader/Terraria/CommonDocs.xml
@@ -27,4 +27,7 @@
 		<para/> Lighting is tracked at Tile Coordinate granularity (<see href="https://github.com/tModLoader/tModLoader/wiki/Coordinates">Coordinates wiki page</see>). Typically the center of an entity, converted to tile coordinates, is used to query the lighting color at the entity's location. That color is then used to draw the entity.
 		<para/> Lighting values in-between tile coordinates can be interpolated using <see cref="GetSubLight(Vector2)"/>, but usually the lighting values at the tile coordinates closest to the center of an entity are sufficient. There are many more GetColorX methods for more advanced situations, if needed. If drawing a really large sprite, one might consider splitting up the drawing to allow sections of the sprite to be drawn at different light values.
 	</LightingGetColor>
+	<CardinalDirections>
+		<para/> The index values are as follows: <br/> 0: Down <br/> 1: Up <br/> 2: Right <br/> 3: Left
+	</CardinalDirections>
 </Common>

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -216,6 +216,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 
 	/// <summary>
 	/// Use this to check on keybinds you have registered. While SetControls is set even while in text entry mode, this hook is only called during gameplay.
+	/// <para/> Read <see href="https://github.com/tModLoader/tModLoader/blob/stable/ExampleMod/Common/Players/ExampleKeybindPlayer.cs">ExampleKeybindPlayer.cs</see> for examples and information on using this hook.
 	/// </summary>
 	/// <param name="triggersSet"></param>
 	public virtual void ProcessTriggers(TriggersSet triggersSet)
@@ -223,11 +224,22 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
-	/// This is called when the player activates their armor set bonus by double tapping down (or up if <see cref="Main.ReversedUpDownArmorSetBonuses"/> is true).
+	/// This is called when the player activates their armor set bonus by double tapping down (or up if <see cref="Main.ReversedUpDownArmorSetBonuses"/> is true). As an example, the Vortex armor uses this to toggle stealth mode.
 	/// <para /> Use this to implement armor set bonuses that need to be activated by the player.
 	/// <para /> Don't forget to check if your armor set is active.
+	/// <para/> While this technically can be used for other effects, it will likely be frustrating for your players if non-armor set effects are being triggered in tandem with armor set bonus effects. Modders can use <see cref="Player.holdDownCardinalTimer"/> and <see cref="Player.doubleTapCardinalTimer"/> directly in other hooks for similar effects if needed.
 	/// </summary>
 	public virtual void ArmorSetBonusActivated()
+	{
+	}
+
+	/// <summary>
+	/// This is called when the player activates their armor set bonus by holding down (or up if <see cref="Main.ReversedUpDownArmorSetBonuses"/> is true) for some amount of time. The <paramref name="holdTime"/> parameter indicates how many ticks the key has been held down for. As an example, the Stardust armor prior to 1.4.4 used to use this to set the location of the Stardust Guardian if <paramref name="holdTime"/> was greater than 60.
+	/// <para /> Use this to implement armor set bonuses that need to be activated by the player.
+	/// <para /> Don't forget to check if your armor set is active.
+	/// <para/> While this technically can be used for other effects, it will likely be frustrating for your players if non-armor set effects are being triggered in tandem with armor set bonus effects. Modders can use <see cref="Player.holdDownCardinalTimer"/> and <see cref="Player.doubleTapCardinalTimer"/> directly in other hooks for similar effects if needed.
+	/// </summary>
+	public virtual void ArmorSetBonusHeld(int holdTime)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -223,6 +223,15 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
+	/// This is called when the player activates their armor set bonus by double tapping down (or up if <see cref="Main.ReversedUpDownArmorSetBonuses"/> is true).
+	/// <para /> Use this to implement armor set bonuses that need to be activated by the player.
+	/// <para /> Don't forget to check if your armor set is active.
+	/// </summary>
+	public virtual void ArmorSetBonusActivated()
+	{
+	}
+
+	/// <summary>
 	/// Use this to modify the control inputs that the player receives. For example, the Confused debuff swaps the values of Player.controlLeft and Player.controlRight. This is called sometime after PreUpdate is called.
 	/// </summary>
 	public virtual void SetControls()

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1467,4 +1467,13 @@ public static class PlayerLoader
 			modPlayer.ArmorSetBonusActivated();
 		}
 	}
+
+	private static HookList HookArmorSetBonusHeld = AddHook<Action<int>>(p => p.ArmorSetBonusHeld);
+
+	public static void ArmorSetBonusHeld(Player player, int holdTime)
+	{
+		foreach (var modPlayer in HookArmorSetBonusHeld.Enumerate(player)) {
+			modPlayer.ArmorSetBonusHeld(holdTime);
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1458,4 +1458,24 @@ public static class PlayerLoader
 
 		return true;
 	}
+
+	private static HookList HookArmorSetBonusActivated = AddHook<Action>(p => p.ArmorSetBonusActivated);
+
+	public static void ArmorSetBonusActivated(Player player)
+	{
+		int keyIndex = 0;
+		bool keyReleased = player.controlDown && player.releaseDown;
+
+		if (Main.ReversedUpDownArmorSetBonuses) {
+			keyIndex = 1;
+			keyReleased = player.controlUp && player.releaseUp;
+		}
+
+		if (!keyReleased || player.doubleTapCardinalTimer[keyIndex] <= 0)
+			return;
+
+		foreach (var modPlayer in HookArmorSetBonusActivated.Enumerate(player)) {
+			modPlayer.ArmorSetBonusActivated();
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1463,17 +1463,6 @@ public static class PlayerLoader
 
 	public static void ArmorSetBonusActivated(Player player)
 	{
-		int keyIndex = 0;
-		bool keyReleased = player.controlDown && player.releaseDown;
-
-		if (Main.ReversedUpDownArmorSetBonuses) {
-			keyIndex = 1;
-			keyReleased = player.controlUp && player.releaseUp;
-		}
-
-		if (!keyReleased || player.doubleTapCardinalTimer[keyIndex] <= 0)
-			return;
-
 		foreach (var modPlayer in HookArmorSetBonusActivated.Enumerate(player)) {
 			modPlayer.ArmorSetBonusActivated();
 		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4023,12 +4023,9 @@
  		infernoCounter++;
  		if (infernoCounter >= 180)
  			infernoCounter = 0;
-@@ -19217,7 +_,12 @@
- 					}
+@@ -19218,6 +_,9 @@
  				}
  
-+				PlayerLoader.ArmorSetBonusActivated(this);
-+
  				controlDownHold = holdDownCardinalTimer[0] >= 45;
 +
 +				PlayerLoader.SetControls(this);
@@ -8970,6 +8967,15 @@
  		item.stack = 6;
  		item.position = base.Center;
  		Item item2 = GetItem(whoAmI, item, GetItemSettings.NPCEntityToPlayerInventorySettings);
+@@ -43921,6 +_,8 @@
+ 		if (keyDir != num)
+ 			return;
+ 
++		PlayerLoader.ArmorSetBonusActivated(this);
++
+ 		if (setVortex && !mount.Active)
+ 			vortexStealthActive = !vortexStealthActive;
+ 
 @@ -44020,7 +_,10 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -158,7 +158,7 @@
  	public int eocDash;
  	public int eocHit;
 +	/// <summary>
-+	/// Similar to <see cref="maxRunSpeed"/>, except this is usually set to a specific value for the active shoe accessory. If accRunSpeed ends up larger than maxRunSpeed, then sprint dust will spawn at high speeds. Basically, this exists to differentiate between sprinting ("run super fast") and running. 
++	/// Similar to <see cref="maxRunSpeed"/>, except this is usually set to a specific value for the active shoe accessory. If accRunSpeed ends up larger than maxRunSpeed, then sprint dust will spawn at high speeds. Basically, this exists to differentiate between sprinting ("run super fast") and running.
 +	/// <para/> Defaults to 3f. Accessories set this to specific values, resulting in the last equipped accessories to dictate the final value. Vanilla shoe accessories set this to <c>6f</c> (<see cref="ItemID.HermesBoots"/>) or <c>6.75</c> (<see cref="ItemID.LightningBoots"/>). This assignment should happen in <see cref="ModItem.UpdateEquip(Player)"/>.
 +	/// <para/> This value is later multiplied by other effects in the same manner as <see cref="maxRunSpeed"/>. They are usually modified in tandem, but not always depending on the desired result. For example, asphalt triples maxRunSpeed but does not affect accRunSpeed, whereas Shadow Armor affects both equally.
 +	/// <para/> These multiplicative adjustments should only be done in <see cref="ModPlayer.PostUpdateRunSpeeds"/> or <see cref="ModItem.HorizontalWingSpeeds"/> to correctly function.
@@ -4023,9 +4023,12 @@
  		infernoCounter++;
  		if (infernoCounter >= 180)
  			infernoCounter = 0;
-@@ -19218,6 +_,9 @@
+@@ -19217,7 +_,12 @@
+ 					}
  				}
  
++				PlayerLoader.ArmorSetBonusActivated(this);
++
  				controlDownHold = holdDownCardinalTimer[0] >= 45;
 +
 +				PlayerLoader.SetControls(this);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -296,7 +296,20 @@
  	public float slotsMinions;
  	public bool pygmy;
  	public bool raven;
-@@ -731,6 +_,11 @@
+@@ -726,11 +_,24 @@
+ 	public bool dontHurtCritters;
+ 	public bool hasLucyTheAxe;
+ 	public bool dontHurtNature;
++	/// <summary>
++	/// Used to count time between repeated directional movement key presses. When a directional key is pressed it is set to a value of 15. The value will count down each update until it reaches 0. If the key is pressed again before it reaches 0 it will trigger <see cref="Player.KeyDoubleTap"/>, which will call <see cref="ModPlayer.ArmorSetBonusActivated"/> if the armor set bonus direction key has been pressed. Updated immediately before <see cref="ModPlayer.SetControls"/>.
++	/// <include file = 'CommonDocs.xml' path='Common/CardinalDirections' />
++	/// </summary>
+ 	public int[] doubleTapCardinalTimer = new int[4];
++	/// <summary>
++	/// Counts how long (in ticks) the player has been holding directional movement keys. Updated immediately before <see cref="ModPlayer.SetControls"/>.
++	/// <include file = 'CommonDocs.xml' path='Common/CardinalDirections' />
++	/// </summary>
+ 	public int[] holdDownCardinalTimer = new int[4];
  	public bool defendedByPaladin;
  	public bool hasPaladinShield;
  	public float[] speedSlice = new float[60];
@@ -471,6 +484,14 @@
  	public bool[] hideVisibleAccessory = new bool[10];
  	public BitsByte hideMisc = (byte)0;
  	public Rectangle headFrame;
+@@ -910,6 +_,7 @@
+ 	public bool releaseCreativeMenu;
+ 	public bool tileInteractionHappened;
+ 	public bool tileInteractAttempted;
++	/// <summary> True when the player has been holding <see cref="controlDown"/> for at least 45 ticks. Used by <see cref="ItemID.ShimmerCloak"/>. See also <see cref="holdDownCardinalTimer"/>. </summary>
+ 	public bool controlDownHold;
+ 	public bool isOperatingAnotherEntity;
+ 	public bool autoReuseAllWeapons;
 @@ -943,7 +_,13 @@
  	public Vector2[] shadowOrigin = new Vector2[3];
  	public int[] shadowDirection = new int[3];
@@ -8987,3 +9008,12 @@
  		IEntitySource projectileSource_SetBonus = GetProjectileSource_SetBonus(3);
  		_ = Main.projectile[Projectile.NewProjectile(projectileSource_SetBonus, MinionRestTargetPoint, Vector2.Zero, 656, damage, 0f, Main.myPlayer)];
  	}
+@@ -44032,6 +_,8 @@
+ 			num = 1;
+ 
+ 		if (keyDir == num) {
++			PlayerLoader.ArmorSetBonusHeld(this, holdTime);
++
+ 			if (setStardust && holdTime >= 60)
+ 				MinionRestTargetPoint = Vector2.Zero;
+ 


### PR DESCRIPTION
### What is the new feature?
Added a hook that is called when the player wants to activate an armor set bonus by double tapping either down or up based on the users settings (e.g. the Vortex set bonus, which is toggling stealth mode).

### Why should this be part of tModLoader?
Without a hook, a detour is needed for modders to easily accomplish activating a set bonus for their modded armour that uses a double tap to activate.

### Are there alternative designs?
Yes, such as putting the hook in different places/combining it into a more universal hook that handles double presses in all directions (which would simplify ExampleShield and dashes).

I went with this implementation because it's simpler and I also had an issue where the double tap timer arrays weren't working as expected and I couldn't be bothered figuring out why.

### Sample usage for the new feature
```cs
public class ArmorSetSystem : ModSystem
{
    public override void ArmorSetBonusActivated()
    {
        if (TheSetIsActive)
            DoTheSetBonus();
    }
}
```

### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
I didn't update, but I could if needed.

### Porting Notes
<!-- List any actions a modder would need to take to update their mod to this new feature -->
If you previously used a detour to activate a set bonus or had your own hotkey, then you can switch over to this hook if you like.

As [Ozzatron stated on discord](https://discord.com/channels/103110554649894912/445276626352209920/1281385529346232371)
You can keep a dedicated hotkey because some people like it more than the double tap.
