### PR TITLE
Fix mod loading failing when a mod includes abstract `Mod` types

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -232,7 +232,7 @@ public static class AssemblyManager
 		if (!GetLoadableTypes(assembly).Any(t => t.Namespace?.StartsWith(modName) == true))
 			throw new Exception(Language.GetTextValue("tModLoader.BuildErrorNamespaceFolderDontMatch"));
 
-		var modTypes = GetLoadableTypes(assembly).Where(t => t.IsSubclassOf(typeof(Mod))).ToArray();
+		var modTypes = GetLoadableTypes(assembly).Where(t => t.IsSubclassOf(typeof(Mod)) && !t.IsAbstract).ToArray();
 
 		if (modTypes.Length > 1)
 			throw new Exception($"{modName} has multiple classes extending Mod. Only one Mod per mod is supported at the moment");


### PR DESCRIPTION
*Fixes #2332.*

### What is the bug?

If your mod had abstract types extending `Mod`, it would fail to load.

### How did you fix the bug?

Filter out abstract `Mod` types.

### Are there alternatives to your fix?

N/A

