### PR TITLE
[Feature] Enable developer features for local mods built from outside of "Mod Sources" folder

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
@@ -58,7 +58,7 @@ public class WorkshopPublishInfoStateForMods : AWorkshopPublishInfoState<TmodFil
 
 		if (Main.MenuUI.CurrentState?.GetType() != typeof(UIReportsPage)) {
 			// Copy the used preview image to the mod's source directory if it's not a resize and if one isn't there already.
-			string iconWorkshopPath = Path.Combine(ModCompile.ModSourcePath, _dataObject.Name, "icon_workshop.png");
+			string iconWorkshopPath = Path.Combine(ModCompile.GetModSource(_dataObject), "icon_workshop.png");
 			if (_previewImagePath != iconWorkshopPath && !resizedPreviewImage && !File.Exists(iconWorkshopPath)) {
 				try {
 					File.Copy(_previewImagePath, iconWorkshopPath, overwrite: true);

--- a/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
@@ -59,7 +59,7 @@ public class WorkshopPublishInfoStateForMods : AWorkshopPublishInfoState<TmodFil
 
 		if (Main.MenuUI.CurrentState?.GetType() != typeof(UIReportsPage)) {
 			// Copy the used preview image to the mod's source directory if it's not a resize and if one isn't there already.
-			string iconWorkshopPath = Path.Combine(BuildProperties.ReadModFile(_dataObject).modSource, "icon_workshop.png");
+			string iconWorkshopPath = Path.Combine(_buildData["sourcesfolder"], "icon_workshop.png");
 			if (_previewImagePath != iconWorkshopPath && !resizedPreviewImage && !File.Exists(iconWorkshopPath)) {
 				try {
 					File.Copy(_previewImagePath, iconWorkshopPath, overwrite: true);

--- a/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
@@ -9,6 +9,7 @@ using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader;
 using Terraria.ModLoader.Core;
 using Terraria.Social;
 using Terraria.Social.Base;
@@ -58,7 +59,7 @@ public class WorkshopPublishInfoStateForMods : AWorkshopPublishInfoState<TmodFil
 
 		if (Main.MenuUI.CurrentState?.GetType() != typeof(UIReportsPage)) {
 			// Copy the used preview image to the mod's source directory if it's not a resize and if one isn't there already.
-			string iconWorkshopPath = Path.Combine(ModCompile.GetModSource(_dataObject), "icon_workshop.png");
+			string iconWorkshopPath = Path.Combine(BuildProperties.ReadModFile(_dataObject).modSource, "icon_workshop.png");
 			if (_previewImagePath != iconWorkshopPath && !resizedPreviewImage && !File.Exists(iconWorkshopPath)) {
 				try {
 					File.Copy(_previewImagePath, iconWorkshopPath, overwrite: true);

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -210,9 +210,7 @@ public static class AssemblyManager
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
-
-			if (Directory.Exists(mod.properties.modSource))
-				m.SourceFolder = mod.properties.modSource;
+			m.SourceFolder = Directory.Exists(mod.properties.modSource) ? mod.properties.modSource : "";
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -209,7 +209,8 @@ public static class AssemblyManager
 			m.Side = mod.properties.side;
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
-			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null; 
+			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
+			m.SourceFolder = mod.properties.modSource;
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -210,7 +210,9 @@ public static class AssemblyManager
 			m.DisplayName = mod.properties.displayName;
 			m.TModLoaderVersion = mod.properties.buildVersion;
 			m.TranslationForMods = mod.properties.translationMod ? mod.properties.RefNames(true).ToList() : null;
-			m.SourceFolder = mod.properties.modSource;
+
+			if (Directory.Exists(mod.properties.modSource))
+				m.SourceFolder = mod.properties.modSource;
 			return m;
 		}
 		catch (Exception e) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/BuildProperties.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/BuildProperties.cs
@@ -67,6 +67,7 @@ internal class BuildProperties
 	internal ModSide side;
 	internal bool playableOnPreview = true;
 	internal bool translationMod = false;
+	internal string modSource = "";
 
 	public IEnumerable<ModReference> Refs(bool includeWeak) =>
 		includeWeak ? modReferences.Concat(weakReferences) : modReferences;
@@ -263,6 +264,10 @@ internal class BuildProperties
 					writer.Write("side");
 					writer.Write((byte)side);
 				}
+				if (modSource.Length > 0) {
+					writer.Write("modSource");
+					writer.Write(modSource);
+				}
 
 				writer.Write("buildVersion");
 				writer.Write(buildVersion.ToString());
@@ -343,6 +348,9 @@ internal class BuildProperties
 				}
 				if (tag == "buildVersion") {
 					properties.buildVersion = new Version(reader.ReadString());
+				}
+				if (tag == "modSource") {
+					properties.modSource = reader.ReadString();
 				}
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -56,23 +56,27 @@ internal class ModCompile
 
 	internal static string[] FindModSources()
 	{
-		Directory.CreateDirectory(ModSourcePath);
-		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
-			var directory = new DirectoryInfo(dir);
-			return directory.Name[0] != '.' && directory.Name != "ModAssemblies" && directory.Name != "Mod Libraries";
-		});
+		var modSources = new List<string>();
+
+		// Find any mod sources defined in the ModSources directory.
+		if (Directory.Exists(ModSourcePath)) {
+			modSources.AddRange(Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
+				var directory = new DirectoryInfo(dir);
+				return directory.Name[0] != '.' && directory.Name != "ModAssemblies" && directory.Name != "Mod Libraries";
+			}));
+		}
 
 		// Find mod sources defined by built .tmod files.
-		var localSources = ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => !string.IsNullOrEmpty(s));
+		modSources.AddRange(ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => !string.IsNullOrEmpty(s)));
 
-		return modSources.Concat(localSources).Distinct().ToArray();
+		return modSources.Distinct().ToArray();
 	}
 
 	// Silence exception reporting in the chat unless actively modding.
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);
 
-	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources().Length > 0;
+	public static bool DeveloperMode => Debugger.IsAttached || FindModSources().Length > 0;
 
 	private static readonly string tMLDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 	private static readonly string oldModReferencesPath = Path.Combine(Program.SavePath, "references");

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -54,7 +54,7 @@ internal class ModCompile
 
 	public static readonly string ModSourcePath = Path.Combine(Program.SavePathShared, "ModSources");
 
-	internal static string[] FindModSources(bool refindAllMods, out LocalMod[] builtMods)
+	internal static string[] FindModSources(bool refindAllMods)
 	{
 		Directory.CreateDirectory(ModSourcePath);
 		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
@@ -63,7 +63,7 @@ internal class ModCompile
 		}).ToHashSet();
 
 		// Also add mod sources defined by built .tmod files.
-		builtMods = refindAllMods ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
+		var builtMods = refindAllMods ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
 		modSources.UnionWith(builtMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
 
 		return modSources.ToArray();
@@ -73,7 +73,7 @@ internal class ModCompile
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);
 
-	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(refindAllMods: false, out _).Length > 0;
+	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(refindAllMods: false).Length > 0;
 
 	private static readonly string tMLDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 	private static readonly string oldModReferencesPath = Path.Combine(Program.SavePath, "references");
@@ -135,7 +135,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 	internal void BuildAll()
 	{
 		var modList = new List<LocalMod>();
-		foreach (var modFolder in FindModSources(refindAllMods: false, out _))
+		foreach (var modFolder in FindModSources(refindAllMods: false))
 			modList.Add(ReadBuildInfo(modFolder));
 
 		//figure out which of the installed mods are required for building

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -54,7 +54,7 @@ internal class ModCompile
 
 	public static readonly string ModSourcePath = Path.Combine(Program.SavePathShared, "ModSources");
 
-	internal static string[] FindModSources(bool refindAllMods)
+	internal static string[] FindModSources(bool updateFoundModCache)
 	{
 		Directory.CreateDirectory(ModSourcePath);
 		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
@@ -63,7 +63,7 @@ internal class ModCompile
 		}).ToHashSet();
 
 		// Also add mod sources defined by built .tmod files.
-		var builtMods = refindAllMods ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
+		var builtMods = updateFoundModCache ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
 		modSources.UnionWith(builtMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
 
 		return modSources.ToArray();
@@ -73,7 +73,7 @@ internal class ModCompile
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);
 
-	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(refindAllMods: false).Length > 0;
+	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(updateFoundModCache: false).Length > 0;
 
 	private static readonly string tMLDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 	private static readonly string oldModReferencesPath = Path.Combine(Program.SavePath, "references");
@@ -135,7 +135,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 	internal void BuildAll()
 	{
 		var modList = new List<LocalMod>();
-		foreach (var modFolder in FindModSources(refindAllMods: false))
+		foreach (var modFolder in FindModSources(updateFoundModCache: false))
 			modList.Add(ReadBuildInfo(modFolder));
 
 		//figure out which of the installed mods are required for building

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -67,6 +67,9 @@ internal class ModCompile
 		}
 
 		// Find mod sources defined by built .tmod files.
+		// It's possible for AllFoundMods to not be populated in low-init scenarios
+		// such as mod building, so we can populate it ourselves.
+		var foundMods = ModOrganizer.AllFoundMods ?? ModOrganizer.FindAllMods();
 		modSources.AddRange(ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => !string.IsNullOrEmpty(s)));
 
 		return modSources.Distinct().ToArray();

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -60,12 +60,12 @@ internal class ModCompile
 		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
 			var directory = new DirectoryInfo(dir);
 			return directory.Name[0] != '.' && directory.Name != "ModAssemblies" && directory.Name != "Mod Libraries";
-		}).ToHashSet();
+		});
 
-		// Also add mod sources defined by built .tmod files.
-		modSources.UnionWith(ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
+		// Find mod sources defined by built .tmod files.
+		var localSources = ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => !string.IsNullOrEmpty(s));
 
-		return modSources.ToArray();
+		return modSources.Concat(localSources).Distinct().ToArray();
 	}
 
 	// Silence exception reporting in the chat unless actively modding.

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -349,6 +349,8 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 		string dllPath = null;
 		string pdbPath() => Path.ChangeExtension(dllPath, "pdb");
 
+		mod.properties.modSource = mod.path;
+
 		// look for pre-compiled paths
 		if (mod.properties.noCompile) {
 			dllPath = Path.Combine(mod.path, dllName);

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -54,20 +54,26 @@ internal class ModCompile
 
 	public static readonly string ModSourcePath = Path.Combine(Program.SavePathShared, "ModSources");
 
-	internal static string[] FindModSources()
+	internal static string[] FindModSources(bool refindAllMods, out LocalMod[] builtMods)
 	{
 		Directory.CreateDirectory(ModSourcePath);
-		return Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
+		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
 			var directory = new DirectoryInfo(dir);
 			return directory.Name[0] != '.' && directory.Name != "ModAssemblies" && directory.Name != "Mod Libraries";
-		}).ToArray();
+		}).ToHashSet();
+
+		// Also add mod sources defined by built .tmod files.
+		builtMods = refindAllMods ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
+		modSources.UnionWith(builtMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
+
+		return modSources.ToArray();
 	}
 
 	// Silence exception reporting in the chat unless actively modding.
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);
 
-	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources().Length > 0;
+	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(refindAllMods: false, out _).Length > 0;
 
 	private static readonly string tMLDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 	private static readonly string oldModReferencesPath = Path.Combine(Program.SavePath, "references");
@@ -129,7 +135,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 	internal void BuildAll()
 	{
 		var modList = new List<LocalMod>();
-		foreach (var modFolder in FindModSources())
+		foreach (var modFolder in FindModSources(refindAllMods: false, out _))
 			modList.Add(ReadBuildInfo(modFolder));
 
 		//figure out which of the installed mods are required for building

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -54,7 +54,7 @@ internal class ModCompile
 
 	public static readonly string ModSourcePath = Path.Combine(Program.SavePathShared, "ModSources");
 
-	internal static string[] FindModSources(bool updateFoundModCache)
+	internal static string[] FindModSources()
 	{
 		Directory.CreateDirectory(ModSourcePath);
 		var modSources = Directory.GetDirectories(ModSourcePath, "*", SearchOption.TopDirectoryOnly).Where(dir => {
@@ -63,8 +63,7 @@ internal class ModCompile
 		}).ToHashSet();
 
 		// Also add mod sources defined by built .tmod files.
-		var builtMods = updateFoundModCache ? ModOrganizer.FindAllMods() : ModOrganizer.AllFoundMods;
-		modSources.UnionWith(builtMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
+		modSources.UnionWith(ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => s.Length > 0));
 
 		return modSources.ToArray();
 	}
@@ -73,7 +72,7 @@ internal class ModCompile
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);
 
-	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources(updateFoundModCache: false).Length > 0;
+	public static bool DeveloperMode => Debugger.IsAttached || Directory.Exists(ModSourcePath) && FindModSources().Length > 0;
 
 	private static readonly string tMLDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 	private static readonly string oldModReferencesPath = Path.Combine(Program.SavePath, "references");
@@ -135,7 +134,7 @@ $@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer
 	internal void BuildAll()
 	{
 		var modList = new List<LocalMod>();
-		foreach (var modFolder in FindModSources(updateFoundModCache: false))
+		foreach (var modFolder in FindModSources())
 			modList.Add(ReadBuildInfo(modFolder));
 
 		//figure out which of the installed mods are required for building

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -72,7 +72,7 @@ internal class ModCompile
 		var foundMods = ModOrganizer.AllFoundMods ?? ModOrganizer.FindAllMods();
 		modSources.AddRange(ModOrganizer.AllFoundMods.Where(m => m.location == ModLocation.Local).Select(m => m.properties.modSource).Where(s => !string.IsNullOrEmpty(s)));
 
-		return modSources.Distinct().ToArray();
+		return modSources.Distinct().Where(Directory.Exists).ToArray();
 	}
 
 	internal static string GetModSource(TmodFile tmod)

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -72,6 +72,14 @@ internal class ModCompile
 		return modSources.Distinct().ToArray();
 	}
 
+	internal static string GetModSource(TmodFile tmod)
+	{
+		var buildInfo = BuildProperties.ReadModFile(tmod);
+		return string.IsNullOrEmpty(buildInfo.modSource) ? Path.Combine(ModSourcePath, tmod.Name) : buildInfo.modSource;
+	}
+
+	internal static string GetModSource(LocalMod mod) => string.IsNullOrEmpty(mod.properties.modSource) ? Path.Combine(ModSourcePath, mod.Name) : mod.properties.modSource;
+
 	// Silence exception reporting in the chat unless actively modding.
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModCompile.cs
@@ -75,14 +75,6 @@ internal class ModCompile
 		return modSources.Distinct().Where(Directory.Exists).ToArray();
 	}
 
-	internal static string GetModSource(TmodFile tmod)
-	{
-		var buildInfo = BuildProperties.ReadModFile(tmod);
-		return string.IsNullOrEmpty(buildInfo.modSource) ? Path.Combine(ModSourcePath, tmod.Name) : buildInfo.modSource;
-	}
-
-	internal static string GetModSource(LocalMod mod) => string.IsNullOrEmpty(mod.properties.modSource) ? Path.Combine(ModSourcePath, mod.Name) : mod.properties.modSource;
-
 	// Silence exception reporting in the chat unless actively modding.
 	public static bool activelyModding;
 	internal static DateTime recentlyBuiltModCheckTimeCutoff = DateTime.Now - TimeSpan.FromSeconds(60);

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -201,7 +201,7 @@ public static class LocalizationLoader
 
 				string modpath = Path.Combine(mod.Name, translationFile.Name).Replace('/', '\\');
 				if (changedFiles.Select(x => Path.Join(x.Mod, x.fileName)).Contains(modpath)) {
-					string path = BuildProperties.ReadModFile(mod.File).modSource;
+					string path = mod.SourceFolder;
 					if (File.Exists(path)) {
 						try {
 							translationFileContents = File.ReadAllText(path);
@@ -327,7 +327,7 @@ public static class LocalizationLoader
 		};
 
 		// TODO: Maybe optimize to only recently built?
-		string sourceFolder = outputPath ?? BuildProperties.ReadModFile(mod.File).modSource;
+		string sourceFolder = outputPath ?? mod.SourceFolder;
 		if (!Directory.Exists(sourceFolder))
 			return;
 
@@ -821,7 +821,7 @@ public static class LocalizationLoader
 			if (mod.File == null)
 				continue;
 
-			string path = BuildProperties.ReadModFile(mod.File).modSource;
+			string path = mod.SourceFolder;
 			if (!Directory.Exists(path))
 				continue;
 

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -314,6 +314,10 @@ public static class LocalizationLoader
 
 	private static void UpdateLocalizationFilesForMod(Mod mod, string outputPath = null, GameCulture specificCulture = null)
 	{
+		// ModLoaderMod does not exist on disk and is not applicable.
+		if (mod.File == null)
+			return;
+
 		var desiredCultures = new HashSet<GameCulture>();
 		if (specificCulture != null)
 			desiredCultures.Add(specificCulture);

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -201,7 +201,7 @@ public static class LocalizationLoader
 
 				string modpath = Path.Combine(mod.Name, translationFile.Name).Replace('/', '\\');
 				if (changedFiles.Select(x => Path.Join(x.Mod, x.fileName)).Contains(modpath)) {
-					string path = ModCompile.GetModSource(mod.File);
+					string path = BuildProperties.ReadModFile(mod.File).modSource;
 					if (File.Exists(path)) {
 						try {
 							translationFileContents = File.ReadAllText(path);
@@ -327,7 +327,7 @@ public static class LocalizationLoader
 		};
 
 		// TODO: Maybe optimize to only recently built?
-		string sourceFolder = outputPath ?? ModCompile.GetModSource(mod.File);
+		string sourceFolder = outputPath ?? BuildProperties.ReadModFile(mod.File).modSource;
 		if (!Directory.Exists(sourceFolder))
 			return;
 
@@ -821,7 +821,7 @@ public static class LocalizationLoader
 			if (mod.File == null)
 				continue;
 
-			string path = ModCompile.GetModSource(mod.File);
+			string path = BuildProperties.ReadModFile(mod.File).modSource;
 			if (!Directory.Exists(path))
 				continue;
 

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -201,7 +201,7 @@ public static class LocalizationLoader
 
 				string modpath = Path.Combine(mod.Name, translationFile.Name).Replace('/', '\\');
 				if (changedFiles.Select(x => Path.Join(x.Mod, x.fileName)).Contains(modpath)) {
-					string path = Path.Combine(ModCompile.ModSourcePath, modpath);
+					string path = ModCompile.GetModSource(mod.File);
 					if (File.Exists(path)) {
 						try {
 							translationFileContents = File.ReadAllText(path);
@@ -323,7 +323,7 @@ public static class LocalizationLoader
 		};
 
 		// TODO: Maybe optimize to only recently built?
-		string sourceFolder = outputPath ?? Path.Combine(ModCompile.ModSourcePath, mod.Name);
+		string sourceFolder = outputPath ?? ModCompile.GetModSource(mod.File);
 		if (!Directory.Exists(sourceFolder))
 			return;
 
@@ -813,7 +813,7 @@ public static class LocalizationLoader
 		// Add a watcher for each loaded mod that has a corresponding mod sources folder
 		// Don't worry about the mod being local or not, for now. The feature might be useful for even workshop tmod files
 		foreach (var mod in ModLoader.Mods) {
-			string path = Path.Combine(ModCompile.ModSourcePath, mod.Name);
+			string path = ModCompile.GetModSource(mod.File);
 			if (!Directory.Exists(path))
 				continue;
 

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -817,6 +817,10 @@ public static class LocalizationLoader
 		// Add a watcher for each loaded mod that has a corresponding mod sources folder
 		// Don't worry about the mod being local or not, for now. The feature might be useful for even workshop tmod files
 		foreach (var mod in ModLoader.Mods) {
+			// ModLoaderMod does not exist on disk and is not applicable.
+			if (mod.File == null)
+				continue;
+
 			string path = ModCompile.GetModSource(mod.File);
 			if (!Directory.Exists(path))
 				continue;

--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -201,7 +201,7 @@ public static class LocalizationLoader
 
 				string modpath = Path.Combine(mod.Name, translationFile.Name).Replace('/', '\\');
 				if (changedFiles.Select(x => Path.Join(x.Mod, x.fileName)).Contains(modpath)) {
-					string path = mod.SourceFolder;
+					string path = Path.Combine(mod.SourceFolder, translationFile.Name);
 					if (File.Exists(path)) {
 						try {
 							translationFileContents = File.ReadAllText(path);

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -50,6 +50,11 @@ public partial class Mod
 	public List<string> TranslationForMods { get; internal set; }
 
 	/// <summary>
+	/// The path to the source folder the mod was built from.
+	/// </summary>
+	public string SourceFolder { get; internal set; }
+
+	/// <summary>
 	/// Whether or not this mod will autoload content by default. Autoloading content means you do not need to manually add content through methods.
 	/// </summary>
 	public bool ContentAutoloadingEnabled { get; init; } = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -323,10 +323,9 @@ internal class UIModSourceItem : UIPanel
 			using (modFile.Open()) // savehere, -tmlsavedirectory, normal (test linux too)
 				localMod = new LocalMod(ModLocation.Local, modFile);
 
-			var properties = BuildProperties.ReadModFile(modFile);
-			string icon = Path.Combine(properties.modSource, "icon_workshop.png");
+			string icon = Path.Combine(localMod.properties.modSource, "icon_workshop.png");
 			if (!File.Exists(icon))
-				icon = Path.Combine(properties.modSource, "icon.png");
+				icon = Path.Combine(localMod.properties.modSource, "icon.png");
 
 			WorkshopHelper.PublishMod(localMod, icon);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -323,9 +323,9 @@ internal class UIModSourceItem : UIPanel
 			using (modFile.Open()) // savehere, -tmlsavedirectory, normal (test linux too)
 				localMod = new LocalMod(ModLocation.Local, modFile);
 
-			string icon = Path.Combine(ModCompile.ModSourcePath, modName, "icon_workshop.png");
+			string icon = Path.Combine(ModCompile.GetModSource(modFile), "icon_workshop.png");
 			if (!File.Exists(icon))
-				icon = Path.Combine(ModCompile.ModSourcePath, modName, "icon.png");
+				icon = Path.Combine(ModCompile.GetModSource(modFile), "icon.png");
 
 			WorkshopHelper.PublishMod(localMod, icon);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -323,9 +323,10 @@ internal class UIModSourceItem : UIPanel
 			using (modFile.Open()) // savehere, -tmlsavedirectory, normal (test linux too)
 				localMod = new LocalMod(ModLocation.Local, modFile);
 
-			string icon = Path.Combine(ModCompile.GetModSource(modFile), "icon_workshop.png");
+			var properties = BuildProperties.ReadModFile(modFile);
+			string icon = Path.Combine(properties.modSource, "icon_workshop.png");
 			if (!File.Exists(icon))
-				icon = Path.Combine(ModCompile.GetModSource(modFile), "icon.png");
+				icon = Path.Combine(properties.modSource, "icon.png");
 
 			WorkshopHelper.PublishMod(localMod, icon);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -412,11 +412,12 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	internal void Populate()
 	{
 		Task.Run(() => {
-			var modSources = ModCompile.FindModSources(updateFoundModCache: true);
+			var modFiles = ModOrganizer.FindAllMods();
+			var modSources = ModCompile.FindModSources();
 
 			foreach (string sourcePath in modSources) {
 				var modName = Path.GetFileName(sourcePath);
-				var builtMod = ModOrganizer.AllFoundMods.Where(m => m.Name == modName).Where(m => m.location == ModLocation.Local).OrderByDescending(m => m.Version).FirstOrDefault();
+				var builtMod = modFiles.Where(m => m.Name == modName).Where(m => m.location == ModLocation.Local).OrderByDescending(m => m.Version).FirstOrDefault();
 				_items.Add(new UIModSourceItem(sourcePath, builtMod, _cts.Token));
 			}
 			_updateNeeded = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -412,7 +412,7 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	internal void Populate()
 	{
 		Task.Run(() => {
-			var modSources = ModCompile.FindModSources(refindAllMods: true);
+			var modSources = ModCompile.FindModSources(updateFoundModCache: true);
 
 			foreach (string sourcePath in modSources) {
 				var modName = Path.GetFileName(sourcePath);

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -412,6 +412,8 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	internal void Populate()
 	{
 		Task.Run(() => {
+			// It's important to call FindAllMods here first to ensure AllFoundMods is
+			// properly initialized and populated when it's referenced in FindModSources.
 			var modFiles = ModOrganizer.FindAllMods();
 			var modSources = ModCompile.FindModSources();
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -412,11 +412,11 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	internal void Populate()
 	{
 		Task.Run(() => {
-			var modSources = ModCompile.FindModSources(refindAllMods: true, out var modFiles);
+			var modSources = ModCompile.FindModSources(refindAllMods: true);
 
 			foreach (string sourcePath in modSources) {
 				var modName = Path.GetFileName(sourcePath);
-				var builtMod = modFiles.Where(m => m.Name == modName).Where(m => m.location == ModLocation.Local).OrderByDescending(m => m.Version).FirstOrDefault();
+				var builtMod = ModOrganizer.AllFoundMods.Where(m => m.Name == modName).Where(m => m.location == ModLocation.Local).OrderByDescending(m => m.Version).FirstOrDefault();
 				_items.Add(new UIModSourceItem(sourcePath, builtMod, _cts.Token));
 			}
 			_updateNeeded = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -412,9 +412,8 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	internal void Populate()
 	{
 		Task.Run(() => {
-			var modSources = ModCompile.FindModSources();
+			var modSources = ModCompile.FindModSources(refindAllMods: true, out var modFiles);
 
-			var modFiles = ModOrganizer.FindAllMods();
 			foreach (string sourcePath in modSources) {
 				var modName = Path.GetFileName(sourcePath);
 				var builtMod = modFiles.Where(m => m.Name == modName).Where(m => m.location == ModLocation.Local).OrderByDescending(m => m.Version).FirstOrDefault();

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -170,7 +170,7 @@ public partial class WorkshopHelper
 		if (bp.buildVersion != modFile.TModLoaderVersion)
 			throw new WebException(Language.GetTextValue("tModLoader.OutdatedModCantPublishError"));
 
-		var changeLogFile = Path.Combine(ModCompile.GetModSource(modFile), "changelog.txt");
+		var changeLogFile = Path.Combine(BuildProperties.ReadModFile(modFile).modSource, "changelog.txt");
 		string changeLog;
 		if (File.Exists(changeLogFile))
 			changeLog = File.ReadAllText(changeLogFile);
@@ -187,7 +187,7 @@ public partial class WorkshopHelper
 			{ "homepage", bp.homepage },
 			{ "description", bp.description },
 			{ "iconpath", iconPath },
-			{ "sourcesfolder", ModCompile.GetModSource(modFile) },
+			{ "sourcesfolder", BuildProperties.ReadModFile(modFile).modSource },
 			{ "modloaderversion", $"{modFile.TModLoaderVersion}" },
 			{ "modreferences", string.Join(", ", bp.modReferences.Select(x => x.mod)) },
 			{ "modside", bp.side.ToFriendlyString() },

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -170,7 +170,7 @@ public partial class WorkshopHelper
 		if (bp.buildVersion != modFile.TModLoaderVersion)
 			throw new WebException(Language.GetTextValue("tModLoader.OutdatedModCantPublishError"));
 
-		var changeLogFile = Path.Combine(ModCompile.ModSourcePath, modFile.Name, "changelog.txt");
+		var changeLogFile = Path.Combine(ModCompile.GetModSource(modFile), "changelog.txt");
 		string changeLog;
 		if (File.Exists(changeLogFile))
 			changeLog = File.ReadAllText(changeLogFile);
@@ -187,7 +187,7 @@ public partial class WorkshopHelper
 			{ "homepage", bp.homepage },
 			{ "description", bp.description },
 			{ "iconpath", iconPath },
-			{ "sourcesfolder", Path.Combine(ModCompile.ModSourcePath, modFile.Name) },
+			{ "sourcesfolder", ModCompile.GetModSource(modFile) },
 			{ "modloaderversion", $"{modFile.TModLoaderVersion}" },
 			{ "modreferences", string.Join(", ", bp.modReferences.Select(x => x.mod)) },
 			{ "modside", bp.side.ToFriendlyString() },

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -170,7 +170,7 @@ public partial class WorkshopHelper
 		if (bp.buildVersion != modFile.TModLoaderVersion)
 			throw new WebException(Language.GetTextValue("tModLoader.OutdatedModCantPublishError"));
 
-		var changeLogFile = Path.Combine(BuildProperties.ReadModFile(modFile).modSource, "changelog.txt");
+		var changeLogFile = Path.Combine(bp.modSource, "changelog.txt");
 		string changeLog;
 		if (File.Exists(changeLogFile))
 			changeLog = File.ReadAllText(changeLogFile);
@@ -187,7 +187,7 @@ public partial class WorkshopHelper
 			{ "homepage", bp.homepage },
 			{ "description", bp.description },
 			{ "iconpath", iconPath },
-			{ "sourcesfolder", BuildProperties.ReadModFile(modFile).modSource },
+			{ "sourcesfolder", bp.modSource },
 			{ "modloaderversion", $"{modFile.TModLoaderVersion}" },
 			{ "modreferences", string.Join(", ", bp.modReferences.Select(x => x.mod)) },
 			{ "modside", bp.side.ToFriendlyString() },


### PR DESCRIPTION
### What is the new feature?

*Resolves #4547.*

Adds a `modSource` property to a mod's build properties when built that allows tModLoader to then discover the mod's source directory.

### Why should this be part of tModLoader?

Allows tModLoader to treat mods not in `ModSources` with the same level of development support as mods in `ModSources`.

### Are there alternative designs?

See #4547 for discussion.

# How to use
1. Make a folder where you want to store custom mod source folders, something like `CustomModSources`, for example. This will be similar to the `ModSources` folder in the default saves folder.
2. Copy the `tModLoader.targets` file from the original `ModSources` folder to your new folder.
3. Move each mod's source code folder to this folder.
4. For each mod, you'll need to build the mod directly at least once. This is usually done in [Visual Studio](https://github.com/tModLoader/tModLoader/wiki/Why-Use-an-IDE#build), but you can also just open the folder and type in `dotnet build` into the address bar and press `Enter`. 
5. After this, the mod should appear in the Develop Mods menu in-game if you need to build in-game. The blue folder icon indicates that the mod was built from a custom location, hovering over it will show that path.


____
![](https://github.com/user-attachments/assets/99585d99-b0db-4871-aa0e-00f0b3c37c48)    
____
![](https://github.com/user-attachments/assets/f9fd8dd4-f64e-4e37-aea1-be4711785753)    
___
![](https://github.com/user-attachments/assets/a6664206-c094-479f-9295-18d30c83132d)    