### PR TITLE
Lime Green Mod Pack statuses for mod packs with additional mods enabled

### DIFF
--- a/desktop.ini
+++ b/desktop.ini
@@ -1,6 +1,0 @@
-[.ShellClassInfo]
-IconResource=C:\Program Files (x86)\Steam\steamapps\common\tModLoader\tModLoader.dll,0
-[ViewState]
-Mode=
-Vid=
-FolderType=Generic

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,6 @@
+[.ShellClassInfo]
+IconResource=C:\Program Files (x86)\Steam\steamapps\common\tModLoader\tModLoader.dll,0
+[ViewState]
+Mode=
+Vid=
+FolderType=Generic

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
@@ -265,7 +265,7 @@ internal class UIModPackItem : UIPanel
 	private void DrawEnabledText(SpriteBatch spriteBatch, Vector2 drawPos)
 	{
 		string text = Language.GetTextValue("tModLoader.ModPackModsAvailableStatus", _numMods, _numModsEnabled, _numModsDisabled, _missing.Count);
-		Color color = (_missing.Count > 0 ? Color.Red : (_numModsDisabled > 0 ? Color.Yellow : Color.Green));
+		Color color = (_missing.Count > 0 ? Color.Red : (_numModsDisabled > 0 ? Color.Yellow : (ModLoader.EnabledMods.Count > _mods.Count() ? Color.LimeGreen : Color.Green)));
 
 		Utils.DrawBorderString(spriteBatch, text, drawPos, color);
 	}


### PR DESCRIPTION
<img width="386" alt="image" src="https://github.com/user-attachments/assets/276e1b0f-3124-4feb-95ad-54fa093bd48c">

### What is the new feature?
As described in #1356, the text in the status of a mod pack turns lime green if the mod pack is enabled and other mods are, too.
### Why should this be part of tModLoader?
Because, if you are playing with a specific mod pack, you might want to know if you have accidentally enabled additional mods.
### Are there alternative designs?
Having a text based indicator
### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
None
### Porting Notes
<!-- List any actions a modder would need to take to update their mod to this new feature -->
None
