### PR TITLE
New MountData params to allow Minecarts to have custom stats after Minecart Upgrade

### DIFF
--- a/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
+++ b/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
@@ -25,8 +25,10 @@ namespace ExampleMod.Content.Mounts
 			MountData.delegations.MinecartDust = DelegateMethods.Minecart.SparksMeow;
 			MountData.delegations.MinecartLandingSound = DelegateMethods.Minecart.LandingSoundFart;
 			MountData.delegations.MinecartBumperSound = DelegateMethods.Minecart.BumperSoundFart;
-
-			// Important to note is that runSpeed, dashSpeed, and acceleration will get overridden when the player has used the Minecart Upgrade Kit. Keep that in mind when changing the values yourself
+			// Important to note is that runSpeed, dashSpeed, and acceleration will get overridden when the player has used the Minecart Upgrade Kit. To add your own Minecart Upgrade Kit values use the MinecartUpgrade version of these.
+			MountData.MinecartUpgradeRunSpeed = 100f;
+			MountData.MinecartUpgradeDashSpeed = 100f;
+			MountData.MinecartUpgradeAcceleration = 50f;
 		}
 
 		public override void UpdateEffects(Player player) {

--- a/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
+++ b/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
@@ -25,10 +25,11 @@ namespace ExampleMod.Content.Mounts
 			MountData.delegations.MinecartDust = DelegateMethods.Minecart.SparksMeow;
 			MountData.delegations.MinecartLandingSound = DelegateMethods.Minecart.LandingSoundFart;
 			MountData.delegations.MinecartBumperSound = DelegateMethods.Minecart.BumperSoundFart;
-			// Important to note is that runSpeed, dashSpeed, and acceleration will get overridden when the player has used the Minecart Upgrade Kit. To add your own Minecart Upgrade Kit values use the MinecartUpgrade version of these.
-			MountData.MinecartUpgradeRunSpeed = 100f;
-			MountData.MinecartUpgradeDashSpeed = 100f;
-			MountData.MinecartUpgradeAcceleration = 50f;
+
+			// Note that runSpeed, dashSpeed, acceleration, jumpHeight, and jumpSpeed will be overridden when the player has used the Minecart Upgrade Kit. To customize the Minecart Upgrade Kit values, assign the MinecartUpgrade version of these:
+			MountData.MinecartUpgradeRunSpeed = 40f;
+			MountData.MinecartUpgradeDashSpeed = 40f;
+			MountData.MinecartUpgradeAcceleration = 0.2f;
 		}
 
 		public override void UpdateEffects(Player player) {

--- a/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
+++ b/ExampleMod/Content/Mounts/ExampleMinecartMount.cs
@@ -26,7 +26,8 @@ namespace ExampleMod.Content.Mounts
 			MountData.delegations.MinecartLandingSound = DelegateMethods.Minecart.LandingSoundFart;
 			MountData.delegations.MinecartBumperSound = DelegateMethods.Minecart.BumperSoundFart;
 
-			// Note that runSpeed, dashSpeed, acceleration, jumpHeight, and jumpSpeed will be overridden when the player has used the Minecart Upgrade Kit. To customize the Minecart Upgrade Kit values, assign the MinecartUpgrade version of these:
+			// Note that runSpeed, dashSpeed, acceleration, jumpHeight, and jumpSpeed will be overridden when the player has used the Minecart Upgrade Kit.
+			// To customize the Minecart Upgrade Kit stats, assign values to the MinecartUpgradeX fields:
 			MountData.MinecartUpgradeRunSpeed = 40f;
 			MountData.MinecartUpgradeDashSpeed = 40f;
 			MountData.MinecartUpgradeAcceleration = 0.2f;

--- a/patches/tModLoader/Terraria/Mount.cs.patch
+++ b/patches/tModLoader/Terraria/Mount.cs.patch
@@ -170,9 +170,9 @@
 +	/// <para/>Notably:<code>
 +	/// runSpeed = 13f;
 +	/// dashSpeed = 13f;
-+	///	acceleration = 0.04f;
++	/// acceleration = 0.04f;
 +	/// jumpHeight = 15;
-+	///	jumpSpeed = 5.15f;
++	/// jumpSpeed = 5.15f;
 +	/// </code>
 +	/// </summary>
 +	public static void SetAsMinecart(MountData newMount, int buff, Asset<Texture2D> texture, int verticalOffset = 0, int playerVerticalOffset = 0)

--- a/patches/tModLoader/Terraria/Mount.cs.patch
+++ b/patches/tModLoader/Terraria/Mount.cs.patch
@@ -26,7 +26,7 @@
  		public Asset<Texture2D> frontTexture = Asset<Texture2D>.Empty;
  		public Asset<Texture2D> frontTextureGlow = Asset<Texture2D>.Empty;
  		public Asset<Texture2D> frontTextureExtra = Asset<Texture2D>.Empty;
-@@ -150,11 +_,14 @@
+@@ -150,11 +_,22 @@
  		public int dashingFrameCount;
  		public int dashingFrameDelay;
  		public bool Minecart;
@@ -37,7 +37,15 @@
  		public bool emitsLight;
  		public MountDelegatesData delegations = new MountDelegatesData();
  		public int playerXOffset;
-+		public float MinecartUpgradeRunSpeed = 20f, MinecartUpgradeAcceleration = 0.1f, MinecartUpgradeJumpSpeed = 5.15f, MinecartUpgradeDashSpeed = 20f;
++		/// <summary> Alternate <see cref="runSpeed"/> for this minecart while the <see href="https://terraria.wiki.gg/wiki/Minecart_Upgrade_Kit">Minecart Upgrade Kit</see> is active. Defaults to <c>20f</c>.</summary>
++		public float MinecartUpgradeRunSpeed = 20f;
++		/// <summary> Alternate <see cref="acceleration"/> for this minecart while the <see href="https://terraria.wiki.gg/wiki/Minecart_Upgrade_Kit">Minecart Upgrade Kit</see> is active. Defaults to <c>0.1f</c>.</summary>
++		public float MinecartUpgradeAcceleration = 0.1f;
++		/// <summary> Alternate <see cref="jumpSpeed"/> for this minecart while the <see href="https://terraria.wiki.gg/wiki/Minecart_Upgrade_Kit">Minecart Upgrade Kit</see> is active. Defaults to <c>5.15f</c>.</summary>
++		public float MinecartUpgradeJumpSpeed = 5.15f;
++		/// <summary> Alternate <see cref="dashSpeed"/> for this minecart while the <see href="https://terraria.wiki.gg/wiki/Minecart_Upgrade_Kit">Minecart Upgrade Kit</see> is active. Defaults to <c>20f</c>.</summary>
++		public float MinecartUpgradeDashSpeed = 20f;
++		/// <summary> Alternate <see cref="jumpHeight"/> for this minecart while the <see href="https://terraria.wiki.gg/wiki/Minecart_Upgrade_Kit">Minecart Upgrade Kit</see> is active. Defaults to <c>15</c>.</summary>
 +		public int MinecartUpgradeJumpHeight = 15;
  	}
  
@@ -51,7 +59,7 @@
  	private static Vector2[] scutlixEyePositions;
  	private static Vector2 scutlixTextureSize;
  	public const int scutlixBaseDamage = 50;
-@@ -182,36 +_,32 @@
+@@ -182,36 +_,42 @@
  	public static int amountOfBeamsAtOnce = 2;
  	public const float maxDrillLength = 48f;
  	private static Vector2 santankTextureSize;
@@ -100,11 +108,16 @@
 +	public object _mountSpecificData;
 -	private bool _active;
 +	public bool _active;
--	public static float SuperCartRunSpeed = 20f;
--	public static float SuperCartDashSpeed = 20f;
--	public static float SuperCartAcceleration = 0.1f;
--	public static int SuperCartJumpHeight = 15;
--	public static float SuperCartJumpSpeed = 5.15f;
++	[Obsolete("Unused, use MountData.MinecartUpgradeRunSpeed instead")]
+ 	public static float SuperCartRunSpeed = 20f;
++	[Obsolete("Unused, use MountData.MinecartUpgradeDashSpeed instead")]
+ 	public static float SuperCartDashSpeed = 20f;
++	[Obsolete("Unused, use MountData.MinecartUpgradeAcceleration instead")]
+ 	public static float SuperCartAcceleration = 0.1f;
++	[Obsolete("Unused, use MountData.MinecartUpgradeJumpHeight instead")]
+ 	public static int SuperCartJumpHeight = 15;
++	[Obsolete("Unused, use MountData.MinecartUpgradeJumpSpeed instead")]
+ 	public static float SuperCartJumpSpeed = 5.15f;
  	private MountDelegatesData _defaultDelegatesData = new MountDelegatesData();
  
 +	/// <summary> True if the player is currently using a mount. </summary>

--- a/patches/tModLoader/Terraria/Mount.cs.patch
+++ b/patches/tModLoader/Terraria/Mount.cs.patch
@@ -160,11 +160,21 @@
  	{
  		newMount.spawnDust = 3;
  		newMount.buff = buff;
-@@ -2075,6 +_,12 @@
+@@ -2075,6 +_,22 @@
  		}
  	}
  
 +	//TODO 1.4.5: Vanilla will remove the 2 buff overload
++	/// <summary>
++	/// This method sets a variety of MountData values common to most minecarts.
++	/// <para/>Notably:<code>
++	/// runSpeed = 13f;
++	/// dashSpeed = 13f;
++	///	acceleration = 0.04f;
++	/// jumpHeight = 15;
++	///	jumpSpeed = 5.15f;
++	/// </code>
++	/// </summary>
 +	public static void SetAsMinecart(MountData newMount, int buff, Asset<Texture2D> texture, int verticalOffset = 0, int playerVerticalOffset = 0)
 +	{
 +		SetAsMinecart(newMount, buff, buff, texture, verticalOffset, playerVerticalOffset);

--- a/patches/tModLoader/Terraria/Mount.cs.patch
+++ b/patches/tModLoader/Terraria/Mount.cs.patch
@@ -26,7 +26,7 @@
  		public Asset<Texture2D> frontTexture = Asset<Texture2D>.Empty;
  		public Asset<Texture2D> frontTextureGlow = Asset<Texture2D>.Empty;
  		public Asset<Texture2D> frontTextureExtra = Asset<Texture2D>.Empty;
-@@ -150,7 +_,8 @@
+@@ -150,11 +_,14 @@
  		public int dashingFrameCount;
  		public int dashingFrameDelay;
  		public bool Minecart;
@@ -36,6 +36,12 @@
  		public Vector3 lightColor = Vector3.One;
  		public bool emitsLight;
  		public MountDelegatesData delegations = new MountDelegatesData();
+ 		public int playerXOffset;
++		public float MinecartUpgradeRunSpeed = 20f, MinecartUpgradeAcceleration = 0.1f, MinecartUpgradeJumpSpeed = 5.15f, MinecartUpgradeDashSpeed = 20f;
++		public int MinecartUpgradeJumpHeight = 15;
+ 	}
+ 
+ 	public static int currentShader = 0;
 @@ -168,7 +_,7 @@
  	public const int DrawBackExtra = 1;
  	public const int DrawFront = 2;
@@ -45,7 +51,7 @@
  	private static Vector2[] scutlixEyePositions;
  	private static Vector2 scutlixTextureSize;
  	public const int scutlixBaseDamage = 50;
-@@ -182,29 +_,29 @@
+@@ -182,36 +_,32 @@
  	public static int amountOfBeamsAtOnce = 2;
  	public const float maxDrillLength = 48f;
  	private static Vector2 santankTextureSize;
@@ -94,17 +100,44 @@
 +	public object _mountSpecificData;
 -	private bool _active;
 +	public bool _active;
- 	public static float SuperCartRunSpeed = 20f;
- 	public static float SuperCartDashSpeed = 20f;
- 	public static float SuperCartAcceleration = 0.1f;
-@@ -212,6 +_,7 @@
- 	public static float SuperCartJumpSpeed = 5.15f;
+-	public static float SuperCartRunSpeed = 20f;
+-	public static float SuperCartDashSpeed = 20f;
+-	public static float SuperCartAcceleration = 0.1f;
+-	public static int SuperCartJumpHeight = 15;
+-	public static float SuperCartJumpSpeed = 5.15f;
  	private MountDelegatesData _defaultDelegatesData = new MountDelegatesData();
  
 +	/// <summary> True if the player is currently using a mount. </summary>
  	public bool Active => _active;
  
  	public int Type => _type;
+@@ -283,7 +_,7 @@
+ 				return _data.runSpeed + 2f;
+ 
+ 			if (_shouldSuperCart)
+-				return SuperCartRunSpeed;
++				return _data.MinecartUpgradeRunSpeed;
+ 
+ 			return _data.runSpeed;
+ 		}
+@@ -292,7 +_,7 @@
+ 	public float DashSpeed {
+ 		get {
+ 			if (_shouldSuperCart)
+-				return SuperCartDashSpeed;
++				return _data.MinecartUpgradeDashSpeed;
+ 
+ 			return _data.dashSpeed;
+ 		}
+@@ -301,7 +_,7 @@
+ 	public float Acceleration {
+ 		get {
+ 			if (_shouldSuperCart)
+-				return SuperCartAcceleration;
++				return _data.MinecartUpgradeAcceleration;
+ 
+ 			return _data.acceleration;
+ 		}
 @@ -2013,7 +_,7 @@
  		}
  	}
@@ -152,7 +185,8 @@
  		}
  
  		if (_shouldSuperCart)
- 			num = SuperCartJumpHeight;
+-			num = SuperCartJumpHeight;
++			num = _data.MinecartUpgradeJumpHeight;
  
 +		MountLoader.JumpHeight(player, _data, ref num, xVelocity);
  		return num;
@@ -172,7 +206,8 @@
  		}
  
  		if (_shouldSuperCart)
- 			num = SuperCartJumpSpeed;
+-			num = SuperCartJumpSpeed;
++			num = _data.MinecartUpgradeJumpSpeed;
 +		
 +		MountLoader.JumpSpeed(player, _data, ref num, xVelocity);
  


### PR DESCRIPTION
### What is the new feature?
The `MountData` class now contains 5 new parameters: `MinecartUpgradeRunSpeed`, `MinecartUpgradeDashSpeed`, `MinecartUpgradeJumpSpeed`, `MinecartUpgradeAcceleration` and `MinecartUpgradeJumpHeight`. These replace the previous SuperCart versions of these parameters in the `Mount` class, which were static and the same for all minecarts. This means that modded minecarts with custom stats can scale up these stats when the Minecart Upgrade Kit is used. See #3597.
### Why should this be part of tModLoader?
Because this makes modders' lives easier when creating minecarts with custom stats. It allows them to keep any bonuses when upgrading minecarts as well as adding a way to customize existing minecarts.
### Are there alternative designs?
Yes, but they are overly complex for little benefit.
See the description of #3597 to see how it would be possible.
### Sample usage for the new feature
From an updated `ExampleMinecartMount`:
`MountData.MinecartUpgradeRunSpeed = 100f;
MountData.MinecartUpgradeDashSpeed = 100f;
MountData.MinecartUpgradeAcceleration = 50f;`
### ExampleMod updates
<!-- If you also updated ExampleMod for your new feature, let us know here -->
The file: `ExampleMinecartMount.cs` has been updated to show off the new parameters.
### Porting Notes
<!-- List any actions a modder would need to take to update their mod to this new feature -->
None