### PR TITLE
Fix #4531 , add TileCounterType.CustomSolid/NonSolid support for AddSpecialDraw

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/MinionBossRelic.cs
+++ b/ExampleMod/Content/Tiles/Furniture/MinionBossRelic.cs
@@ -81,21 +81,15 @@ namespace ExampleMod.Content.Tiles.Furniture
 			// Therefore we register the top-left of the tile as a "special point"
 			// This allows us to draw things in SpecialDraw
 			if (drawData.tileFrameX % FrameWidth == 0 && drawData.tileFrameY % FrameHeight == 0) {
-				Main.instance.TilesRenderer.AddSpecialLegacyPoint(i, j);
+				Main.instance.TilesRenderer.AddSpecialPoint(i, j, Terraria.GameContent.Drawing.TileDrawing.TileCounterType.CustomNonSolid);
 			}
 		}
 
 		public override void SpecialDraw(int i, int j, SpriteBatch spriteBatch) {
-			// This is lighting-mode specific, always include this if you draw tiles manually
-			Vector2 offScreen = new Vector2(Main.offScreenRange);
-			if (Main.drawToScreen) {
-				offScreen = Vector2.Zero;
-			}
-
 			// Take the tile, check if it actually exists
 			Point p = new Point(i, j);
 			Tile tile = Main.tile[p.X, p.Y];
-			if (tile == null || !tile.HasTile) {
+			if (!tile.HasTile) {
 				return;
 			}
 
@@ -116,7 +110,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			// Some math magic to make it smoothly move up and down over time
 			const float TwoPi = (float)Math.PI * 2f;
 			float offset = (float)Math.Sin(Main.GlobalTimeWrappedHourly * TwoPi / 5f);
-			Vector2 drawPos = worldPos + offScreen - Main.screenPosition + new Vector2(0f, -40f) + new Vector2(0f, offset * 4f);
+			Vector2 drawPos = worldPos - Main.screenPosition + new Vector2(0f, -40f) + new Vector2(0f, offset * 4f);
 
 			// Draw the main texture
 			spriteBatch.Draw(texture, drawPos, frame, color, 0f, origin, 1f, effects, 0f);

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
@@ -1,3 +1,8 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using Terraria.ModLoader;
+
 namespace Terraria.GameContent.Drawing;
 
 public partial class TileDrawing
@@ -15,5 +20,24 @@ public partial class TileDrawing
 	{
 		Tile tile = Main.tile[tileX, tileY];
 		return IsTileDangerous(tileX, tileY, player, tile, tile.type);
+	}
+
+	private void DrawCustom(bool solidLayer)
+	{
+		if (solidLayer) {
+			Main.spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, Main.DefaultSamplerState, DepthStencilState.None, Main.Rasterizer, null, Main.Transform);
+		}
+
+		int index = (int)(solidLayer ? TileCounterType.CustomSolid : TileCounterType.CustomNonSolid);
+		int specialCount = _specialsCount[index];
+		for (int i = 0; i < specialCount; i++) {
+			Point p = _specialPositions[index][i];
+			Tile tile = Main.tile[p.X, p.Y];
+			TileLoader.SpecialDraw(tile.TileType, p.X, p.Y, Main.spriteBatch);
+		}
+
+		if (solidLayer) {
+			Main.spriteBatch.End();
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -495,9 +495,9 @@
  
 +	/// <summary>
 +	/// Registers a tile coordinate to have additional drawing code executed after all tiles are drawn. <see cref="ModTile.SpecialDraw"/> (or <see cref="GlobalTile.SpecialDraw(int, int, int, SpriteBatch)"/>) will be called with the same coordinates after all tiles have been rendered. For multitiles, make sure to only call this for the top left corner of the multitile to prevent duplicate draws by checking <see cref="TileObjectData.IsTopLeft(int, int)"/> first. This should be called in <see cref="ModTile.DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/> (or <see cref="GlobalTile.DrawEffects(int, int, int, SpriteBatch, ref TileDrawInfo)"/>)
-+	/// <para/> This is useful for drawing additional visuals to a tile, especially visuals that might render outside the bounds of a single Tile. Attempting to draw outside the bounds will not work in normal tile drawing methods because the visuals will be overwritten by the next tile drawn. 
++	/// <para/> This is useful for drawing additional visuals which overlap multiple tiles.
 +	/// <para/> Some examples include how the <see cref="TileID.LihzahrdAltar"/> draws a sun texture hovering over the tile and how <see cref="TileID.ItemFrame"/> draws the contained item sprite over the tile.
-+	/// <para/> This additional drawing will draw to the tile rendering targets, meaning it will render at 15fps and requires adjusting for <see cref="Main.offScreenRange"/>. For a smoother animations <see cref="AddSpecialPoint(int, int, TileCounterType)"/> can be used with <see cref="TileCounterType.CustomSolid"/> or CustomNonSolid to render at full frame rate.
++	/// <para/> This additional drawing will draw to the tile rendering targets, meaning it will render at 15fps and requires adjusting for <see cref="Main.offScreenRange"/>. As mentioned in <see cref="ModTile.AnimateTile(ref int, ref int)"/>, any animation done using this method should stick to animating at multiples of 4 frames to avoid jerky animation. For smoother animations <see cref="AddSpecialPoint(int, int, TileCounterType)"/> can be used with <see cref="TileCounterType.CustomSolid"/> or CustomNonSolid to render at full frame rate.
 +	/// </summary>
 -	private void AddSpecialLegacyPoint(int x, int y)
 +	public void AddSpecialLegacyPoint(int x, int y)

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/GameContent/Drawing/TileDrawing.cs
 +++ src/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs
-@@ -11,25 +_,31 @@
+@@ -11,29 +_,39 @@
  using Terraria.Graphics;
  using Terraria.Graphics.Capture;
  using Terraria.ID;
@@ -34,13 +34,33 @@
  		ReverseVine,
  		TeleportationPylon,
  		MasterTrophy,
-@@ -114,7 +_,11 @@
+ 		AnyDirectionalGrass,
++		/// <summary> Will cause <see cref="ModTile.SpecialDraw(int, int, SpriteBatch)"/> to be called. </summary>
++		CustomNonSolid,
++		/// <summary> Will cause <see cref="ModTile.SpecialDraw(int, int, SpriteBatch)"/> to be called. </summary>
++		CustomSolid,
+ 		Count
+ 	}
+ 
+@@ -56,8 +_,8 @@
+ 	private const float FORCE_FOR_MIN_WIND = 0.08f;
+ 	private const float FORCE_FOR_MAX_WIND = 1.2f;
+ 	private int _leafFrequency = 100000;
+-	private int[] _specialsCount = new int[13];
++	private int[] _specialsCount = new int[(int)TileCounterType.Count];
+-	private Point[][] _specialPositions = new Point[13][];
++	private Point[][] _specialPositions = new Point[(int)TileCounterType.Count][];
+ 	private Dictionary<Point, int> _displayDollTileEntityPositions = new Dictionary<Point, int>();
+ 	private Dictionary<Point, int> _hatRackTileEntityPositions = new Dictionary<Point, int>();
+ 	private Dictionary<Point, int> _trainingDummyTileEntityPositions = new Dictionary<Point, int>();
+@@ -114,7 +_,12 @@
  
  	private Gore[] _gore => Main.gore;
  
 +	/// <summary>
 +	/// Registers a tile coordinate to use custom drawing code corresponding to the <see cref="TileCounterType"/> provided. This is mostly used to apply wind and player interaction effects to tiles.
-+	/// <para/> For multitiles, make sure to only call this for the top left corner of the multitile to prevent duplicate draws by checking <see cref="TileObjectData.IsTopLeft(int, int)"/> first. This should be called in <c>ModTile.PreDraw</c> (or <c>GlobalTile.PreDraw</c>) and false should be returned to prevent the default tile drawing.
++	/// <para/> For multitiles, make sure to only call this for the top left corner of the multitile to prevent duplicate draws by checking <see cref="TileObjectData.IsTopLeft(int, int)"/> first. This should be called in <c>ModTile.PreDraw</c> (or <c>GlobalTile.PreDraw</c>) and false should be returned to prevent the default tile drawing. It can also be called in <see cref="ModTile.DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/> as well.
++	/// <para/> When <see cref="TileCounterType.CustomNonSolid"/> or <see cref="TileCounterType.CustomSolid"/> is used, <see cref="ModTile.SpecialDraw(int, int, SpriteBatch)"/> will be called to allow custom rendering. Compared to using <see cref="AddSpecialLegacyPoint(int, int)"/>, SpecialDraw will be called at 60fps rather than 15fps, the sampler state will default to PointClamp instead of LinearClamp, and adjusting for <see cref="Main.offScreenRange"/> is no longer necessary because the render target is the screen rather than the tile render targets.
 +	/// </summary>
 -	private void AddSpecialPoint(int x, int y, TileCounterType type)
 +	public void AddSpecialPoint(int x, int y, TileCounterType type)
@@ -101,6 +121,32 @@
  				TilePaintSystemV2.TreeFoliageVariantKey treeFoliageVariantKey = default(TilePaintSystemV2.TreeFoliageVariantKey);
  				treeFoliageVariantKey.TextureIndex = textureIndex;
  				treeFoliageVariantKey.PaintColor = tile.color();
+@@ -321,7 +_,10 @@
+ 			_specialsCount[9] = 0;
+ 			_specialsCount[10] = 0;
+ 			_specialsCount[11] = 0;
++			_specialsCount[(int)TileCounterType.CustomNonSolid] = 0;
+ 		}
++		if(solidLayer && flag)
++			_specialsCount[(int)TileCounterType.CustomSolid] = 0;
+ 	}
+ 
+ 	public void PostDrawTiles(bool solidLayer, bool forRenderTargets, bool intoRenderTargets)
+@@ -338,12 +_,14 @@
+ 			DrawTrees();
+ 			DrawVines();
+ 			DrawReverseVines();
++			DrawCustom(solidLayer);
+ 			Main.spriteBatch.End();
+ 		}
+ 
+ 		if (solidLayer && !intoRenderTargets) {
+ 			DrawEntities_HatRacks();
+ 			DrawEntities_DisplayDolls();
++			DrawCustom(solidLayer);
+ 		}
+ 	}
+ 
 @@ -396,8 +_,10 @@
  		byte b = (byte)(100f + 150f * Main.martianLight);
  		_martianGlow = new Color(b, b, b, 0);
@@ -424,7 +470,7 @@
  	{
  		int num = x - tileFrameX / 18;
  		int num2 = y - tileFrameY / 18;
-@@ -4922,18 +_,35 @@
+@@ -4922,18 +_,36 @@
  		if (solidLayer) {
  			_displayDollTileEntityPositions.Clear();
  			_hatRackTileEntityPositions.Clear();
@@ -450,7 +496,8 @@
 +	/// <summary>
 +	/// Registers a tile coordinate to have additional drawing code executed after all tiles are drawn. <see cref="ModTile.SpecialDraw"/> (or <see cref="GlobalTile.SpecialDraw(int, int, int, SpriteBatch)"/>) will be called with the same coordinates after all tiles have been rendered. For multitiles, make sure to only call this for the top left corner of the multitile to prevent duplicate draws by checking <see cref="TileObjectData.IsTopLeft(int, int)"/> first. This should be called in <see cref="ModTile.DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/> (or <see cref="GlobalTile.DrawEffects(int, int, int, SpriteBatch, ref TileDrawInfo)"/>)
 +	/// <para/> This is useful for drawing additional visuals to a tile, especially visuals that might render outside the bounds of a single Tile. Attempting to draw outside the bounds will not work in normal tile drawing methods because the visuals will be overwritten by the next tile drawn. 
-+	/// <para/> Some examples include how the <see cref="TileID.LihzahrdAltar"/> draws a sun texture hovering over the tile and how <see cref="TileID.ItemFrame"/> draws the contained item sprite over the tile. 
++	/// <para/> Some examples include how the <see cref="TileID.LihzahrdAltar"/> draws a sun texture hovering over the tile and how <see cref="TileID.ItemFrame"/> draws the contained item sprite over the tile.
++	/// <para/> This additional drawing will draw to the tile rendering targets, meaning it will render at 15fps and requires adjusting for <see cref="Main.offScreenRange"/>. For a smoother animations <see cref="AddSpecialPoint(int, int, TileCounterType)"/> can be used with <see cref="TileCounterType.CustomSolid"/> or CustomNonSolid to render at full frame rate.
 +	/// </summary>
 -	private void AddSpecialLegacyPoint(int x, int y)
 +	public void AddSpecialLegacyPoint(int x, int y)

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -384,6 +384,7 @@ public abstract class ModTile : ModBlockType
 	///}</code>
 	///	or, to mimic another tile, simply:
 	///	<code>frame = Main.tileFrame[TileID.FireflyinaBottle];</code></example>
+	///	<para/> <b>Note:</b> For the smoothest animation, <paramref name="frameCounter"/> should count up to a multiple of 4 before advancing the <paramref name="frame"/> value. This is because tiles are rendered every 4 game draws but this method is called every game update. Values that aren't multiples of 4 would result in some frames drawing for twice as long as the next animation frame, resulting in jerky animation. Similarly, attempting to change frames at intervals shorter than 4 will result in skipped animation frames.
 	/// </summary>
 	public virtual void AnimateTile(ref int frame, ref int frameCounter)
 	{
@@ -404,7 +405,7 @@ public abstract class ModTile : ModBlockType
 
 	/// <summary>
 	/// Allows you to make stuff happen whenever the tile at the given coordinates is drawn. For example, creating dust or changing the color the tile is drawn in.
-	/// SpecialDraw will only be called if coordinates are added using Main.instance.TilesRenderer.AddSpecialLegacyPoint here.
+	/// <para/> Can also be used to register this tile location for additional rendering after all tiles are drawn normally. <see cref="SpecialDraw(int, int, SpriteBatch)"/> will be called if coordinates are added using <c>Main.instance.TilesRenderer.AddSpecialLegacyPoint</c> or <c>Main.instance.TilesRenderer.AddSpecialPoint(i, j, TileCounterType.CustomNonSolid or CustomSolid)</c> here or in <see cref="ModBlockType.PreDraw(int, int, SpriteBatch)"/>.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
@@ -415,7 +416,7 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Special Draw. Only called if coordinates are added using <c>Main.instance.TilesRenderer.AddSpecialLegacyPoint</c> during <see cref="DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/>. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
+	/// Special Draw. Allows for additional rendering after all tiles are drawn normally. Only called if coordinates are added using <c>Main.instance.TilesRenderer.AddSpecialLegacyPoint</c> or <c>Main.instance.TilesRenderer.AddSpecialPoint(i, j, TileCounterType.CustomNonSolid or CustomSolid)</c> during <see cref="DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/> or <see cref="ModBlockType.PreDraw(int, int, SpriteBatch)"/>. Useful for drawing things that would otherwise be impossible to draw due to draw order, such as items in item frames.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>


### PR DESCRIPTION
### What is the bug?
As mentioned in #4531, the example relic tile, `MinionBossRelic`, did not match the vanilla visuals exactly. The reason for this is because of 2 things, the sampler state being `LinearClamp` instead of `PointClamp` and the rendering happening at a lower frame rate due to how tiles are typically rendered.

This video shows the vanilla and modded relics with their animations at 10x speed. You can see how the modded relic is rendering at a much slower frame rate. If you look closely you can also see how the modded relic sometimes renders interpolated pixels, giving it a blurry visual.

https://github.com/user-attachments/assets/b9267a1d-a511-49ef-a4a7-b31cba7811ff

### How did you fix the bug?
`Main.instance.TilesRenderer.AddSpecialPoint` was augmented to support custom modded rendering. This will call `ModTile.SpecialDraw` similar to `AddSpecialLegacyPoint`, but instead will render to the screen at 60fps rather than to the tile render target at 15fps. By default the sprite batch will also have `PointClamp` by default in this situation.

This video shows toggling between the fixed and unfixed behaviors.

https://github.com/user-attachments/assets/59c445b7-aa88-4697-be23-4061f8a22082

This does not just apply to relics, but to any custom tile rendering a mod might desire. Having `AddSpecialPoint` support means less IL edits or detours for those who found the previous approach lacking.

### Are there alternatives to your fix?
One option is to not use `SpecialDraw` since it is already used by `AddSpecialLegacyPoint`. This would require a separate `SpecialDraw2` or similar method. The argument for this is the code modders would use in each case does have slight differences, specifically `Main.offScreenRange` and the `MatrixTransform` used in `SpriteBatch.Begin` if the modder is restarting the sprite batch. The argument against is it would just complicate things. 

One other consideration is a modder using both `AddSpecialLegacyPoint` and `AddSpecialPoint` on the same tile. I'm not sure why this would be useful, but it might be difficult to do that and determine which code path to take in `SpecialDraw`.

# Porting Notes
Modders wishing to fix relic tiles specifically can just follow the changes shown in `MinionBossRelic.cs` for this PR.

More generally, modders using `AddSpecialLegacyPoint` that would prefer the effect rendered with a smoother animation can make the following changes:

- Use `AddSpecialPoint` with `CustomNonSolid` or `CustomSolid` instead of `AddSpecialLegacyPoint`, depending on if the tile is `Main.tileSolid` (or TileID.Sets.DrawTileInSolidLayer) or not.
```diff
-Main.instance.TilesRenderer.AddSpecialLegacyPoint(i, j);
+Main.instance.TilesRenderer.AddSpecialPoint(i, j, Terraria.GameContent.Drawing.TileDrawing.TileCounterType.CustomNonSolid);
```
- Adjust `SpecialDraw` code to no longer care about `Main.offScreenRange`. It should also use `Main.Transform` instead of `Matrix.Identity` if calling `SpriteBatch.Begin`.

Finally, this PR updates the documentation for `ModTile.AnimateTile` to mention that tiles should animate using frame counts that are multiples of 4 for the smoothest animation due to how often the game renders tiles. We recommend modders revisit their animated tiles and ensure that tile animation is happening using frame counts that are multiples of 4 for tiles that want to avoid jerky animation.

To visualize the issue, here is the sequence of frames rendered when using a frame counter of 5 to animate 6 frames of tile animation. Note how some tile frames are repeated for multiple game renders.
![image](https://github.com/user-attachments/assets/236083ab-1e18-47ff-baa7-17e3231c17f9)
