### PR TITLE
Fix Missing Sound Mappings

### DIFF
--- a/patches/tModLoader/Terraria/Audio/LegacySoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacySoundPlayer.cs.patch
@@ -19,6 +19,14 @@
  	public Asset<SoundEffect>[] SoundNpcKilled = new Asset<SoundEffect>[SoundID.NPCDeathCount];
  	public SoundEffectInstance[] SoundInstanceNpcKilled = new SoundEffectInstance[SoundID.NPCDeathCount];
  	public SoundEffectInstance SoundInstanceMoonlordCry;
+@@ -60,6 +_,7 @@
+ 	public SoundEffectInstance SoundInstanceShatter;
+ 	public Asset<SoundEffect> SoundCamera;
+ 	public SoundEffectInstance SoundInstanceCamera;
++	internal const int ZombieSoundCount = 131; // Maintenance helper. Keep equal with the lower array's length, add new fields to SoundID.TML.cs if increased.
+ 	public Asset<SoundEffect>[] SoundZombie = new Asset<SoundEffect>[131];
+ 	public SoundEffectInstance[] SoundInstanceZombie = new SoundEffectInstance[131];
+ 	public Asset<SoundEffect>[] SoundRoar = new Asset<SoundEffect>[3];
 @@ -99,6 +_,7 @@
  
  	private void LoadAll()

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -172,7 +172,6 @@ partial class SoundID
 	public static readonly SoundStyle NPCHit55 = NPCHitSound(55) with { Volume = 0.5f };
 	public static readonly SoundStyle NPCHit56 = NPCHitSound(56) with { Volume = 0.5f };
 	public static readonly SoundStyle NPCHit57 = NPCHitSound(57) with { Volume = 0.6f, SoundLimitBehavior = IgnoreNew };
-	public static int NPCHitCount = 58; // Added by tML
 	public static readonly SoundStyle NPCDeath1 = NPCDeathSound(1);
 	public static readonly SoundStyle NPCDeath2 = NPCDeathSound(2);
 	public static readonly SoundStyle NPCDeath3 = NPCDeathSound(3);
@@ -239,7 +238,6 @@ partial class SoundID
 	public static readonly SoundStyle NPCDeath64 = NPCDeathSound(64);
 	public static readonly SoundStyle NPCDeath65 = NPCDeathSound(65);
 	public static readonly SoundStyle NPCDeath66 = NPCDeathSound(66);
-	public static int NPCDeathCount = 66; // TML: Changed from short to int.
 	public static readonly SoundStyle Item1 = ItemSound(stackalloc int[] { 1, 18, 19 });
 	public static readonly SoundStyle Item2 = ItemSound(2);
 	public static readonly SoundStyle Item3 = ItemSound(3);
@@ -551,6 +549,7 @@ partial class SoundID
 	public static readonly SoundStyle Zombie128 = ZombieSound(128);
 	public static readonly SoundStyle Zombie129 = ZombieSound(129);
 	public static readonly SoundStyle Zombie130 = ZombieSound(130);
+	public static readonly int ZombieSoundCount = LegacySoundPlayer.ZombieSoundCount; // Added by TML just like ZombieX.
 
 	// Mapping
 
@@ -590,10 +589,10 @@ partial class SoundID
 			}
 		}
 
-		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 179);
-		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 58);
-		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 67);
-		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 130);
+		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, ItemSoundCount);
+		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, NPCHitCount);
+		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, NPCDeathCount);
+		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, ZombieSoundCount);
 	}
 
 	// Helper methods

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -590,10 +590,10 @@ partial class SoundID
 			}
 		}
 
-		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 172);
-		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 65);
-		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 57);
-		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 118);
+		AddNumberedStyles(LegacySoundIDs.Item, nameof(LegacySoundIDs.Item), 0, 179);
+		AddNumberedStyles(LegacySoundIDs.NPCHit, nameof(LegacySoundIDs.NPCHit), 0, 58);
+		AddNumberedStyles(LegacySoundIDs.NPCKilled, "NPCDeath", 0, 67);
+		AddNumberedStyles(LegacySoundIDs.Zombie, nameof(LegacySoundIDs.Zombie), 0, 130);
 	}
 
 	// Helper methods

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -714,6 +714,10 @@ partial class SoundID
 		LegacySoundIDs.Research => Research,
 		LegacySoundIDs.ResearchComplete => ResearchComplete,
 		LegacySoundIDs.QueenSlime => QueenSlime,
+		LegacySoundIDs.Clown => Clown,
+		LegacySoundIDs.Cockatiel => Cockatiel,
+		LegacySoundIDs.Macaw => Macaw,
+		LegacySoundIDs.Toucan => Toucan,
 		_ => null,
 	};
 }

--- a/patches/tModLoader/Terraria/ID/SoundID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/SoundID.cs.patch
@@ -64,13 +64,34 @@
  	public static readonly LegacySoundStyle NPCHit1 = new LegacySoundStyle(3, 1);
  	public static readonly LegacySoundStyle NPCHit2 = new LegacySoundStyle(3, 2);
  	public static readonly LegacySoundStyle NPCHit3 = new LegacySoundStyle(3, 3);
+@@ -149,6 +_,9 @@
+ 	public static readonly LegacySoundStyle NPCHit55 = new LegacySoundStyle(3, 55);
+ 	public static readonly LegacySoundStyle NPCHit56 = new LegacySoundStyle(3, 56);
+ 	public static readonly LegacySoundStyle NPCHit57 = new LegacySoundStyle(3, 57);
++	*/
++	public static readonly int NPCHitCount = 58; // Added by TML, keep this and SoundID.TML.cs up to date.
++	/*
+ 	public static readonly LegacySoundStyle NPCDeath1 = new LegacySoundStyle(4, 1);
+ 	public static readonly LegacySoundStyle NPCDeath2 = new LegacySoundStyle(4, 2);
+ 	public static readonly LegacySoundStyle NPCDeath3 = new LegacySoundStyle(4, 3);
+@@ -215,7 +_,9 @@
+ 	public static readonly LegacySoundStyle NPCDeath64 = new LegacySoundStyle(4, 64);
+ 	public static readonly LegacySoundStyle NPCDeath65 = new LegacySoundStyle(4, 65);
+ 	public static readonly LegacySoundStyle NPCDeath66 = new LegacySoundStyle(4, 66);
+-	public static short NPCDeathCount = 67;
++	*/
++	public static readonly int NPCDeathCount = 67; // TML: Changed from short to int and made readonly, keep this and SoundID.TML.cs up to date.
++	/*
+ 	public static readonly LegacySoundStyle Item1 = new LegacySoundStyle(2, 1);
+ 	public static readonly LegacySoundStyle Item2 = new LegacySoundStyle(2, 2);
+ 	public static readonly LegacySoundStyle Item3 = new LegacySoundStyle(2, 3);
 @@ -394,8 +_,12 @@
  	public static readonly LegacySoundStyle Item176 = new LegacySoundStyle(2, 176);
  	public static readonly LegacySoundStyle Item177 = new LegacySoundStyle(2, 177);
  	public static readonly LegacySoundStyle Item178 = new LegacySoundStyle(2, 178);
 -	public static short ItemSoundCount = 179;
 +	*/
-+	public static int ItemSoundCount = 179; // TML: Changed from short to int.
++	public static readonly int ItemSoundCount = 179; // TML: Changed from short to int and made readonly, keep this and SoundID.TML.cs up to date.
 +	/*
  	public static readonly LegacySoundStyle DD2_GoblinBomb = new LegacySoundStyle(2, 14).WithVolume(0.5f);
 +	*/


### PR DESCRIPTION
### What is the bug?  
The `LegacyArrayedStylesMap` indexes in `SoundID.TML.cs` were incorrect, causing `Failed to get legacy sound style` errors. Some indexes were lower than intended, leading to missing sound mappings.  

Also added 4 Existing `LegacySoundIDs` to the `GetLegacyStyle` Mapping.

This is also why #4425 is happening (along with other sounds).
Resolves #4425.

### How did you fix the bug?  
Updated the values for `LegacySoundIDs.Item`, `LegacySoundIDs.NPCHit`, `LegacySoundIDs.NPCKilled`, and `LegacySoundIDs.Zombie` to their correct ranges:  

In the `AddNumberedStyles` calls, changed the length of the generated map array
- `LegacySoundIDs.Item`: `172 → 179`  
- `LegacySoundIDs.NPCHit`: `65 → 58` 
- `LegacySoundIDs.NPCKilled`: `57 → 67`  
- `LegacySoundIDs.Zombie`: `118 → 130`  

I also added the missing mapping to the `GetLegacyStyle` function. (now clowns can finally laugh 🤡)

### Are there alternatives to your fix?  
Probably not.