### PR TITLE
Null out shopCustomPrice when stacking items to fix #4370

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -1515,6 +1515,11 @@ public static class ItemLoader
 			source.favorited = false;
 		}
 
+		if (destination.shopCustomPrice != source.shopCustomPrice) {
+			// If attempting to stack items with custom prices, null them out to prevent exploits. Fixes #4370 while preserving normal resell behavior.
+			destination.shopCustomPrice = null;
+		}
+
 		destination.stack += numTransferred;
 		if (!infiniteSource)
 			source.stack -= numTransferred;


### PR DESCRIPTION
Fixes #4370.

The issue is caused by `Item.shopCustomPrice` being preserved for shop items after being bought. When items are stacked, the stack will end up with a higher sell value than intended (destination `shopCustomPrice` is preserved).

There are several approaches to fix this issue, they are listed here so that if we need to revisit this bug later the pros and cons are listed.

1. Set `Item.shopCustomPrice` to `null` when the item is bought. Currently, items using `shopSpecialCurrency` will have both `shopSpecialCurrency` and `shopCustomPrice` reset. Shop items with just `shopCustomPrice`, however, are not. This seems intentional. This allows users to buy items from tavernkeep and immediately sell them back for full refund value rather than 1/5th of that value. Taking this approach would prevent users from selling back an item they don't want for the full refund if it happens to have a custom price, which would be very annoying to the user.
2. Adjust the `SellItem`/`GetItemExpectedPrice` logic to handle this, nulling out `shopCustomPrice` and adjusting the prices once `ItemShopSellbackHelper` is exhausted of sellback entries. This approach could work, but would be very complicated and error prone to implement. It would require reworking the sell value tooltip as well. Overall, this is too invasive of a change for a bugfix.
3. Null out `shopCustomPrice` when stacking items. This is the approach taken in the PR. This approach preserves sellback behavior but will silently prevent money exploits. Users will only lose out on selling back for full price if they happen to stack purchased items with existing items obtained elsewhere. 