### PR TITLE
Modifiable chlorophyte conversions

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleVanillaConversionTiles.cs
+++ b/ExampleMod/Content/Tiles/ExampleVanillaConversionTiles.cs
@@ -42,6 +42,8 @@ namespace ExampleMod.Content.Tiles
 		public override void Convert(int i, int j, int conversionType) {
 			switch (conversionType) {
 				// Purification powder doesn't convert hallow tiles back into purity, so we don't check for BiomeCoversionID.PurificationPowder
+				// And Chlorophyte conversion is usually the same as purity, except it tries to create jungle tiles and destroy plants. In this case, neither is needed to it's gonna have the exact same behavior as purity
+				case BiomeConversionID.Chlorophyte:
 				case BiomeConversionID.Purity:
 				case BiomeConversionID.Sand: // Yellow (desert) solution also converts evil/hallowed tiles back into purity, so don't forget that check!
 					WorldGen.ConvertTile(i, j, TileID.DesertFossil);
@@ -96,6 +98,7 @@ namespace ExampleMod.Content.Tiles
 
 		public override void Convert(int i, int j, int conversionType) {
 			switch (conversionType) {
+				case BiomeConversionID.Chlorophyte:
 				case BiomeConversionID.Purity:
 				case BiomeConversionID.Sand:
 				case BiomeConversionID.PurificationPowder:
@@ -142,6 +145,7 @@ namespace ExampleMod.Content.Tiles
 
 		public override void Convert(int i, int j, int conversionType) {
 			switch (conversionType) {
+				case BiomeConversionID.Chlorophyte:
 				case BiomeConversionID.Purity:
 				case BiomeConversionID.Sand:
 				case BiomeConversionID.PurificationPowder:

--- a/patches/tModLoader/Terraria/ID/BiomeConversionID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/BiomeConversionID.cs.patch
@@ -8,10 +8,11 @@
  {
  	public const int Purity = 0;
  	public const int Corruption = 1;
-@@ -10,4 +_,6 @@
+@@ -10,4 +_,7 @@
  	public const int Sand = 5;
  	public const int Snow = 6;
  	public const int Dirt = 7;
 +	public const int PurificationPowder = 8; // Added by TML
-+	public static readonly int Count = 9;
++	public const int Chlorophyte = 9; // Added by TML
++	public static readonly int Count = 10;
  }

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2910,7 +2910,7 @@
  		if (!Main.remixWorld)
  			return;
  
-+		if (!TileLoader.Convert(x, y, 0))
++		if (!TileLoader.Convert(x, y, 9))
 +			return;
 +
  		if (Main.tile[x, y].type == 23 || Main.tile[x, y].type == 199 || Main.tile[x, y].type == 661 || Main.tile[x, y].type == 662) {
@@ -2937,6 +2937,25 @@
  			int num = genRand.Next(4);
  			int num2 = 0;
  			int num3 = 0;
+@@ -50637,6 +_,18 @@
+ 					if (!InWorld(num8, num9, 2) || !Main.tile[num8, num9].active())
+ 						continue;
+ 
++					int preHookType = Main.tile[num8, num9].type;
++					bool convertTile = TileLoader.Convert(num8, num9, 9);
++
++					if (preHookType != Main.tile[num8, num9].type) {
++						flag = true;
++
++						continue;
++					}
++
++					if (!convertTile)
++						continue;
++
+ 					if (Main.tile[num8, num9].type == 661 || Main.tile[num8, num9].type == 662 || Main.tile[num8, num9].type == 23 || Main.tile[num8, num9].type == 199 || Main.tile[num8, num9].type == 2 || Main.tile[num8, num9].type == 477 || Main.tile[num8, num9].type == 492 || Main.tile[num8, num9].type == 109) {
+ 						Main.tile[num8, num9].type = 60;
+ 						SquareTileFrame(num8, num9);
 @@ -50708,6 +_,9 @@
  				if (!InWorld(num11, num12, 10))
  					continue;


### PR DESCRIPTION
### What is the bug?
Modded tiles as of right now only get cured by chlorophyte if they try to spread near it, natrual chlorophyte spreading does not affect them.
Additionally, Chlorophyte has some special properties other than just curing tiles, it also converts grass -> jungle grass, dirt -> mud -> chloropyte, and breaks plants. But currently, these special properties are only limited to vanilla tiles. 
I believe modders should have full control over chlorophyte as well, allowing for greater accuracy, and to give some modded tiles custom interactions with chlorophyte.

### How did you fix the bug?
To fix the first bug I just implemented tile curing to natrual chlorophyte spreading. 
But after seeing the second bug, I also added a new BiomeConversionID for chlorophyte and changed every chlorophyte interaction with modded tiles to implement the new ID.

### Are there alternatives to your fix?
I haven't discovered any viable alternatives so far.