### PR TITLE
Added Player.breathEffectiveness to facilitate "extends underwater breathing"

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -85,6 +85,8 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	/// </summary>
 	public const int ManaCrystalMax = 9;
 
+	public StatModifier breathEffectiveness = StatModifier.Default;
+
 	public RefReadOnlyArray<ModPlayer> ModPlayers => modPlayers;
 
 	RefReadOnlyArray<ModPlayer> IEntityWithInstances<ModPlayer>.Instances => modPlayers;

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -86,7 +86,7 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	public const int ManaCrystalMax = 9;
 
 	/// <summary>
-	/// How effectively the player can hold their breath underwater. Controls how long it takes for <see cref="breath"/> to decrease. Breathing Rod doubles this value and Diving Gear multiplies it by 6.
+	/// How effectively the player can hold their breath underwater. Controls how long it takes for <see cref="breath"/> to decrease. Breathing Reed adds 1 (100%) to this value and Diving Gear multiplies it by 6.
 	/// <para/> Modded effects should add to this instead of multiplying to avoid values getting unreasonable large. Adding 1.5f for example will increase breath time by 150%.
 	/// <para/> Applied in the calculation of <see cref="breathCDMax"/>.
 	/// </summary>

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -88,6 +88,7 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	/// <summary>
 	/// How effectively the player can hold their breath underwater. Controls how long it takes for <see cref="breath"/> to decrease. Breathing Rod doubles this value and Diving Gear multiplies it by 6.
 	/// <para/> Modded effects should add to this instead of multiplying to avoid values getting unreasonable large. Adding 1.5f for example will increase breath time by 150%.
+	/// <para/> Applied in the calculation of <see cref="breathCDMax"/>.
 	/// </summary>
 	public StatModifier breathEffectiveness = StatModifier.Default;
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -85,6 +85,10 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 	/// </summary>
 	public const int ManaCrystalMax = 9;
 
+	/// <summary>
+	/// How effectively the player can hold their breath underwater. Controls how long it takes for <see cref="breath"/> to decrease. Breathing Rod doubles this value and Diving Gear multiplies it by 6.
+	/// <para/> Modded effects should add to this instead of multiplying to avoid values getting unreasonable large. Adding 1.5f for example will increase breath time by 150%.
+	/// </summary>
 	public StatModifier breathEffectiveness = StatModifier.Default;
 
 	public RefReadOnlyArray<ModPlayer> ModPlayers => modPlayers;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1097,7 +1097,7 @@
  	public bool ZoneUnderworldHeight {
  		get {
  			return zone3[4];
-@@ -1998,10 +_,13 @@
+@@ -1998,18 +_,20 @@
  
  	public Vector2 Directions => new Vector2(direction, gravDir);
  
@@ -1107,10 +1107,19 @@
 +	/// <summary> How long it takes for <see cref="breathCD"/> to cause <see cref="breath"/> to decrease by 1. Defaults to 7 and is increased by factors such as holding a Breathing Reed, which doubles this, or having a Diving Gear, which multiplies this by 6, to make the process of losing breath value slower. </summary>
  	public int breathCDMax {
  		get {
-+			// TODO: hook or StatModifier breathEffectiveness
- 			int num = 7;
+-			int num = 7;
++			int num = 1;
  			if (inventory[selectedItem].type == 186 && itemAnimation == 0)
  				num *= 2;
+ 
+ 			if (accDivingHelm)
+ 				num *= 6;
+ 
+-			return num;
++			return (int)((breathEffectiveness * num).ApplyTo(7));
+ 		}
+ 	}
+ 
 @@ -2085,6 +_,10 @@
  		}
  	}
@@ -3366,11 +3375,12 @@
  		calmed = false;
  		beetleOrbs = 0;
  		beetleBuff = false;
-@@ -14505,6 +_,7 @@
+@@ -14505,6 +_,8 @@
  		dashType = 0;
  		spikedBoots = 0;
  		blackBelt = false;
 +		breathMax = 200; // Added by TML.
++		breathEffectiveness = StatModifier.Default;
  		lavaMax = 0;
  		archery = false;
  		poisoned = false;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1104,7 +1104,7 @@
 +	/// <summary> The <see cref="Item"/> within the <see cref="inventory"/> currently selected by the player. </summary>
  	public Item HeldItem => inventory[selectedItem];
  
-+	/// <summary> How long it takes for <see cref="breathCD"/> to cause <see cref="breath"/> to decrease by 1. Defaults to 7 and is increased by factors such as holding a Breathing Reed, which doubles this, or having a Diving Gear, which multiplies this by 6, to make the process of losing breath value slower. </summary>
++	/// <summary> How long it takes for <see cref="breathCD"/> to cause <see cref="breath"/> to decrease by 1. Defaults to 7 before <see cref="breathEffectiveness"/> is applied. </summary>
  	public int breathCDMax {
  		get {
 -			int num = 7;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1108,15 +1108,17 @@
  	public int breathCDMax {
  		get {
 -			int num = 7;
-+			int num = 1;
++			var calculated = breathEffectiveness;
  			if (inventory[selectedItem].type == 186 && itemAnimation == 0)
- 				num *= 2;
+-				num *= 2;
++				calculated += 1;
  
  			if (accDivingHelm)
- 				num *= 6;
+-				num *= 6;
++				calculated *= 6;
  
 -			return num;
-+			return (int)((breathEffectiveness * num).ApplyTo(7));
++			return (int)(calculated.ApplyTo(7));
  		}
  	}
  

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -403,7 +403,7 @@
  	public int heldProj = -1;
 +	/// <summary> A countdown timer for <see cref="breath"/>. Ticks up every frame the player is holding their breath underwater. Once it reaches <see cref="breathCDMax"/>, resets back to 0 and breath is reduced by 1. </summary>
  	public int breathCD;
-+	/// <summary> The max value of <see cref="breath"/>. Defaults to 200. The total ticks before starting to drown is <c>breathMax * breathCDMax</c>. <para/> Effects like Breathing Rod and Diving Gear affect <see cref="breathEffectiveness"/> rather than edit this value. </summary>
++	/// <summary> The max value of <see cref="breath"/>. Defaults to 200. The total ticks before starting to drown is <c>breathMax * breathCDMax</c>. <para/> Effects like Breathing Reed and Diving Gear affect <see cref="breathEffectiveness"/> rather than edit this value. </summary>
  	public int breathMax = 200;
 +	/// <summary> The current amount of breath the player has (<see href="https://terraria.wiki.gg/wiki/Breath_meter">Breath info on the wiki</see>). <see cref="breathCD"/> controls how often the value decreases. Once 0, the player will start to take drowning damage. When out of liquid increases by 3 each tick. </summary>
  	public int breath = 200;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -403,7 +403,7 @@
  	public int heldProj = -1;
 +	/// <summary> A countdown timer for <see cref="breath"/>. Ticks up every frame the player is holding their breath underwater. Once it reaches <see cref="breathCDMax"/>, resets back to 0 and breath is reduced by 1. </summary>
  	public int breathCD;
-+	/// <summary> The max value of <see cref="breath"/>. Defaults to 200. The total ticks before starting to drown is <c>breathMax * breathCDMax</c>.</summary>
++	/// <summary> The max value of <see cref="breath"/>. Defaults to 200. The total ticks before starting to drown is <c>breathMax * breathCDMax</c>. <para/> Effects like Breathing Rod and Diving Gear affect <see cref="breathEffectiveness"/> rather than edit this value. </summary>
  	public int breathMax = 200;
 +	/// <summary> The current amount of breath the player has (<see href="https://terraria.wiki.gg/wiki/Breath_meter">Breath info on the wiki</see>). <see cref="breathCD"/> controls how often the value decreases. Once 0, the player will start to take drowning damage. When out of liquid increases by 3 each tick. </summary>
  	public int breath = 200;


### PR DESCRIPTION
Modders currently adjust `Player.breath` to fake an effect similar to diving helmet, as mentioned in #4396. https://github.com/tModLoader/tModLoader/commit/0d55bc751d5b2b7c5fabb5ea5e3a028a2215283a fixed some issues with doing that for current modders, but complete support would allow for better control.

Currently, adjusting `Player.breath` can linearly lengthen underwater breathing time, but the effect isn't numerically equivalent to vanilla approaches. Vanilla approaches are multiplicative, which currently isn't possible to do correctly due to mod execution order. Also, adjusting `Player.breath` past 400 results in a 2nd row of bubbles that keeps extending, which is not ideal.

This PR adds `Player.breathEffectiveness` as a `StatModifier`, allowing for base/additive/multiplicative adjustments to breathing time without adjusting `Player.breath`, which would be incompatible with multiple mods doing conflicting effects.

As a result, `Player.breath` now represents a breath capacity, while `Player.breathEffectiveness` represents a breath efficiency. Combined this should allow for, modders to individually adjust both. For example, a race with low breath capacity, an accessory doubling breathing efficiency, and an accessory increasing breathing capacity should all work together correctly no matter the load order.

For most modders, they'll want to switch from adjusting `Player.breath` to adjusting `Player.breathEffectiveness` instead for compatibility and avoiding the strange bubble indicator issue.

Also, `Player.accDivingHelm` applies a 6x multiplicative effect and Breathing Reed applies a 100% additive effect. We recommend modders stick to additive effects for the most part unless they are making an upgrade to diving helmets, otherwise the multiplicative effects will scale very quickly.

Sample usages:
```
public override void UpdateAccessory(Player player, bool hideVisual) {
	player.breathMax += 200; // double breath capacity.
	player.breathEffectiveness += .5f; // Increase breath efficiency by 50%, additively.
```