### PR TITLE
Simple Vanilla Tree Shaking Hook

### DIFF
--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -1,0 +1,48 @@
+using Terraria;
+using Terraria.ID;
+using Terraria.Enums;
+using Terraria.ModLoader;
+using Terraria.DataStructures;
+using ExampleMod.Content.Items;
+using ExampleMod.Content.Projectiles;
+
+namespace ExampleMod.Common.GlobalTiles
+{
+	public class GlobalShakeTrees : GlobalTile {
+		// With this hook, we can make things happen when a tree is shook.
+		// See ExampleSourceDependentItemTweaks for another example for tree shaking.
+		public override void ShakeTree(int x, int y, TreeTypes treeType) {
+
+			// Normal forest trees have a 33% chance to drop an Example Item.
+			if (treeType == TreeTypes.Forest && WorldGen.genRand.NextBool(3)) {
+				Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ModContent.ItemType<ExampleItem>());
+			}
+
+			// Glowing Mushroom trees have 10% chance to drop between 3 and 10 Mushroom Torches.
+			if (treeType == TreeTypes.Mushroom && WorldGen.genRand.NextBool(10)) {
+				Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ItemID.MushroomTorch, WorldGen.genRand.Next(3, 11));
+			}
+
+			// Snow (Boreal) trees have a 5% chance to spawn an Example Paper Airplane projectile that flies left or right.
+			// The owner of the projectile is set to Main.myPlayer which means the server owns the projectile in multiplayer.
+			if (treeType == TreeTypes.Snow && WorldGen.genRand.NextBool(20)) {
+				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-16, 16), 0f, ModContent.ProjectileType<ExamplePaperAirplaneProjectile>(), Damage: 4, KnockBack: 1f, Owner: Main.myPlayer);
+			}
+
+			// Jungle (Mahogany) trees have a 14% chance to spawn a Giant Flying Fox if located on the surface and in Hardmode.
+			// y == 0 is the top of the world, so y < Main.worldSurface is the area from the surface height to the top of the world.
+			if (treeType == TreeTypes.Jungle && WorldGen.genRand.NextBool(7) && y < Main.worldSurface && Main.hardMode) {
+				NPC.NewNPC(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, NPCID.GiantFlyingFox);
+			}
+
+			// In this example, there is 20% chance for any tree to shoot a hostile arrow downwards on No Traps and Get Fixed Boi worlds.
+			if (WorldGen.genRand.NextBool(5) && Main.noTrapsWorld) {
+				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, (float)Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
+			}
+
+			// ModTree will always count a Forest tree.
+			// ModPalmTree will always count as Palm tree.
+			// To make things happen when your modded tree is shook, override ModTree.Shake(). See ExampleTree.
+		}
+	}
+}

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -50,9 +50,9 @@ namespace ExampleMod.Common.GlobalTiles
 
 			// In this example, we want to target Example Trees specifically. We don't want other modded trees such as Example Palm Tree.
 			if (treeType == TreeTypes.Custom) {
-				WorldGen.GetTreeBottom(x, y, out int newX, out int newY); // Finds the block that the tree is planted on.
+				WorldGen.GetTreeBottom(x, y, out int baseX, out int baseY); // Finds the block that the tree is planted on.
 				// If the block the tree is planted on is an Example Block, we know we have found an Example Tree.
-				if (Main.tile[newX, newY].TileType == ModContent.TileType<ExampleBlock>() && WorldGen.genRand.NextBool(2)) {
+				if (Main.tile[baseX, baseY].TileType == ModContent.TileType<ExampleBlock>() && WorldGen.genRand.NextBool(2)) {
 					Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ItemID.Coconut);
 				}
 			}

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -6,6 +6,7 @@ using Terraria.DataStructures;
 using ExampleMod.Content.Items;
 using ExampleMod.Content.Projectiles;
 using ExampleMod.Content.NPCs;
+using ExampleMod.Content.Tiles;
 
 namespace ExampleMod.Common.GlobalTiles
 {
@@ -41,11 +42,21 @@ namespace ExampleMod.Common.GlobalTiles
 				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
 			}
 
-			// Modded trees will be tree type ModTree or ModPalmTree.
-			// In this example, there is a 50% chance for ANY modded tree or modded palm tree to drop a Party Zombie at night.
-			if ((treeType == TreeTypes.ModTree || treeType == TreeTypes.ModPalmTree) && WorldGen.genRand.NextBool(2) && !Main.dayTime) {
+			// Modded trees will be tree type Custom by default.
+			// In this example, there is a 50% chance for a modded tree to drop a Party Zombie at night.
+			if (treeType == TreeTypes.Custom && WorldGen.genRand.NextBool(2) && !Main.dayTime) {
 				NPC.NewNPC(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, ModContent.NPCType<PartyZombie>());
 			}
+
+			// In this example, we want to target Example Trees specifically. We don't want other modded trees such as Example Palm Tree.
+			if (treeType == TreeTypes.Custom) {
+				WorldGen.GetTreeBottom(x, y, out int newX, out int newY); // Finds the block that the tree is planted on.
+				// If the block the tree is planted on is an Example Block, we know we have found an Example Tree.
+				if (Main.tile[newX, newY].TileType == ModContent.TileType<ExampleBlock>() && WorldGen.genRand.NextBool(2)) {
+					Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ItemID.Coconut);
+				}
+			}
+
 			// To make things happen when your modded tree is shook, override ModTree.Shake() instead. See ExampleTree.
 		}
 	}

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -1,3 +1,4 @@
+﻿using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.Enums;
@@ -5,6 +6,8 @@ using Terraria.ModLoader;
 using Terraria.DataStructures;
 using ExampleMod.Content.Items;
 using ExampleMod.Content.Projectiles;
+using ExampleMod.Content.NPCs;
+using Terraria.Localization;
 
 namespace ExampleMod.Common.GlobalTiles
 {
@@ -40,9 +43,12 @@ namespace ExampleMod.Common.GlobalTiles
 				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
 			}
 
-			// ModTree will always count a Forest tree.
-			// ModPalmTree will always count as Palm tree.
-			// To make things happen when your modded tree is shook, override ModTree.Shake(). See ExampleTree.
+			// Modded trees will be type ModTree or ModPalmTree.
+			// In this example, there is a 50% chance for ANY modded tree or modded palm tree to drop a Party Zombie at night.
+			if ((treeType == TreeTypes.ModTree || treeType == TreeTypes.ModPalmTree) && WorldGen.genRand.NextBool(2) && !Main.dayTime) {
+				NPC.NewNPCDirect(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, ModContent.NPCType<PartyZombie>());
+			}
+			// To make things happen when your modded tree is shook, override ModTree.Shake() instead. See ExampleTree.
 		}
 	}
 }

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -11,41 +11,41 @@ using ExampleMod.Content.Tiles;
 namespace ExampleMod.Common.GlobalTiles
 {
 	public class GlobalShakeTrees : GlobalTile {
-		// With this hook, we can make things happen when a tree is shook.
+		// With this hook, we can determine the item drop when a tree is shaken.
 		// See ExampleSourceDependentItemTweaks for another example for tree shaking.
-		public override void ShakeTree(int x, int y, TreeTypes treeType) {
-
-			// Normal forest trees have a 33% chance to drop an Example Item.
-			if (treeType == TreeTypes.Forest && WorldGen.genRand.NextBool(3)) {
+		public override bool ShakeTree(int x, int y, TreeTypes treeType) {
+			// Normal forest trees have a 5% chance to drop an Example Item.
+			if (treeType == TreeTypes.Forest && WorldGen.genRand.NextBool(20)) {
 				Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ModContent.ItemType<ExampleItem>());
+				// We return true to indicate that the primary item has dropped and prevent the game from attempting to drop other items.
+				return true;
 			}
 
 			// Glowing Mushroom trees have 10% chance to drop between 3 and 10 Mushroom Torches.
 			if (treeType == TreeTypes.Mushroom && WorldGen.genRand.NextBool(10)) {
 				Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ItemID.MushroomTorch, WorldGen.genRand.Next(3, 11));
+				return true;
 			}
 
 			// Snow (Boreal) trees have a 5% chance to spawn an Example Paper Airplane projectile that flies left or right.
 			// The owner of the projectile is set to Main.myPlayer which means the server owns the projectile in multiplayer.
 			if (treeType == TreeTypes.Snow && WorldGen.genRand.NextBool(20)) {
 				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-16, 16), 0f, ModContent.ProjectileType<ExamplePaperAirplaneProjectile>(), Damage: 4, KnockBack: 1f, Owner: Main.myPlayer);
+				return true;
 			}
 
 			// Jungle (Mahogany) trees have a 14% chance to spawn a Giant Flying Fox if located on the surface and in Hardmode.
 			// y == 0 is the top of the world, so y < Main.worldSurface is the area from the surface height to the top of the world.
 			if (treeType == TreeTypes.Jungle && WorldGen.genRand.NextBool(7) && y < Main.worldSurface && Main.hardMode) {
 				NPC.NewNPC(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, NPCID.GiantFlyingFox);
-			}
-
-			// In this example, there is 20% chance for any tree to shoot a hostile arrow downwards on No Traps and Get Fixed Boi worlds.
-			if (WorldGen.genRand.NextBool(5) && Main.noTrapsWorld) {
-				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
+				return true;
 			}
 
 			// Modded trees will be tree type Custom by default.
 			// In this example, there is a 50% chance for a modded tree to drop a Party Zombie at night.
 			if (treeType == TreeTypes.Custom && WorldGen.genRand.NextBool(2) && !Main.dayTime) {
 				NPC.NewNPC(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, ModContent.NPCType<PartyZombie>());
+				return true;
 			}
 
 			// In this example, we want to target Example Trees specifically. We don't want other modded trees such as Example Palm Tree.
@@ -54,10 +54,26 @@ namespace ExampleMod.Common.GlobalTiles
 				// If the block the tree is planted on is an Example Block, we know we have found an Example Tree.
 				if (Main.tile[baseX, baseY].TileType == ModContent.TileType<ExampleBlock>() && WorldGen.genRand.NextBool(2)) {
 					Item.NewItem(WorldGen.GetItemSource_FromTreeShake(x, y), x * 16, y * 16, 16, 16, ItemID.Coconut);
+					return true;
 				}
 			}
 
 			// To make things happen when your modded tree is shook, override ModTree.Shake() instead. See ExampleTree.
+			return false;
+		}
+
+		// With PreShakeTree we can spawn bonus items or prevent existing item drop options.
+		// These bonus drops will not replace the primary item drop choice.
+		public override void PreShakeTree(int x, int y, TreeTypes treeType) {
+			// In this example, there is 20% chance for any tree to shoot a hostile arrow downwards on No Traps and Get Fixed Boi worlds.
+			if (WorldGen.genRand.NextBool(5) && Main.noTrapsWorld) {
+				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
+			}
+
+			// This prevents acorns from dropping from normal forest trees during the night
+			if(treeType == TreeTypes.Forest && !Main.dayTime) {
+				NPCLoader.blockLoot.Add(ItemID.Acorn);
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -37,7 +37,7 @@ namespace ExampleMod.Common.GlobalTiles
 
 			// In this example, there is 20% chance for any tree to shoot a hostile arrow downwards on No Traps and Get Fixed Boi worlds.
 			if (WorldGen.genRand.NextBool(5) && Main.noTrapsWorld) {
-				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, (float)Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
+				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
 			}
 
 			// ModTree will always count a Forest tree.

--- a/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
+++ b/ExampleMod/Common/GlobalTiles/ShakeTrees.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Xna.Framework;
-using Terraria;
+﻿using Terraria;
 using Terraria.ID;
 using Terraria.Enums;
 using Terraria.ModLoader;
@@ -7,7 +6,6 @@ using Terraria.DataStructures;
 using ExampleMod.Content.Items;
 using ExampleMod.Content.Projectiles;
 using ExampleMod.Content.NPCs;
-using Terraria.Localization;
 
 namespace ExampleMod.Common.GlobalTiles
 {
@@ -43,10 +41,10 @@ namespace ExampleMod.Common.GlobalTiles
 				Projectile.NewProjectile(new EntitySource_ShakeTree(x, y), x * 16, y * 16, Main.rand.Next(-100, 101) * 0.002f, 8f, ProjectileID.WoodenArrowHostile, Damage: 10, KnockBack: 0f, Owner: Main.myPlayer);
 			}
 
-			// Modded trees will be type ModTree or ModPalmTree.
+			// Modded trees will be tree type ModTree or ModPalmTree.
 			// In this example, there is a 50% chance for ANY modded tree or modded palm tree to drop a Party Zombie at night.
 			if ((treeType == TreeTypes.ModTree || treeType == TreeTypes.ModPalmTree) && WorldGen.genRand.NextBool(2) && !Main.dayTime) {
-				NPC.NewNPCDirect(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, ModContent.NPCType<PartyZombie>());
+				NPC.NewNPC(WorldGen.GetNPCSource_ShakeTree(x, y), x * 16, y * 16, ModContent.NPCType<PartyZombie>());
 			}
 			// To make things happen when your modded tree is shook, override ModTree.Shake() instead. See ExampleTree.
 		}

--- a/patches/tModLoader/Terraria/Enums/TreeTypes.cs.patch
+++ b/patches/tModLoader/Terraria/Enums/TreeTypes.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/Enums/TreeTypes.cs
++++ src/tModLoader/Terraria/Enums/TreeTypes.cs
+@@ -14,5 +_,7 @@
+ 	PalmCrimson,
+ 	PalmCorrupt,
+ 	PalmHallowed,
+-	Ash
++	Ash,
++	ModTree,
++	ModPalmTree
+ }

--- a/patches/tModLoader/Terraria/Enums/TreeTypes.cs.patch
+++ b/patches/tModLoader/Terraria/Enums/TreeTypes.cs.patch
@@ -1,11 +1,10 @@
 --- src/TerrariaNetCore/Terraria/Enums/TreeTypes.cs
 +++ src/tModLoader/Terraria/Enums/TreeTypes.cs
-@@ -14,5 +_,7 @@
+@@ -14,5 +_,6 @@
  	PalmCrimson,
  	PalmCorrupt,
  	PalmHallowed,
 -	Ash
 +	Ash,
-+	ModTree,
-+	ModPalmTree
++	Custom // Added by TML
  }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -319,8 +319,7 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// <br>This hook runs when any tree is shook. This allows you to add drops when you shake trees.</br>
-	/// <br><see cref="TreeTypes.None"/> will not allow the tree to be shaken.</br>
+	/// This hook runs when any tree is shaken. This allows you to add drops when you shake trees.
 	/// </summary>
 	/// <param name="x">The x tile coordinate of the tree.</param>
 	/// <param name="y">The y tile coordinate of the top of the tree.</param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -319,13 +319,28 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// This hook runs when any tree is shaken. This allows you to add drops when you shake trees.
+	/// This hook runs before <see cref="ShakeTree(int, int, TreeTypes)"/> and is intended to be used to spawn bonus tree shaking drops and prevent existing drops using <see cref="NPCLoader.blockLoot"/>.
+	/// <para/> The tile coordinates provided indicates the leafy top of the tree where entities should be spawned.
+	/// <para/> Runs on the server or singleplayer.
 	/// </summary>
 	/// <param name="x">The x tile coordinate of the tree.</param>
 	/// <param name="y">The y tile coordinate of the top of the tree.</param>
 	/// <param name="treeType">The type of tree that is being shaken. Modded trees will be <see cref="TreeTypes.Custom"/> by default.</param>
-	public virtual void ShakeTree(int x, int y, TreeTypes treeType)
+	public virtual void PreShakeTree(int x, int y, TreeTypes treeType)
 	{
+	}
 
+	/// <summary>
+	/// This hook runs when any tree is shaken (See the <see href="https://terraria.wiki.gg/wiki/Trees#Shaking">Tree Shaking wiki page</see>). It is intended to be used to drop the primary item (or NPC). Use <see cref="PreShakeTree(int, int, TreeTypes)"/> to implement bonus drops instead, since this method isn't guaranteed to be called if another mod rolls an item drop.
+	/// <para/> If a drop happens, return true to signify that a primary drop has been spawned and to prevent other mods and vanilla code from also attempting to drop the primary item. When spawning the drop be sure to use <see cref="EntitySource_ShakeTree"/> as the source.
+	/// <para/> The tile coordinates provided indicates the leafy top of the tree where entities should be spawned.
+	/// <para/> Returns false by default. Runs on the server or singleplayer.
+	/// </summary>
+	/// <param name="x">The x tile coordinate of the tree.</param>
+	/// <param name="y">The y tile coordinate of the top of the tree.</param>
+	/// <param name="treeType">The type of tree that is being shaken. Modded trees will be <see cref="TreeTypes.Custom"/> by default.</param>
+	public virtual bool ShakeTree(int x, int y, TreeTypes treeType)
+	{
+		return false;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -319,11 +319,12 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// This hook runs when any tree is shook. This allows you to add drops when you shake trees.
+	/// <br>This hook runs when any tree is shook. This allows you to add drops when you shake trees.</br>
+	/// <br><see cref="TreeTypes.None"/> will not allow the tree to be shaken.</br>
 	/// </summary>
 	/// <param name="x">The x tile coordinate of the tree.</param>
 	/// <param name="y">The y tile coordinate of the top of the tree.</param>
-	/// <param name="treeType">The type of tree that is being shaken. Modded trees will be <see cref="TreeTypes.ModTree"/> or <see cref="TreeTypes.ModPalmTree"/></param>
+	/// <param name="treeType">The type of tree that is being shaken. Modded trees will be <see cref="TreeTypes.Custom"/> by default.</param>
 	public virtual void ShakeTree(int x, int y, TreeTypes treeType)
 	{
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -319,11 +319,11 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// Runs when any tree when it is shook. This allows you to add drops when you shake trees.
+	/// Runs when any tree is shook. This allows you to add drops when you shake trees.
 	/// </summary>
 	/// <param name="x">The x coordinate of the tree.</param>
-	/// <param name="y">The y coordinate of the tree.</param>
-	/// <param name="treeType">The type of tree that it is.</param>
+	/// <param name="y">The y coordinate of the top of the tree.</param>
+	/// <param name="treeType">The type of tree that it is. Modded trees will be <see cref="TreeTypes.ModTree"/> or <see cref="TreeTypes.ModPalmTree"/></param>
 	public virtual void ShakeTree(int x, int y, TreeTypes treeType)
 	{
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -319,11 +319,11 @@ public abstract class GlobalTile : GlobalBlockType
 	}
 
 	/// <summary>
-	/// Runs when any tree is shook. This allows you to add drops when you shake trees.
+	/// This hook runs when any tree is shook. This allows you to add drops when you shake trees.
 	/// </summary>
-	/// <param name="x">The x coordinate of the tree.</param>
-	/// <param name="y">The y coordinate of the top of the tree.</param>
-	/// <param name="treeType">The type of tree that it is. Modded trees will be <see cref="TreeTypes.ModTree"/> or <see cref="TreeTypes.ModPalmTree"/></param>
+	/// <param name="x">The x tile coordinate of the tree.</param>
+	/// <param name="y">The y tile coordinate of the top of the tree.</param>
+	/// <param name="treeType">The type of tree that is being shaken. Modded trees will be <see cref="TreeTypes.ModTree"/> or <see cref="TreeTypes.ModPalmTree"/></param>
 	public virtual void ShakeTree(int x, int y, TreeTypes treeType)
 	{
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using Terraria.DataStructures;
 using Terraria.ID;
+using Terraria.Enums;
 
 namespace Terraria.ModLoader;
 
@@ -315,5 +316,16 @@ public abstract class GlobalTile : GlobalBlockType
 	/// </summary>
 	public virtual void PostSetupTileMerge()
 	{
+	}
+
+	/// <summary>
+	/// Runs when any tree when it is shook. This allows you to add drops when you shake trees.
+	/// </summary>
+	/// <param name="x">The x coordinate of the tree.</param>
+	/// <param name="y">The y coordinate of the tree.</param>
+	/// <param name="treeType">The type of tree that it is.</param>
+	public virtual void ShakeTree(int x, int y, TreeTypes treeType)
+	{
+
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
@@ -180,7 +180,7 @@ public abstract class ModTree : ITree
 	/// <summary>
 	/// Used mostly for vanilla tree shake loot tables
 	/// </summary>
-	public virtual TreeTypes CountsAsTreeType => TreeTypes.Forest;
+	public virtual TreeTypes CountsAsTreeType => TreeTypes.ModTree;
 
 	/// <summary>
 	/// Return the type of dust created when this tree is destroyed. Returns 7 by default.
@@ -276,7 +276,7 @@ public abstract class ModPalmTree : ITree
 	/// <summary>
 	/// Used mostly for vanilla tree shake loot tables
 	/// </summary>
-	public virtual TreeTypes CountsAsTreeType => TreeTypes.Palm;
+	public virtual TreeTypes CountsAsTreeType => TreeTypes.ModPalmTree;
 
 	/// <summary>
 	/// Return the type of dust created when this palm tree is destroyed. Returns 215 by default.

--- a/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlants.cs
@@ -178,9 +178,10 @@ public abstract class ModTree : ITree
 	public abstract Asset<Texture2D> GetTexture();
 
 	/// <summary>
-	/// Used mostly for vanilla tree shake loot tables
+	/// <br>Used mostly for vanilla tree shake loot tables</br>
+	/// <br>Defaults to <see cref="TreeTypes.Custom"/>. Set to <see cref="TreeTypes.None"/> to prevent the tree from being able to be shaken.</br>
 	/// </summary>
-	public virtual TreeTypes CountsAsTreeType => TreeTypes.ModTree;
+	public virtual TreeTypes CountsAsTreeType => TreeTypes.Custom;
 
 	/// <summary>
 	/// Return the type of dust created when this tree is destroyed. Returns 7 by default.
@@ -274,9 +275,10 @@ public abstract class ModPalmTree : ITree
 	public abstract Asset<Texture2D> GetTexture();
 
 	/// <summary>
-	/// Used mostly for vanilla tree shake loot tables
+	/// <br>Used mostly for vanilla tree shake loot tables</br>
+	/// <br>Defaults to <see cref="TreeTypes.Custom"/>. Set to <see cref="TreeTypes.None"/> to prevent the tree from being able to be shaken.</br>
 	/// </summary>
-	public virtual TreeTypes CountsAsTreeType => TreeTypes.ModPalmTree;
+	public virtual TreeTypes CountsAsTreeType => TreeTypes.Custom;
 
 	/// <summary>
 	/// Return the type of dust created when this palm tree is destroyed. Returns 215 by default.

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -96,7 +96,8 @@ public static class TileLoader
 	private static DelegateChangeWaterfallStyle[] HookChangeWaterfallStyle;
 	private static Action<int, int, int, Item>[] HookPlaceInWorld;
 	private static Action[] HookPostSetupTileMerge;
-	private static Action<int, int, TreeTypes>[] HookShakeTree;
+	private static Action<int, int, TreeTypes>[] HookPreShakeTree;
+	private static Func<int, int, TreeTypes, bool>[] HookShakeTree;
 
 	internal static int ReserveTileID()
 	{
@@ -243,6 +244,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateChangeWaterfallStyle>(ref HookChangeWaterfallStyle, globalTiles, g => g.ChangeWaterfallStyle);
 		ModLoader.BuildGlobalHook(ref HookPlaceInWorld, globalTiles, g => g.PlaceInWorld);
 		ModLoader.BuildGlobalHook(ref HookPostSetupTileMerge, globalTiles, g => g.PostSetupTileMerge);
+		ModLoader.BuildGlobalHook(ref HookPreShakeTree, globalTiles, g => g.PreShakeTree);
 		ModLoader.BuildGlobalHook(ref HookShakeTree, globalTiles, g => g.ShakeTree);
 
 		if (!unloading) {
@@ -1243,10 +1245,16 @@ public static class TileLoader
 		}
 	}
 
-	public static void GlobalShakeTree(int x, int y, TreeTypes treeType)
+	public static bool GlobalShakeTree(int x, int y, TreeTypes treeType)
 	{
-		foreach (var hook in HookShakeTree) {
+		foreach (var hook in HookPreShakeTree) {
 			hook(x, y, treeType);
 		}
+
+		foreach (var hook in HookShakeTree) {
+			if (hook(x, y, treeType))
+				return true;
+		}
+		return false;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -14,6 +14,7 @@ using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.ObjectData;
 using static Terraria.GameContent.ItemDropRules.Conditions;
+using static Terraria.ModLoader.BackupIO;
 
 namespace Terraria.ModLoader;
 
@@ -96,6 +97,7 @@ public static class TileLoader
 	private static DelegateChangeWaterfallStyle[] HookChangeWaterfallStyle;
 	private static Action<int, int, int, Item>[] HookPlaceInWorld;
 	private static Action[] HookPostSetupTileMerge;
+	private static Action<int, int, TreeTypes>[] HookShakeTree;
 
 	internal static int ReserveTileID()
 	{
@@ -242,6 +244,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateChangeWaterfallStyle>(ref HookChangeWaterfallStyle, globalTiles, g => g.ChangeWaterfallStyle);
 		ModLoader.BuildGlobalHook(ref HookPlaceInWorld, globalTiles, g => g.PlaceInWorld);
 		ModLoader.BuildGlobalHook(ref HookPostSetupTileMerge, globalTiles, g => g.PostSetupTileMerge);
+		ModLoader.BuildGlobalHook(ref HookShakeTree, globalTiles, g => g.ShakeTree);
 
 		if (!unloading) {
 			loaded = true;
@@ -1238,6 +1241,13 @@ public static class TileLoader
 					tileTypeAndTileStyleToItemType.TryAdd((item.createTile, item.placeStyle), item.type);
 				}
 			}
+		}
+	}
+
+	public static void GlobalShakeTree(int x, int y, TreeTypes treeType)
+	{
+		foreach (var hook in HookShakeTree) {
+			hook(x, y, treeType);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -14,7 +14,6 @@ using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
 using Terraria.ObjectData;
 using static Terraria.GameContent.ItemDropRules.Conditions;
-using static Terraria.ModLoader.BackupIO;
 
 namespace Terraria.ModLoader;
 

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2437,10 +2437,12 @@
  		if (Main.getGoodWorld && genRand.Next(17) == 0) {
  			Projectile.NewProjectile(GetProjectileSource_ShakeTree(x, y), x * 16, y * 16, (float)Main.rand.Next(-100, 101) * 0.002f, 0f, 28, 0, 0f, Main.myPlayer, 16f, 16f);
  		}
-@@ -45310,11 +_,18 @@
+@@ -45310,11 +_,20 @@
  			Item.NewItem(Type: (genRand.Next(2) != 0) ? 5278 : 5277, source: GetItemSource_FromTreeShake(x, y), X: x * 16, Y: y * 16, Width: 16, Height: 16);
  		}
  
++		TileLoader.GlobalShakeTree(x, y, treeType);
++
 +		if (!createLeaves)
 +			return;
 +

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2428,11 +2428,13 @@
  		switch (tileType) {
  			case 2:
  			case 477:
-@@ -45086,6 +_,8 @@
+@@ -45086,6 +_,10 @@
  		if (!IsTileALeafyTreeTop(x, y) || Collision.SolidTiles(x - 2, x + 2, y - 2, y + 2))
  			return;
  
 +		bool createLeaves = true;
++
++		if (TileLoader.GlobalShakeTree(x, y, treeType)) { } else
 +		if (!PlantLoader.ShakeTree(x, y, Main.tile[x, num].type, ref createLeaves)) { } else
  		if (Main.getGoodWorld && genRand.Next(17) == 0) {
  			Projectile.NewProjectile(GetProjectileSource_ShakeTree(x, y), x * 16, y * 16, (float)Main.rand.Next(-100, 101) * 0.002f, 0f, 28, 0, 0f, Main.myPlayer, 16f, 16f);
@@ -2441,7 +2443,7 @@
  			Item.NewItem(Type: (genRand.Next(2) != 0) ? 5278 : 5277, source: GetItemSource_FromTreeShake(x, y), X: x * 16, Y: y * 16, Width: 16, Height: 16);
  		}
  
-+		TileLoader.GlobalShakeTree(x, y, treeType);
++		NPCLoader.blockLoot.Clear(); // Clear PreShakeTree values
 +
 +		if (!createLeaves)
 +			return;
@@ -2458,6 +2460,14 @@
  			if (Main.netMode == 2)
  				NetMessage.SendData(112, -1, -1, null, 1, x, y, 1f, passStyle);
  
+@@ -45336,6 +_,7 @@
+ 		}
+ 	}
+ 
++	/// <summary> If given a tree tile coordinate, will output the coordinates of the tree tile at the bottom of the tree. </summary>
+ 	public static void GetTreeBottom(int i, int j, out int x, out int y)
+ 	{
+ 		x = i;
 @@ -45397,6 +_,17 @@
  		fossilBreak = false;
  	}


### PR DESCRIPTION
### What is the new feature?

Implements #4413 : Tree shaking hook for vanilla trees. New hooks, `GlobalTile.PreShakeTree(int x, int y, TreeTypes treeType)` and `GlobalTile.ShakeTree(int x, int y, TreeTypes treeType)`, are added which run in `WorldGen.ShakeTree` before all of the vanilla drop logic. `PreShakeTree` is for bonus drops and blocking items while `ShakeTree` is for drops that follow the existing pattern of a primary item drop. 

Enum `TreeTypes` is also updated to include `Custom`. `ModTree`s no longer default to Forest trees and `ModPalmTree`s no longer default to Palm trees.

### Why should this be part of tModLoader?

As stated in the issue, making things happen when shaking a vanilla tree requires Detouring `WorldGen.ShakeTree` or IL edit `PlantLoader.ShakeTree`. The detour isn't that straight forward because it requires you to copy a lot of the checks that `ShakeTree` does and requires you to reflect a few fields which are private.

### Are there alternative designs?

* The hook could be incorporated into `PlantLoader` instead of `GlobalTile` as suggested in the issue.
* The names of everything, of course.
* The vanilla tree shaking system doesn't support Gem trees (and Bamboo and Cactus), which some people may want to add drops to. That is beyond the scope of this PR, though.

### Sample usage for the new feature

Showcase in `ExampleMod/Common/GlobalTiles/ShakeTrees.cs`

### ExampleMod updates

`GlobalShakeTrees` class showscases some uses for the new hook. It shows spawning items, projectiles, and NPCs.

### Short Summary

* New `GlobalTile.ShakeTree` hook to add drops when shaking trees.
* New `GlobalTile.PreShakeTree` hook to add bonus drops when shaking trees or prevent specific items from dropping.

### Porting Notes

* `ModTree` and `ModPalmTree` `CountsAsTreeType` now defaults to `TreeTypes.Custom` instead of `TreeTypes.Forest` and `TreeTypes.Palm` respectively. Adjust this back if that behavior was desired.
