### PR TITLE
ExampleCameraModifier

### DIFF
--- a/ExampleMod/Common/ExampleCameraModifier.cs
+++ b/ExampleMod/Common/ExampleCameraModifier.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Terraria.Graphics.CameraModifiers;
+using Terraria;
+using Microsoft.Xna.Framework;
+
+namespace ExampleMod.Common
+{
+	// This example shows a Camera Modifier that pans the camera to a chosen point.
+	// CameraModifierShowcase.cs shows how this can be used
+	public class ExampleCameraModifier : ICameraModifier
+	{
+		private int _framesToLast;
+		private int _framesLasted;
+		public Vector2 _position;
+
+		// This makes sure that other modifiers of the same identity don't run at the same time
+		public string UniqueIdentity { get; private set; }
+		public bool Finished { get; private set; }
+		public ExampleCameraModifier(Vector2 position, int frames, string uniqueIdentity = null) {
+			_position = position - new Vector2(Main.screenWidth / 2, Main.screenHeight / 2);
+			_framesToLast = frames;
+			UniqueIdentity = uniqueIdentity;
+		}
+		public void Update(ref CameraInfo cameraInfo) {
+			float lerpT = MathHelper.Clamp(MathF.Sin(MathHelper.Pi * Utils.GetLerpValue(0, _framesToLast, _framesLasted)) * 2, 0, 1);
+
+			// Smoothly pans the camera from the start position to the desired position, and back
+			cameraInfo.CameraPosition = Vector2.Lerp(cameraInfo.CameraPosition, _position, lerpT);
+
+			// Pauses the effect if the game is tabbed out or paused
+			if (!Main.gameInactive && !Main.gamePaused)
+				_framesLasted++;
+
+			if (_framesLasted >= _framesToLast)
+				Finished = true;
+		}
+	}
+}

--- a/ExampleMod/Common/ExampleCameraModifier.cs
+++ b/ExampleMod/Common/ExampleCameraModifier.cs
@@ -7,34 +7,52 @@ namespace ExampleMod.Common
 {
 	// This example shows a Camera Modifier that pans the camera to a chosen point.
 	// CameraModifierShowcase.cs shows how this can be used
+	// Also see how MinionBossBody uses an existing ICameraModifier implementation (PunchCameraModifier) to do a simple screenshake
 	public class ExampleCameraModifier : ICameraModifier
 	{
-		private int _framesToLast;
-		private int _framesLasted;
-		public Vector2 _position;
+		private int framesToLast;
+		private int framesElapsed;
+		public Vector2 targetPosition;
 
 		// This makes sure that other modifiers of the same identity don't run at the same time
 		public string UniqueIdentity { get; private set; }
 		public bool Finished { get; private set; }
 
 		public ExampleCameraModifier(Vector2 position, int frames, string uniqueIdentity = null) {
-			_position = position - new Vector2(Main.screenWidth / 2, Main.screenHeight / 2);
-			_framesToLast = frames;
+			targetPosition = position - new Vector2(Main.screenWidth / 2, Main.screenHeight / 2);
+			framesToLast = frames;
 			UniqueIdentity = uniqueIdentity;
 		}
 
 		public void Update(ref CameraInfo cameraInfo) {
-			// Smoothly pans the camera from the start position to the desired position, and back
-			float progress = Utils.GetLerpValue(0, _framesToLast, _framesLasted);
-			float lerpT = MathHelper.Clamp(MathF.Sin(MathHelper.Pi * progress) * 2, 0, 1); // Multiplying by 2 here makes the camera linger at the desired position for longer
-			cameraInfo.CameraPosition = Vector2.Lerp(cameraInfo.CameraPosition, _position, lerpT);
+			// Smoothly pans the camera from the start position to the desired position and then back:
+
+			// We will use progress to determine where the camera should be with respect to how much time has passed.
+			float progress = Utils.GetLerpValue(0, framesToLast, framesElapsed); // Equivalent to "(float)framesElapsed / framesToLast"
+
+			// There are many approaches to interpolating between 2 values, such as using any of these methods:
+			// MathF.Sin, MathHelper.Lerp, MathHelper.SmoothStep, Utils.MultiLerp, Utils.Turn01ToCyclic010
+			// Each of these will result in different movement behaviors, such as how they accelerate.
+			// In this example, however, we will use the Remap method and a switch expression to implement a linear interpolation split into 3 separate phases/segments
+			// For the fist 50% of the animation time the value will ramp from 0 to 1,
+			// then hold at 1 for 30% of the time,
+			// then quickly travel back to 0 in the last 20% of the animation time
+			float lerpAmount = progress switch {
+				< 0.5f => Utils.Remap(progress, 0, 0.5f, 0, 1),
+				> 0.8f => Utils.Remap(progress, 0.8f, 1f, 1, 0),
+				_ => 1, // progress is between 0.5 and 0.8
+			};
+
+			cameraInfo.CameraPosition = Vector2.Lerp(cameraInfo.CameraPosition, targetPosition, lerpAmount);
 
 			// Pauses the effect if the game is tabbed out or paused
-			if (!Main.gameInactive && !Main.gamePaused)
-				_framesLasted++;
+			if (!Main.gameInactive && !Main.gamePaused) {
+				framesElapsed++;
+			}
 
-			if (_framesLasted >= _framesToLast)
+			if (framesElapsed >= framesToLast) {
 				Finished = true;
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/ExampleCameraModifier.cs
+++ b/ExampleMod/Common/ExampleCameraModifier.cs
@@ -16,15 +16,17 @@ namespace ExampleMod.Common
 		// This makes sure that other modifiers of the same identity don't run at the same time
 		public string UniqueIdentity { get; private set; }
 		public bool Finished { get; private set; }
+
 		public ExampleCameraModifier(Vector2 position, int frames, string uniqueIdentity = null) {
 			_position = position - new Vector2(Main.screenWidth / 2, Main.screenHeight / 2);
 			_framesToLast = frames;
 			UniqueIdentity = uniqueIdentity;
 		}
-		public void Update(ref CameraInfo cameraInfo) {
-			float lerpT = MathHelper.Clamp(MathF.Sin(MathHelper.Pi * Utils.GetLerpValue(0, _framesToLast, _framesLasted)) * 2, 0, 1);
 
+		public void Update(ref CameraInfo cameraInfo) {
 			// Smoothly pans the camera from the start position to the desired position, and back
+			float progress = Utils.GetLerpValue(0, _framesToLast, _framesLasted);
+			float lerpT = MathHelper.Clamp(MathF.Sin(MathHelper.Pi * progress) * 2, 0, 1); // Multiplying by 2 here makes the camera linger at the desired position for longer
 			cameraInfo.CameraPosition = Vector2.Lerp(cameraInfo.CameraPosition, _position, lerpT);
 
 			// Pauses the effect if the game is tabbed out or paused

--- a/ExampleMod/Content/Items/CameraModifierShowcase.cs
+++ b/ExampleMod/Content/Items/CameraModifierShowcase.cs
@@ -5,7 +5,7 @@ using ExampleMod.Common;
 
 namespace ExampleMod.Content.Items
 {
-	// Showcases a usage of ExampleCameraModifier.cs ingame.
+	// Showcases a usage of ExampleCameraModifier.cs in-game.
 	public class CameraModifierShowcase : ModItem
 	{
 		public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.JimsDrone}";
@@ -13,7 +13,6 @@ namespace ExampleMod.Content.Items
 		public override void SetDefaults() {
 			Item.width = 20;
 			Item.height = 20;
-			Item.maxStack = 1;
 			Item.rare = ItemRarityID.Blue;
 			Item.useAnimation = 300;
 			Item.useTime = 300;
@@ -24,7 +23,8 @@ namespace ExampleMod.Content.Items
 		}
 
 		public override bool? UseItem(Player player) {
-			Main.instance.CameraModifiers.Add(new ExampleCameraModifier(Main.MouseWorld, 300, FullName)); // Pans the camera to the mouse, lasting 300 frames
+			// Pans the camera targeting the current mouse location, lasting 300 frames
+			Main.instance.CameraModifiers.Add(new ExampleCameraModifier(Main.MouseWorld, 300, FullName));
 			return true;
 		}
 	}

--- a/ExampleMod/Content/Items/CameraModifierShowcase.cs
+++ b/ExampleMod/Content/Items/CameraModifierShowcase.cs
@@ -9,21 +9,22 @@ namespace ExampleMod.Content.Items
 	public class CameraModifierShowcase : ModItem
 	{
 		public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.JimsDrone}";
+
 		public override void SetDefaults() {
 			Item.width = 20;
 			Item.height = 20;
 			Item.maxStack = 1;
 			Item.rare = ItemRarityID.Blue;
-			Item.useAnimation = 30;
-			Item.useTime = 30;
+			Item.useAnimation = 300;
+			Item.useTime = 300;
 			Item.noUseGraphic = true;
 			Item.useStyle = ItemUseStyleID.HoldUp;
 			Item.consumable = false;
 			Item.useTurn = false;
 		}
+
 		public override bool? UseItem(Player player) {
-			// Pans the camera to the mouse, lasting 300 frames
-			Main.instance.CameraModifiers.Add(new ExampleCameraModifier(Main.MouseWorld, 300, FullName));
+			Main.instance.CameraModifiers.Add(new ExampleCameraModifier(Main.MouseWorld, 300, FullName)); // Pans the camera to the mouse, lasting 300 frames
 			return true;
 		}
 	}

--- a/ExampleMod/Content/Items/CameraModifierShowcase.cs
+++ b/ExampleMod/Content/Items/CameraModifierShowcase.cs
@@ -1,0 +1,30 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+using ExampleMod.Common;
+
+namespace ExampleMod.Content.Items
+{
+	// Showcases a usage of ExampleCameraModifier.cs ingame.
+	public class CameraModifierShowcase : ModItem
+	{
+		public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.JimsDrone}";
+		public override void SetDefaults() {
+			Item.width = 20;
+			Item.height = 20;
+			Item.maxStack = 1;
+			Item.rare = ItemRarityID.Blue;
+			Item.useAnimation = 30;
+			Item.useTime = 30;
+			Item.noUseGraphic = true;
+			Item.useStyle = ItemUseStyleID.HoldUp;
+			Item.consumable = false;
+			Item.useTurn = false;
+		}
+		public override bool? UseItem(Player player) {
+			// Pans the camera to the mouse, lasting 300 frames
+			Main.instance.CameraModifiers.Add(new ExampleCameraModifier(Main.MouseWorld, 300, FullName));
+			return true;
+		}
+	}
+}

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 685/685, 100%, missing 0
-ru-RU, 6/685, 1%, missing 679
-zh-Hans, 2/685, 0%, missing 683
+en-US, 687/687, 100%, missing 0
+ru-RU, 6/687, 1%, missing 681
+zh-Hans, 2/687, 0%, missing 685

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -1158,6 +1158,11 @@ Mods: {
 					Spreads the underworld
 					'''
 			}
+
+			CameraModifierShowcase: {
+				DisplayName: Camera Modifier Showcase
+				Tooltip: ""
+			}
 		}
 
 		# Projectile display names mainly show in chat when a player dies from it.

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -1158,6 +1158,11 @@ Mods: {
 					Spreads the underworld
 					''' */
 			}
+
+			CameraModifierShowcase: {
+				// DisplayName: Camera Modifier Showcase
+				// Tooltip: ""
+			}
 		}
 
 		# Projectile display names mainly show in chat when a player dies from it.

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -1158,6 +1158,11 @@ Mods: {
 					Spreads the underworld
 					''' */
 			}
+
+			CameraModifierShowcase: {
+				// DisplayName: Camera Modifier Showcase
+				// Tooltip: ""
+			}
 		}
 
 		# Projectile display names mainly show in chat when a player dies from it.

--- a/patches/tModLoader/Terraria/Graphics/CameraModifiers/ICameraModifier.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/CameraModifiers/ICameraModifier.cs.patch
@@ -1,0 +1,12 @@
+--- src/TerrariaNetCore/Terraria/Graphics/CameraModifiers/ICameraModifier.cs
++++ src/tModLoader/Terraria/Graphics/CameraModifiers/ICameraModifier.cs
+@@ -2,6 +_,9 @@
+ 
+ public interface ICameraModifier
+ {
++	/// <summary>
++	/// Will cause any other active camera modifiers with the same value to be cleared when this camera modifier is added
++	/// </summary>
+ 	string UniqueIdentity { get; }
+ 
+ 	bool Finished { get; }


### PR DESCRIPTION
### What are the changes to ExampleMod?
The addition of an example camera modifier, this lets modders know about the existence of `ICameraModifier` and showcases a simple camera panning movement. A `CameraModifierShowcase` item was added to show how modifiers get added as well.

### Do these changes need additional documentation?
They seem straightforward enough, `ICameraModifier` is pretty limited in its function so this is mostly just to let people know about its existence.