### PR TITLE
ModMapLayer positioning

### DIFF
--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -16,11 +16,9 @@ namespace ExampleMod.Common
 	// ModMapLayers are used to draw icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. This example adds an icon over the dungeon.
 	public class ExampleMapLayer : ModMapLayer
 	{
-		public override Position GetDefaultPosition() {
-			// Here you can define where to put this layer in the vanilla map layer order.
-			// In this case we go before the pings layer since all other vanilla map layers are ordered before pings,
-			return new Before(IMapLayer.Pings);
-		}
+		// Here you can define where to put this layer in the vanilla map layer order.
+		// In this case we go before the pings layer since all other vanilla map layers are ordered before pings,
+		public override Position GetDefaultPosition() => new Before(IMapLayer.Pings);
 
 		// In the Draw method, we draw everything. Consulting vanilla examples in the source code is a good resource for properly using this Draw method.
 		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
@@ -58,9 +56,7 @@ namespace ExampleMod.Common
 	// This example makes any ExampleItems that are on the ground in the world show up on the map.
 	public class ExampleItemMapLayer : ModMapLayer
 	{
-		public override Position GetDefaultPosition() {
-			return new Before(IMapLayer.Pings);
-		}
+		public override Position GetDefaultPosition() => new Before(IMapLayer.Pings);
 
 		public override IEnumerable<Position> GetModdedConstraints() {
 			// By default, modded map layers are positioned between two vanilla layers (via After and Before) and are ordered in load order.
@@ -71,6 +67,12 @@ namespace ExampleMod.Common
 		}
 
 		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
+			// We can check Main.mapStyle or Main.mapFullscreen to limit drawing to specific map modes.
+			// This example doesn't draw on the overlay map, but draws on the minimap and fullscreen map.
+			if (Main.mapStyle == 2) {
+				return;
+			}
+
 			foreach (Item item in Main.ActiveItems) {
 				if (item.type == ModContent.ItemType<ExampleItem>()) {
 					Texture2D itemTexture = TextureAssets.Item[item.type].Value;

--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ExampleMod.Content.Items;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 using System.IO;
 using Terraria;
 using Terraria.DataStructures;
@@ -7,6 +10,7 @@ using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader;
 using Terraria.UI;
+using static Terraria.Map.IMapLayer;
 
 namespace ExampleMod.Common
 {
@@ -14,6 +18,8 @@ namespace ExampleMod.Common
 	public class ExampleMapLayer : ModMapLayer
 	{
 		public override Position GetDefaultPosition() {
+			// Here you can define where to put this layer in the vanilla map layer order.
+			// In this case we go before the pings layer since all other vanilla map layers are ordered before pings,
 			return new Before(IMapLayer.Pings);
 		}
 
@@ -47,6 +53,35 @@ namespace ExampleMod.Common
 		public override void NetReceive(BinaryReader reader) {
 			Main.dungeonX = reader.ReadInt32();
 			Main.dungeonY = reader.ReadInt32();
+		}
+	}
+
+	// This example makes any ExampleItems that are on the ground in the world show up on the map.
+	public class ExampleItemMapLayer : ModMapLayer
+	{
+		public override Position GetDefaultPosition() {
+			return new Before(IMapLayer.Pings);
+		}
+
+		public override IEnumerable<Position> GetModdedConstraints() {
+			// By default, modded map layers are positioned between two vanilla layers (via After and Before) and are ordered in load order.
+			// This hook allows you to organize where this map layer is located relative to other modded map layers that are also
+			// placed between the same two vanilla map layers.
+			// In this case ExampleItems will always show up underneath the dungeon icon.
+			yield return new Before(ModContent.GetInstance<ExampleMapLayer>());
+		}
+
+		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
+			foreach (Item item in Main.ActiveItems) {
+				if (item.type == ModContent.ItemType<ExampleItem>()) {
+					Texture2D itemTexture = TextureAssets.Item[item.type].Value;
+
+					// item.position is in world coordinates, so divide by 16 to convert it to tile coordinates.
+					Vector2 tilePosition = item.position / 16f;
+
+					context.Draw(itemTexture, tilePosition, Alignment.Center);
+				}
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -13,6 +13,10 @@ namespace ExampleMod.Common
 	// ModMapLayers are used to draw icons and other things over the map. Pylons and spawn/bed icons are examples of vanilla map layers. This example adds an icon over the dungeon.
 	public class ExampleMapLayer : ModMapLayer
 	{
+		public override Position GetDefaultPosition() {
+			return new Before(IMapLayer.Pings);
+		}
+
 		// In the Draw method, we draw everything. Consulting vanilla examples in the source code is a good resource for properly using this Draw method.
 		public override void Draw(ref MapOverlayDrawContext context, ref string text) {
 			// Here we define the scale that we wish to draw the icon when hovered and not hovered.

--- a/ExampleMod/Common/ExampleMapLayer.cs
+++ b/ExampleMod/Common/ExampleMapLayer.cs
@@ -10,7 +10,6 @@ using Terraria.Localization;
 using Terraria.Map;
 using Terraria.ModLoader;
 using Terraria.UI;
-using static Terraria.Map.IMapLayer;
 
 namespace ExampleMod.Common
 {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -232,7 +232,7 @@
  	public static RenderTarget2D screenTarget;
  	public static RenderTarget2D screenTargetSwap;
  	public static int maxMapUpdates = 250000;
-@@ -560,8 +_,8 @@
+@@ -560,14 +_,21 @@
  	public static bool clearMap;
  	public static int mapTargetX = 5;
  	public static int mapTargetY = 2;
@@ -243,6 +243,29 @@
  	public static bool[,] initMap = new bool[mapTargetX, mapTargetY];
  	public static bool[,] mapWasContentLost = new bool[mapTargetX, mapTargetY];
  	public const int numInfoIcons = 13;
+ 	public static Microsoft.Xna.Framework.Color OurFavoriteColor = new Microsoft.Xna.Framework.Color(255, 231, 69);
+ 	public static bool mapInit;
+ 	public static bool mapEnabled = true;
++	/// <summary>
++	/// Dictates how the non-<see cref="mapFullscreen"/> map is displayed.
++	/// <para/> Can be one of the following values/modes:
++	/// <br/><b>0:</b> The minimap has been hidden.
++	/// <br/><b>1:</b> The minimap is visible.
++	/// <br/><b>2:</b> The overlay map is visible.
++	/// </summary>
+ 	public static int mapStyle = 1;
+ 	public static float grabMapX;
+ 	public static float grabMapY;
+@@ -580,6 +_,9 @@
+ 	public static float mapMinimapAlpha = 1f;
+ 	public static float mapOverlayScale = 2.5f;
+ 	public static float mapOverlayAlpha = 0.35f;
++	/// <summary>
++	/// If true, the map is currently in fullscreen mode. See also <see cref="Main.mapStyle"/>, note that the overlay map does not count as the fullscreen map.
++	/// </summary>
+ 	public static bool mapFullscreen;
+ 	public static bool resetMapFull;
+ 	public static float mapFullscreenScale = 4f;
 @@ -592,12 +_,12 @@
  	private int lastTileX;
  	private int firstTileY;

--- a/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria.ModLoader;
+﻿using System.Collections.Generic;
 
 namespace Terraria.Map;
+
 public partial interface IMapLayer
 {
 	public static IMapLayer Spawn { get; private set; } = new SpawnMapLayer();
@@ -23,8 +19,6 @@ public partial interface IMapLayer
 	#region Sort Positions
 
 	public abstract class Position;
-
-	public sealed class Append : Position;
 
 	public sealed class Before : Position
 	{

--- a/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
@@ -8,15 +8,17 @@ using Terraria.ModLoader;
 namespace Terraria.Map;
 public partial interface IMapLayer
 {
-	public static IMapLayer Spawn = new SpawnMapLayer();
-	public static IMapLayer Pylons = new TeleportPylonsMapLayer();
-	public static IMapLayer Pings = Main.Pings;
+	public static IMapLayer Spawn { get; private set; } = new SpawnMapLayer();
+	public static IMapLayer Pylons { get; private set; } = new TeleportPylonsMapLayer();
+	public static IMapLayer Pings { get; private set; } = new PingMapLayer();
 
 	bool Visible { get; internal set; }
 
 	void Hide() => Visible = false;
 
-	Position GetDefaultPosition() => new Append();
+	Position GetDefaultPosition() => new Before(null);
+
+	IEnumerable<Position> GetModdedConstraints() => null;
 
 	#region Sort Positions
 

--- a/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace Terraria.Map;
+public partial interface IMapLayer
+{
+	public static IMapLayer Spawn = new SpawnMapLayer();
+	public static IMapLayer Pylons = new TeleportPylonsMapLayer();
+	public static IMapLayer Pings = Main.Pings;
+
+	bool Visible { get; internal set; }
+
+	void Hide() => Visible = false;
+
+	Position GetDefaultPosition() => new Append();
+
+	#region Sort Positions
+
+	public abstract class Position;
+
+	public sealed class Append : Position;
+
+	public sealed class Before : Position
+	{
+		public IMapLayer Layer { get; }
+
+		public Before(IMapLayer layer)
+		{
+			Layer = layer;
+		}
+	}
+
+	public sealed class After : Position
+	{
+		public IMapLayer Layer { get; }
+
+		public After(IMapLayer layer)
+		{
+			Layer = layer;
+		}
+	}
+
+	#endregion
+}

--- a/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Terraria.Map;
+﻿namespace Terraria.Map;
 
 public partial interface IMapLayer
 {
@@ -11,34 +9,4 @@ public partial interface IMapLayer
 	bool Visible { get; internal set; }
 
 	void Hide() => Visible = false;
-
-	Position GetDefaultPosition() => new Before(null);
-
-	IEnumerable<Position> GetModdedConstraints() => null;
-
-	#region Sort Positions
-
-	public abstract class Position;
-
-	public sealed class Before : Position
-	{
-		public IMapLayer Layer { get; }
-
-		public Before(IMapLayer layer)
-		{
-			Layer = layer;
-		}
-	}
-
-	public sealed class After : Position
-	{
-		public IMapLayer Layer { get; }
-
-		public After(IMapLayer layer)
-		{
-			Layer = layer;
-		}
-	}
-
-	#endregion
 }

--- a/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.cs.patch
@@ -1,13 +1,10 @@
 --- src/TerrariaNetCore/Terraria/Map/IMapLayer.cs
 +++ src/tModLoader/Terraria/Map/IMapLayer.cs
-@@ -3,4 +_,10 @@
- public interface IMapLayer
+@@ -1,6 +_,6 @@
+ namespace Terraria.Map;
+ 
+-public interface IMapLayer
++public partial interface IMapLayer
  {
  	void Draw(ref MapOverlayDrawContext context, ref string text);
-+
-+	// Added by TML.
-+	bool Visible { get; internal set; }
-+
-+	// Added by TML.
-+	void Hide() => Visible = false;
  }

--- a/patches/tModLoader/Terraria/Map/MapOverlayDrawContext.cs.patch
+++ b/patches/tModLoader/Terraria/Map/MapOverlayDrawContext.cs.patch
@@ -1,0 +1,24 @@
+--- src/TerrariaNetCore/Terraria/Map/MapOverlayDrawContext.cs
++++ src/tModLoader/Terraria/Map/MapOverlayDrawContext.cs
+@@ -33,8 +_,10 @@
+ 		_drawScale = drawScale;
+ 	}
+ 
++	/// <inheritdoc cref="Draw(Texture2D, Vector2, Color, SpriteFrame, float, float, Alignment)"/>
+ 	public DrawResult Draw(Texture2D texture, Vector2 position, Alignment alignment) => Draw(texture, position, new SpriteFrame(1, 1), alignment);
+ 
++	/// <inheritdoc cref="Draw(Texture2D, Vector2, Color, SpriteFrame, float, float, Alignment)"/>
+ 	public DrawResult Draw(Texture2D texture, Vector2 position, SpriteFrame frame, Alignment alignment)
+ 	{
+ 		position = (position - _mapPosition) * _mapScale + _mapOffset;
+@@ -48,6 +_,10 @@
+ 		return new DrawResult(new Rectangle((int)position.X, (int)position.Y, (int)((float)texture.Width * _drawScale), (int)((float)texture.Height * _drawScale)).Contains(Main.MouseScreen.ToPoint()));
+ 	}
+ 
++	/// <summary>
++	/// Draws the texture (icon) over the map using the provided arguments. Check the returned <see cref="DrawResult.IsMouseOver"/> to check if the mouse is hovering over this icon. This is usually used to assign the <c>text</c> parameter of <see cref="ModLoader.ModMapLayer.Draw(ref MapOverlayDrawContext, ref string)"/> to the hover text of the icon.
++	/// <para/> Note that the <paramref name="position"/> argument expects tile coordinates expressed as a Vector2. Don't scale tile coordinates to world coordinates by multiplying by 16. If you are working with world coordinates you'll need to divide them by 16 to convert them to tile coordinates.
++	/// </summary>
+ 	public DrawResult Draw(Texture2D texture, Vector2 position, Color color, SpriteFrame frame, float scaleIfNotSelected, float scaleIfSelected, Alignment alignment)
+ 	{
+ 		position = (position - _mapPosition) * _mapScale + _mapOffset;

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Terraria.Map;
-using static Terraria.Map.IMapLayer;
-
 namespace Terraria.ModLoader;
 public static class MapLayerLoader
 {
@@ -21,60 +19,70 @@ public static class MapLayerLoader
 
 	private static IEnumerable<IMapLayer> ModdedLayers => MapLayers.Skip(DefaultLayerCount);
 
+	internal static void Add(IMapLayer layer) => MapLayers.Add(layer);
+
 	internal static void Unload()
 	{
 		MapLayers.RemoveRange(DefaultLayerCount, MapLayerCount - DefaultLayerCount);
-		
-		var overlay = new MapIconOverlay();
-		foreach (IMapLayer layer in MapLayers) {
-			overlay.AddLayer(layer);
-		}
-		Main.MapIcons = overlay;
 	}
 
 	internal static void ResizeArrays()
 	{
-		List<IMapLayer> sortedLayers = MapLayers[..DefaultLayerCount];
+		var sortingSlots = new List<IMapLayer>[DefaultLayerCount + 1];
+		for (int i = 0; i < sortingSlots.Length; ++i)
+			sortingSlots[i] = [];
+
 		foreach (IMapLayer layer in ModdedLayers) {
-			Position position = layer.GetDefaultPosition();
+			var position = layer.GetDefaultPosition();
 
 			switch (position) {
-				case Before before: {
-					int index = sortedLayers.IndexOf(before.Layer);
-					if (index is not -1) {
-						sortedLayers.Insert(index, layer);
-					}
-					else {
-						sortedLayers.Add(layer);
-					}
+				case IMapLayer.After after: {
+					int afterParent = MapLayers.IndexOf(after.Layer) is int index and not -1 ? index + 1 : 0;
+					sortingSlots[afterParent].Add(layer);
 
 					break;
 				}
-				case After after: {
-					int index = sortedLayers.IndexOf(after.Layer);
-					if (index is not -1) {
-						sortedLayers.Insert(index + 1, layer);
-					}
-					else {
-						sortedLayers.Add(layer);
-					}
+				case IMapLayer.Before before: {
+					int beforeParent = MapLayers.IndexOf(before.Layer) is int index and not -1 ? index : sortingSlots.Length - 1;
+					sortingSlots[beforeParent].Add(layer);
 
 					break;
-				}
-				case Append: {
-					sortedLayers.Add(layer);
-					break;
-				}
+				}	
 				default: {
-					throw new ArgumentException($"IMapLayer {layer} has unknown {position}");
+					var ex = new ArgumentException($"IMapLayer {layer} has unknown Position {position}");
+					if (layer is ModMapLayer modLayer)
+						ex.Data["mod"] = modLayer.Mod.Name;
+					throw ex;
 				}
 			}
 		}
 
+		List<IMapLayer> sortedLayers = [];
+
+		for (int i = 0; i < DefaultLayerCount + 1; i++) {
+			var elements = sortingSlots[i];
+			var sort = new TopoSort<IMapLayer>(elements,
+				l => l.GetModdedConstraints()?.OfType<IMapLayer.After>().Select(a => a.Layer).Where(elements.Contains) ?? [],
+				l => l.GetModdedConstraints()?.OfType<IMapLayer.Before>().Select(b => b.Layer).Where(elements.Contains) ?? []);
+
+			foreach (IMapLayer layer in sort.Sort()) {
+				sortedLayers.Add(layer);
+			}
+
+			if (i < DefaultLayerCount)
+				sortedLayers.Add(MapLayers[i]);
+		}
+
+		Main.MapIcons = CreateOverlayWithLayers(sortedLayers);
+		Main.Pings = (PingMapLayer)IMapLayer.Pings;
+	}
+
+	private static MapIconOverlay CreateOverlayWithLayers(IEnumerable<IMapLayer> layers)
+	{
 		var overlay = new MapIconOverlay();
-		foreach (IMapLayer layer in sortedLayers) {
+		foreach (IMapLayer layer in layers) {
 			overlay.AddLayer(layer);
 		}
-		Main.MapIcons = overlay;
+		return overlay;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -37,23 +37,35 @@ public static class MapLayerLoader
 
 			switch (position) {
 				case IMapLayer.After after: {
-					int afterParent = MapLayers.IndexOf(after.Layer) is int index and not -1 ? index + 1 : 0;
-					sortingSlots[afterParent].Add(layer);
+					int afterIndex = MapLayers.IndexOf(after.Layer);
+					if (afterIndex >= DefaultLayerCount)
+						throw BlameMapLayerException(new ArgumentException($"IMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
+					int slotIndex = afterIndex is not -1 ? afterIndex + 1 : 0;
+
+					sortingSlots[slotIndex].Add(layer);
 					break;
 				}
 				case IMapLayer.Before before: {
-					int beforeParent = MapLayers.IndexOf(before.Layer) is int index and not -1 ? index : sortingSlots.Length - 1;
-					sortingSlots[beforeParent].Add(layer);
+					int beforeIndex = MapLayers.IndexOf(before.Layer);
+					if (beforeIndex >= DefaultLayerCount)
+						throw BlameMapLayerException(new ArgumentException($"IMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
+					int slotIndex = beforeIndex is not -1 ? beforeIndex : sortingSlots.Length - 1;
+
+					sortingSlots[slotIndex].Add(layer);
 					break;
 				}	
 				default: {
 					var ex = new ArgumentException($"IMapLayer {layer} has unknown Position {position}");
-					if (layer is ModMapLayer modLayer)
-						ex.Data["mod"] = modLayer.Mod.Name;
-					throw ex;
+					throw BlameMapLayerException(ex);
 				}
+			}
+
+			Exception BlameMapLayerException(Exception ex) {
+				if (layer is ModMapLayer moddedLayer)
+					ex.Data["mod"] = moddedLayer.Mod.Name;
+				return ex;
 			}
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.Map;
+using static Terraria.Map.IMapLayer;
+
+namespace Terraria.ModLoader;
+public static class MapLayerLoader
+{
+	public static int MapLayerCount => MapLayers.Count;
+
+	internal static readonly List<IMapLayer> MapLayers = [
+		IMapLayer.Spawn,
+		IMapLayer.Pylons,
+		IMapLayer.Pings
+	];
+
+	internal static readonly int DefaultLayerCount = MapLayers.Count;
+
+	private static IEnumerable<IMapLayer> ModdedLayers => MapLayers.Skip(DefaultLayerCount);
+
+	internal static void Unload()
+	{
+		MapLayers.RemoveRange(DefaultLayerCount, MapLayerCount - DefaultLayerCount);
+		
+		var overlay = new MapIconOverlay();
+		foreach (IMapLayer layer in MapLayers) {
+			overlay.AddLayer(layer);
+		}
+		Main.MapIcons = overlay;
+	}
+
+	internal static void ResizeArrays()
+	{
+		List<IMapLayer> sortedLayers = MapLayers[..DefaultLayerCount];
+		foreach (IMapLayer layer in ModdedLayers) {
+			Position position = layer.GetDefaultPosition();
+
+			switch (position) {
+				case Before before: {
+					int index = sortedLayers.IndexOf(before.Layer);
+					if (index is not -1) {
+						sortedLayers.Insert(index, layer);
+					}
+					else {
+						sortedLayers.Add(layer);
+					}
+
+					break;
+				}
+				case After after: {
+					int index = sortedLayers.IndexOf(after.Layer);
+					if (index is not -1) {
+						sortedLayers.Insert(index + 1, layer);
+					}
+					else {
+						sortedLayers.Add(layer);
+					}
+
+					break;
+				}
+				case Append: {
+					sortedLayers.Add(layer);
+					break;
+				}
+				default: {
+					throw new ArgumentException($"IMapLayer {layer} has unknown {position}");
+				}
+			}
+		}
+
+		var overlay = new MapIconOverlay();
+		foreach (IMapLayer layer in sortedLayers) {
+			overlay.AddLayer(layer);
+		}
+		Main.MapIcons = overlay;
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -17,6 +17,10 @@ public static class MapLayerLoader
 
 	internal static readonly int DefaultLayerCount = MapLayers.Count;
 
+	internal static IMapLayer FirstVanillaLayer => MapLayers[0];
+
+	internal static IMapLayer LastVanillaLayer => MapLayers[DefaultLayerCount - 1];
+
 	private static IEnumerable<ModMapLayer> ModdedLayers => MapLayers.Skip(DefaultLayerCount).Cast<ModMapLayer>();
 
 	internal static void Add(IMapLayer layer) => MapLayers.Add(layer);
@@ -38,22 +42,18 @@ public static class MapLayerLoader
 			switch (position) {
 				case ModMapLayer.After after: {
 					int afterIndex = MapLayers.IndexOf(after.Layer);
-					if (afterIndex >= DefaultLayerCount)
+					if (afterIndex >= DefaultLayerCount || afterIndex is -1)
 						throw BlameMapLayerException(new ArgumentException($"ModMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
-					int slotIndex = afterIndex is not -1 ? afterIndex + 1 : 0;
-
-					sortingSlots[slotIndex].Add(layer);
+					sortingSlots[afterIndex + 1].Add(layer);
 					break;
 				}
 				case ModMapLayer.Before before: {
 					int beforeIndex = MapLayers.IndexOf(before.Layer);
-					if (beforeIndex >= DefaultLayerCount)
+					if (beforeIndex >= DefaultLayerCount || beforeIndex is -1)
 						throw BlameMapLayerException(new ArgumentException($"ModMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
-					int slotIndex = beforeIndex is not -1 ? beforeIndex : sortingSlots.Length - 1;
-
-					sortingSlots[slotIndex].Add(layer);
+					sortingSlots[beforeIndex].Add(layer);
 					break;
 				}	
 				default: {

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -17,7 +17,7 @@ public static class MapLayerLoader
 
 	internal static readonly int DefaultLayerCount = MapLayers.Count;
 
-	private static IEnumerable<IMapLayer> ModdedLayers => MapLayers.Skip(DefaultLayerCount);
+	private static IEnumerable<ModMapLayer> ModdedLayers => MapLayers.Skip(DefaultLayerCount).Cast<ModMapLayer>();
 
 	internal static void Add(IMapLayer layer) => MapLayers.Add(layer);
 
@@ -28,28 +28,28 @@ public static class MapLayerLoader
 
 	internal static void ResizeArrays()
 	{
-		var sortingSlots = new List<IMapLayer>[DefaultLayerCount + 1];
+		var sortingSlots = new List<ModMapLayer>[DefaultLayerCount + 1];
 		for (int i = 0; i < sortingSlots.Length; ++i)
 			sortingSlots[i] = [];
 
-		foreach (IMapLayer layer in ModdedLayers) {
+		foreach (ModMapLayer layer in ModdedLayers) {
 			var position = layer.GetDefaultPosition();
 
 			switch (position) {
-				case IMapLayer.After after: {
+				case ModMapLayer.After after: {
 					int afterIndex = MapLayers.IndexOf(after.Layer);
 					if (afterIndex >= DefaultLayerCount)
-						throw BlameMapLayerException(new ArgumentException($"IMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
+						throw BlameMapLayerException(new ArgumentException($"ModMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
 					int slotIndex = afterIndex is not -1 ? afterIndex + 1 : 0;
 
 					sortingSlots[slotIndex].Add(layer);
 					break;
 				}
-				case IMapLayer.Before before: {
+				case ModMapLayer.Before before: {
 					int beforeIndex = MapLayers.IndexOf(before.Layer);
 					if (beforeIndex >= DefaultLayerCount)
-						throw BlameMapLayerException(new ArgumentException($"IMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
+						throw BlameMapLayerException(new ArgumentException($"ModMapLayer {layer} did not refer to a vanilla map layer in GetDefaultPosition()"));
 
 					int slotIndex = beforeIndex is not -1 ? beforeIndex : sortingSlots.Length - 1;
 
@@ -57,7 +57,7 @@ public static class MapLayerLoader
 					break;
 				}	
 				default: {
-					var ex = new ArgumentException($"IMapLayer {layer} has unknown Position {position}");
+					var ex = new ArgumentException($"ModMapLayer {layer} has unknown Position {position}");
 					throw BlameMapLayerException(ex);
 				}
 			}
@@ -74,8 +74,8 @@ public static class MapLayerLoader
 		for (int i = 0; i < DefaultLayerCount + 1; i++) {
 			var elements = sortingSlots[i];
 			var sort = new TopoSort<IMapLayer>(elements,
-				l => l.GetModdedConstraints()?.OfType<IMapLayer.After>().Select(a => a.Layer).Where(elements.Contains) ?? [],
-				l => l.GetModdedConstraints()?.OfType<IMapLayer.Before>().Select(b => b.Layer).Where(elements.Contains) ?? []);
+				l => (l as ModMapLayer)?.GetModdedConstraints()?.OfType<ModMapLayer.After>().Select(a => a.Layer).Where(elements.Contains) ?? [],
+				l => (l as ModMapLayer)?.GetModdedConstraints()?.OfType<ModMapLayer.Before>().Select(b => b.Layer).Where(elements.Contains) ?? []);
 
 			foreach (IMapLayer layer in sort.Sort()) {
 				sortedLayers.Add(layer);

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Terraria.Map;
+
 namespace Terraria.ModLoader;
+
 public static class MapLayerLoader
 {
 	public static int MapLayerCount => MapLayers.Count;

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -19,7 +19,6 @@ using Terraria.ModLoader.IO;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.ModLoader.Utilities;
-using Terraria.Map;
 using Terraria.GameContent.Creative;
 using Terraria.Graphics.Effects;
 using Terraria.GameContent.Skies;

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -544,7 +544,8 @@ public static class ModContent
 		Config.ConfigManager.Unload();
 		CustomCurrencyManager.Initialize();
 		EffectsTracker.RemoveModEffects();
-		Main.MapIcons = new MapIconOverlay().AddLayer(new SpawnMapLayer()).AddLayer(new TeleportPylonsMapLayer()).AddLayer(Main.Pings);
+		// Main.MapIcons = new MapIconOverlay().AddLayer(new SpawnMapLayer()).AddLayer(new TeleportPylonsMapLayer()).AddLayer(Main.Pings);
+		MapLayerLoader.Unload();
 		ItemTrader.ChlorophyteExtractinator = ItemTrader.CreateChlorophyteExtractinator();
 		Main.gameTips.Reset();
 
@@ -583,6 +584,7 @@ public static class ModContent
 		BuffLoader.ResizeArrays();
 		PlayerLoader.ResizeArrays();
 		PlayerDrawLayerLoader.ResizeArrays();
+		MapLayerLoader.ResizeArrays();
 		HairLoader.ResizeArrays();
 		EmoteBubbleLoader.ResizeArrays();
 		BuilderToggleLoader.ResizeArrays();

--- a/patches/tModLoader/Terraria/ModLoader/ModContent.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModContent.cs
@@ -526,6 +526,7 @@ public static class ModContent
 
 		GlobalBackgroundStyleLoader.Unload();
 		PlayerDrawLayerLoader.Unload();
+		MapLayerLoader.Unload();
 		SystemLoader.Unload();
 		ResizeArrays(true);
 		for (int k = 0; k < Recipe.maxRecipes; k++) {
@@ -544,8 +545,6 @@ public static class ModContent
 		Config.ConfigManager.Unload();
 		CustomCurrencyManager.Initialize();
 		EffectsTracker.RemoveModEffects();
-		// Main.MapIcons = new MapIconOverlay().AddLayer(new SpawnMapLayer()).AddLayer(new TeleportPylonsMapLayer()).AddLayer(Main.Pings);
-		MapLayerLoader.Unload();
 		ItemTrader.ChlorophyteExtractinator = ItemTrader.CreateChlorophyteExtractinator();
 		Main.gameTips.Reset();
 

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -11,8 +11,23 @@ public abstract class ModMapLayer : ModType, IMapLayer
 {
 	public bool Visible { get; set; } = true;
 
+	/// <summary>
+	/// Returns the map layer's default position in regard to vanilla's map layer ordering. Make use of e.g. <see cref="Before"/>/<see cref="After"/>, and provide a map layer.<br/><br/>
+	///
+	/// <b>NOTE:</b> The position must specify a vanilla <see cref="IMapLayer"/> otherwise an exception will be thrown.<br/>
+	/// By default, this hook positions this map layer after all vanilla layers.
+	/// </summary>
 	public virtual Position GetDefaultPosition() => new Before(null);
 
+	/// <summary>
+	/// Modded layers are placed between vanilla layers via <see cref="GetDefaultPosition"/> and, by default, are sorted in load order.<br/>
+	/// This hook allow you to sort this map layer before/after other modded layers that were placed between the same two vanilla layers.<br/>
+	/// Example:
+	/// <para>
+	/// <c>yield return new After(ModContent.GetInstance&lt;ExampleMapLayer&gt;());</c>
+	/// </para>
+	/// By default, this hook returns <see langword="null"/>, which indicates that this map layer has no modded ordering constraints.
+	/// </summary>
 	public virtual IEnumerable<Position> GetModdedConstraints() => null;
 
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -9,6 +9,8 @@ public abstract class ModMapLayer : ModType, IMapLayer
 {
 	public bool Visible { get; set; } = true;
 
+	public virtual Position GetDefaultPosition() => new Append();
+
 	/// <summary>
 	/// This method is called when this MapLayer is to be drawn. Map layers are drawn after the map itself is drawn. Use <see cref="MapOverlayDrawContext.Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Color, DataStructures.SpriteFrame, float, float, Terraria.UI.Alignment)"/> as described in ExampleMod and in vanilla examples for full compatibility and simplicity of code.
 	/// </summary>
@@ -19,6 +21,6 @@ public abstract class ModMapLayer : ModType, IMapLayer
 	protected sealed override void Register()
 	{
 		ModTypeLookup<ModMapLayer>.Register(this);
-		Main.MapIcons.AddLayer(this);
+		MapLayerLoader.Add(this);
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Terraria.Map;
-using static Terraria.Map.IMapLayer;
 
 namespace Terraria.ModLoader;
 
@@ -42,4 +41,30 @@ public abstract class ModMapLayer : ModType, IMapLayer
 		ModTypeLookup<ModMapLayer>.Register(this);
 		MapLayerLoader.Add(this);
 	}
+
+	#region Sort Positions
+
+	public abstract class Position;
+
+	public sealed class Before : Position
+	{
+		public IMapLayer Layer { get; }
+
+		public Before(IMapLayer layer)
+		{
+			Layer = layer;
+		}
+	}
+
+	public sealed class After : Position
+	{
+		public IMapLayer Layer { get; }
+
+		public After(IMapLayer layer)
+		{
+			Layer = layer;
+		}
+	}
+
+	#endregion
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -11,16 +11,16 @@ public abstract class ModMapLayer : ModType, IMapLayer
 	public bool Visible { get; set; } = true;
 
 	/// <summary>
-	/// Returns the map layer's default position in regard to vanilla's map layer ordering. Make use of e.g. <see cref="Before"/>/<see cref="After"/>, and provide a map layer.<br/><br/>
+	/// Returns the map layer's default position in regard to vanilla's map layer ordering. Make use of e.g. <see cref="Before"/>/<see cref="After"/>, and provide a map layer. You can also use <see cref="BeforeFirstVanillaLayer"/> or <see cref="AfterLastVanillaLayer"/> to put your layer at the start/end of the vanilla layer order.<br/><br/>
 	///
 	/// <b>NOTE:</b> The position must specify a vanilla <see cref="IMapLayer"/> otherwise an exception will be thrown.<br/>
 	/// By default, this hook positions this map layer after all vanilla layers.
 	/// </summary>
-	public virtual Position GetDefaultPosition() => new Before(null);
+	public virtual Position GetDefaultPosition() => AfterLastVanillaLayer;
 
 	/// <summary>
 	/// Modded layers are placed between vanilla layers via <see cref="GetDefaultPosition"/> and, by default, are sorted in load order.<br/>
-	/// This hook allow you to sort this map layer before/after other modded layers that were placed between the same two vanilla layers.<br/>
+	/// This hook allows you to sort this map layer before/after other modded layers that were placed between the same two vanilla layers.<br/>
 	/// Example:
 	/// <para>
 	/// <c>yield return new After(ModContent.GetInstance&lt;ExampleMapLayer&gt;());</c>
@@ -43,6 +43,9 @@ public abstract class ModMapLayer : ModType, IMapLayer
 	}
 
 	#region Sort Positions
+
+	public static Position BeforeFirstVanillaLayer => new Before(MapLayerLoader.FirstVanillaLayer);
+	public static Position AfterLastVanillaLayer => new After(MapLayerLoader.LastVanillaLayer);
 
 	public abstract class Position;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -12,8 +12,7 @@ public abstract class ModMapLayer : ModType, IMapLayer
 
 	/// <summary>
 	/// Returns the map layer's default position in regard to vanilla's map layer ordering. Make use of e.g. <see cref="Before"/>/<see cref="After"/>, and provide a map layer. You can also use <see cref="BeforeFirstVanillaLayer"/> or <see cref="AfterLastVanillaLayer"/> to put your layer at the start/end of the vanilla layer order.<br/><br/>
-	///
-	/// <b>NOTE:</b> The position must specify a vanilla <see cref="IMapLayer"/> otherwise an exception will be thrown.<br/>
+	/// <b>NOTE:</b> The position must specify a vanilla <see cref="IMapLayer"/> otherwise an exception will be thrown. Use <see cref="GetModdedConstraints"/> to order modded layers.<br/><br/>
 	/// By default, this hook positions this map layer after all vanilla layers.
 	/// </summary>
 	public virtual Position GetDefaultPosition() => AfterLastVanillaLayer;
@@ -31,6 +30,9 @@ public abstract class ModMapLayer : ModType, IMapLayer
 
 	/// <summary>
 	/// This method is called when this MapLayer is to be drawn. Map layers are drawn after the map itself is drawn. Use <see cref="MapOverlayDrawContext.Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Color, DataStructures.SpriteFrame, float, float, Terraria.UI.Alignment)"/> as described in ExampleMod and in vanilla examples for full compatibility and simplicity of code.
+	/// <para/> <paramref name="context"/>: Contains the scaling and positional data of the map being drawn. You should use the MapOverlayDrawContext.Draw method for all drawing.
+	/// <para/> <paramref name="text"/>: The mouse hover text. Assign a value typically if the user is hovering over something you draw.
+	/// <para/> Note that MapLayers are drawn on the fullscreen map, overlay map, and minimap. Use <see cref="Main.mapFullscreen"/> and <see cref="Main.mapStyle"/> to limit drawing to specific map modes if appropriate.
 	/// </summary>
 	/// <param name="context">Contains the scaling and positional data of the map being drawn. You should use the MapOverlayDrawContext.Draw method for all drawing</param>
 	/// <param name="text">The mouse hover text. Assign a value typically if the user is hovering over something you draw</param>

--- a/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModMapLayer.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Terraria.Map;
+using static Terraria.Map.IMapLayer;
 
 namespace Terraria.ModLoader;
 
@@ -9,7 +11,9 @@ public abstract class ModMapLayer : ModType, IMapLayer
 {
 	public bool Visible { get; set; } = true;
 
-	public virtual Position GetDefaultPosition() => new Append();
+	public virtual Position GetDefaultPosition() => new Before(null);
+
+	public virtual IEnumerable<Position> GetModdedConstraints() => null;
 
 	/// <summary>
 	/// This method is called when this MapLayer is to be drawn. Map layers are drawn after the map itself is drawn. Use <see cref="MapOverlayDrawContext.Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Color, DataStructures.SpriteFrame, float, float, Terraria.UI.Alignment)"/> as described in ExampleMod and in vanilla examples for full compatibility and simplicity of code.


### PR DESCRIPTION
### What is the new feature?
Allows modders to position their `ModMapLayers` between vanilla layers. (Feature 1 of #4583)
It adds the following methods to `ModMapLayer`:

- `public virtual Position GetDefaultPosition()`
- `public virtual IEnumerable<Position> GetModdedConstraints()`

### Why should this be part of tModLoader?
Currently map layers are added after all vanilla layers. This means that modded layers are drawn on top of vanilla layers. By being able to position modded layers it will be easier to deal with cases where icons overlap.
### Are there alternative designs?
The positioning approach used is the same as was used for `ExtraJumps` (#3552), but there are also the designs of `PlayerDrawLayers`, and `BuilderToggles`.
### Sample usage for the new feature
Indicates that the new layer will be ordered before the vanilla pings layer.
```c#
public override Position GetDefaultPosition() {
	return new Before(IMapLayer.Pings);
}
```
Specifies that this layer will show up in ordering after `ExampleMapLayer`. (assuming they are in the same vanilla slot)
```c#
public override IEnumerable<Position> GetModdedConstraints() {
	yield return new After(ModContent.GetInstance<ExampleMapLayer>());
}
```
### ExampleMod updates
Added `ExampleItemMapLayer` which makes any `ExampleItems` that are on the ground in the world show up on the map. It showcases how to use `GetModdedConstraints()` and orders itself before `ExampleMapLayer`.

### Porting Notes
Shouldn't be any breaking changes. Use the new methods if you want.
