### PR TITLE
Made critter cage lids account for multi-column spritesheets

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -340,6 +340,14 @@
  				break;
  		}
  
+@@ -1181,6 +_,7 @@
+ 				value4 = normalTileRect;
+ 				value4.Y = 0;
+ 				value4.Height = 10;
++				value4.X %= num10 < 3 ? 108 : 54; // Added by TML. Accounts for tilesheets with multiple columns
+ 				Main.spriteBatch.Draw(TextureAssets.CageTop[num10].Value, position, value4, drawData.finalColor, 0f, _zero, 1f, drawData.tileSpriteEffect, 0f);
+ 			}
+ 			else {
 @@ -1265,6 +_,9 @@
  			case 662:
  				return 4;


### PR DESCRIPTION
### What is the bug?
Modded critter cages that use `TileID.Sets.CritterCageLidStyle[]` and  more than one column (Either because they have a lot of frames, or because it was exported with animations split into columns) have the top lid break because the frame coordinates aren't wrapping properly.

### How did you fix the bug?
Made the X frame of the critter cage lid get wrapped around by the tile's width (account for 6x3 vs 3x2 critter cages)

### Are there alternatives to your fix?
Can't think of anything more straightforward than this. A more general system for critter cages of any width could maybe get made, but at this point just use custom drawing code.