### PR TITLE
Custom Mod Config Element Styles

### DIFF
--- a/ExampleMod/Common/Configs/CustomUI/DynamicLabelColorProvider.cs
+++ b/ExampleMod/Common/Configs/CustomUI/DynamicLabelColorProvider.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader.Config;
+
+namespace ExampleMod.Common.Configs.CustomUI
+{
+	public class DynamicLabelColorProvider : ModConfigStylesProvider
+	{
+		public override void ModifyLabelColor(Func<object> getObject, bool isMouseHovering, bool canWrite, ref Color labelColor) {
+			labelColor = Main.DiscoColor;
+		}
+	}
+}

--- a/ExampleMod/Common/Configs/CustomUI/FloatToPercentProvider.cs
+++ b/ExampleMod/Common/Configs/CustomUI/FloatToPercentProvider.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ModLoader.Config;
+
+namespace ExampleMod.Common.Configs.CustomUI
+{
+	public class FloatToPercentProvider : ModConfigStylesProvider
+	{
+		public override void ModifyLabel(Func<object> getObject, string configElementLabel, ref string label) {
+			label = configElementLabel + ": " + ((float)getObject()).ToString("0%");
+		}
+	}
+}

--- a/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
+++ b/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseMisc.cs
@@ -40,6 +40,12 @@ namespace ExampleMod.Common.Configs.ModConfigShowcases
 		// In this case, CustomModConfigItem is annotating the Enum instead of the Field. Either is acceptable and can be used for different situations.
 		public Corner corner;
 
+		[CustomModConfigStyles(typeof(DynamicLabelColorProvider))]
+		public float customLabelColor;
+
+		[CustomModConfigStyles(typeof(FloatToPercentProvider))]
+		public float percent = 0.5f;
+
 		// You can put multiple attributes in the same [] if you like.
 		// ColorHueSliderAttribute displays Hue Saturation Lightness. Passing in false means only Hue is shown.
 		[DefaultValue(typeof(Color), "255, 0, 0, 255"), ColorHSLSlider(false), ColorNoAlpha]

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 590/590, 100%, missing 0
-ru-RU, 7/590, 1%, missing 583
-zh-Hans, 2/590, 0%, missing 588
+en-US, 593/593, 100%, missing 0
+ru-RU, 7/593, 1%, missing 586
+zh-Hans, 2/593, 0%, missing 591

--- a/ExampleMod/Localization/en-US_Mods.ExampleMod.Configs.hjson
+++ b/ExampleMod/Localization/en-US_Mods.ExampleMod.Configs.hjson
@@ -389,6 +389,16 @@ ModConfigShowcaseMisc: {
 		Label: List of Ints
 		Tooltip: ""
 	}
+
+	customLabelColor: {
+		Label: custom Label Color
+		Tooltip: ""
+	}
+
+	percent: {
+		Label: percent
+		Tooltip: ""
+	}
 }
 
 ModConfigShowcaseRanges: {

--- a/ExampleMod/Localization/ru-RU_Mods.ExampleMod.Configs.hjson
+++ b/ExampleMod/Localization/ru-RU_Mods.ExampleMod.Configs.hjson
@@ -389,6 +389,16 @@ ModConfigShowcaseMisc: {
 		// Label: List of Ints
 		// Tooltip: ""
 	}
+
+	customLabelColor: {
+		// Label: custom Label Color
+		// Tooltip: ""
+	}
+
+	percent: {
+		// Label: percent
+		// Tooltip: ""
+	}
 }
 
 ModConfigShowcaseRanges: {

--- a/ExampleMod/Localization/zh-Hans_Mods.ExampleMod.Configs.hjson
+++ b/ExampleMod/Localization/zh-Hans_Mods.ExampleMod.Configs.hjson
@@ -389,6 +389,16 @@ ModConfigShowcaseMisc: {
 		// Label: List of Ints
 		// Tooltip: ""
 	}
+
+	customLabelColor: {
+		// Label: custom Label Color
+		// Tooltip: ""
+	}
+
+	percent: {
+		// Label: percent
+		// Tooltip: ""
+	}
 }
 
 ModConfigShowcaseRanges: {

--- a/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/ConfigAttributes.cs
@@ -550,6 +550,19 @@ public class ExpandAttribute : Attribute
 	}
 }
 
+/// <summary>
+/// Use this attribute to customize some styles of the config element. The type must inherit from <see cref="ModConfigStylesProvider"/>.
+/// </summary>
+public class CustomModConfigStylesAttribute : Attribute
+{
+	public Type Type { get; }
+
+	public CustomModConfigStylesAttribute(Type type)
+	{
+		Type = type;
+	}
+}
+
 // Unimplemented ideas below:
 /*
 

--- a/patches/tModLoader/Terraria/ModLoader/Config/ModConfigStylesProvider.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/ModConfigStylesProvider.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader.Config.UI;
+using Terraria.UI;
+
+namespace Terraria.ModLoader.Config;
+
+/// <summary>
+/// This class allows you to customize some styles of the config element.
+/// Used as the parameter of <see cref="CustomModConfigStylesAttribute"/>.
+/// </summary>
+public class ModConfigStylesProvider
+{
+	/// <summary>
+	/// Allows you to dynamically modify label color.
+	/// </summary>
+	/// <param name="getObject">The func to get the config element value.</param>
+	/// <param name="isMouseHovering">See <see cref="UIElement.IsMouseHovering"/>.</param>
+	/// <param name="canWrite">See <see cref="PropertyFieldWrapper.CanWrite"/>.</param>
+	/// <param name="labelColor">The final color of the label.</param>
+	public virtual void ModifyLabelColor(Func<object> getObject, bool isMouseHovering, bool canWrite, ref Color labelColor)
+	{
+		
+	}
+
+	/// <summary>
+	/// Allows you to dynamically modify label text.
+	/// </summary>
+	/// <param name="getObject"></param>
+	/// <param name="configElementLabel">See <see cref="ConfigElement.Label"/>.</param>
+	/// <param name="label">The label to display.</param>
+	public virtual void ModifyLabel(Func<object> getObject, string configElementLabel, ref string label)
+	{
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -600,7 +600,7 @@ internal static class Interface
 			if ((originalRepresentation.StartsWith('"') || type == typeof(string)) && !inputString.StartsWith('"'))
 				inputString = $"\"{inputString}\"";
 			else if (type.IsArray || type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(List<>) || type.GetGenericTypeDefinition() == typeof(HashSet<>))) {
-				if (!inputString.StartsWith("["))
+				if (!inputString.StartsWith('['))
 					inputString = $"[{inputString}]";
 			}
 			else if (type.IsClass && originalRepresentation.StartsWith('{') && !inputString.StartsWith('{')) {


### PR DESCRIPTION
### What is the new feature?
Provide some ways to modify the styles of config elements through adding `CustomModConfigStylesAttribute` and `ModConfigStylesProvider`.

### Why should this be part of tModLoader?
Modders can customize the styles without creating a new kind of ConfigElement. (#4420, #4422)
Using `CustomModConfigStylesAttribute`  could be easier and more flexible.

### Are there alternative designs?
Split it to several attributes.

### Sample usage for the new feature
```C#
public class DynamicLabelColorProvider : ModConfigStylesProvider
{
	public override void ModifyLabelColor(Func<object> getObject, bool isMouseHovering, bool canWrite, ref Color labelColor) {
		labelColor = Main.DiscoColor;
	}
}
public class FloatToPercentProvider : ModConfigStylesProvider
{
	public override void ModifyLabel(Func<object> getObject, string configElementLabel, ref string label) {
		label = configElementLabel + ": " + ((float)getObject()).ToString("0%");
	}
}
```
```C#
public class ModConfigShowcaseMisc : ModConfig
{
	[CustomModConfigStyles(typeof(DynamicLabelColorProvider))]
	public float customLabelColor;

	[CustomModConfigStyles(typeof(FloatToPercentProvider))]
	public float percent = 0.5f;
}
```
https://github.com/user-attachments/assets/e377149c-460d-4739-8d64-2181a3efe7e0

### ExampleMod updates
`ExampleMod.Common.Configs.CustomUI.DynamicLabelColorProvider`
`ExampleMod.Common.Configs.CustomUI.FloatToPercentProvider`
`ExampleMod.Common.Configs.ModConfigShowcases.ModConfigShowcaseMisc`
