### PR TITLE
Made DynamicSpriteFont.SpriteCharacterData public

### DIFF
--- a/patches/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs.patch
+++ b/patches/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/ReLogic/Graphics/DynamicSpriteFont.cs
++++ src/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs
+@@ -10,7 +_,7 @@
+ 
+ public class DynamicSpriteFont : IFontMetrics
+ {
+-	private struct SpriteCharacterData
++	public struct SpriteCharacterData
+ 	{
+ 		public readonly Texture2D Texture;
+ 		public readonly Rectangle Glyph;

--- a/patches/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs.patch
+++ b/patches/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs.patch
@@ -1,9 +1,11 @@
 --- src/TerrariaNetCore/ReLogic/Graphics/DynamicSpriteFont.cs
 +++ src/tModLoader/ReLogic/Graphics/DynamicSpriteFont.cs
-@@ -10,7 +_,7 @@
+@@ -10,7 +_,9 @@
  
  public class DynamicSpriteFont : IFontMetrics
  {
++	public Dictionary<char, SpriteCharacterData> SpriteCharacters => _spriteCharacters;
++	public SpriteCharacterData DefaultCharacterData => _defaultCharacterData;
 -	private struct SpriteCharacterData
 +	public struct SpriteCharacterData
  	{


### PR DESCRIPTION
### What is the new feature?
SpriteCharacterData can now be accessed outside of DynamicSpriteFont.
_spriteCharacters and _defaultCharacterData were given accessor properties.

### Why should this be part of tModLoader?
Currently creating or manipulating fonts with code in any way requires heavy use of reflection, while doing so is not widely useful, those mods which do have use for it currently must sacrifice all manner of compile-time error checking in all code involving it.

### Are there alternative designs?
_spriteCharacters and/or _defaultCharacterData could be made public instead of being given accessor properties.