### PR TITLE
Update documentation of ModifyDamage hooks to clarify they should not include side effects

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -315,7 +315,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, etc., that an NPC does to a player.
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="target"></param>
@@ -359,7 +359,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC does to a friendly NPC.
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="target"></param>
@@ -408,8 +408,8 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC takes from a melee weapon. 
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
-	/// Runs on the local client. <br/>
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
+	/// <para/> Runs on the local client.
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="player"></param>
@@ -444,7 +444,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC takes from a projectile.
-  	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="projectile"></param>
@@ -466,7 +466,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to use a custom damage formula for when an NPC takes damage from any source. For example, you can change the way defense works or use a different crit multiplier.
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="modifiers"></param>

--- a/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalNPC.cs
@@ -315,6 +315,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, etc., that an NPC does to a player.
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="target"></param>
@@ -358,6 +359,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC does to a friendly NPC.
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="target"></param>
@@ -405,7 +407,8 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 	}
 
 	/// <summary>
-	/// Allows you to modify the damage, knockback, etc., that an NPC takes from a melee weapon. <br/>
+	/// Allows you to modify the damage, knockback, etc., that an NPC takes from a melee weapon. 
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
 	/// Runs on the local client. <br/>
 	/// </summary>
 	/// <param name="npc"></param>
@@ -441,6 +444,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that an NPC takes from a projectile.
+  	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="projectile"></param>
@@ -462,6 +466,7 @@ public abstract class GlobalNPC : GlobalType<NPC, GlobalNPC>
 
 	/// <summary>
 	/// Allows you to use a custom damage formula for when an NPC takes damage from any source. For example, you can change the way defense works or use a different crit multiplier.
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
 	/// </summary>
 	/// <param name="npc"></param>
 	/// <param name="modifiers"></param>

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -418,8 +418,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to modify the damage, etc., that this NPC does to a player. 
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
-	/// Runs on the local client. <br/>
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
+	/// <para/> Runs on the local client.
 	/// </summary>
 	/// <param name="target"></param>
 	/// <param name="modifiers"></param>
@@ -459,8 +459,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that this NPC does to a friendly NPC. 
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
-	/// Runs in single player or on the server. <br/>
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
+	/// <para/> Runs in single player or on the server.
 	/// </summary>
 	/// <param name="target"></param>
 	/// <param name="modifiers"></param>
@@ -506,8 +506,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that this NPC takes from a melee weapon. 
-    /// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
-	/// Runs on the local client. <br/>
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
+	/// <para/> Runs on the local client.
 	/// </summary>
 	/// <param name="player"></param>
 	/// <param name="item"></param>
@@ -540,8 +540,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that this NPC takes from a projectile. This method is only called for the owner of the projectile, meaning that in multi-player, projectiles owned by a player call this method on that client, and projectiles owned by the server such as enemy projectiles call this method on the server.
-	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
- 	/// </summary>
+	/// <para/> This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
+	/// </summary>
 	/// <param name="projectile"></param>
 	/// <param name="modifiers"></param>
 	public virtual void ModifyHitByProjectile(Projectile projectile, ref NPC.HitModifiers modifiers)
@@ -560,7 +560,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to use a custom damage formula for when this NPC takes damage from any source. For example, you can change the way defense works or use a different crit multiplier.
- 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+	/// This hook should be used ONLY to modify properties of the HitModifiers. Any extra side effects should occur in OnHit hooks instead.
 	/// </summary>
 	/// <param name="modifiers"></param>
 	public virtual void ModifyIncomingHit(ref NPC.HitModifiers modifiers)

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -417,7 +417,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to modify the damage, etc., that this NPC does to a player. <br/>
+	/// Allows you to modify the damage, etc., that this NPC does to a player. 
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
 	/// Runs on the local client. <br/>
 	/// </summary>
 	/// <param name="target"></param>
@@ -457,7 +458,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to modify the damage, knockback, etc., that this NPC does to a friendly NPC. <br/>
+	/// Allows you to modify the damage, knockback, etc., that this NPC does to a friendly NPC. 
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
 	/// Runs in single player or on the server. <br/>
 	/// </summary>
 	/// <param name="target"></param>
@@ -503,7 +505,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	}
 
 	/// <summary>
-	/// Allows you to modify the damage, knockback, etc., that this NPC takes from a melee weapon. <br/>
+	/// Allows you to modify the damage, knockback, etc., that this NPC takes from a melee weapon. 
+    /// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks! <br/>
 	/// Runs on the local client. <br/>
 	/// </summary>
 	/// <param name="player"></param>
@@ -537,7 +540,8 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to modify the damage, knockback, etc., that this NPC takes from a projectile. This method is only called for the owner of the projectile, meaning that in multi-player, projectiles owned by a player call this method on that client, and projectiles owned by the server such as enemy projectiles call this method on the server.
-	/// </summary>
+	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
+ 	/// </summary>
 	/// <param name="projectile"></param>
 	/// <param name="modifiers"></param>
 	public virtual void ModifyHitByProjectile(Projectile projectile, ref NPC.HitModifiers modifiers)
@@ -556,6 +560,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 
 	/// <summary>
 	/// Allows you to use a custom damage formula for when this NPC takes damage from any source. For example, you can change the way defense works or use a different crit multiplier.
+ 	/// This hook should be used ONLY to modify properties of the HitModifiers, any extra effects should occur in OnHit hooks!
 	/// </summary>
 	/// <param name="modifiers"></param>
 	public virtual void ModifyIncomingHit(ref NPC.HitModifiers modifiers)


### PR DESCRIPTION
### What is the new feature?
XML comments have been updated to clarify modify hooks should not contain side effects, and they should instead occur in OnHit hooks.

### Why should this be part of tModLoader?
Mods may wish to do simulation hits against NPCs to calculate things such as armor penetration or estimated hit damage. Doing this requires calling the modify methods. If side effects occur in those hooks, those will also be called creating bugs.

### Are there alternative designs?
Much more complicated reworks to NPCs to make everything taken into account in damage calculations stats, which would likely also be a functionality reduction. Alternatively a few select stats which might be desireable to calculate such as defense could be exposed?

### Sample usage for the new feature
N/A

### ExampleMod updates
N/A

