### PR TITLE
Added `MusicID.Sets.SkipsVolumeRemap[]`

### DIFF
--- a/patches/tModLoader/Terraria/Audio/ASoundEffectBasedAudioTrack.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/ASoundEffectBasedAudioTrack.cs.patch
@@ -1,0 +1,13 @@
+--- src/TerrariaNetCore/Terraria/Audio/ASoundEffectBasedAudioTrack.cs
++++ src/tModLoader/Terraria/Audio/ASoundEffectBasedAudioTrack.cs
+@@ -80,6 +_,10 @@
+ 				_soundEffectInstance.Volume = volume;
+ 				break;
+ 			}
++			case "VolumeDirect": {
++				_soundEffectInstance.Volume = value;
++				break;
++			}
+ 			case "Pitch":
+ 				_soundEffectInstance.Pitch = value;
+ 				break;

--- a/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
@@ -1,9 +1,13 @@
 --- src/TerrariaNetCore/Terraria/Audio/LegacyAudioSystem.cs
 +++ src/tModLoader/Terraria/Audio/LegacyAudioSystem.cs
-@@ -4,6 +_,7 @@
+@@ -2,8 +_,11 @@
+ using System.Collections;
+ using System.Collections.Generic;
  using System.IO;
++using System.Linq;
  using Microsoft.Xna.Framework.Audio;
  using ReLogic.Content.Sources;
++using Terraria.ID;
 +using Terraria.ModLoader.Engine;
  
  namespace Terraria.Audio;
@@ -59,7 +63,26 @@
  	public void LoadCue(int cueIndex, string cueName)
  	{
  		CueAudioTrack cueAudioTrack = new CueAudioTrack(SoundBank, cueName);
-@@ -256,7 +_,8 @@
+@@ -245,18 +_,25 @@
+ 					MusicReplayDelay = Main.rand.Next(14400, 21601);
+ 
+ 				AudioTracks[i].Reuse();
++				if (MusicID.Sets.SkipsVolumeRemap[i])
++					AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
++				else
+-				AudioTracks[i].SetVariable("Volume", totalVolume);
++					AudioTracks[i].SetVariable("Volume", totalVolume);
+ 				AudioTracks[i].Play();
+ 			}
+ 		}
+ 		else {
++			if (MusicID.Sets.SkipsVolumeRemap[i])
++				AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
++			else
+-			AudioTracks[i].SetVariable("Volume", totalVolume);
++				AudioTracks[i].SetVariable("Volume", totalVolume);
+ 		}
+ 	}
  
  	public void UpdateCommonTrackTowardStopping(int i, float totalVolume, ref float tempFade, bool isMainTrackAudible)
  	{
@@ -69,3 +92,15 @@
  			return;
  
  		if (AudioTracks[i].IsPlaying || !AudioTracks[i].IsStopped) {
+@@ -271,7 +_,10 @@
+ 				AudioTracks[i].Stop(AudioStopOptions.Immediate);
+ 			}
+ 			else {
++				if (MusicID.Sets.SkipsVolumeRemap[i])
++					AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
++				else
+-				AudioTracks[i].SetVariable("Volume", totalVolume);
++					AudioTracks[i].SetVariable("Volume", totalVolume);
+ 			}
+ 		}
+ 		else {

--- a/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
@@ -63,24 +63,18 @@
  	public void LoadCue(int cueIndex, string cueName)
  	{
  		CueAudioTrack cueAudioTrack = new CueAudioTrack(SoundBank, cueName);
-@@ -245,18 +_,25 @@
+@@ -245,18 +_,19 @@
  					MusicReplayDelay = Main.rand.Next(14400, 21601);
  
  				AudioTracks[i].Reuse();
-+				if (MusicID.Sets.SkipsVolumeRemap[i])
-+					AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
-+				else
 -				AudioTracks[i].SetVariable("Volume", totalVolume);
-+					AudioTracks[i].SetVariable("Volume", totalVolume);
++				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", totalVolume);
  				AudioTracks[i].Play();
  			}
  		}
  		else {
-+			if (MusicID.Sets.SkipsVolumeRemap[i])
-+				AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
-+			else
 -			AudioTracks[i].SetVariable("Volume", totalVolume);
-+				AudioTracks[i].SetVariable("Volume", totalVolume);
++			AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", totalVolume);
  		}
  	}
  
@@ -92,15 +86,12 @@
  			return;
  
  		if (AudioTracks[i].IsPlaying || !AudioTracks[i].IsStopped) {
-@@ -271,7 +_,10 @@
+@@ -271,7 +_,7 @@
  				AudioTracks[i].Stop(AudioStopOptions.Immediate);
  			}
  			else {
-+				if (MusicID.Sets.SkipsVolumeRemap[i])
-+					AudioTracks[i].SetVariable("VolumeDirect", totalVolume);
-+				else
 -				AudioTracks[i].SetVariable("Volume", totalVolume);
-+					AudioTracks[i].SetVariable("Volume", totalVolume);
++				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect"  : "Volume", totalVolume);
  			}
  		}
  		else {

--- a/patches/tModLoader/Terraria/ID/MusicID.cs
+++ b/patches/tModLoader/Terraria/ID/MusicID.cs
@@ -1,9 +1,20 @@
 using System;
+using Terraria.ModLoader;
 
 namespace Terraria.ID;
 
 public static class MusicID
 {
+
+	public static partial class Sets
+	{
+		public static SetFactory Factory = new SetFactory(MusicLoader.MusicCount);
+		/// <summary>
+		/// Skips Terraria's <see cref="Terraria.Audio.ASoundEffectBasedAudioTrack.ReMapVolumeToMatchXact(float)"/> function to make music play at its intended volume.
+		/// <para/>This should be set in <see cref="ModType.SetStaticDefaults()"/>, preferably <see cref="ModSystem"/>
+		/// </summary>
+		public static bool[] SkipsVolumeRemap = Factory.CreateBoolSet(false);
+	}
 	// Names derived from the music box that plays each: https://terraria.wiki.gg/wiki/Music_Box
 	public const short OverworldDay = 1;
 	public const short Eerie = 2;

--- a/patches/tModLoader/Terraria/ID/MusicID.cs
+++ b/patches/tModLoader/Terraria/ID/MusicID.cs
@@ -5,7 +5,6 @@ namespace Terraria.ID;
 
 public static class MusicID
 {
-
 	public static partial class Sets
 	{
 		public static SetFactory Factory = new SetFactory(MusicLoader.MusicCount);

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -66,6 +66,10 @@ public partial class Mod
 	/// </summary>
 	public bool MusicAutoloadingEnabled { get; init; } = true;
 	/// <summary>
+	/// Whether or not all music loaded by this mod will automatically have <see cref="MusicID.Sets.SkipsVolumeRemap"/> set to true.
+	/// </summary>
+	public bool MusicSkipsVolumeRemap { get; init; } = false;
+	/// <summary>
 	/// Whether or not this mod will automatically add images in the "Backgrounds" folder as background textures to the game. This means you do not need to manually call <see cref="BackgroundTextureLoader.AddBackgroundTexture(Mod, string)"/>.
 	/// </summary>
 	public bool BackgroundAutoloadingEnabled { get; init; } = true;

--- a/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
@@ -229,6 +229,10 @@ public sealed class MusicLoader : ILoader
 		if (Main.audioSystem is not LegacyAudioSystem legacyAudioSystem)
 			return;
 
+		//Sets
+		LoaderUtils.ResetStaticMembers(typeof(MusicID));
+
+		//Etc
 		Array.Resize(ref legacyAudioSystem.AudioTracks, MusicCount);
 		Array.Resize(ref Main.musicFade, MusicCount);
 		Array.Resize(ref Main.musicNoCrossFade, MusicCount);

--- a/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MusicLoader.cs
@@ -21,6 +21,7 @@ public sealed class MusicLoader : ILoader
 	internal static readonly Dictionary<int, Dictionary<int, int>> tileToMusic = new();
 	internal static readonly Dictionary<string, int> musicByPath = new();
 	internal static readonly Dictionary<string, string> musicExtensions = new();
+	internal static readonly Dictionary<int, bool> musicSkipsVolumeRemap = new();
 
 	public static int MusicCount { get; private set; } = MusicID.Count;
 
@@ -94,6 +95,7 @@ public sealed class MusicLoader : ILoader
 
 		musicByPath[musicPath] = id;
 		musicExtensions[musicPath] = chosenExtension;
+		musicSkipsVolumeRemap[id] = mod.MusicSkipsVolumeRemap;
 	}
 
 	/// <summary>
@@ -244,6 +246,7 @@ public sealed class MusicLoader : ILoader
 				return;
 
 			legacyAudioSystem.AudioTracks[slot] = GetMusic(sound);
+			MusicID.Sets.SkipsVolumeRemap[slot] = musicSkipsVolumeRemap[slot];
 		}
 
 		Main.audioSystem = legacyAudioSystem;
@@ -256,6 +259,7 @@ public sealed class MusicLoader : ILoader
 		tileToMusic.Clear();
 		musicByPath.Clear();
 		musicExtensions.Clear();
+		musicSkipsVolumeRemap.Clear();
 		MusicCount = MusicID.Count;
 	}
 }


### PR DESCRIPTION
(KEEPS THE OLD BEHAVIOR AS DEFAULT)
### What is the new feature?
Resolves #2649
Adds a new flag to Music IDs to skip `ASoundEffectBasedAudioTrack.ReMapVolumeToMatchXact()`, a function that more or less halves music volume.

### Why should this be part of tModLoader?
Many modders and players have [reported](https://github.com/tModLoader/tModLoader/issues/2649) that tModLoader very clearly makes modded music quieter than their files. 
This is a fix to that while still keeping the old behavior as the default, letting old mod music stay at its current volume and not become too loud after updating if the modders don't adjust it.

### Are there alternative designs?
Not sure, this seems intuitive enough and it's an entirely optional change

### Sample usage for the new feature
Fixing quiet music

To selectively specify music to use the non-remapped volume setting:
```cs
public class MusicSystem : ModSystem {
	public override void SetStaticDefaults() {
		MusicID.Sets.SkipsVolumeRemap[MusicLoader.GetMusicSlot(Mod, "Assets/Music/MySong")] = true;
	}
}
```

Another option is to set the flag for the whole mod:
```cs
public ExampleMod() {
	MusicSkipsVolumeRemap = true;
}
```

# Porting notes
- If you want to use the new feature, either apply `Mod.MusicSkipsVolumeRemap` or `MusicID.Sets.SkipsVolumeRemap` code.
- You'll need to export or convert your music once again while undoing the volume adjustments made to the music files to work around the old behavior. 