### PR TITLE
Fix dotnet detection under steam runtime. Fixes #4450

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -102,6 +102,18 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 			File.WriteAllBytes(path, bytes);
 	}
 
+	public static Process StartOnHost(ProcessStartInfo info)
+	{
+		// Steam runtime uses pressure vessel to 'sandbox' the application, providing its own set of system libraries and applications.
+		// We can run commands on the host via `steam-runtime-launch-client --alongside-steam --host -- <the command for the app>`
+		// See the steam runtime docs: https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/slr-for-game-developers.md#running-commands-outside-the-container
+		if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PRESSURE_VESSEL_RUNTIME"))) {
+			info.Arguments = "--alongside-steam --host -- " + info.FileName + " " + info.Arguments;
+			info.FileName = "steam-runtime-launch-client";
+		}
+		return Process.Start(info);
+	}
+
 	internal static IList<string> sourceExtensions = new List<string> { ".csproj", ".cs", ".sln" };
 
 	private IBuildStatus status;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -36,7 +36,7 @@ internal class UIModSourceItem : UIPanel
 	private Task<string[]> langFileTask;
 	private Task<bool> sourceUpgradeTask;
 	private CancellationToken _modSourcesToken;
-	
+
 	public UIModSourceItem(string mod, LocalMod builtMod, CancellationToken modSourcesToken)
 	{
 		_mod = mod;
@@ -420,16 +420,22 @@ internal class UIModSourceItem : UIPanel
 			string csprojFile = Path.Combine(_mod, $"{modFolderName}.csproj");
 
 			string args = $"\"{csprojFile}\"";
-			var tMLPath = Path.GetFileName(Assembly.GetExecutingAssembly().Location);
-			var porterPath = Path.Combine(Path.GetDirectoryName(tMLPath), "tModPorter", (Platform.IsWindows ? "tModPorter.bat" : "tModPorter.sh"));
+			var tMLPath = Path.GetDirectoryName(Path.GetFullPath(Assembly.GetExecutingAssembly().Location));
+			var porterPath = Path.Combine(tMLPath, "tModPorter", (Platform.IsWindows ? "tModPorter.bat" : "tModPorter.sh"));
 
 			var porterInfo = new ProcessStartInfo() {
 				FileName = porterPath,
 				Arguments = args,
+				WorkingDirectory = tMLPath,
 				UseShellExecute = true
 			};
 
-			var porter = Process.Start(porterInfo);
+			try {
+				var porter = ModCompile.StartOnHost(porterInfo);
+			}
+			catch (Exception ex) {
+				Logging.tML.Error("Failed to start tModPorter", ex);
+			}
 		};
 
 		Append(portModButton);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -296,12 +296,14 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	private static IEnumerable<string> GetPossibleSystemDotnetPaths()
 	{
 		if (GetCommandToFindPathOfExecutable() is string cmd) {
-			yield return ModCompile.StartOnHost(new ProcessStartInfo {
+			string whereResult = ModCompile.StartOnHost(new ProcessStartInfo {
 				FileName = cmd,
 				Arguments = "dotnet",
 				UseShellExecute = false,
 				RedirectStandardOutput = true
 			}).StandardOutput.ReadToEnd().Split("\n")[0].Trim();
+			if (!string.IsNullOrWhiteSpace(whereResult))
+				yield return whereResult;
 		}
 
 		// OSX fallback

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -296,14 +296,12 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	private static IEnumerable<string> GetPossibleSystemDotnetPaths()
 	{
 		if (GetCommandToFindPathOfExecutable() is string cmd) {
-			string whereResult = ModCompile.StartOnHost(new ProcessStartInfo {
+			yield return ModCompile.StartOnHost(new ProcessStartInfo {
 				FileName = cmd,
 				Arguments = "dotnet",
 				UseShellExecute = false,
 				RedirectStandardOutput = true
 			}).StandardOutput.ReadToEnd().Split("\n")[0].Trim();
-			if (!string.IsNullOrWhiteSpace(whereResult))
-				yield return whereResult;
 		}
 
 		// OSX fallback
@@ -388,6 +386,9 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 
 	private static bool DoesDotnetWork(string path)
 	{
+		if (string.IsNullOrWhiteSpace(path))
+			return false;
+
 		try {
 			// Try and execute each possible dotnet installation path,
 			// we can't simply check if the file exists as we may be inside a steam-runtime container environment

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -296,7 +296,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	private static IEnumerable<string> GetPossibleSystemDotnetPaths()
 	{
 		if (GetCommandToFindPathOfExecutable() is string cmd) {
-			yield return Process.Start(new ProcessStartInfo {
+			yield return ModCompile.StartOnHost(new ProcessStartInfo {
 				FileName = cmd,
 				Arguments = "dotnet",
 				UseShellExecute = false,
@@ -329,7 +329,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	private static string GetSystemDotnetPath()
 	{
 		try {
-			if (GetPossibleSystemDotnetPaths().FirstOrDefault(File.Exists) is string path) {
+			if (GetPossibleSystemDotnetPaths().FirstOrDefault(DoesDotnetWork) is string path) {
 				Logging.tML.Debug($"System dotnet install located at: {path}");
 				return path;
 			}
@@ -347,7 +347,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 
 		try {
 			string dotnetFilename = GetSystemDotnetPath() ?? "dotnet";
-			string output = Process.Start(new ProcessStartInfo {
+			string output = ModCompile.StartOnHost(new ProcessStartInfo {
 				FileName = dotnetFilename,
 				Arguments = "--list-sdks",
 				UseShellExecute = false,
@@ -380,6 +380,28 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 			Logging.tML.Debug("Flatpak sandbox detected");
 			return true;
 		}
+
+		return false;
+	}
+
+	private static bool DoesDotnetWork(string path)
+	{
+		try {
+			// Try and execute each possible dotnet installation path,
+			// we can't simply check if the file exists as we may be inside a steam-runtime container environment
+			// and the path may point to a file on the host.
+			var proc = ModCompile.StartOnHost(new ProcessStartInfo {
+				FileName = path,
+				Arguments = "--version"
+			});
+			if (proc == null) return false;
+
+			proc.WaitForExit();
+			if (proc.ExitCode == 0) {
+				return true;
+			}
+		}
+		catch (Exception) { }
 
 		return false;
 	}

--- a/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
+++ b/patches/tModLoader/Terraria/release_extras/tModPorter/tModPorter.sh
@@ -28,12 +28,18 @@ fi
 
 cd "$(dirname "$0")"/..
 if [[ ! -z "$DOTNET_ROOT" ]]; then
-	echo "DOTNET_ROOT is $DOTNET_ROOT"
-	export DOTNET_ROOT=$HOME/.dotnet
-	export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+    echo "DOTNET_ROOT is $DOTNET_ROOT"
+else
+    export DOTNET_ROOT=$HOME/.dotnet
 fi
+export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 
 DOTNET_PATH=$(which dotnet)
+if [[ "$?" != "0" ]]; then
+  echo "dotnet not found on PATH. Either add dotnet to PATH, set DOTNET_ROOT to the install path, or provide an install in ~/.dotnet"
+  read -n 1 -s -r -p "Press any key to continue"
+  exit 1
+fi
 DOTNET_X64_PATH=$(dirname $DOTNET_PATH)/x64/dotnet
 if [[ -f $DOTNET_X64_PATH ]]; then
 	DOTNET_PATH=$DOTNET_X64_PATH


### PR DESCRIPTION
### What is the bug?
https://github.com/tModLoader/tModLoader/issues/4450 tModLoader fails to detect dotnet when running under steam runtime/pressure vessel on Linux.

### How did you fix the bug?
We find and execute dotnet via `steam-runtime-launch-client` as per the steam [runtime documentation](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/slr-for-game-developers.md#running-commands-outside-the-container).

Cleaned up the path detection in `tModPorter.sh` as per @Chicken-Bones's recommendation.

Added error reporting to `tModPorter.sh` if dotnet is missing or not found.

### Are there alternatives to your fix?
No.
