### PR TITLE
description_workshop generates by default when creating mods

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "Du kannst keinen Mod der in einer Beta-Version von tModLoader erstellt wurde veröffentlichen",
 		// "ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		// "ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		// "ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		// "ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		"OutdatedModCantPublishError": "Du kannst keinen Mod der in einer alten tModLoader Version erstellt wurde veröffentlichen",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "You cannot publish a Mod built on a beta version of tModLoader",
 		"ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		"ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		"ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		"ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		"ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		"ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		"OutdatedModCantPublishError": "You cannot publish a Mod built on an old version of tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "No puedes publicar un mod basado en una versión beta de tModLoader",
 		// "ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		// "ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		// "ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		// "ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		"OutdatedModCantPublishError": "No puedes publicar un mod creado para una versión antigua de tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "Vous ne pouvez pas publier un Mod compilé en version Beta de tModLoader",
 		// "ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		// "ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		// "ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		// "ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		"OutdatedModCantPublishError": "Vous ne pouvez pas publier un Mod compilé avec une version obsolète de tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -77,6 +77,8 @@
 		// "BetaModCantPublishError": "You cannot publish a Mod built on a beta version of tModLoader",
 		// "ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		// "ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		// "ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		// "ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		// "OutdatedModCantPublishError": "You cannot publish a Mod built on an old version of tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "Nie możesz opublikować moda zbudowanego na wersji beta tModLoadera",
 		"ModDescriptionMissing": "Plik {0} nie istnieje. Utwórz poprawny opis swojego moda.",
 		"ModDescriptionLengthTooShort": "Opis moda jest za krótki, proszę utwórz poprawny opis w {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		"ModWorkshopIconResizeWarning": "Zostanie zmieniony rozmiar z {0} na {1}.",
 		"ModUsesDefaultIcon": "Proszę utworzyć własną ikonę dla swojego moda, modyfikując {0}.",
 		"OutdatedModCantPublishError": "Nie możesz opublikować moda zbudowanego na starszej wersji tModLoadera",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "Você não pode publicar um mod construído em uma versão beta do tModLoader",
 		"ModDescriptionMissing": "O arquivo {0} não existe. Certifique-se de que haja uma descrição válida para seu mod.",
 		"ModDescriptionLengthTooShort": "A descrição do mod é muito curta. Crie uma descrição válida para seu mod modificando o arquivo {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		"ModWorkshopIconResizeWarning": "Será redimensionado de {0} para {1}.",
 		"ModUsesDefaultIcon": "Crie um ícone personalizado para seu mod modificando o arquivo {0}.",
 		"OutdatedModCantPublishError": "Você não pode publicar um mod construído em uma versão antiga do tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -75,6 +75,8 @@
 		"BetaModCantPublishError": "Вы не можете опубликовать мод, собранный на бета-версии tModLoader",
 		"ModDescriptionMissing": "Файл {0} отсутствует. Пожалуйста, добавьте корректное описание для вашего мода.",
 		"ModDescriptionLengthTooShort": "Описание мода слишком короткое. Пожалуйста, отредактируйте файл {0}, чтобы указать корректное описание.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		"ModWorkshopIconResizeWarning": "Размер иконки будет изменён с {0} на {1}.",
 		"ModUsesDefaultIcon": "Пожалуйста, создайте собственную иконку для мода, отредактировав файл {0}.",
 		"OutdatedModCantPublishError": "Вы не можете опубликовать мод, собранный на устаревшей версии tModLoader",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -77,6 +77,8 @@
 		"BetaModCantPublishError": "你无法发布基于测试版本tModLoader的模组",
 		// "ModDescriptionMissing": "The file {0} doesn't exist. Please create a valid description for your mod.",
 		// "ModDescriptionLengthTooShort": "Mod description is too short, please create a valid description for your mod by modifying {0}.",
+		// "ModDescriptionInvalid": "Mod description is equal to or too similar to the description template, please create a valid description for your mod by modifying {0}.",
+		// "ModWorkshopDescriptionInvalid": "Workshop description is equal to or too similar to the description template, please create a valid description for your workshop page by modifying {0}. You can also delete {0} if you wish to use {1} as the description of your workshop page.",
 		// "ModWorkshopIconResizeWarning": "Will be resized from {0} to {1}.",
 		// "ModUsesDefaultIcon": "Please create a custom icon for your mod by modifying {0}.",
 		"OutdatedModCantPublishError": "你无法发布基于旧版本tModLoader的模组",

--- a/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop.txt
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop.txt
@@ -1,8 +1,1 @@
-Modify this file with a description of your mod, this will show up on the Steam Workshop page when you publish the mod.
-
-You may delete this file if you want the Workshop page to use the exact same description as the one in description.txt
-[list]
-	[*] Steam Workshop pages allow for more flexible formatting, 
-	[*] [h1]check out https://steamcommunity.com/comment/Guide/formattinghelp for a list of formatting options[/h1]
-[/list]
-
+This description will show up on the steam page, check out https://steamcommunity.com/comment/Guide/formattinghelp.

--- a/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop.txt
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop.txt
@@ -1,0 +1,8 @@
+Modify this file with a description of your mod, this will show up on the Steam Workshop page when you publish the mod.
+
+You may delete this file if you want the Workshop page to use the exact same description as the one in description.txt
+[list]
+	[*] Steam Workshop pages allow for more flexible formatting, 
+	[*] [h1]check out https://steamcommunity.com/comment/Guide/formattinghelp for a list of formatting options[/h1]
+[/list]
+

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 9
-ru-RU 2
-pt-BR 3
-pl-PL 4
-it-IT 952
-fr-FR 567
-es-ES 376
-de-DE 377
+zh-Hans 11
+ru-RU 4
+pt-BR 5
+pl-PL 6
+it-IT 954
+fr-FR 569
+es-ES 378
+de-DE 379


### PR DESCRIPTION
### What is the new feature?
Added a `description_workshop.txt` with an example description to the Templates folder. 
Upon creating a new mod, tModLoader would automatically add said file to the mod's folder.

### Why should this be part of tModLoader?
A lot of modders (myself included up until a few days ago) are completely unaware of the existence of the `description_workshop.txt` file. Having it automatically generate would help these modders realize that they can separate the description for the workshop page and that of the in-game page.

This would also prevent cases where updating a mod that lacks a `description_workshop.txt` would completely reset its workshop page to use the `description.txt` even if the prior version had a different description written through the steam interface (something that has happened to me)

### Are there alternative designs?
I don't think so? Maybe allowing modders to write base descriptions right from the mod creation menu but that's an entirely different thing.

### ExampleMod
ExampleMod already contains a `description_workshop.txt`, which further proves that this should be a thing by default as well.