### PR TITLE
Fix ugly text rendering in various places

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureInterface.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureInterface.cs.patch
@@ -5,7 +5,7 @@
  	private void DrawButtons(SpriteBatch sb)
  	{
 +		sb.End();
-+		sb.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
++		sb.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix); // #4578 vanilla fix
 +
  		new Vector2(Main.mouseX, Main.mouseY);
  		int num = 9;
@@ -16,7 +16,7 @@
  			Main.instance.MouseText(text, 0, 0);
 +
 +		sb.End();
-+		sb.Begin(SpriteSortMode.Deferred, null, null, null, null, null, Main.UIScaleMatrix);
++		sb.Begin(SpriteSortMode.Deferred, null, null, null, null, null, Main.UIScaleMatrix); // #4578 vanilla fix
  	}
  
  	private static bool GetMapCoords(int PinX, int PinY, int Goal, out Point result)

--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureInterface.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureInterface.cs.patch
@@ -1,0 +1,22 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Capture/CaptureInterface.cs
++++ src/tModLoader/Terraria/Graphics/Capture/CaptureInterface.cs
+@@ -955,6 +_,9 @@
+ 
+ 	private void DrawButtons(SpriteBatch sb)
+ 	{
++		sb.End();
++		sb.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullCounterClockwise, null, Main.UIScaleMatrix);
++
+ 		new Vector2(Main.mouseX, Main.mouseY);
+ 		int num = 9;
+ 		for (int i = 0; i < num; i++) {
+@@ -1072,6 +_,9 @@
+ 
+ 		if (text != "")
+ 			Main.instance.MouseText(text, 0, 0);
++
++		sb.End();
++		sb.Begin(SpriteSortMode.Deferred, null, null, null, null, null, Main.UIScaleMatrix);
+ 	}
+ 
+ 	private static bool GetMapCoords(int PinX, int PinY, int Goal, out Point result)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -4998,6 +4998,16 @@
  		spriteBatch.End();
  		spriteBatch.Begin(SpriteSortMode.Deferred, null, SamplerState.PointClamp, null, null, null, GameViewMatrix.ZoomMatrix);
  		PlayerInput.SetZoom_UI();
+@@ -34983,6 +_,9 @@
+ 		DrawInterface_Resources_ClearBuffs();
+ 		if (!ingameOptionsWindow && !playerInventory && !inFancyUI)
+ 			DrawInterface_Resources_Buffs();
++
++		spriteBatch.End();
++		spriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, UIScaleMatrix);
+ 	}
+ 
+ 	public static void DrawInterface_Resources_ClearBuffs()
 @@ -35027,10 +_,18 @@
  			if (num5 == 147)
  				bannerMouseOver = true;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5004,7 +5004,7 @@
  			DrawInterface_Resources_Buffs();
 +
 +		spriteBatch.End();
-+		spriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, UIScaleMatrix);
++		spriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, UIScaleMatrix); // #4578 vanilla fix
  	}
  
  	public static void DrawInterface_Resources_ClearBuffs()


### PR DESCRIPTION
`Main.GUIBarsDrawInner` sets the sampler state to `PointClamp`, which ends up leaking into text rendering in a few places. This includes
- Mouse text in `IngameFancyUI`, including the bestiary.
- Mouse text in the options menu.
- Camera mode.

I believe this issue also affects vanilla.

Here are a few screenshots showing the difference before and after this patch:
| **Before** | **After** |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/30bf2d5e-a9db-4383-a441-ddb0c0422faa) | ![image](https://github.com/user-attachments/assets/37742b63-7e55-47c3-b98a-d15f9120388e) |
| ![image](https://github.com/user-attachments/assets/4dcd59ed-bac4-43b3-9109-7fbf023b5f2d) | ![image](https://github.com/user-attachments/assets/31557f46-6bcd-4e40-b703-166d50719a60) |
| ![image](https://github.com/user-attachments/assets/e74b36b5-0a4a-455c-85db-5b7ba448ec1c) | ![image](https://github.com/user-attachments/assets/1c0c28f4-d2f3-4eab-9c08-e45f040c0b12) |

I opted to reset the sampler state at the end of `GUIBarsDrawInner`, but it could also probably be handled by setting it at the top of the affected functions (like `MouseTextInner`).

As far as I can tell, the parameters I give to `spriteBatch.Begin` are the same as the ones set prior to every call to `GUIBarsDrawInner`, but I'm not 100% sure. I think optimally, there would be some way to save and restore the sprite batch state, a bit like the proposal in #4072.