### PR TITLE
Added MusicID.Sets.VolumeMult[]

### DIFF
--- a/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
@@ -1,11 +1,12 @@
 --- src/TerrariaNetCore/Terraria/Audio/LegacyAudioSystem.cs
 +++ src/tModLoader/Terraria/Audio/LegacyAudioSystem.cs
-@@ -2,8 +_,11 @@
+@@ -2,8 +_,12 @@
  using System.Collections;
  using System.Collections.Generic;
  using System.IO;
 +using System.Linq;
  using Microsoft.Xna.Framework.Audio;
++using Microsoft.Xna.Framework;
  using ReLogic.Content.Sources;
 +using Terraria.ID;
 +using Terraria.ModLoader.Engine;
@@ -63,18 +64,26 @@
  	public void LoadCue(int cueIndex, string cueName)
  	{
  		CueAudioTrack cueAudioTrack = new CueAudioTrack(SoundBank, cueName);
-@@ -245,18 +_,19 @@
+@@ -239,24 +_,27 @@
+ 		if (tempFade > 1f)
+ 			tempFade = 1f;
+ 
++		float volume = totalVolume * (MusicID.Sets.SkipsVolumeRemap[i] ? MathHelper.Clamp(MusicID.Sets.TrackVolumeWithoutRemap[i], 0, 2f) : 1f);
++
+ 		if (!AudioTracks[i].IsPlaying && active) {
+ 			if (MusicReplayDelay == 0) {
+ 				if (Main.SettingMusicReplayDelayEnabled)
  					MusicReplayDelay = Main.rand.Next(14400, 21601);
  
  				AudioTracks[i].Reuse();
 -				AudioTracks[i].SetVariable("Volume", totalVolume);
-+				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", totalVolume);
++				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", volume);
  				AudioTracks[i].Play();
  			}
  		}
  		else {
 -			AudioTracks[i].SetVariable("Volume", totalVolume);
-+			AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", totalVolume);
++			AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", volume);
  		}
  	}
  
@@ -86,12 +95,13 @@
  			return;
  
  		if (AudioTracks[i].IsPlaying || !AudioTracks[i].IsStopped) {
-@@ -271,7 +_,7 @@
+@@ -271,7 +_,8 @@
  				AudioTracks[i].Stop(AudioStopOptions.Immediate);
  			}
  			else {
 -				AudioTracks[i].SetVariable("Volume", totalVolume);
-+				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect"  : "Volume", totalVolume);
++				float volume = totalVolume * (MusicID.Sets.SkipsVolumeRemap[i] ? MathHelper.Clamp(MusicID.Sets.TrackVolumeWithoutRemap[i], 0, 2f) : 1f);
++				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", volume);
  			}
  		}
  		else {

--- a/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacyAudioSystem.cs.patch
@@ -68,7 +68,7 @@
  		if (tempFade > 1f)
  			tempFade = 1f;
  
-+		float volume = totalVolume * (MusicID.Sets.SkipsVolumeRemap[i] ? MathHelper.Clamp(MusicID.Sets.TrackVolumeWithoutRemap[i], 0, 2f) : 1f);
++		float volume = totalVolume * MathHelper.Clamp(MusicID.Sets.VolumeMult[i], 0, MusicID.Sets.SkipsVolumeRemap[i] ? 2f : 1f);
 +
  		if (!AudioTracks[i].IsPlaying && active) {
  			if (MusicReplayDelay == 0) {
@@ -100,7 +100,7 @@
  			}
  			else {
 -				AudioTracks[i].SetVariable("Volume", totalVolume);
-+				float volume = totalVolume * (MusicID.Sets.SkipsVolumeRemap[i] ? MathHelper.Clamp(MusicID.Sets.TrackVolumeWithoutRemap[i], 0, 2f) : 1f);
++				float volume = totalVolume * MathHelper.Clamp(MusicID.Sets.VolumeMult[i], 0, MusicID.Sets.SkipsVolumeRemap[i] ? 2f : 1f);
 +				AudioTracks[i].SetVariable(MusicID.Sets.SkipsVolumeRemap[i] ? "VolumeDirect" : "Volume", volume);
  			}
  		}

--- a/patches/tModLoader/Terraria/ID/MusicID.cs
+++ b/patches/tModLoader/Terraria/ID/MusicID.cs
@@ -13,6 +13,13 @@ public static class MusicID
 		/// <para/>This should be set in <see cref="ModType.SetStaticDefaults()"/>, preferably <see cref="ModSystem"/>
 		/// </summary>
 		public static bool[] SkipsVolumeRemap = Factory.CreateBoolSet(false);
+
+		/// <summary>
+		/// A multiplier of the specified track's volume.
+		/// <para/> This only applies if <see cref="SkipsVolumeRemap"/> is set to <see langword="true"/> for the same track.
+		/// <para/> Clamped between 0 and 2.
+		/// </summary>
+		public static float[] TrackVolumeWithoutRemap = Factory.CreateFloatSet(1);
 	}
 	// Names derived from the music box that plays each: https://terraria.wiki.gg/wiki/Music_Box
 	public const short OverworldDay = 1;

--- a/patches/tModLoader/Terraria/ID/MusicID.cs
+++ b/patches/tModLoader/Terraria/ID/MusicID.cs
@@ -16,10 +16,9 @@ public static class MusicID
 
 		/// <summary>
 		/// A multiplier of the specified track's volume.
-		/// <para/> This only applies if <see cref="SkipsVolumeRemap"/> is set to <see langword="true"/> for the same track.
-		/// <para/> Clamped between 0 and 2.
+		/// <para/> Clamped between 0 and 2 for tracks that have <see cref="SkipsVolumeRemap"/> set to <see langword="true"/>, but between 0 and 1 otherwise.
 		/// </summary>
-		public static float[] TrackVolumeWithoutRemap = Factory.CreateFloatSet(1);
+		public static float[] VolumeMult = Factory.CreateFloatSet(1);
 	}
 	// Names derived from the music box that plays each: https://terraria.wiki.gg/wiki/Music_Box
 	public const short OverworldDay = 1;


### PR DESCRIPTION
### What is the new feature?
Continuation of https://github.com/tModLoader/tModLoader/pull/4530
Adds `MusicID.Sets.VolumeMult[]` which modifies the volume of specified music tracks.
Clamped between 0 and 2 as a reasonable value, but if a track has `SkipsVolumeRemap[]` set to false, `VolumeMult[]` gets clamped between 0 and 1 because:
![bild](https://github.com/user-attachments/assets/b1f04d7c-2407-4cf5-acc0-d317509f2edd)


### Why should this be part of tModLoader?
Quite a few people reported that the recent `SkipsVolumeRemap[]` addition made certain tracks too loud, so this feature gives modders the ability to selectively adjust the volume of music.

This also consequently allows modders to adjust the volume of music in real-time without tampering with the volume slider or `Main.musicFade`.

### Are there alternative designs?
None that I can think of.  

### Sample usage for the new feature
The intended usage of adjusting the overall volume of a track:
```cs
public class MusicSystem : ModSystem {
    public override void SetStaticDefaults() 
    {
        MusicID.Sets.VolumeMult[MusicLoader.GetMusicSlot(Mod, "Assets/Music/MySong")] = 0.8f;
    }
}
```

But also the ability to adjust the volume of certain tracks in real time for something like a cutscene:
```cs
public override void SomeMethodThatUpdates()
{
    MusicID.Sets.VolumeMult[MusicLoader.GetMusicSlot(Mod, "Assets/Music/MySong")] = MathHelper.SmoothStep(1, 0, t);
    //It's important to reset this to its original value afterwards though, otherwise it will stay as 0 until the game reloads
}
```