### PR TITLE
feat: postpone hash verification until read error or mod load

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -200,6 +200,7 @@
 		"LoadErrorDependencyMissing": "Missing mod: {0} required by {1}",
 		"LoadErrorErrorReadingModFile": "Error reading mod file {0}",
 		"LoadErrorHashMismatchCorrupted": "Hash mismatch, data blob has been modified or corrupted",
+		"LoadErrorHashMismatchCorruptedWithModName": "Unable to verify integrity of {0}: hash mismatch; data blob has been modified or corrupted",
 		"LoadErrorDependencyVersionTooLow": "{0} requires {2} version {1} or greater but version {3} is installed",
 		"LoadErrorMajorVersionMismatch": "{0} targets {2} version {1} but you have a newer major version ({3}) which may not be compatible. {0} must be updated.",
 		"LoadErrorRecentlyBuiltLocalModWithLowerVersionWorkshop": "{0} v{1} was recently built, but was not selected to load because the subscribed workshop copy (v{2}) is newer.\nEither update build.txt and rebuild the mod or temporarily unsubscribe from the mod.",

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -143,6 +143,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 		try {
 			ModOrganizer.EnsureDependenciesExist(modList, true);
 			ModOrganizer.EnsureTargetVersionsMet(modList);
+			ModOrganizer.EnsureHashesAreValid(modList);
 			var sortedModList = ModOrganizer.Sort(modList);
 			modsToBuild = sortedModList.OfType<BuildingMod>().ToList();
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -375,6 +375,7 @@ internal static class ModOrganizer
 			EnsureRecentlyBuildModsAreLoading(modsToLoad);
 			EnsureDependenciesExist(modsToLoad, false);
 			EnsureTargetVersionsMet(modsToLoad);
+			EnsureHashesAreValid(modsToLoad);
 			return Sort(modsToLoad);
 		}
 		catch (ModSortingException e) {
@@ -518,6 +519,20 @@ internal static class ModOrganizer
 				}
 			}
 
+		if (errored.Count > 0)
+			throw new ModSortingException(errored, errorLog.ToString());
+	}
+
+	internal static void EnsureHashesAreValid(ICollection<LocalMod> mods)
+	{
+		var errored = new HashSet<LocalMod>();
+		var errorLog = new StringBuilder();
+		foreach (var mod in mods) {
+			if (!mod.modFile.VerifyHash()) {
+				errored.Add(mod);
+				errorLog.AppendLine(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted", mod));
+			}
+		}
 		if (errored.Count > 0)
 			throw new ModSortingException(errored, errorLog.ToString());
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -530,7 +530,7 @@ internal static class ModOrganizer
 		foreach (var mod in mods) {
 			if (!mod.modFile.VerifyHash()) {
 				errored.Add(mod);
-				errorLog.AppendLine(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted", mod));
+				errorLog.AppendLine(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorruptedWithModName", mod));
 			}
 		}
 		if (errored.Count > 0)

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -451,8 +451,9 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 
 	internal bool VerifyHash()
 	{
+		IDisposable handle = null;
 		if (fileStream == null)
-			return false;
+			handle = Open();
 
 		if (hashStartPos == 0)
 			return false;
@@ -464,6 +465,7 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		fileStream.Position = hashStartPos;
 		var result = Hash.SequenceEqual(sha1.ComputeHash(fileStream));
 		fileStream.Position = oldPos;
+		handle?.Dispose();
 		return result;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -1,5 +1,4 @@
 using Ionic.Zlib;
-using Microsoft.Build.Tasks;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -474,7 +474,6 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 
 		// It shouldn't be possible to get this far with an unknown hash starting
 		// position:
-		// - header reading is not wrapped in a trap that calls this,
 		// - erroneous user code would fail due to no file stream or similar,
 		// - saving, etc. does not use this.
 		Debug.Assert(hashStartPos != 0);

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -360,7 +360,10 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 				f.Offset += fileStartPos;
 		}
 		catch (Exception e) {
-			VerifyHashOrThrow(e);
+			if (!VerifyHash())
+				throw new Exception(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted"), e);
+
+			// If the hash is fine, let it bubble up like normal.
 			throw;
 		}
 	}
@@ -456,20 +459,5 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		using var fs = File.OpenRead(path);
 		fs.Position = hashStartPos;
 		return Hash.SequenceEqual(SHA1.Create().ComputeHash(fs));
-	}
-
-	private void VerifyHashOrThrow(Exception exception)
-	{
-		if (fileStream == null)
-			throw new IOException($"File not open: {path}", exception);
-
-		// It shouldn't be possible to get this far with an unknown hash starting
-		// position:
-		// - erroneous user code would fail due to no file stream or similar,
-		// - saving, etc. does not use this.
-		Debug.Assert(hashStartPos != 0);
-
-		if (!VerifyHash())
-			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted"), exception);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -337,9 +337,14 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		//currently unused, included to read the entire data-blob as a byte-array without decompressing or waiting to hit end of stream
 		int datalen = reader.ReadInt32();
 
-		try {
-			hashStartPos = fileStream.Position;
+		// Verification.  We postpone hash verification until an error occurs during
+		// reading to avoid expensive calculations.  We can compare data lengths
+		// instead.
+		hashStartPos = fileStream.Position;
+		if (datalen != fileStream.Length - hashStartPos)
+			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted"));
 
+		try {
 			if (TModLoaderVersion < new Version(0, 11)) {
 				Upgrade();
 				return;

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -452,13 +452,9 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		if (hashStartPos == 0)
 			return false;
 
-		if (sharedEntryReadStream != null)
-			throw new IOException($"Previous entry read stream not closed: {sharedEntryReadStream.Name}");
-
-		using (Open()) {
-			fileStream.Position = hashStartPos;
-			return Hash.SequenceEqual(SHA1.Create().ComputeHash(fileStream));
-		}
+		using var fs = File.OpenRead(path);
+		fs.Position = hashStartPos;
+		return Hash.SequenceEqual(SHA1.Create().ComputeHash(fs));
 	}
 
 	private void VerifyHashOrThrow(Exception exception)

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -327,9 +327,8 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		//currently unused, included to read the entire data-blob as a byte-array without decompressing or waiting to hit end of stream
 		int datalen = reader.ReadInt32();
 
-		// Verification.  We postpone hash verification until an error occurs during
-		// reading to avoid expensive calculations.  We can compare data lengths
-		// instead.
+		// Verification.  We postpone hash verification until mod loading or an error
+		// occurs during reading.
 		hashStartPos = fileStream.Position;
 		if (datalen != fileStream.Length - hashStartPos)
 			throw new Exception(Language.GetTextValue("tModLoader.LoadErrorHashMismatchCorrupted"));

--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -69,6 +69,7 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 	// Starting position of the hashable part of the stream.
 	private long hashStartPos;
 	private bool? hashVerified;
+
 	internal TmodFile(string path, string name = null, Version version = null)
 	{
 		this.path = path;


### PR DESCRIPTION
### What is the new feature?

`.tmod` file loading as been adjusted to only verify data blob lengths rather than full hash verification. Instead, hash verification has been postponed to mod loading to minimize unnecessary hashing. Hashes will also be taken if the initial `TmodFile::Read` invocation fails.

### Why should this be part of tModLoader?

It significantly speeds up start-up times.

### Are there alternative designs?

A better hashing algorithm and streaming in the background are possible but unnecessary (the former) and terrible (the latter).

