### PR TITLE
Bash launch script fixes

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader-FamilyShare.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+cd "$(dirname "$0")" ||
+read -n 1 -s -r -p "Can't cd to script directory. Press any button to exit..." && exit 1
+
 export SteamClientLaunch=1
 chmod a+x ./start-tModLoader.sh
 ./start-tModLoader.sh

--- a/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoader.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" ||
+read -n 1 -s -r -p "Can't cd to script directory. Press any button to exit..." && exit 1
 
 chmod a+x ./LaunchUtils/ScriptCaller.sh
 ./LaunchUtils/ScriptCaller.sh "$@" &

--- a/patches/tModLoader/Terraria/release_extras/start-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/start-tModLoaderServer.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-cd "$(dirname "$0")" || exit
+cd "$(dirname "$0")" ||
+read -n 1 -s -r -p "Can't cd to script directory. Press any button to exit..." && exit 1
 
 launch_args="-server"
 


### PR DESCRIPTION
### What is the bug?
1. `start-tModLoader-FamilyShare.sh` doesn't cd to script directory, and will fail when started from elsewhere.

2. `start-tModLoader.sh` doesn't exit explicitly when cd fails, which is inconsistent with `start-tModLoaderServer.sh`.

3. `start-tModLoaderServer.sh` exits immediately when cd fails, which causes certain terminals to close immediately.

### How did you fix the bug?
All launch scripts now execute this instead:
```
cd "$(dirname "$0")" ||
read -n 1 -s -r -p "Can't cd to script directory. Press any button to exit..." && exit 1
```

### Are there alternatives to your fix?
There are, but they are likely more intrusive changes.

<!--
We recommend using one of our pull request templates if you want your PR taken seriously.
You can update your URL with a param to take in the correct template, or you can simply open one of the urls and copy the raw text.

If you already have params in your URL you will see ?xx=yy after the main url, in that case you need to add the template as &template=xxx
Otherwise add it as ?template=xxx

Want to PR a bug fix? 
template=bug_fix.md

Want to PR a new feature? 
template=new_feature.md

Want to PR changes to ExampleMod?
template=example_mod.md

If you can't figure this out, simply open the link directly and copy the template:
Bug fix: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
New feature: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/new_feature.md
Example mod: https://raw.githubusercontent.com/tModLoader/tModLoader/master/.github/PULL_REQUEST_TEMPLATE/example_mod.md
-->