### PR TITLE
Fix Missing Sound Mappings

### DIFF
--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -590,10 +590,10 @@ partial class SoundID
 			}
 		}
 
-		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 172);
-		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 65);
-		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 57);
-		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 118);
+		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 179);
+		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 58);
+		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 67);
+		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 130);
 	}
 
 	// Helper methods

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -714,6 +714,10 @@ partial class SoundID
 		LegacySoundIDs.Research => Research,
 		LegacySoundIDs.ResearchComplete => ResearchComplete,
 		LegacySoundIDs.QueenSlime => QueenSlime,
+		LegacySoundIDs.Clown => Clown,
+		LegacySoundIDs.Cockatiel => Cockatiel,
+		LegacySoundIDs.Macaw => Macaw,
+		LegacySoundIDs.Toucan => Toucan,
 		_ => null,
 	};
 }


### PR DESCRIPTION
### What is the bug?  
The `LegacyArrayedStylesMap` indexes in `SoundID.TML.cs` were incorrect, causing `Failed to get legacy sound style` errors. Some indexes were lower than intended, leading to missing sound mappings.  

Also added 4 Existing `LegacySoundIDs` to the `GetLegacyStyle` Mapping.

This is also why #4425 is happening (along with other sounds).

### How did you fix the bug?  
Updated the values for `LegacySoundIDs.Item`, `LegacySoundIDs.NPCHit`, `LegacySoundIDs.NPCKilled`, and `LegacySoundIDs.Zombie` to their correct ranges:  

In the `AddNumberedStyles` calls, changed the length of the generated map array
- `LegacySoundIDs.Item`: `172 → 179`  
- `LegacySoundIDs.NPCHit`: `65 → 58` 
- `LegacySoundIDs.NPCKilled`: `57 → 67`  
- `LegacySoundIDs.Zombie`: `118 → 130`  

I also added the missing mapping to the `GetLegacyStyle` function. (now clowns can finally laugh 🤡)

### Are there alternatives to your fix?  
Probably not.