### PR TITLE
Add primitive handling for unexpected mod removal

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "The following mods were added or updated from the workshop since last launch (you can disable this message in the settings):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nNew Mods:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nUpdated Mods:",
+		"ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nSome dependencies are missing:",
 		"InstallDependencies": "Install Dependencies",
 		"ContinueAnyway": "Continue Anyway",


### PR DESCRIPTION
This PR is related to issues with the following scenario:
1) An owner deletes the mod from workshop
2) A contributor reuploads the mod to workshop as part of a 'Ownership Transfer' scheme, given Valve has not been able to support transfers of Workshop items.

This PR is currently highly relevant for the Infernum Calamity Add-on as they recently undergone this scenario so some urgency is needed.
UX Images
![image](https://github.com/user-attachments/assets/352027b5-4814-40a9-bca2-6979b4b429cc)
![image](https://github.com/user-attachments/assets/7631c28d-2bf7-4900-b235-a35545295da7)


LastLaunchedMods.txt
![image](https://github.com/user-attachments/assets/de373eda-3805-4dfa-9ce3-71e82907811d)




