### PR TITLE
Fix NewText max width calculations to take UIScale into account (Fix #4625)

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -950,6 +950,14 @@
  	private static bool _canShowMeteorFall;
  	private static bool _isResizingAndRemakingTargets = false;
  
+@@ -2160,6 +_,7 @@
+ 
+ 			_uiScaleUsed = value;
+ 			_uiScaleMatrix = Matrix.CreateScale(value, value, 1f);
++			chatMonitor.OnResolutionChange(); // TML fix: scale NewText by UIScale.
+ 		}
+ 	}
+ 
 @@ -2212,6 +_,7 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/UI/Chat/ChatMessageContainer.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatMessageContainer.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/UI/Chat/ChatMessageContainer.cs
++++ src/tModLoader/Terraria/UI/Chat/ChatMessageContainer.cs
+@@ -55,7 +_,7 @@
+ 			_prepared = true;
+ 			int num = _widthLimitInPixels;
+ 			if (num == -1)
+-				num = Main.screenWidth - 320;
++				num = (int)((Main.screenWidth - 320) / Main.UIScale); // TML fix: scale NewText by UIScale.
+ 
+ 			List<List<TextSnippet>> list = Utils.WordwrapStringSmart(OriginalText, _color, FontAssets.MouseText.Value, num, 10);
+ 			_parsedText.Clear();

--- a/patches/tModLoader/Terraria/UI/Chat/ChatMessageContainer.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatMessageContainer.cs.patch
@@ -5,7 +5,7 @@
  			int num = _widthLimitInPixels;
  			if (num == -1)
 -				num = Main.screenWidth - 320;
-+				num = (int)((Main.screenWidth - 320) / Main.UIScale); // TML fix: scale NewText by UIScale.
++				num = (int)(Main.screenWidth / Main.UIScale - 320); // TML fix: scale NewText by UIScale.
  
  			List<List<TextSnippet>> list = Utils.WordwrapStringSmart(OriginalText, _color, FontAssets.MouseText.Value, num, 10);
  			_parsedText.Clear();


### PR DESCRIPTION
Fixes #4625 

Tested using a long custom named set description and the `/customsets` command:
```cs
public static bool[] FlamingWeapon = ItemID.Sets.Factory.CreateNamedSet(FlamingWeaponCustomSetKey)
	.Description("Causes \"Hahahah, burn!\" to randomly show in chat when used. See https://github.com/tModLoader/tModLoader/pull/4381 and https://github.com/tModLoader/tModLoader/wiki for more information.")
	.RegisterBoolSet(false, ItemID.FieryGreatsword, ModContent.ItemType<ExampleSword>());
```

### Screenshots

150% zoom: (line wrapping calculation no longer goes off-screen or overlaps with accessories/setting button)

![image](https://github.com/user-attachments/assets/c42c08aa-e622-4ecc-98a0-b3598d1fc840)

50% zoom: (no longer wraps to the next line early)

![image](https://github.com/user-attachments/assets/70d58e1a-56da-4d8f-8080-9b52918f6f80)

### Other
Resizing the window and adjusting zoom ingame also works as expected.