### PR TITLE
Localize custom player death messages (PlayerDeathReason.ByCustomReason)

### DIFF
--- a/ExampleMod/Content/Items/ExampleOnBuyItem.cs
+++ b/ExampleMod/Content/Items/ExampleOnBuyItem.cs
@@ -39,7 +39,7 @@ namespace ExampleMod.Content.Items
 
 			// This is only ever called on the local client, so the local player will do.
 			Player player = Main.LocalPlayer;
-			player.KillMe(PlayerDeathReason.ByCustomReason(DeathMessage.Format(player.name)), 9999, 0);
+			player.KillMe(PlayerDeathReason.ByCustomReason(DeathMessage.ToNetworkText(player.name)), 9999, 0);
 		}
 	}
 }

--- a/ExampleMod/Content/NPCs/ExampleGlobalNPC.cs
+++ b/ExampleMod/Content/NPCs/ExampleGlobalNPC.cs
@@ -1,4 +1,5 @@
 using Terraria;
+using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 
@@ -33,6 +34,11 @@ namespace ExampleMod.Content.NPCs
 			}
 
 			foreach (Item item in items) {
+				// Skip 'air' items and null items.
+				if (item == null || item.type == ItemID.None) {
+					continue;
+				}
+
 				int value = item.shopCustomPrice ?? item.value;
 				item.shopCustomPrice = value * 2;
 			}

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
@@ -1,6 +1,7 @@
 --- src/TerrariaNetCore/Terraria/DataStructures/PlayerDeathReason.cs
 +++ src/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs
-@@ -1,5 +_,7 @@
+@@ -1,5 +_,8 @@
++using System;
  using System.IO;
  using Terraria.Localization;
 +using Terraria.ModLoader;
@@ -24,13 +25,13 @@
 +	private int _sourceItemType => _sourceItem?.type ?? 0;
 +	private int _sourceItemPrefix => _sourceItem?.prefix ?? 0;
  	private string _sourceCustomReason;
-+	private NetworkText _sourceCustomReasonLocalized;
++	private NetworkText _customReason;
  
 +	/*
  	public int? SourceProjectileType {
  		get {
  			if (_sourceProjectileLocalIndex == -1)
-@@ -22,7 +_,25 @@
+@@ -22,7 +_,26 @@
  			return _sourceProjectileType;
  		}
  	}
@@ -43,8 +44,9 @@
 +	public ref int SourceOtherIndex => ref _sourceOtherIndex;
 +	public ref int SourceProjectileType => ref _sourceProjectileType;
 +	public ref Item SourceItem => ref _sourceItem;
++	[Obsolete("CustomReason should be used instead")]
 +	public ref string SourceCustomReason => ref _sourceCustomReason;
-+	public ref NetworkText SourceCustomReasonLocalized => ref _sourceCustomReasonLocalized;
++	public ref NetworkText CustomReason => ref _customReason;
 +
 +	/// <summary>
 +	/// Only safe for use when the local player is the one taking damage! <br/>
@@ -68,37 +70,30 @@
  			return true;
  		}
  
-@@ -65,6 +_,10 @@
+@@ -65,6 +_,11 @@
  		};
  	}
  
 +	/// <summary>
 +	/// A custom death message.
-+	/// <para/> This overload does not support localization, all players will see the same text regardless of their language settings. Use <see cref="ByCustomReason(LocalizedText)"/> or <see cref="ByCustomReason(NetworkText)"/> instead for localization support.
++	/// <para/> This overload does not support localization, all players will see the same text regardless of their language settings. Use <see cref="ByCustomReason(NetworkText)"/> instead for localization support.
 +	/// </summary>
++	[Obsolete("Use the NetworkText version instead")]
  	public static PlayerDeathReason ByCustomReason(string reasonInEnglish)
  	{
  		return new PlayerDeathReason {
-@@ -72,18 +_,45 @@
+@@ -72,18 +_,37 @@
  		};
  	}
  
-+	/// <inheritdoc cref="ByCustomReason(NetworkText)"/>
-+	public static PlayerDeathReason ByCustomReason(LocalizedText reason)
-+	{
-+		return new PlayerDeathReason {
-+			_sourceCustomReasonLocalized = reason.ToNetworkText()
-+		};
-+	}
-+
 +	/// <summary>
 +	/// A localized custom death message. Each client will see the death message in their own language, unlike with <see cref="ByCustomReason(string)"/>.
-+	/// <para/> Text substitutions can be provided by using <see cref="LocalizedText.ToNetworkText(object[])"/> or <see cref="LocalizedText.WithFormatArgs(object[])"/>
++	/// <para/> Text substitutions can be provided by using <see cref="LocalizedText.ToNetworkText(object[])"/> or <see cref="NetworkText.FromKey(string, object[])"/>.
 +	/// </summary>
 +	public static PlayerDeathReason ByCustomReason(NetworkText reason)
 +	{
 +		return new PlayerDeathReason {
-+			_sourceCustomReasonLocalized = reason
++			_customReason = reason
 +		};
 +	}
 +
@@ -142,8 +137,8 @@
  
  	public NetworkText GetDeathText(string deadPlayerName)
  	{
-+		if (_sourceCustomReasonLocalized != null)
-+			return _sourceCustomReasonLocalized;
++		if (_customReason != null)
++			return _customReason;
 +
  		if (_sourceCustomReason != null)
  			return NetworkText.FromLiteral(_sourceCustomReason);
@@ -155,7 +150,7 @@
 +		/*
  		bitsByte[6] = _sourceItemPrefix != 0;
 +		*/
-+		bitsByte[6] = _sourceCustomReasonLocalized != null;
++		bitsByte[6] = _customReason != null;
  		bitsByte[7] = _sourceCustomReason != null;
  		writer.Write(bitsByte);
  		if (bitsByte[0])
@@ -172,7 +167,7 @@
  			writer.Write((byte)_sourceItemPrefix);
 +		*/
 +		if (bitsByte[6])
-+			_sourceCustomReasonLocalized.Serialize(writer);
++			_customReason.Serialize(writer);
  
  		if (bitsByte[7])
  			writer.Write(_sourceCustomReason);
@@ -191,7 +186,7 @@
 +			playerDeathReason._sourceItem = ItemIO.Receive(reader);
 +
 +		if (bitsByte[6])
-+			playerDeathReason._sourceCustomReasonLocalized = NetworkText.Deserialize(reader);
++			playerDeathReason._customReason = NetworkText.Deserialize(reader);
  
  		if (bitsByte[7])
  			playerDeathReason._sourceCustomReason = reader.ReadString();

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
@@ -8,7 +8,7 @@
  
  namespace Terraria.DataStructures;
  
-@@ -10,19 +_,31 @@
+@@ -10,19 +_,33 @@
  	private int _sourceProjectileLocalIndex = -1;
  	private int _sourceOtherIndex = -1;
  	private int _sourceProjectileType;
@@ -22,7 +22,7 @@
 +	private int _sourceItemType => _sourceItem?.type ?? 0;
 +	private int _sourceItemPrefix => _sourceItem?.prefix ?? 0;
  	private string _sourceCustomReason;
- 
+-
 -	public int? SourceProjectileType {
 -		get {
 -			if (_sourceProjectileLocalIndex == -1)
@@ -32,6 +32,8 @@
 -		}
 -	}
 -
++	private NetworkText _sourceCustomReasonLocalized;
++
 +	// Ref fields added by TML.
 +	public ref int SourcePlayerIndex => ref _sourcePlayerIndex;
 +	public ref int SourceNPCIndex => ref _sourceNPCIndex;
@@ -40,6 +42,7 @@
 +	public ref int SourceProjectileType => ref _sourceProjectileType;
 +	public ref Item SourceItem => ref _sourceItem;
 +	public ref string SourceCustomReason => ref _sourceCustomReason;
++	public ref NetworkText SourceCustomReasonLocalized => ref _sourceCustomReasonLocalized;
 +
 +	/// <summary>
 +	/// Only safe for use when the local player is the one taking damage! <br/>
@@ -63,10 +66,40 @@
  			return true;
  		}
  
-@@ -72,18 +_,26 @@
+@@ -65,6 +_,10 @@
  		};
  	}
  
++	/// <summary>
++	/// A custom death message.
++	/// <para/> This overload does not support localization, all players will see the same text regardless of their language settings. Use <see cref="ByCustomReason(LocalizedText)"/> or <see cref="ByCustomReason(NetworkText)"/> instead for localization support.
++	/// </summary>
+ 	public static PlayerDeathReason ByCustomReason(string reasonInEnglish)
+ 	{
+ 		return new PlayerDeathReason {
+@@ -72,18 +_,45 @@
+ 		};
+ 	}
+ 
++	/// <inheritdoc cref="ByCustomReason(NetworkText)"/>
++	public static PlayerDeathReason ByCustomReason(LocalizedText reason)
++	{
++		return new PlayerDeathReason {
++			_sourceCustomReasonLocalized = reason.ToNetworkText()
++		};
++	}
++
++	/// <summary>
++	/// A localized custom death message. Each client will see the death message in their own language, unlike with <see cref="ByCustomReason(string)"/>.
++	/// <para/> Text substitutions can be provided by using <see cref="LocalizedText.ToNetworkText(object[])"/> or <see cref="LocalizedText.WithFormatArgs(object[])"/>
++	/// </summary>
++	public static PlayerDeathReason ByCustomReason(NetworkText reason)
++	{
++		return new PlayerDeathReason {
++			_sourceCustomReasonLocalized = reason
++		};
++	}
++
 +	/*
  	public static PlayerDeathReason ByPlayer(int index)
 +	*/
@@ -91,7 +124,7 @@
  			_sourceOtherIndex = type
  		};
  	}
-@@ -96,10 +_,12 @@
+@@ -96,16 +_,21 @@
  			_sourceProjectileType = Main.projectile[projectileIndex].type
  		};
  
@@ -104,7 +137,27 @@
  
  		return playerDeathReason;
  	}
-@@ -140,10 +_,14 @@
+ 
+ 	public NetworkText GetDeathText(string deadPlayerName)
+ 	{
++		if (_sourceCustomReasonLocalized != null)
++			return _sourceCustomReasonLocalized;
++
+ 		if (_sourceCustomReason != null)
+ 			return NetworkText.FromLiteral(_sourceCustomReason);
+ 
+@@ -121,7 +_,10 @@
+ 		bitsByte[3] = _sourceOtherIndex != -1;
+ 		bitsByte[4] = _sourceProjectileType != 0;
+ 		bitsByte[5] = _sourceItemType != 0;
++		/*
+ 		bitsByte[6] = _sourceItemPrefix != 0;
++		*/
++		bitsByte[6] = _sourceCustomReasonLocalized != null;
+ 		bitsByte[7] = _sourceCustomReason != null;
+ 		writer.Write(bitsByte);
+ 		if (bitsByte[0])
+@@ -140,10 +_,16 @@
  			writer.Write((short)_sourceProjectileType);
  
  		if (bitsByte[5])
@@ -116,10 +169,12 @@
  		if (bitsByte[6])
  			writer.Write((byte)_sourceItemPrefix);
 +		*/
++		if (bitsByte[6])
++			_sourceCustomReasonLocalized.Serialize(writer);
  
  		if (bitsByte[7])
  			writer.Write(_sourceCustomReason);
-@@ -168,11 +_,15 @@
+@@ -168,11 +_,18 @@
  		if (bitsByte[4])
  			playerDeathReason._sourceProjectileType = reader.ReadInt16();
  
@@ -132,6 +187,9 @@
 +		*/
 +		if (bitsByte[5])
 +			playerDeathReason._sourceItem = ItemIO.Receive(reader);
++
++		if (bitsByte[6])
++			playerDeathReason._sourceCustomReasonLocalized = NetworkText.Deserialize(reader);
  
  		if (bitsByte[7])
  			playerDeathReason._sourceCustomReason = reader.ReadString();

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDeathReason.cs.patch
@@ -8,32 +8,34 @@
  
  namespace Terraria.DataStructures;
  
-@@ -10,19 +_,33 @@
+@@ -10,10 +_,21 @@
  	private int _sourceProjectileLocalIndex = -1;
  	private int _sourceOtherIndex = -1;
  	private int _sourceProjectileType;
--	private int _sourceItemType;
--	private int _sourceItemPrefix;
 +
 +	// Added
 +	private Item _sourceItem;
 +
 +	// Changed to reference _sourceItem
++	/*
+ 	private int _sourceItemType;
+ 	private int _sourceItemPrefix;
++	*/
 +	private int _sourceItemType => _sourceItem?.type ?? 0;
 +	private int _sourceItemPrefix => _sourceItem?.prefix ?? 0;
  	private string _sourceCustomReason;
--
--	public int? SourceProjectileType {
--		get {
--			if (_sourceProjectileLocalIndex == -1)
--				return null;
--
--			return _sourceProjectileType;
--		}
--	}
--
 +	private NetworkText _sourceCustomReasonLocalized;
-+
+ 
++	/*
+ 	public int? SourceProjectileType {
+ 		get {
+ 			if (_sourceProjectileLocalIndex == -1)
+@@ -22,7 +_,25 @@
+ 			return _sourceProjectileType;
+ 		}
+ 	}
++	*/
+ 
 +	// Ref fields added by TML.
 +	public ref int SourcePlayerIndex => ref _sourcePlayerIndex;
 +	public ref int SourceNPCIndex => ref _sourceNPCIndex;


### PR DESCRIPTION
Fixes #4224 

Currently, `PlayerDeathReason.ByCustomReason` takes a `string` and that `string` is synced across the network to other clients. Those clients will see the custom death reason in the language of the player who died, not in their chosen language.

This PR adds additional `PlayerDeathReason.ByCustomReason` overloads that support localization and marks the existing overload as `Obsolete`.

This image shows the fixed behavior. One player is on Chinese the other English. Each sees the message in their own language:
![image](https://github.com/user-attachments/assets/2b3c6366-618a-44cb-a344-af0f8ecbf2c1)

Without the fix each player would either see the message in English or in Chinese, depending on which player died.

# Discussion
1. ~~We could get rid of the `ByCustomReason(LocalizedText reason)` overload if using `LocalizedText.WithFormatArgs` like this is not advised. The docs for `LocalizedText.WithFormatArgs` suggest that it is not a correct approach.~~

2. ~~Should `ByCustomReason(string reasonInEnglish)` be marked as `Obsolete` to encourage usage of the new overloads?~~

# Porting Notes
- If already using `LocalizedText`, change `localizedText.Format(substitutions)` to `localizedText.ToNetworkText(substitutions)`.
```diff
-player.KillMe(PlayerDeathReason.ByCustomReason(DeathMessage.Format(player.name)), 9999, 0);
+player.KillMe(PlayerDeathReason.ByCustomReason(DeathMessage.ToNetworkText(player.name)), 9999, 0);
```
- If still using `string` directly, consider supporting custom death message localization by following the example shown in `ExampleOnBuyItem.SetStaticDefaults` and `OnCreated`.
