### PR TITLE
Allow `ModPlayer::DrawEffects`' `fullBright` parameter to work without modifying other variables

### DIFF
--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -141,7 +141,8 @@
 +		bool fullBright = false;
 +		PlayerLoader.DrawEffects(this, ref num12, ref num13, ref num14, ref num15, ref fullBright);
 +
- 		if (num12 != 1f || num13 != 1f || num14 != 1f || num15 != 1f) {
+-		if (num12 != 1f || num13 != 1f || num14 != 1f || num15 != 1f) {
++		if (num12 != 1f || num13 != 1f || num14 != 1f || num15 != 1f || fullBright) {
 -			if (drawPlayer.onFire || drawPlayer.onFire2 || drawPlayer.onFrostBurn || drawPlayer.onFire3 || drawPlayer.onFrostBurn2) {
 +			if (drawPlayer.onFire || drawPlayer.onFire2 || drawPlayer.onFrostBurn || drawPlayer.onFire3 || drawPlayer.onFrostBurn2 || fullBright) {
  				colorEyeWhites = drawPlayer.GetImmuneAlpha(Color.White, shadow);

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1038,7 +1038,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
-	/// Allows you to create special effects when this player is drawn, such as creating dust, modifying the color the player is drawn in, etc. The fullBright parameter makes it so that the drawn player ignores the modified color and lighting. Note that the fullBright parameter only works if r, g, b, and/or a is not equal to 1. Make sure to add the indexes of any dusts you create to drawInfo.DustCache, and the indexes of any gore you create to drawInfo.GoreCache. <br/>
+	/// Allows you to create special effects when this player is drawn, such as creating dust, modifying the color the player is drawn in, etc. The fullBright parameter makes it so that the drawn player ignores the modified color and lighting. Make sure to add the indexes of any dusts you create to drawInfo.DustCache, and the indexes of any gore you create to drawInfo.GoreCache. <br/>
 	/// This will be called multiple times a frame if a player afterimage is being drawn. Check <code>if(drawinfo.shadow == 0f)</code> to do some logic only when drawing the original player image. For example, spawning dust only for the original player image is commonly the desired behavior.
 	/// </summary>
 	/// <param name="drawInfo"></param>


### PR DESCRIPTION
*Fixes #4317.*

### What is the bug?

Previously,  `ModPlayer::DrawEffects`' `fullBright` parameter required modifying the color parameters.

### How did you fix the bug?

Added an explicit check for `fullbright` as well.

### Are there alternatives to your fix?

You could do what documentation previously suggested and modify another variable, but that's hacky.
