### PR TITLE
Bugfixes for TileLoader.Convert and WorldGen.SpreadInfectionToNearbyTile

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.TML.cs
+++ b/patches/tModLoader/Terraria/WorldGen.TML.cs
@@ -110,7 +110,7 @@ public partial class WorldGen
 				return;
 
 			int preConversionType = Main.tile[testX, testY].type;
-			Convert(testX, testY, conversionType, size: 1, tiles: true, walls: false);
+			Convert(testX, testY, conversionType, size: 0, tiles: true, walls: false);
 			if (preConversionType != Main.tile[testX, testY].type)
 				keepSpreading = genRand.NextBool(2); // 1 in 2 chance to attempt to spread to another tile if we successfuly converted the first one
 		}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2950,7 +2950,7 @@
  						continue;
  
 +					int preHookType = Main.tile[num11, num12].type;
-+					bool convertTile = !TileLoader.Convert(num11, num12, 1);
++					bool convertTile = TileLoader.Convert(num11, num12, 1);
 +
 +					if (preHookType != Main.tile[num11, num12].type) {
 +						if (genRand.Next(2) == 0)
@@ -2980,7 +2980,7 @@
  						continue;
  
 +					int preHookType = Main.tile[num13, num14].type;
-+					bool convertTile = !TileLoader.Convert(num13, num14, 4);
++					bool convertTile = TileLoader.Convert(num13, num14, 4);
 +
 +					if (preHookType != Main.tile[num13, num14].type) {
 +						if (genRand.Next(2) == 0)
@@ -3003,7 +3003,7 @@
 +				continue;
 +
 +			int preHookType = Main.tile[num15, num16].type;
-+			bool convertTile = !TileLoader.Convert(num15, num16, 2);
++			bool convertTile = TileLoader.Convert(num15, num16, 2);
 +
 +			if (preHookType != Main.tile[num15, num16].type) {
 +				if (genRand.Next(2) == 0)


### PR DESCRIPTION
Vanilla tiles can spread once more (Removed a ! where there shouldn't have been one)
WorldGen.SpreadInfectionToNearbyTile helper method now converts tile in 1x1 instead of 3x3