### PR TITLE
Fix `PlayerDisconnect` hook being called with bogus player

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1102,6 +1102,8 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 
 	/// <summary>
 	/// Called when a player disconnects.
+	/// <para/> Called on the server when this player disconnects.
+	/// <para/> Called on other clients when this player disconnects.
 	/// </summary>
 	public virtual void PlayerDisconnect()
 	{

--- a/patches/tModLoader/Terraria/Netplay.cs.patch
+++ b/patches/tModLoader/Terraria/Netplay.cs.patch
@@ -21,6 +21,21 @@
  		int num = FindNextOpenClientSlot();
  		if (num != -1) {
  			Clients[num].Reset();
+@@ -298,8 +_,13 @@
+ 		for (int i = 0; i < 256; i++) {
+ 			if (Clients[i].PendingTermination) {
+ 				if (Clients[i].PendingTerminationApproved) {
+-					Clients[i].Reset();
++					// TML: Re-order to prevent RemoteClient.Reset from re-instantiating the player before
++					//      execution ends up in PlayerLoader.PlayerDisconnect, which would invoke the hook
++					//      with useless Player/ModPlayer data.
++					//      Set the RemoteClient.State to 0 so SyncOnePlayer will still treat them as disconnected.
++					Clients[i].State = 0;
+ 					NetMessage.SyncDisconnectedPlayer(i);
++					Clients[i].Reset();
+ 				}
+ 
+ 				continue;
 @@ -312,7 +_,7 @@
  			}
  


### PR DESCRIPTION
### What is the bug?
The `ModPlayer.PlayerDisconnect` hook can be invoked with a bogus/useless player. This is because the player object is re-instantiated by a call to `RemoteClient.Reset` before the player disconnection proceeds.

See commit message for details.

### How did you fix the bug?
Re-ordering the calls to `RemoteClient.Reset` and `NetMessage.SyncDisconnectedPlayer` resolves this, ensuring the disconnection hook is invoked _before_ the player is re-instantiated.

### Are there alternatives to your fix?
No.

I don't _believe_ this fix has any other side-effects (pertaining to the Terraria code), but there's always the possibility I've missed something.