### PR TITLE
Moved TileLoader.DrawEffects to a better position in DrawSingleTile

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -185,14 +185,14 @@
  				if (drawData.tileLight.R < sightColor.R)
  					drawData.tileLight.R = sightColor.R;
  
-@@ -715,6 +_,7 @@
+@@ -720,6 +_,7 @@
  
- 		Rectangle rectangle = new Rectangle(drawData.tileFrameX + drawData.addFrX, drawData.tileFrameY + drawData.addFrY, drawData.tileWidth, drawData.tileHeight - drawData.halfBrickHeight);
- 		Vector2 vector = new Vector2((float)(tileX * 16 - (int)screenPosition.X) - ((float)drawData.tileWidth - 16f) / 2f, tileY * 16 - (int)screenPosition.Y + drawData.tileTop + drawData.halfBrickHeight) + screenOffset;
+ 		drawData.colorTint = Color.White;
+ 		drawData.finalColor = GetFinalLight(drawData.tileCache, drawData.typeCache, drawData.tileLight, drawData.colorTint);
 +		TileLoader.DrawEffects(tileX, tileY, drawData.typeCache, Main.spriteBatch, ref drawData);
- 		if (!flag)
- 			return;
- 
+ 		switch (drawData.typeCache) {
+ 			case 136:
+ 				switch (drawData.tileFrameX / 18) {
 @@ -974,7 +_,13 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -185,11 +185,20 @@
  				if (drawData.tileLight.R < sightColor.R)
  					drawData.tileLight.R = sightColor.R;
  
-@@ -720,6 +_,7 @@
+@@ -715,11 +_,16 @@
+ 
+ 		Rectangle rectangle = new Rectangle(drawData.tileFrameX + drawData.addFrX, drawData.tileFrameY + drawData.addFrY, drawData.tileWidth, drawData.tileHeight - drawData.halfBrickHeight);
+ 		Vector2 vector = new Vector2((float)(tileX * 16 - (int)screenPosition.X) - ((float)drawData.tileWidth - 16f) / 2f, tileY * 16 - (int)screenPosition.Y + drawData.tileTop + drawData.halfBrickHeight) + screenOffset;
++		/*
+ 		if (!flag)
+ 			return;
++		*/
  
  		drawData.colorTint = Color.White;
  		drawData.finalColor = GetFinalLight(drawData.tileCache, drawData.typeCache, drawData.tileLight, drawData.colorTint);
 +		TileLoader.DrawEffects(tileX, tileY, drawData.typeCache, Main.spriteBatch, ref drawData);
++		if (!flag)
++			return;
  		switch (drawData.typeCache) {
  			case 136:
  				switch (drawData.tileFrameX / 18) {


### PR DESCRIPTION
### What is the bug?
TileLoader.DrawEffects is being called before the check for if tile is rendered and the setting of drawdata.tintcolor and finalcolor.
This means that even if the tile isn't rendered on screen (for example if the tile is hidden with ecto coating) the draw effects are still being called for the tile.
This also in addition means that modded tiles (and global tiles) are unable to edit the drawdata.tintColor and drawdata.finalcolor of tiles. Such as editing the color at which rainbow tiles are drawn with or players being able to make their own tile with a color similar to rainbow bricks. (A mod I currently help develop has to use glowmasks to make their tile be colored differently due to finalcolor being inaccessible)

### How did you fix the bug?
Moved the position of TileLoader.DrawEffects to be after the setting of drawdata.finalcolor

### Are there alternatives to your fix?
Moving the setting of drawdata.tintcolor and drawdata.finalcolor to before the flag check if the tile is rendered as some mods may use DrawEffect for their tiles to spawn dusts or gores. Although this should be done in either pre or postdraw. This also has effects at messing with possible IL edits for DrawSingleTile as some edits may want to edit drawdata after the tile rendering check and use the setting of finalcolor as a hook point.