### PR TITLE
Fix various ProjectileLoader/NPCLoader.ReceiveExtraAI exception messages, optimize message size, and reorder modded and global bytes in message

### DIFF
--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -269,7 +269,7 @@
  					item4.position = position3;
  					item4.velocity = velocity3;
  					item4.active = true;
-@@ -1419,11 +_,18 @@
+@@ -1419,11 +_,16 @@
  				if (num158 == 668)
  					NPC.deerclopsBoss = num155;
  
@@ -278,10 +278,8 @@
  					nPC5.releaseOwner = reader.ReadByte();
  
 +				// Extra AI is read into a temporary buffer for parity with ProjectileLoader code, and to avoid exceptions causing underreads.
-+				byte[] extraAI = bitsByte12[3] ? NPCLoader.ReadExtraAI(reader) : null;
-+				if (extraAI != null) {
-+					NPCLoader.ReceiveExtraAI(nPC5, extraAI);
-+				}
++				if (bitsByte12[3])
++					NPCLoader.ReceiveExtraAI(nPC5, NPCLoader.ReadExtraAI(reader));
 +
  				break;
  			}

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -269,7 +269,7 @@
  					item4.position = position3;
  					item4.velocity = velocity3;
  					item4.active = true;
-@@ -1419,11 +_,15 @@
+@@ -1419,11 +_,18 @@
  				if (num158 == 668)
  					NPC.deerclopsBoss = num155;
  
@@ -278,7 +278,10 @@
  					nPC5.releaseOwner = reader.ReadByte();
  
 +				// Extra AI is read into a temporary buffer for parity with ProjectileLoader code, and to avoid exceptions causing underreads.
-+				NPCLoader.ReceiveExtraAI(nPC5, NPCLoader.ReadExtraAI(reader));
++				byte[] extraAI = bitsByte12[3] ? NPCLoader.ReadExtraAI(reader) : null;
++				if (extraAI != null) {
++					NPCLoader.ReceiveExtraAI(nPC5, extraAI);
++				}
 +
  				break;
  			}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -354,18 +354,19 @@ public static class NPCLoader
 
 	public static byte[] WriteExtraAI(NPC npc)
 	{
+		// Data is ordered as follows: GlobalProjectile BitWriter, ModProjectile Bytes, GlobalProjectile Bytes
 		using var stream = new MemoryStream();
 		using var modWriter = new BinaryWriter(stream);
 
-		npc.ModNPC?.SendExtraAI(modWriter);
-
 		using var bufferedStream = new MemoryStream();
-		using var globalWriter = new BinaryWriter(bufferedStream);
+		using var binaryWriter = new BinaryWriter(bufferedStream);
 
 		BitWriter bitWriter = new BitWriter();
 
+		npc.ModNPC?.SendExtraAI(binaryWriter);
+
 		foreach (var g in HookSendExtraAI.Enumerate(npc)) {
-			g.SendExtraAI(npc, bitWriter, globalWriter);
+			g.SendExtraAI(npc, bitWriter, binaryWriter);
 		}
 	
 		bitWriter.Flush(modWriter);
@@ -394,9 +395,10 @@ public static class NPCLoader
 
 		GlobalNPC lastGlobalNPC = null;
 		try {
-			npc.ModNPC?.ReceiveExtraAI(modReader);
-
 			BitReader bitReader = new BitReader(modReader);
+
+			var bitReaderEnd = stream.Position;
+			npc.ModNPC?.ReceiveExtraAI(modReader);
 
 			foreach (var g in HookReceiveExtraAI.Enumerate(npc)) {
 				lastGlobalNPC = g;
@@ -408,15 +410,7 @@ public static class NPCLoader
 			}
 
 			if (stream.Position < stream.Length) {
-				// Calculate original length of Read7BitEncodedInt
-				int bitReaderOverhead = 1;
-				int temp = bitReader.MaxBits;
-				while (temp > 0x7Fu) {
-					bitReaderOverhead++;
-					temp >>= 7;
-				}
-				var bytesLength = stream.Length - (int)Math.Ceiling(bitReader.MaxBits / 8f) - bitReaderOverhead;
-				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
+				throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length - bitReaderEnd} bytes in ReceiveExtraAI, more info below");
 			}
 		}
 		catch (Exception) {

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -370,7 +370,9 @@ public static class NPCLoader
 		bitWriter.Flush(modWriter);
 		modWriter.Write(bufferedStream.ToArray());
 
-		return stream.ToArray();
+		byte[] bytes = stream.ToArray();
+		// If the only byte is the bitWriter.Flush length byte, no extra data.
+		return bytes.Length == 1 && bytes[0] == 0 ? null : bytes;
 	}
 
 	public static byte[] ReadExtraAI(BinaryReader reader)

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -17,6 +17,7 @@ using Terraria.ModLoader.Utilities;
 using HookList = Terraria.ModLoader.Core.GlobalHookList<Terraria.ModLoader.GlobalNPC>;
 using Terraria.ModLoader.IO;
 using Terraria.GameContent.Personalities;
+using System.Diagnostics;
 
 namespace Terraria.ModLoader;
 
@@ -366,13 +367,17 @@ public static class NPCLoader
 		foreach (var g in HookSendExtraAI.Enumerate(npc)) {
 			g.SendExtraAI(npc, bitWriter, globalWriter);
 		}
-
+	
 		bitWriter.Flush(modWriter);
 		modWriter.Write(bufferedStream.ToArray());
 
 		byte[] bytes = stream.ToArray();
 		// If the only byte is the bitWriter.Flush length byte, no extra data.
-		return bytes.Length == 1 && bytes[0] == 0 ? null : bytes;
+		if (bytes.Length == 1) {
+			Debug.Assert(bytes[0] == 0);
+			return null;
+		}
+		return bytes;
 	}
 
 	public static byte[] ReadExtraAI(BinaryReader reader)
@@ -387,14 +392,14 @@ public static class NPCLoader
 		using var stream = extraAI.ToMemoryStream();
 		using var modReader = new BinaryReader(stream);
 
-		npc.ModNPC?.ReceiveExtraAI(modReader);
-
-		BitReader bitReader = new BitReader(modReader);
-
-		bool anyGlobals = false;
+		GlobalNPC lastGlobalNPC = null;
 		try {
+			npc.ModNPC?.ReceiveExtraAI(modReader);
+
+			BitReader bitReader = new BitReader(modReader);
+
 			foreach (var g in HookReceiveExtraAI.Enumerate(npc)) {
-				anyGlobals = true;
+				lastGlobalNPC = g;
 				g.ReceiveExtraAI(npc, bitReader, modReader);
 			}
 
@@ -414,16 +419,18 @@ public static class NPCLoader
 				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
 			}
 		}
-		catch (Exception e) {
+		catch (Exception) {
 			string message = $"Error in ReceiveExtraAI for NPC {npc.ModNPC?.FullName ?? npc.TypeName}";
-			if (anyGlobals) {
+			if (lastGlobalNPC != null) {
 				message += ", may be caused by one of these GlobalNPCs:";
 				foreach (var g in HookReceiveExtraAI.Enumerate(npc)) {
 					message += $"\n\t{g.FullName}";
+					if (lastGlobalNPC == g)
+						break;
 				}
 			}
 
-			Logging.tML.Error(message, e);
+			Logging.tML.Error(message);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -401,7 +401,15 @@ public static class NPCLoader
 			}
 
 			if (stream.Position < stream.Length) {
-				throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length} bytes in ReceiveExtraAI, more info below");
+				// Calculate original length of Read7BitEncodedInt
+				int bitReaderOverhead = 1;
+				int temp = bitReader.MaxBits;
+				while (temp > 0x7Fu) {
+					bitReaderOverhead++;
+					temp >>= 7;
+				}
+				var bytesLength = stream.Length - (int)Math.Ceiling(bitReader.MaxBits / 8f) - bitReaderOverhead;
+				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
 			}
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -208,18 +208,19 @@ public static class ProjectileLoader
 
 	public static byte[] WriteExtraAI(Projectile projectile)
 	{
+		// Data is ordered as follows: GlobalProjectile BitWriter, ModProjectile Bytes, GlobalProjectile Bytes
 		using var stream = new MemoryStream();
 		using var modWriter = new BinaryWriter(stream);
 
-		projectile.ModProjectile?.SendExtraAI(modWriter);
-
 		using var bufferedStream = new MemoryStream();
-		using var globalWriter = new BinaryWriter(bufferedStream);
+		using var binaryWriter = new BinaryWriter(bufferedStream);
 
 		BitWriter bitWriter = new BitWriter();
 
+		projectile.ModProjectile?.SendExtraAI(binaryWriter);
+
 		foreach (var g in HookSendExtraAI.Enumerate(projectile)) {
-			g.SendExtraAI(projectile, bitWriter, globalWriter);
+			g.SendExtraAI(projectile, bitWriter, binaryWriter);
 		}
 
 		bitWriter.Flush(modWriter);
@@ -248,9 +249,10 @@ public static class ProjectileLoader
 
 		GlobalProjectile lastGlobalProjectile = null;
 		try {
-			projectile.ModProjectile?.ReceiveExtraAI(modReader);
-
 			BitReader bitReader = new BitReader(modReader);
+
+			var bitReaderEnd = stream.Position;
+			projectile.ModProjectile?.ReceiveExtraAI(modReader);
 
 			foreach (var g in HookReceiveExtraAI.Enumerate(projectile)) {
 				lastGlobalProjectile = g;
@@ -262,18 +264,10 @@ public static class ProjectileLoader
 			}
 
 			if (stream.Position < stream.Length) {
-				// Calculate original length of Read7BitEncodedInt
-				int bitReaderOverhead = 1;
-				int temp = bitReader.MaxBits;
-				while (temp > 0x7Fu) {
-					bitReaderOverhead++;
-					temp >>= 7;
-				}
-				var bytesLength = stream.Length - (int)Math.Ceiling(bitReader.MaxBits / 8f) - bitReaderOverhead;
-				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
+				throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length - bitReaderEnd} bytes in ReceiveExtraAI, more info below");
 			}
 		}
-		catch (Exception) {
+		catch (Exception e) {
 			string message = $"Error in ReceiveExtraAI for Projectile {projectile.ModProjectile?.FullName ?? projectile.Name}";
 			if (lastGlobalProjectile != null) {
 				message += ", may be caused by one of these GlobalProjectiles:";

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -254,7 +254,15 @@ public static class ProjectileLoader
 			}
 
 			if (stream.Position < stream.Length) {
-				throw new IOException($"Read underflow {stream.Length - stream.Position} of {stream.Length} bytes in ReceiveExtraAI, more info below");
+				// Calculate original length of Read7BitEncodedInt
+				int bitReaderOverhead = 1;
+				int temp = bitReader.MaxBits;
+				while (temp > 0x7Fu) {
+					bitReaderOverhead++;
+					temp >>= 7;
+				}
+				var bytesLength = stream.Length - (int)Math.Ceiling(bitReader.MaxBits / 8f) - bitReaderOverhead;
+				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
 			}
 		}
 		catch (IOException e) {

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -224,7 +224,9 @@ public static class ProjectileLoader
 		bitWriter.Flush(modWriter);
 		modWriter.Write(bufferedStream.ToArray());
 
-		return stream.ToArray();
+		byte[] bytes = stream.ToArray();
+		// If the only byte is the bitWriter.Flush length byte, no extra data.
+		return bytes.Length == 1 && bytes[0] == 0 ? null : bytes;
 	}
 
 	public static byte[] ReadExtraAI(BinaryReader reader)

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -226,7 +227,11 @@ public static class ProjectileLoader
 
 		byte[] bytes = stream.ToArray();
 		// If the only byte is the bitWriter.Flush length byte, no extra data.
-		return bytes.Length == 1 && bytes[0] == 0 ? null : bytes;
+		if (bytes.Length == 1) {
+			Debug.Assert(bytes[0] == 0);
+			return null;
+		}
+		return bytes;
 	}
 
 	public static byte[] ReadExtraAI(BinaryReader reader)
@@ -241,14 +246,14 @@ public static class ProjectileLoader
 		using var stream = extraAI.ToMemoryStream();
 		using var modReader = new BinaryReader(stream);
 
-		projectile.ModProjectile?.ReceiveExtraAI(modReader);
-
-		BitReader bitReader = new BitReader(modReader);
-
-		bool anyGlobals = false;
+		GlobalProjectile lastGlobalProjectile = null;
 		try {
+			projectile.ModProjectile?.ReceiveExtraAI(modReader);
+
+			BitReader bitReader = new BitReader(modReader);
+
 			foreach (var g in HookReceiveExtraAI.Enumerate(projectile)) {
-				anyGlobals = true;
+				lastGlobalProjectile = g;
 				g.ReceiveExtraAI(projectile, bitReader, modReader);
 			}
 
@@ -268,16 +273,18 @@ public static class ProjectileLoader
 				throw new IOException($"Read underflow {stream.Length - stream.Position} of {bytesLength} bytes in ReceiveExtraAI, more info below");
 			}
 		}
-		catch (IOException e) {
+		catch (Exception) {
 			string message = $"Error in ReceiveExtraAI for Projectile {projectile.ModProjectile?.FullName ?? projectile.Name}";
-			if (anyGlobals) {
+			if (lastGlobalProjectile != null) {
 				message += ", may be caused by one of these GlobalProjectiles:";
 				foreach (var g in HookReceiveExtraAI.Enumerate(projectile)) {
 					message += $"\n\t{g.FullName}";
+					if (lastGlobalProjectile == g)
+						break;
 				}
 			}
 
-			Logging.tML.Error(message, e);
+			Logging.tML.Error(message);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -246,6 +246,7 @@ public static class ProjectileLoader
 		bool anyGlobals = false;
 		try {
 			foreach (var g in HookReceiveExtraAI.Enumerate(projectile)) {
+				anyGlobals = true;
 				g.ReceiveExtraAI(projectile, bitReader, modReader);
 			}
 
@@ -268,11 +269,13 @@ public static class ProjectileLoader
 		catch (IOException e) {
 			string message = $"Error in ReceiveExtraAI for Projectile {projectile.ModProjectile?.FullName ?? projectile.Name}";
 			if (anyGlobals) {
-				message += ", may be caused by one of these GlobalNPCs:";
+				message += ", may be caused by one of these GlobalProjectiles:";
 				foreach (var g in HookReceiveExtraAI.Enumerate(projectile)) {
 					message += $"\n\t{g.FullName}";
 				}
 			}
+
+			Logging.tML.Error(message, e);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -111,7 +111,19 @@
  					break;
  				}
  				case 22:
-@@ -636,9 +_,11 @@
+@@ -602,6 +_,11 @@
+ 					bitsByte4[0] = nPC2.statsAreScaledForThisManyPlayers > 1;
+ 					bitsByte4[1] = nPC2.SpawnedFromStatue;
+ 					bitsByte4[2] = nPC2.strengthMultiplier != 1f;
++
++					byte[] extraAI = NPCLoader.WriteExtraAI(nPC2);
++					bool hasExtraAI = extraAI?.Length > 0;
++					bitsByte4[3] = hasExtraAI; // This bit is unused by vanilla
++
+ 					writer.Write(bitsByte4);
+ 					for (int m = 0; m < NPC.maxAI; m++) {
+ 						if (array[m])
+@@ -636,9 +_,13 @@
  						}
  					}
  
@@ -119,7 +131,9 @@
 +					if (nPC2.type >= 0 && Main.npcCatchable[nPC2.type])
  						writer.Write((byte)nPC2.releaseOwner);
  
-+					NPCLoader.SendExtraAI(writer, NPCLoader.WriteExtraAI(nPC2));
++					if (hasExtraAI) {
++						NPCLoader.SendExtraAI(writer, extraAI);
++					}
 +
  					break;
  				}


### PR DESCRIPTION
This PR fixes various issues with Projectile and NPC network syncing.

## Fix ReceiveExtraAI exception reported byte length messages
The current exception messages are misleading. For example, when sending 100 bits and 3 bytes, but reading 100 bits and 1 byte, the error should say that 2 of 3 bytes were unread, but the way it is currently doesn't take into account the `BitReader` length overhead or the `BitReader` bytes.
Old
`Read underflow 2 of 17 bytes in ReceiveExtraAI`
Fixed
`Read underflow 2 of 3 bytes in ReceiveExtraAI`

(There are 17 bytes total, but only 3 are pertaining to the error. 1 byte for BitReader length, 13 bytes to read 100 bits, and 3 bytes of actual data.)

Similarly, if just sending bytes and no bits, the `BitReader` length still requires a byte and is still not taken into account. Here is sending 10 bytes but reading 5:

Old
`Read underflow 5 of 11 bytes in ReceiveExtraAI`
Fixed
`Read underflow 5 of 10 bytes in ReceiveExtraAI`

## Fix "may be caused by one of these GlobalProjectile" hint
For some reason, the `ProjectileLoader.ReceiveExtraAI` code did not report `GlobalProjectile` classes as potential sources of the sync exception as `NPCLoader.ReceiveExtraAI` does. The code has been updated to match and `GlobalProjectile` classes will be mentioned in exception logs as expected now.

In addition, the last GlobalProjectile/NPC accessed during the ReceiveExtraAI enumeration is tracked so that the listing of the potential cause of an exception is limited to just the Global classes that were actually called. 

The exception message previously was logged twice, so the duplicate logging of the exception was removed.

### Fix #3275, WriteExtraAI can now properly send 0 bytes of modded data
Due to `BitWriter.Flush` writing the bit length, code intended to skip sending modded Projectile/NPC data did not work. Data was always sent even if the ModProjectile/NPC and all GlobalProjectile/NPC did not write any bytes or bits. 

Code has been added to check if no real data is being sent and `hasExtraAI` bools now work correctly to limit sending this extra data. `SyncNPC` message code did not originally have a `hasExtraAI` check, likely due to some legacy consideration such as all available bits in the existing message being used already. There are unused bits now so this has been implemented.

### Reorder WriteExtraAI to make underflow exceptions more reliable
Finally, the order of the bytes and bits has been changed to simplify the code and make the exception messages more reliable. The old order was `ModProjectile Bytes, GlobalProjectile BitWriter, GlobalProjectile Bytes, new order is `GlobalProjectile BitWriter, ModProjectile Bytes, GlobalProjectile Bytes`. (both for Projectile and NPC.) 

The old order meant that an error in reading `ModProjectile` bytes would make the error reporting for `BitReader.MaxBits` inaccurate. It would potentially mislead a modder.

# Porting Notes
No effort by modders should be required. 