### PR TITLE
Documentation Standardization

### DIFF
--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -425,8 +425,8 @@
 +
 +		/// <summary>
 +		/// Determines the number of NPC of the corresponding BannerID that are required to be killed to obtain the given banner item type (<see cref="Item.type"/>). 
-+		/// <br/> Defaults to <c><see cref="DefaultKillsForBannerNeeded"/> (50)</c>.
-+		/// <para/> This is also used to determine how many kills are needed to fully unlock the Bestiary entry for each NPC type using the corresponding BannerID, although Bestiary kill counts are tracked individually for each NPC type instead of sharing a kill count with all other NPC types using the same BannerID as they do for banner dropping purposes.
++		/// <br/><br/> Defaults to <c><see cref="DefaultKillsForBannerNeeded"/> (50)</c>.
++		/// <br/><br/> This is also used to determine how many kills are needed to fully unlock the Bestiary entry for each NPC type using the corresponding BannerID, although Bestiary kill counts are tracked individually for each NPC type instead of sharing a kill count with all other NPC types using the same BannerID as they do for banner dropping purposes.
 +		/// </summary>
  		public static int[] KillsToBanner = Factory.CreateIntSet(DefaultKillsForBannerNeeded, 3838, 1000, 3845, 200, 3837, 500, 3844, 200, 3843, 50, 3839, 150, 3840, 100, 3842, 200, 3841, 100, 3846, 50, 2971, 150, 2982, 150, 2931, 100, 2961, 100, 2994, 100, 2985, 10, 4541, 10, 2969, 10, 2986, 10, 2915, 10, 4602, 10, 4542, 25, 4543, 25, 4546, 25, 4545, 25, 2901, 25, 2902, 25, 1631, 25, 2913, 25, 4688, 25, 3390, 25, 4973, 25, 4974, 25, 4975, 25, 2934, 25, 1670, 25, 1694, 25, 2958, 25, 2960, 25, 3441, 25, 3780, 25, 3397, 25, 3403, 25);
 +

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -179,8 +179,9 @@ partial class TileID
 		public static bool[] MultiTileSway = Factory.CreateBoolSet(false);
 
 		/// <summary>
-		/// If true, players landing on these tiles will not suffer <see href="https://terraria.wiki.gg/wiki/Fall_damage#Tiles">fall damage</see>. Vanilla entries include Cloud, RainCloud, SnowCloud, and PoopBlock. Defaults to false.
-		/// <para/> See also <see cref="Main.tileBouncy"/>.
+		/// If true, players landing on these tiles will not suffer <see href="https://terraria.wiki.gg/wiki/Fall_damage#Tiles">fall damage</see>. Vanilla entries include Cloud, RainCloud, SnowCloud, and PoopBlock.
+		/// <br/><br/> Defaults to <see langword="false"/>.
+		/// <br/><br/> See also <see cref="Main.tileBouncy"/>.
 		/// </summary>
 		public static bool[] NegatesFallDamage = Factory.CreateBoolSet(Cloud, RainCloud, SnowCloud, PoopBlock);
 


### PR DESCRIPTION
WIP

This PR will standardize the comments in tModLoader to fix issues that prevent documentation from rendering correctly in Visual Studio, Rider, the online documentation (doxygen), and Visual Studio Code.

## Paragraphs

In recent years, we've been preferring `<para/>` in XML documentation to create double line breaks to start new paragraphs. This, however, has been found to not render correctly in Rider and doxygen:

**Current:**
```xml
/// <summary>
/// Determines the number of NPC of the corresponding BannerID that are required to be killed to obtain the given banner item type (<see cref="Item.type"/>). 
/// <br/> Defaults to <c><see cref="DefaultKillsForBannerNeeded"/> (50)</c>.
/// <para/> This is also used to determine how many kills are needed to fully unlock the Bestiary entry for each NPC type using the corresponding BannerID, although Bestiary kill counts are tracked individually for each NPC type instead of sharing a kill count with all other NPC types using the same BannerID as they do for banner dropping purposes.
/// </summary>
public static int[] KillsToBanner = Factory.CreateIntSet(DefaultKillsForBannerNeeded, 3838, 1000,.....);
```
**VS (intended):**
![image](https://github.com/user-attachments/assets/f373e633-4103-44dd-b041-c90eee2d9d26)

**doxygen (missing newlines)**
![image](https://github.com/user-attachments/assets/8b5ce993-ac4e-4fb8-9075-f4497b25fb97)

## Defaults to X
Many entries show `Defaults to false` or `Defaults to 0`. We want to make sure that the default values are highlighted as a langword or code always, for readability:

`Defaults to <see langword="false"/>` instead of `Defaults to false`
`Defaults to <c>1</c>` instead of `Defaults to 1`

**VS (intended):**
![image](https://github.com/user-attachments/assets/a418cfe5-da64-41e6-8bfb-5402df816f02)
![image](https://github.com/user-attachments/assets/b65847a1-9b2a-47d2-807f-92029607e669)


## `<see>` inside `<c>`
For some reason, `<see>`  entries within `<c>` tags don't render correctly in Rider.

```xml
/// <br/> If this value reaches or exceeds <c>120</c>, the NPC gains <c><see cref="lifeRegenCount"/> / 120</c> health and this value decreases until it no longer exceeds <c>120</c>.
```

**VS (intended):**
![image](https://github.com/user-attachments/assets/0d21da74-7736-4979-a3bd-ac66040b7da5)

**Rider (missing)**
![image](https://github.com/user-attachments/assets/56470173-50f2-4750-abec-f9b59db8531f)

**VS Code (extra ticks "`")** -- https://github.com/dotnet/vscode-csharp/issues/5130
<img width="893" height="138" alt="Code_2025-08-05_14-46-15" src="https://github.com/user-attachments/assets/ca7bec5b-a993-4c4f-a6e6-43f0f014d298" />

## Comments vs Commented-out code
Single line comments containing actual comments should have a space after `//`. Single line comments commenting out actual code should not:
```cs
// If only the sound stopping when the projectile is killed is required, this simpler code can be used:
//soundSlot = SoundEngine.PlaySound(soundStyleTwister, Projectile.position, soundInstance => tracker.IsActiveAndInGame());
```
There are a few remining places where this is incorrect.