### PR TITLE
Allows modders to modify dust particles without copying AI method. Fixes #4150.

### DIFF
--- a/patches/tModLoader/Terraria/Dust.cs.patch
+++ b/patches/tModLoader/Terraria/Dust.cs.patch
@@ -142,10 +142,13 @@
  	public static int NewDust(Vector2 Position, int Width, int Height, int Type, float SpeedX = 0f, float SpeedY = 0f, int Alpha = 0, Color newColor = default(Color), float Scale = 1f)
  	{
  		if (Main.gameMenu)
-@@ -168,6 +_,8 @@
+@@ -168,6 +_,11 @@
  			if (dust.type == 80)
  				dust.alpha = 50;
  
++			if (dust.type == -1) // If the dust type is -1, set the dust particles to be transparent
++				dust.alpha = 255;
++
 +			DustLoader.SetupDust(dust);
 +
  			if (dust.type == 34 || dust.type == 35 || dust.type == 152) {

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -35,6 +35,15 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	/// <summary> Determines which <see cref="ImmunityCooldownID"/> to use when this projectile damages a player. Defaults to -1 (<see cref="ImmunityCooldownID.General"/>). </summary>
 	public int CooldownSlot { get; set; } = -1;
 
+	/// <summary>
+	///	Determines if the projectile has a custom dust. <br/>
+	///	Needs to be called within <see cref="ModProjectile.SetDefaults"/> to change. <br/>
+	///	Defaults to -1 to prevent older mods from losing functionality as well as determining if there is a custom dust being used. <br/>
+	///	You must set this to a valid DustID or ModContent.DustType. <br/>
+	///	Currently is only implemented for aiType 10 <br/>
+	/// </summary>
+	public int CustomDustID { get; set; } = -1;
+
 	/// <summary> How far to the right of its position this projectile should be drawn. Defaults to 0. </summary>
 	public int DrawOffsetX { get; set; }
 
@@ -46,6 +55,15 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 
 	/// <summary> If this projectile is held by the player, determines whether it is drawn in front of or behind the player's arms. Defaults to false. </summary>
 	public bool DrawHeldProjInFrontOfHeldItemAndArms { get; set; }
+
+	/// <summary>
+	///	Determines whether or not the projectile has dust enabled. <br/>
+	///	Needs to be called within <see cref="ModProjectile.SetDefaults"/> to disable. <br/>
+	///	Defaults to false to prevent older mods from losing functionality. <br/>
+	///	This will override any dust setting set. <br/>
+	///	Currently is only implemented for aiType 10 <br/>
+	/// </summary>
+	public bool DustDisabled { get; set; } = false;
 
 	/// <summary>
 	/// The file name of this type's texture file in the mod loader's file space. <br/>

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1,5 +1,12 @@
 --- src/TerrariaNetCore/Terraria/Projectile.cs
 +++ src/tModLoader/Terraria/Projectile.cs
+@@ -1,5 +_,6 @@
+ using System;
+ using System.Collections.Generic;
++using System.Security.Cryptography.X509Certificates;
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Audio;
+ using ReLogic.Utilities;
 @@ -20,14 +_,16 @@
  using Terraria.Graphics.Shaders;
  using Terraria.ID;
@@ -410,22 +417,44 @@
  			for (int j = 0; j < 200; j++) {
  				perIDStaticNPCImmunity[i][j] = 0u;
  			}
-@@ -232,8 +_,46 @@
+@@ -232,8 +_,68 @@
  		}
  	}
  
++	public bool DustDisabled {
++		get => ModProjectile?.DustDisabled ?? false;
++		set {
++			if (ModProjectile != null) {
++				ModProjectile.DustDisabled = value;
++			}
++		}
++	}
++
++	public int CustomDustID {
++		get => ModProjectile?.CustomDustID ?? -1;
++		set {
++			if (ModProjectile != null) {
++				ModProjectile.CustomDustID = value;
++			}
++		}
++	}
++
 +	// Added by TML.
 +	public void CloneDefaults(int TypeToClone)
 +	{
 +		int originalType = type;
 +		var originalModProjectile = ModProjectile;
 +		var originalGlobals = _globals;
++		bool originalDustDisabled = DustDisabled;
++		int originalCustomDustID = CustomDustID;
 +
 +		SetDefaults(TypeToClone);
 +
 +		type = originalType;
 +		ModProjectile = originalModProjectile;
 +		_globals = originalGlobals;
++		DustDisabled = originalDustDisabled;
++		CustomDustID = originalCustomDustID;
 +
 +		int num = ProjectileID.Sets.TrailCacheLength[type];
 +		if (num != oldPos.Length) {
@@ -457,6 +486,16 @@
  		ownerHitCheckDistance = 1000f;
  		counterweight = false;
  		sentry = false;
+@@ -252,6 +_,9 @@
+ 		usesIDStaticNPCImmunity = false;
+ 		usesOwnerMeleeHitCD = false;
+ 		appliesImmunityTimeOnSingleHits = false;
++
++	
++
+ 		int num = 10;
+ 		if (Type >= 0)
+ 			num = ProjectileID.Sets.TrailCacheLength[Type];
 @@ -284,9 +_,11 @@
  		minionSlots = 0f;
  		soundDelay = 0;
@@ -1774,6 +1813,25 @@
  			if (Main.netMode == 1)
  				NetMessage.SendData(21, -1, -1, null, number, 1f);
  		}
+@@ -40518,7 +_,17 @@
+ 
+ 	private void AI_010()
+ 	{
++		if ((DustDisabled == true) && (ModProjectile != null)) { // Added by TML
++			if (Main.rand.Next(2) == 0) {
++				int num = Dust.NewDust(new Vector2(position.X, position.Y), width, height, -1, 0f, velocity.Y / 2f);
++				Main.dust[num].velocity.X *= 0.4f;
++			}
++		}
++		else if (CustomDustID != -1) { // Added by TML
++			int num = Dust.NewDust(new Vector2(position.X, position.Y), width, height, CustomDustID, 0f, velocity.Y / 2f);
++			Main.dust[num].velocity.X *= 0.4f;
++		}
+-		if (type == 31 && ai[0] != 2f) {
++		else if (type == 31 && ai[0] != 2f) {
+ 			if (Main.rand.Next(2) == 0) {
+ 				int num = Dust.NewDust(new Vector2(position.X, position.Y), width, height, 32, 0f, velocity.Y / 2f);
+ 				Main.dust[num].velocity.X *= 0.4f;
 @@ -46762,7 +_,7 @@
  			}
  


### PR DESCRIPTION
_Fixes #4150_ 

### **What is the bug?**

Previously, in order to customize sand projectile dust, you had to override the entirety of the entity with the AI method, as well as there being no good way to disable projectile dust. 

### **How did you fix the bug?**

Added two properties, CustomDustID and DustDisabled that allows the modder to easily set the projectile dust id and disable dust particles within the SetDefault override in ModProjectile. This was only implemented for aiStyle 10 but could be implemented for all projectile types. 

### **Are there alternatives to your fix?**

Not that I am aware of. From what I gathered from the discord, before this implementation, there was no good way to customize projectile dust or disable dust without overriding the AI method.  