### PR TITLE
Fix #4624

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClass.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using ReLogic.Reflection;
+using Terraria.ID;
 using Terraria.Localization;
 
 namespace Terraria.ModLoader;
@@ -13,6 +15,16 @@ namespace Terraria.ModLoader;
 /// </remarks>
 public abstract class DamageClass : ModType, ILocalizedModType
 {
+	public class Sets
+	{
+		/// <summary>
+		/// Used for creating sets indexed by DamageClass type (<see cref="DamageClass.Type"/>).
+		/// <para/> <inheritdoc cref="SetFactory"/>
+		/// </summary>
+		public static SetFactory Factory = new SetFactory(DamageClassLoader.DamageClassCount, nameof(DamageClass), Search);
+	}
+	public static IdDictionary Search = IdDictionary.Create<DamageClass, int>();
+
 	/// <summary>
 	/// Default damage class for non-classed weapons and items, does not benefit from Generic bonuses
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -28,7 +28,7 @@ public static class DamageClassLoader
 	static DamageClassLoader()
 	{
 		RegisterDefaultClasses();
-		ResizeArrays(fromStaticCtor: true);
+		RebuildEffectInheritanceCache();
 	}
 
 	internal static int Add(DamageClass damageClass)
@@ -37,10 +37,12 @@ public static class DamageClassLoader
 		return DamageClasses.Count - 1;
 	}
 
-	internal static void ResizeArrays(bool fromStaticCtor = false)
+	internal static void ResizeArrays()
 	{
-		if (!fromStaticCtor) { // prevents double registration
-			LoaderUtils.ResetStaticMembers(typeof(DamageClass));
+		LoaderUtils.ResetStaticMembers(typeof(DamageClass));
+
+		foreach (var damageClass in DamageClasses) {
+			DamageClass.Search.Add(damageClass.FullName, damageClass.Type); // SetupContent isn't called on vanilla classes, so doing this here counts them all.
 		}
 
 		RebuildEffectInheritanceCache();

--- a/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DamageClassLoader.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Terraria.ID;
+using Terraria.ModLoader.Core;
 
 namespace Terraria.ModLoader;
 
@@ -26,7 +28,7 @@ public static class DamageClassLoader
 	static DamageClassLoader()
 	{
 		RegisterDefaultClasses();
-		ResizeArrays();
+		ResizeArrays(fromStaticCtor: true);
 	}
 
 	internal static int Add(DamageClass damageClass)
@@ -35,8 +37,12 @@ public static class DamageClassLoader
 		return DamageClasses.Count - 1;
 	}
 
-	internal static void ResizeArrays()
+	internal static void ResizeArrays(bool fromStaticCtor = false)
 	{
+		if (!fromStaticCtor) { // prevents double registration
+			LoaderUtils.ResetStaticMembers(typeof(DamageClass));
+		}
+
 		RebuildEffectInheritanceCache();
 	}
 


### PR DESCRIPTION
Fixes #4624 by adding `DamageClass.Search` and `DamageClass.Sets.Factory`.

Modders should be able to use it to set custom DamageClass metadata.

The implementation does cause all the vanilla DamageClass instances to be reinitialized since they are also static fields of the class, I'm not sure if there is any potential issue with that.