### PR TITLE
Fix MouseText misalignment

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2726,7 +2726,7 @@
  			X += 34;
  
  		new Microsoft.Xna.Framework.Color(mouseTextColor, mouseTextColor, mouseTextColor, mouseTextColor);
-+		Vector2 vector = FontAssets.MouseText.Value.MeasureString(cursorText);
++		Vector2 vector = ChatManager.GetStringSize(FontAssets.MouseText.Value, cursorText, Vector2.One);
  		if (HoverItem.type > 0) {
  			MouseText_DrawItemTooltip(info, num, diff, X, Y);
  			return;


### PR DESCRIPTION
<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->
### What is the bug?
When the mouse text contains tags (like [i:GoldBar]), it miscalculated the size of the string.
For example, if you write `Main.instance.MouseText("[i:MusicBoxOWUndergroundCorruption][i:MusicBoxOWUndergroundCorruption][i:MusicBoxOWUndergroundCorruption]"); ` in a draw method, and when you mouse is close to the right edge, you would find the text (or three music box) far away from the left of the mouse.
### How did you fix the bug?
Main.MouseTextInner uses `FontAssets.MouseText.Value.MeasureString` to measure the string size, but uses `ChatManager.DrawColorCodedStringWithShadow` to draw. I change the measure method to `ChatManager.GetStringSize` to match the draw method.
### Are there alternatives to your fix?
None.