### PR TITLE
Let damage classes inherit generic weapon prefixes

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -150,7 +150,7 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 	/// Allows you to change whether or not a weapon receives generic prefixes. Return true if the item should receive generic prefixes and false if it should only receive them from another category.
 	/// </summary>
 	public virtual bool WeaponPrefix()
-		=> Item.DamageType.GetsPrefixesFor(DamageClass.Melee) && Item.noUseGraphic;
+		=> (Item.DamageType.GetsPrefixesFor(DamageClass.Melee) && Item.noUseGraphic) || Item.DamageType.GetsPrefixesFor(DamageClass.Generic);
 
 	/// <summary>
 	/// Allows you to change whether or not a weapon receives ranged prefixes. Return true if the item should receive ranged prefixes and false if it should not.


### PR DESCRIPTION
### What is the bug?
I forgot to let damage classes inherit generic weapon prefixes in #4175 

### How did you fix the bug?
`ModItem.WeaponPrefix` default implementation now also checks if the damage class inherits prefixes from `DamageClass.Generic`

### Are there alternatives to your fix?
I don't believe there are any alternatives which would not take control over whether or not an item gets generic weapon prefixes away from modders