### PR TITLE
Allow Player.Hurt to be cancelled

### DIFF
--- a/patches/tModLoader/Terraria/Player.TML.Hurt.cs
+++ b/patches/tModLoader/Terraria/Player.TML.Hurt.cs
@@ -212,11 +212,11 @@ public partial class Player
 		/// <summary>
 		/// The amount of damage received by the player. How much life the player will lose. <br/>
 		/// Is NOT capped at the player's current life.<br/>
-		/// Cannot be set to less than 1.
+		/// Cannot be set to less than 0.
 		/// </summary>
 		public int Damage {
 			readonly get => _damage;
-			set => _damage = Math.Max(value, 1);
+			set => _damage = Math.Max(value, 0);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/Player.TML.Hurt.cs
+++ b/patches/tModLoader/Terraria/Player.TML.Hurt.cs
@@ -107,6 +107,13 @@ public partial class Player
 		/// </summary>
 		public MultipliableFloat KnockbackImmunityEffectiveness = new();
 
+		private bool _cancelled = default;
+		/// <summary>
+		/// Cancels the Hurt. Further hooks like <see cref="ModPlayer.FreeDodge"/> and <see cref="ModPlayer.OnHurt(HurtInfo)"/> will not be called. <br/>
+		/// Does not automatically apply immune frames, so the player can get hit again next frame. 
+		/// </summary>
+		public void Cancel() => _cancelled = true;
+
 		private bool _dustDisabled = default;
 		/// <summary>
 		/// Prevents dust from spawning
@@ -161,6 +168,7 @@ public partial class Player
 				SourceDamage = (int)SourceDamage.ApplyTo(damage),
 				Damage = (int)GetDamage(damage, defense, defenseEffectiveness),
 				Knockback = GetKnockback(knockback, knockbackImmune),
+				Cancelled = _cancelled,
 				DustDisabled = _dustDisabled,
 				SoundDisabled = _soundDisabled,
 			};
@@ -228,6 +236,11 @@ public partial class Player
 		/// The amount of knockback to apply. Should always be >= 0.
 		/// </summary>
 		public float Knockback = 0;
+
+		/// <summary>
+		/// <inheritdoc cref="HurtModifiers.Cancel"/>
+		/// </summary>
+		public bool Cancelled = false;
 
 		/// <summary>
 		/// If true, dust will not spawn

--- a/patches/tModLoader/Terraria/Player.TML.Hurt.cs
+++ b/patches/tModLoader/Terraria/Player.TML.Hurt.cs
@@ -212,11 +212,11 @@ public partial class Player
 		/// <summary>
 		/// The amount of damage received by the player. How much life the player will lose. <br/>
 		/// Is NOT capped at the player's current life.<br/>
-		/// Cannot be set to less than 0.
+		/// Cannot be set to less than 1.
 		/// </summary>
 		public int Damage {
 			readonly get => _damage;
-			set => _damage = Math.Max(value, 0);
+			set => _damage = Math.Max(value, 1);
 		}
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5388,6 +5388,7 @@
 +			modifiers.ScalingArmorPenetration += scalingArmorPenetration;
 +
 +			// ogre knockback re-implemented from below
+-			if (dodgeable) {
 +			if (flag2) {
 +				// this gives the right values for X knockback.
 +				// Y knockback will be slightly different, but mostly accurate
@@ -5398,7 +5399,7 @@
 +			ApplyVanillaHurtEffectModifiers(ref modifiers);
 +			info = modifiers.ToHurtInfo(Damage, statDefense, pvp ? 0.5f : DefenseEffectiveness.Value, knockback, noKnockback);
 +
- 			if (dodgeable) {
++			if (info.Dodgeable) {
 +				if (whoAmI == Main.myPlayer && PlayerLoader.FreeDodge(this, info))
 +					return 0.0;
 +

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5370,7 +5370,7 @@
  		bool flag = !immune;
  		bool flag2 = false;
  		int hitContext = cooldownCounter;
-@@ -29530,7 +_,34 @@
+@@ -29530,7 +_,36 @@
  		}
  
  		if (flag) {
@@ -5398,6 +5398,8 @@
 +
 +			ApplyVanillaHurtEffectModifiers(ref modifiers);
 +			info = modifiers.ToHurtInfo(Damage, statDefense, pvp ? 0.5f : DefenseEffectiveness.Value, knockback, noKnockback);
++			if (info.Cancelled)
++				return 0.0;
 +
 +			if (info.Dodgeable) {
 +				if (whoAmI == Main.myPlayer && PlayerLoader.FreeDodge(this, info))


### PR DESCRIPTION
### What is the new feature?
This is a convenience feature, making it easier for mods to make a player situationally ignore certain damage instances.

Adds `HurtModifiers.Cancel()` and `HurtInfo.Cancelled`. Cancelling a hurt has the same effect as returning `true` from `FreeDodge`, though even undodgeable hurts can be cancelled. Unlike `FreeDodge`, immune frames are not applied, so the player can still be hit by another attack this tick, or the same attack next hit.

### Why should this be part of tModLoader?

This is already possible, or should've been if not for a bug, failing to call `FreeDodge when `HurtInfo.Dodgeable` was overridden to `true`. This change just makes it easier. This is preferable to otherwise requested '0 damage' hits.

### Are there alternative designs?

- Should we apply i-frames? Perhaps an argument to `Cancel` could indicate i-frame duration?
- Some mods may want to trigger on-hit effects, and just negate the damage portion.

### Sample usage for the new feature

```cs
	public virtual void ModifyHurt(ref Player.HurtModifiers modifiers)
	{
		if (condition)
			modifiers.Cancel();
	}
```

### ExampleMod updates
None

### Porting Notes
None. Modders do not need to check if a `HurtInfo` is `Cancelled`, tML will not be passing cancelled hurts to hooks.