### PR TITLE
Fix shimmer lag by passing `quiet: true` to `AddBuff`

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2922,6 +2922,15 @@
  		bool result = false;
  		if (type == 2 || type == -43 || type == 190 || type == 191 || type == 192 || type == 193 || type == 194 || type == 317 || type == 318 || type == 133)
  			result = true;
+@@ -74607,7 +_,7 @@
+ 
+ 			if (Collision.shimmer) {
+ 				shimmerWet = true;
+-				AddBuff(353, 100);
++				AddBuff(BuffID.Shimmer, 100, true); // TML: Pass true to quiet as clients execute this as well.
+ 			}
+ 		}
+ 
 @@ -74862,6 +_,9 @@
  		if (IsABestiaryIconDummy)
  			newColor = Color.White;


### PR DESCRIPTION
### What is the bug?
Clients and servers will constantly (and redundantly) sync the `Shimmer` buff. This wastes bandwidth, and will eventually cause significant lag to certain clients.

See commit message for details.

### How did you fix the bug?
Passing `quiet: true` to `AddBuff`

### Are there alternatives to your fix?
No.

