### PR TITLE
Use DisplayNameClean if available for Missing & New Mods

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UICharacterListItem.TML.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Terraria.IO;
 using Terraria.Localization;
 using Terraria.ModLoader;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.Utilities;
@@ -37,8 +38,8 @@ partial class UICharacterListItem
 
 		if (data.Player.usedMods != null) {
 			string[] currentModNames = ModLoader.ModLoader.Mods.Select(m => m.Name).ToArray();
-			var missingMods = data.Player.usedMods.Except(currentModNames).ToList();
-			var newMods = currentModNames.Except(new[] { "ModLoader" }).Except(data.Player.usedMods).ToList();
+			var missingMods = data.Player.usedMods.Except(currentModNames).Select(ModOrganizer.GetDisplayNameCleanFromLocalModsOrDefaultToModName).ToList();
+			var newMods = currentModNames.Except(new[] { "ModLoader" }).Except(data.Player.usedMods).Select(ModOrganizer.GetDisplayNameCleanFromLocalModsOrDefaultToModName).ToList();
 			bool checkModPack = System.IO.Path.GetFileNameWithoutExtension(ModLoader.Core.ModOrganizer.ModPackActive) != data.Player.modPack;
 
 			if (checkModPack || missingMods.Count > 0 || newMods.Count > 0) {

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using Terraria.IO;
 using Terraria.Localization;
+using Terraria.ModLoader.Core;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.Utilities;
@@ -55,9 +56,9 @@ public partial class UIWorldListItem : AWorldListItem
 		// TODO: Should we also show a separate button for mods that were present during worldgen but aren't enabled?
 		if (data.usedMods != null) {
 			string[] currentModNames = ModLoader.ModLoader.Mods.Select(m => m.Name).ToArray();
-			var missingMods = data.usedMods.Except(currentModNames).ToList();
-			var newMods = currentModNames.Except(new[] { "ModLoader" }).Except(data.usedMods).ToList();
-			bool checkModPack = System.IO.Path.GetFileNameWithoutExtension(ModLoader.Core.ModOrganizer.ModPackActive) != data.modPack;
+			var missingMods = data.usedMods.Except(currentModNames).Select(ModOrganizer.GetDisplayNameCleanFromLocalModsOrDefaultToModName).ToList();
+			var newMods = currentModNames.Except(new[] { "ModLoader" }).Except(data.usedMods).Select(ModOrganizer.GetDisplayNameCleanFromLocalModsOrDefaultToModName).ToList();
+			bool checkModPack = System.IO.Path.GetFileNameWithoutExtension(ModOrganizer.ModPackActive) != data.modPack;
 
 			if (checkModPack || missingMods.Count > 0 || newMods.Count > 0) {
 				UIImageButton modListWarning = new UIImageButton(UICommon.ButtonErrorTexture) {

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -788,4 +788,14 @@ internal static class ModOrganizer
 
 		return parentDir;
 	}
+
+	// NOTE: This does not search the workshop, only checks locally available mods
+	internal static string GetDisplayNameCleanFromLocalModsOrDefaultToModName(string modname)
+	{
+		var localMods = AllFoundMods.Where(m => string.Equals(modname, m.Name));
+		if (!localMods.Any())
+			return modname;
+
+		return localMods.FirstOrDefault().DisplayNameClean;
+	}
 }


### PR DESCRIPTION
Addresses the conversation included in the Collaborators Chat. 

Uses the DisplayNameClean if available instead of internal name so that mods that are very different (like QoL Terraria which has ImproveGame) are player understandable.

![image](https://github.com/user-attachments/assets/0374af9a-f730-4b57-80fe-2571d0a48116)