### PR TITLE
Catch sourceUpgradeTask exception and add button to view exception

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": ".NET SDK herunterladen",
 		"DevModsInSandbox": "tModLoader kann keine Mods entwickeln, während er in einer Sandbox läuft (wie Flatpak). Bitte stell sicher dass Steam direkt auf dem System installiert ist.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "Die folgenden Mods wurden seit letztem Start vom Workshop aus hinzugefügt oder aktualisiert (Du kannst diese Nachricht in den Einstellungen deaktivieren):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nNeue Mods:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nAktualisierte Mods:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nEinige Abhängigkeiten fehlen:",
 		"InstallDependencies": "Installiere Abhängigkeiten",
 		"ContinueAnyway": "Trotzdem fortfahren",
@@ -514,6 +515,8 @@
 		"MSNetSDKNotFound": "Um Mods zu erstellen, muss die .NET {0} SDK installiert sein, diese wurde aber nicht erkannt. Klicke die  „.NET SDK herunterladen“  Schaltfläche unten, um zu Installationsanweisungen zu gelangen. Nach dem Installieren muss tModLoader möglicherweise neu gestartet werden.",
 		"DownloadNetSDK": ".NET SDK herunterladen",
 		"DevModsInSandbox": "tModLoader kann keine Mods entwickeln, während er in einer Sandbox läuft (wie Flatpak). Bitte stell sicher dass Steam direkt auf dem System installiert ist.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": "Download .NET SDK",
 		"DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
 		"MSSourceIssue": "Mod Source Issue",
-		"MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		"MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		"CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -515,6 +515,8 @@
 		"MSNetSDKNotFound": "Making mods for tModLoader requires the .NET {0} SDK to be installed, but it has not been detected. Click the \"Download .NET {0} SDK\" button below for installation instructions. After installing, you may need to restart tModLoader.",
 		"DownloadNetSDK": "Download .NET SDK",
 		"DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
+		"MSSourceIssue": "Mod Source Issue",
+		"MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		"CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "Los siguientes mods se han añadido o actualizado desde el último inicio (puedes desactivar este mensaje en la configuración):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nMods nuevos:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nMods actualizados:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nFaltan algunas dependencias:",
 		"InstallDependencies": "Instalar dependencias",
 		"ContinueAnyway": "Continuar de todas formas",
@@ -514,6 +515,8 @@
 		"MSNetSDKNotFound": "Para crear mods para tModLoader en Visual Studio, ahora es necesario instalar el SDK .NET {0}, lo cual se puede hacer instalando Visual Studio 2022. La guía de migración en GitHub te mostrará los cambios de código necesarios para adaptar los mods a la versión 1.4. La guía también te enseñará a utilizar tModPorter para migrar una gran parte del mod automáticamente.",
 		"DownloadNetSDK": "Descargar el SDK de .NET",
 		"DevModsInSandbox": "tModLoader no puede desarrollar mods cuando se ejecuta en un entorno aislado (como Flatpak). Asegúrate de instalar Steam directamente en tu sistema.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": "Descargar el SDK de .NET",
 		"DevModsInSandbox": "tModLoader no puede desarrollar mods cuando se ejecuta en un entorno aislado (como Flatpak). Asegúrate de instalar Steam directamente en tu sistema.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -23,6 +23,7 @@
 		// "ShowNewUpdatedModsInfoMessage": "The following mods were added or updated from the workshop since last launch (you can disable this message in the settings):\n",
 		// "ShowNewUpdatedModsInfoMessageNewMods": "\nNew Mods:",
 		// "ShowNewUpdatedModsInfoMessageUpdatedMods": "\nUpdated Mods:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		// "DependenciesNeededForOtherMods": "\nSome dependencies are missing:",
 		// "InstallDependencies": "Install Dependencies",
 		// "ContinueAnyway": "Continue Anyway",
@@ -514,6 +515,8 @@
 		// "MSNetSDKNotFound": "Making mods for tModLoader requires the .NET {0} SDK to be installed, but it has not been detected. Click the \"Download .NET {0} SDK\" button below for installation instructions. After installing, you may need to restart tModLoader.",
 		// "DownloadNetSDK": "Download .NET SDK",
 		// "DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -516,7 +516,7 @@
 		// "DownloadNetSDK": "Download .NET SDK",
 		// "DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -518,7 +518,7 @@
 		// "DownloadNetSDK": "Download .NET SDK",
 		// "DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -25,6 +25,7 @@
 		// "ShowNewUpdatedModsInfoMessage": "The following mods were added or updated from the workshop since last launch (you can disable this message in the settings):\n",
 		// "ShowNewUpdatedModsInfoMessageNewMods": "\nNew Mods:",
 		// "ShowNewUpdatedModsInfoMessageUpdatedMods": "\nUpdated Mods:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		// "DependenciesNeededForOtherMods": "\nSome dependencies are missing:",
 		// "InstallDependencies": "Install Dependencies",
 		// "ContinueAnyway": "Continue Anyway",
@@ -516,6 +517,8 @@
 		// "MSNetSDKNotFound": "Making mods for tModLoader requires the .NET {0} SDK to be installed, but it has not been detected. Click the \"Download .NET {0} SDK\" button below for installation instructions. After installing, you may need to restart tModLoader.",
 		// "DownloadNetSDK": "Download .NET SDK",
 		// "DevModsInSandbox": "tModLoader cannot develop mods while running in a sandbox (such as Flatpak). Please make sure to install Steam directly on your system.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		// "CreateModName": "ModName (no spaces)",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": "Pobierz .NET SDK",
 		"DevModsInSandbox": "tModLoader nie może rozwijać modów podczas działania w piaskownicy (np. w przypadku Flatpak). Upewnij się, że zainstalowano Steam bezpośrednio na Twoim systemie.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		"CreateModName": "NazwaModa (bez spacji)",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "Poniższe Mody zostały zaktualizowane lub dodane do Steam Workshop od czasu ostatniego uruchomienia gry (możesz wyłączyć to powiadomienie w ustawieniach):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nNowe Mody:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nZaktualizowane Mody:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nBrakuje niektórych zależności:",
 		"InstallDependencies": "Zainstaluj zależności",
 		"ContinueAnyway": "Kontynuuj mimo to",
@@ -514,6 +515,8 @@
 		"MSNetSDKNotFound": "Tworzenie modów dla tModLoadera wymaga zainstalowania .NET {0} SDK, ale nie zostało to wykryte. Kliknij poniżej przycisk \"Pobierz .NET SDK\" w celu uzyskania instrukcji instalacji. Po zainstalowaniu może być konieczne ponowne uruchomienie tModLoadera.",
 		"DownloadNetSDK": "Pobierz .NET SDK",
 		"DevModsInSandbox": "tModLoader nie może rozwijać modów podczas działania w piaskownicy (np. w przypadku Flatpak). Upewnij się, że zainstalowano Steam bezpośrednio na Twoim systemie.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		"CreateModName": "NazwaModa (bez spacji)",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": "Baixar SDK do .NET",
 		"DevModsInSandbox": "tModLoader não consegue desenvolver mods quando executado em um sandbox (como Flatpak). Certifique-se de instalar o Steam diretamente no seu sistema.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		"CreateModName": "Nome do Mod (sem espaços)",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "Os mods a seguir foram adicionados ou atualizados desde o último lançamento (você pode desativar esta mensagem nas configurações):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nNovos mods:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nMods atualizados:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nAlgumas dependências estão ausentes:",
 		"InstallDependencies": "Instalar Dependências",
 		"ContinueAnyway": "Continue Mesmo Assim",
@@ -514,6 +515,8 @@
 		"MSNetSDKNotFound": "A criação de mods para o tModLoader no Visual Studio agora requer a instalação do SDK do .NET {0}. Isto é instalado mais facilmente instalando o Visual Studio 2022.\n\nO Guia de Migração encontrado no Github ensinará as alterações de código necessárias para portar mods para 1.4. O guia também ensina como usar o tModPorter para migrar uma grande parte do mod para você.",
 		"DownloadNetSDK": "Baixar SDK do .NET",
 		"DevModsInSandbox": "tModLoader não consegue desenvolver mods quando executado em um sandbox (como Flatpak). Certifique-se de instalar o Steam diretamente no seu sistema.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		"CreateModName": "Nome do Mod (sem espaços)",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -516,7 +516,7 @@
 		"DownloadNetSDK": "Загрузить .NET SDK",
 		"DevModsInSandbox": "tModLoader не может разрабатывать моды в среде песочницы (например, в Flatpak). Пожалуйста, убедитесь, что вы установили Steam непосредственно на вашу систему.",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		"CreateModName": "Имя мода (без пробелов)",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -23,6 +23,7 @@
 		"ShowNewUpdatedModsInfoMessage": "С прошлого запуска были добавлены или обновлены следующие моды из Мастерской (вы можете отключить это сообщение в настройках):\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\nБыли добавлены новые моды:",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nБыли обновлены следующие моды:",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\nОтсутствуют некоторые зависимости:",
 		"InstallDependencies": "Установить зависимости",
 		"ContinueAnyway": "Продолжить в любом случае",
@@ -514,6 +515,8 @@
 		"MSNetSDKNotFound": "Разработка модов для tModLoader требует установки .NET {0} SDK, но оно не было обнаружено. Нажмите кнопку \"Загрузить .NET SDK\" ниже для получения подробных инструкций. После установки вам возможно понадобится перезапустить tModLoader.",
 		"DownloadNetSDK": "Загрузить .NET SDK",
 		"DevModsInSandbox": "tModLoader не может разрабатывать моды в среде песочницы (например, в Flatpak). Пожалуйста, убедитесь, что вы установили Steam непосредственно на вашу систему.",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		"CreateModName": "Имя мода (без пробелов)",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -25,6 +25,7 @@
 		"ShowNewUpdatedModsInfoMessage": "自从上一次启动以来，以下模组被添加或更新（你可以在设置中关掉这个提示）：\n",
 		"ShowNewUpdatedModsInfoMessageNewMods": "\n新增模组：",
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\n更新模组：",
+		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Downloads Dependencies' to have option to redownload",
 		"DependenciesNeededForOtherMods": "\n以下依赖缺失：",
 		"InstallDependencies": "安装依赖",
 		"ContinueAnyway": "忽略并继续",
@@ -516,6 +517,8 @@
 		"MSNetSDKNotFound": "模组制作现在需要安装 .NET {0} SDK（不是运行时），但它并未被检测到。 点击下方的“下载 .NET {0} SDK”按钮获取安装指南。 安装完成后，您可能需要重启 tModLoader。",
 		"DownloadNetSDK": "下载 .NET SDK",
 		"DevModsInSandbox": "在沙盒（如 Flatpak）中运行的 tModLoader 无法开发模组，请直接在你的系统上安装 Steam",
+		// "MSSourceIssue": "Mod Source Issue",
+		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
 
 		// Create Mod
 		"CreateModName": "模组内部名称（无空格）",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -518,7 +518,7 @@
 		"DownloadNetSDK": "下载 .NET SDK",
 		"DevModsInSandbox": "在沙盒（如 Flatpak）中运行的 tModLoader 无法开发模组，请直接在你的系统上安装 Steam",
 		// "MSSourceIssue": "Mod Source Issue",
-		// "MSSourceIssueMessage": "The following error was found with this mod's source: {0}",
+		// "MSSourceIssueMessage": "The following error was found with the {0} mod's source code: {1}",
 
 		// Create Mod
 		"CreateModName": "模组内部名称（无空格）",

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -205,17 +205,23 @@ internal class UIModSourceItem : UIPanel
 
 		// Display Run tModPorter when .csproj is valid
 		if (sourceUpgradeTask is { IsCompleted: true }) {
-			bool result = sourceUpgradeTask.Result;
+			try {
+				bool result = sourceUpgradeTask.Result;
 
-			// Source upgrade needed.
-			if (result) {
-				AddCsProjUpgradeButton();
+				// Source upgrade needed.
+				if (result) {
+					AddCsProjUpgradeButton();
+				}
+				else {
+					AddModPorterButton();
+				}
 			}
-			else {
-				AddModPorterButton();
+			catch (Exception e) {
+				AddErrorButton(e);
 			}
-
-			sourceUpgradeTask = null;
+			finally {
+				sourceUpgradeTask = null;
+			}
 		}
 	}
 
@@ -440,6 +446,25 @@ internal class UIModSourceItem : UIPanel
 		};
 
 		Append(portModButton);
+
+		contextButtonsLeft -= 26;
+	}
+
+	private void AddErrorButton(Exception e)
+	{
+		var modSaveErrorWarning = new UIHoverImage(UICommon.ButtonErrorTexture, Language.GetTextValue("tModLoader.MSSourceIssue")) {
+			RemoveFloatingPointsFromDrawPosition = true,
+			UseTooltipMouseText = true,
+			Left = { Pixels = contextButtonsLeft, Percent = 1f },
+			Top = { Pixels = 4 }
+		};
+
+		string fullError = Language.GetTextValue("tModLoader.MSSourceIssueMessage", "\n\n" + e.ToString());
+		modSaveErrorWarning.OnLeftClick += (a, b) => {
+			Interface.infoMessage.Show(fullError, 888, Interface.modSources);
+		};
+
+		Append(modSaveErrorWarning);
 
 		contextButtonsLeft -= 26;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -206,7 +206,7 @@ internal class UIModSourceItem : UIPanel
 		// Display Run tModPorter when .csproj is valid
 		if (sourceUpgradeTask is { IsCompleted: true }) {
 			try {
-				bool result = sourceUpgradeTask.Result;
+				bool result = sourceUpgradeTask.GetAwaiter().GetResult();
 
 				// Source upgrade needed.
 				if (result) {
@@ -459,7 +459,7 @@ internal class UIModSourceItem : UIPanel
 			Top = { Pixels = 4 }
 		};
 
-		string fullError = Language.GetTextValue("tModLoader.MSSourceIssueMessage", "\n\n" + e.ToString());
+		string fullError = Language.GetTextValue("tModLoader.MSSourceIssueMessage", modName, "\n\n" + e.ToString());
 		modSaveErrorWarning.OnLeftClick += (a, b) => {
 			Interface.infoMessage.Show(fullError, 888, Interface.modSources);
 		};

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 16
+zh-Hans 5
 ru-RU 6
-pt-BR 10
-pl-PL 11
-it-IT 959
-fr-FR 574
-es-ES 383
-de-DE 384
+pt-BR 13
+pl-PL 14
+it-IT 962
+fr-FR 577
+es-ES 386
+de-DE 387


### PR DESCRIPTION
https://github.com/tModLoader/tModLoader/commit/6497b9d8c8b564695b9a5b584522184f5677ecf4 added a check for "dllReferences contains duplicate of modReferences" in `ReadBuildFile`. Since `ReadBuildFile` runs on the Mod Sources menu to check if the mod source needs an upgrade, this exception can be thrown when visiting the menu rather than just when building. When the exception happens in this manner, it is currently uncaught and crashes to desktop.

This change is on stable currently (although other similar issues can cause the same exception), so we will need to cherrypick this to stable and preview.

This fix catches the exception and adds a button the modder can click to view the error.

https://github.com/user-attachments/assets/eecc587e-7653-46be-a310-3d01342a5072

