### PR TITLE
ModCommand IsCaseSensitive property

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1634,7 +1634,7 @@
 +						Console.WriteLine(entry.Item1 + new string('\t', num2 - entry.Item1.Length / 8) + entry.Item2);
 +					}
  				}
-+				else if (CommandLoader.HandleCommand(text, commandCaller)) { }
++				else if (CommandLoader.HandleCommand(text2, commandCaller)) { }
  				else if (text == Language.GetTextValue("CLI.Settle_Command")) {
  					if (!Liquid.panicMode)
  						Liquid.StartPanic();

--- a/patches/tModLoader/Terraria/ModLoader/CommandLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/CommandLoader.cs
@@ -84,9 +84,8 @@ public static class CommandLoader
 
 	internal static bool HandleCommand(string input, CommandCaller caller)
 	{
-		var args = input.TrimEnd().Split(' ');
-		var name = args[0];
-		args = args.Skip(1).ToArray();
+		int sep = input.IndexOf(" ");
+		string name = (sep >= 0 ? input.Substring(0, sep) : input).ToLower();
 
 		if (caller.CommandType != CommandType.Console) {
 			if (name == "" || name[0] != '/')
@@ -100,6 +99,12 @@ public static class CommandLoader
 
 		if (mc == null)//error in command name (multiple commands or missing mod etc)
 			return true;
+
+		if (!mc.IsCaseSensitive)
+			input = input.ToLower();
+
+		var args = input.TrimEnd().Split(' ');
+		args = args.Skip(1).ToArray();
 
 		try {
 			mc.Action(caller, input, args);

--- a/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModCommand.cs
@@ -49,6 +49,8 @@ public abstract class ModCommand : ModType
 	public virtual string Usage => "/" + Command;
 	/// <summary>A short description of this command.</summary>
 	public virtual string Description => "";
+	///<summary>If false (default), the arguments to <see cref="Action"/> will be provided as lowercase.</summary>
+	public virtual bool IsCaseSensitive => false;
 
 	protected override sealed void Register()
 	{


### PR DESCRIPTION
When creating a ModCommand, the input passed into the Action method is lower-cased, making case-sensitive operations impossible. A new property, `ModCommand.IsCaseSensitive` has been added to disable this behaviour.

Command names themselves remain case insensitive.

### What is the bug?
Text that is passed into the `CommandLoader.HandleCommand` method are lower-cased internally by Terraria.

### How did you fix the bug?
Change the argument passed into `HandleCommand` from `text` to `text2` for server console commands
`text` performs a `ToLower()`. `text2` is a copy of text before it lower-cased.

Rewrote `CommandLoader.HandleCommand` to lowercase the arguments only if `!mc.IsCaseSensitive`

### Are there alternatives to your fix?
We could leave casing to the implementors of each `ModCommand.Action`, but this would be a breaking change and force unnecessary work on the majority of command implementors.