### PR TITLE
Add check for broken TML methods when verifying mod assemblies

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -334,16 +334,32 @@ public static class AssemblyManager
 
 	private static IDictionary<Assembly, Type[]> GetLoadableTypes(ModLoadContext mod, MetadataLoadContext mlc)
 	{
+		Type loadingType = null;
 		try {
 			return mod.Assemblies.ToDictionary(a => a, asm =>
 				mlc.LoadFromAssemblyName(asm.GetName()).GetTypes()
 					.Where(mType => IsLoadable(mod, mType))
-					.Select(mType => asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false))
+					.Select(mType => {
+						loadingType = mType;
+						return asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false);
+					})
 					.ToArray());
 		}
 		catch (Exception e) {
+			if (loadingType != null) {
+				foreach (MethodInfo method in loadingType?.GetMethods()) {
+					// check if it is an abstract method which is not overriden, and originates from tModLoader's assembly
+					if (method.IsAbstract && method.DeclaringType != loadingType &&	method.DeclaringType != null && Assembly.GetAssembly(method.DeclaringType)?.ToString() == Assembly.GetExecutingAssembly().ToString()) {
+						throw new Exceptions.GetLoadableTypesException(
+							"This mod seems to contain a class which inherits from TML but do not implement required methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in class \"{loadingType.FullName}\" caused this error.\n\n" +	e.Message,
+							e
+						);
+					}
+				}
+			}
+
 			throw new Exceptions.GetLoadableTypesException(
-				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (e.Data["type"] is Type type ? $"The \"{type.FullName}\" class caused this error.\n\n" : "") + e.Message,
+				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + $"The \"{loadingType}\" class caused this error.\n\n" + e.Message,
 				e
 			);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -359,7 +359,7 @@ public static class AssemblyManager
 			}
 
 			throw new Exceptions.GetLoadableTypesException(
-				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + $"The \"{loadingType}\" class caused this error.\n\n" + e.Message,
+				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (loadingType != null? $"The \"{loadingType}\" class caused this error.\n\n" : "") + e.Message,
 				e
 			);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -348,10 +348,10 @@ public static class AssemblyManager
 		catch (Exception e) {
 			if (loadingType != null) {
 				foreach (MethodInfo method in loadingType?.GetMethods()) {
-					// check if it is an abstract method which is not overriden, and originates from tModLoader's assembly
-					if (method.IsAbstract && method.DeclaringType != loadingType &&	method.DeclaringType != null && Assembly.GetAssembly(method.DeclaringType)?.ToString() == Assembly.GetExecutingAssembly().ToString()) {
-						throw new Exceptions.GetLoadableTypesException(
-							"This mod seems to contain a class which inherits from TML but do not implement required methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in class \"{loadingType.FullName}\" caused this error.\n\n" +	e.Message,
+					// Check if it is an abstract method which is not overridden and originates from tModLoader's assembly
+					if (method.IsAbstract && method.DeclaringType != loadingType &&	method.DeclaringType != null && Assembly.GetAssembly(method.DeclaringType)?.FullName == Assembly.GetExecutingAssembly().FullName) {
+						throw new Exception(
+							"This mod seems to contain a class which inherits from a tModLoader class but does not implement required abstract methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{loadingType.FullName}\" caused this error.\n\n" + e.Message,
 							e
 						);
 					}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -334,24 +334,27 @@ public static class AssemblyManager
 
 	private static IDictionary<Assembly, Type[]> GetLoadableTypes(ModLoadContext mod, MetadataLoadContext mlc)
 	{
-		Type loadingType = null;
 		try {
 			return mod.Assemblies.ToDictionary(a => a, asm =>
 				mlc.LoadFromAssemblyName(asm.GetName()).GetTypes()
 					.Where(mType => IsLoadable(mod, mType))
-					.Select(mType => {
-						loadingType = mType;
-						return asm.GetType(mType.FullName, throwOnError: true, ignoreCase: false);
-					})
+					.Select(mType => GetType(asm, mType))
 					.ToArray());
 		}
 		catch (Exception e) {
-			if (loadingType != null) {
-				foreach (MethodInfo method in loadingType?.GetMethods()) {
-					// Check if it is an abstract method which is not overridden and originates from tModLoader's assembly
-					if (method.IsAbstract && method.DeclaringType != loadingType &&	method.DeclaringType != null && Assembly.GetAssembly(method.DeclaringType)?.FullName == Assembly.GetExecutingAssembly().FullName) {
+			if (e.Data["type"] != null) {
+				foreach (MethodInfo method in ((Type)e.Data["type"]).GetMethods()) {
+					// Check if it is an abstract method which is not overridden
+					if (method.IsAbstract && method.DeclaringType != null && method.DeclaringType != (Type)e.Data["type"]) {
+						if (method.DeclaringType.Assembly.FullName == Assembly.GetExecutingAssembly().FullName)	{
+							throw new Exception(
+								"This mod seems to contain a class which inherits from a tModLoader class but does not implement required abstract methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{((Type)e.Data["type"]).FullName}\" caused this error.\n\n" + e.Message,
+								e
+							);
+						}
+
 						throw new Exception(
-							"This mod seems to contain a class which inherits from a tModLoader class but does not implement required abstract methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{loadingType.FullName}\" caused this error.\n\n" + e.Message,
+							"This mod seems to contain a class which inherits from a class in another mod but does not implement required abstract methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{((Type)e.Data["type"]).FullName}\" caused this error.\n\n" + e.Message,
 							e
 						);
 					}
@@ -359,7 +362,7 @@ public static class AssemblyManager
 			}
 
 			throw new Exceptions.GetLoadableTypesException(
-				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (loadingType != null? $"The \"{loadingType}\" class caused this error.\n\n" : "") + e.Message,
+				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (e.Data["type"] != null? $"The \"{((Type)e.Data["type"]).FullName}\" class caused this error.\n\n" : "") + e.Message,
 				e
 			);
 		}
@@ -385,6 +388,24 @@ public static class AssemblyManager
 			return type.GetInterfaces().All(i => IsLoadable(mod, i));
 		}
 		catch (FileNotFoundException e) {
+			e.Data["type"] = type;
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Gets and validates the <see cref="Type"/> from the given <see cref="Assembly"/>.
+	/// </summary>
+	/// <param name="assembly">Assembly to load type from</param>
+	/// <param name="type">Target type to get</param>
+	/// <returns></returns>
+	#nullable enable
+	private static Type? GetType(Assembly assembly, Type type) {
+	#nullable disable
+		try {
+			return assembly.GetType(type.FullName, throwOnError: true, ignoreCase: false);
+		}
+		catch (TypeLoadException e)	{
 			e.Data["type"] = type;
 			throw;
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -342,19 +342,20 @@ public static class AssemblyManager
 					.ToArray());
 		}
 		catch (Exception e) {
-			if (e.Data["type"] != null) {
-				foreach (MethodInfo method in ((Type)e.Data["type"]).GetMethods()) {
+			Type type = (Type)e.Data["type"];
+			if (type != null) {
+				foreach (MethodInfo method in type.GetMethods()) {
 					// Check if it is an abstract method which is not overridden
-					if (method.IsAbstract && method.DeclaringType != null && method.DeclaringType != (Type)e.Data["type"]) {
+					if (method.IsAbstract && method.DeclaringType != null && method.DeclaringType != type) {
 						if (method.DeclaringType.Assembly.FullName == Assembly.GetExecutingAssembly().FullName)	{
 							throw new Exception(
-								"This mod seems to contain a class which inherits from a tModLoader class but does not implement required abstract methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{((Type)e.Data["type"]).FullName}\" caused this error.\n\n" + e.Message,
+								"This mod seems to contain a class which inherits from a tModLoader class but does not implement required abstract methods. Use tModPorter to update required methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{type.FullName}\" caused this error.\n\n" + e.Message,
 								e
 							);
 						}
 
 						throw new Exception(
-							"This mod seems to contain a class which inherits from a class in another mod but does not implement required abstract methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{((Type)e.Data["type"]).FullName}\" caused this error.\n\n" + e.Message,
+							"This mod seems to contain a class which inherits from a class in another mod but does not implement required abstract methods." + "\n\n" + $"The method \"{method.Name}\" in the class \"{type.FullName}\" caused this error.\n\n" + e.Message,
 							e
 						);
 					}
@@ -362,7 +363,7 @@ public static class AssemblyManager
 			}
 
 			throw new Exceptions.GetLoadableTypesException(
-				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (e.Data["type"] != null? $"The \"{((Type)e.Data["type"]).FullName}\" class caused this error.\n\n" : "") + e.Message,
+				"This mod seems to inherit from classes in another mod. Use the [ExtendsFromMod] attribute to allow this mod to load when that mod is not enabled." + "\n\n" + (type != null? $"The \"{type.FullName}\" class caused this error.\n\n" : "") + e.Message,
 				e
 			);
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/AssemblyManager.cs
@@ -402,7 +402,6 @@ public static class AssemblyManager
 	/// <returns></returns>
 	#nullable enable
 	private static Type? GetType(Assembly assembly, Type type) {
-	#nullable disable
 		try {
 			return assembly.GetType(type.FullName, throwOnError: true, ignoreCase: false);
 		}
@@ -411,6 +410,7 @@ public static class AssemblyManager
 			throw;
 		}
 	}
+	#nullable disable
 
 	internal static Task JITModAsync(Mod mod, CancellationToken token) => JITAssembliesAsync(GetModAssemblies(mod.Name), mod.PreJITFilter, token);
 	internal static void JITMod(Mod mod) => JITAssemblies(GetModAssemblies(mod.Name), mod.PreJITFilter);


### PR DESCRIPTION
### What is the bug?
fixes https://github.com/tModLoader/tModLoader/issues/3820

### How did you fix the bug?
Added a new variable to keep track of where the validation fails, then iterated through that type's methods to find a method which meets the following conditions:
- Method is abstract
- Method has a declaring type
- The type which declares the method is NOT the type that failed validation
- Assembly which first declared the method is the TML assembly

When a method meets these conditions, the validation will throw an error prompting the user to use tModPorter.

### Are there alternatives to your fix?
- The original caught error (which triggers the code in the pr) has no easily accessible data in it but contains the failed method and type in the message, which could be regex'ed out instead of searching for the method. 
- More minor, but this pr compares assemblies using `.ToString()`, which feels hacky. An alternative is to use `.FullName`

### Other Notes
- There is a very long if statement, could be compacted in accordance with formatting guidelines.
- Somehow reducing the nesting inside the `catch`

The mod I used to test this is linked. It reproduces this bug by having a class which inherits `BuilderToggle` without implementing the abstract method `DisplayValue()`.
[TestMod.zip](https://github.com/user-attachments/files/19146315/TestMod.zip)
