### PR TITLE
Update ExampleBar.cs

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleBar.cs
+++ b/ExampleMod/Content/Tiles/ExampleBar.cs
@@ -23,6 +23,7 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override bool TileFrame(int i, int j, ref bool resetFrame, ref bool noBreak) {
+			// This check will destroy this tile if the tile below has become slopped such that it doesn't have a solid top side. 
 			WorldGen.Check1x1(i, j, Type);
 			return false;
 		}

--- a/ExampleMod/Content/Tiles/ExampleBar.cs
+++ b/ExampleMod/Content/Tiles/ExampleBar.cs
@@ -21,5 +21,10 @@ namespace ExampleMod.Content.Tiles
 
 			AddMapEntry(new Color(200, 200, 200), Language.GetText("MapObject.MetalBar")); // localized text for "Metal Bar"
 		}
+
+		public override bool TileFrame(int i, int j, ref bool resetFrame, ref bool noBreak) {
+			WorldGen.Check1x1(i, j, Type);
+			return false;
+		}
 	}
 }

--- a/ExampleMod/Content/Tiles/ExampleBar.cs
+++ b/ExampleMod/Content/Tiles/ExampleBar.cs
@@ -23,9 +23,12 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override bool TileFrame(int i, int j, ref bool resetFrame, ref bool noBreak) {
-			// This check will destroy this tile if the tile below has become slopped such that it doesn't have a solid top side. 
-			WorldGen.Check1x1(i, j, Type);
-			return false;
+			// This check will destroy this tile if the tile below has become slopped such that it doesn't have a solid top side.
+			// This is necessary in this case because Bar tiles can be placed ontop of each other but can also be hammered to be half bricks despite being tileSolidTop.
+			if (!WorldGen.SolidTileAllowBottomSlope(i, j + 1)) {
+				WorldGen.KillTile(i, j);
+			}
+			return true;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Enums/AnchorType.cs.patch
+++ b/patches/tModLoader/Terraria/Enums/AnchorType.cs.patch
@@ -1,15 +1,17 @@
 --- src/TerrariaNetCore/Terraria/Enums/AnchorType.cs
 +++ src/tModLoader/Terraria/Enums/AnchorType.cs
-@@ -6,12 +_,17 @@
+@@ -6,12 +_,19 @@
  public enum AnchorType
  {
  	None = 0,
-+	/// <summary> Solid tiles: <see cref="Main.tileSolid"/> but not <see cref="Main.tileSolidTop"/>, <see cref="Main.tileNoAttach"/>, or sloped (unless <see cref="ObjectData.TileObjectData.FlattenAnchors"/> is true). </summary>
++	/// <summary> Solid tiles: <see cref="Main.tileSolid"/> but not <see cref="Main.tileSolidTop"/>, <see cref="Main.tileNoAttach"/>, or sloped (unless <see cref="ObjectData.TileObjectData.FlattenAnchors"/> is true).
++	/// <br/><br/> Sloped solid tiles that are not sloped on the side being anchored to are covered by <see cref="SolidSide"/>. </summary>
  	SolidTile = 1,
 +	/// <summary> Platforms with a top surface and tiles that are <see cref="Main.tileSolid"/> and <see cref="Main.tileSolidTop"/> (such as <see cref="ID.TileID.PlanterBox"/> and <see cref="ID.TileID.MetalBars"/>) </summary>
  	SolidWithTop = 2,
 +	/// <summary> Table tiles: <see cref="Main.tileTable"/> but not <see cref="ID.TileID.Sets.Platforms"/>. Also includes <see cref="SolidWithTop"/> tiles. </summary>
  	Table = 4,
++	/// <summary> Solid tiles with full side facing the tile: <see cref="Main.tileSolid"/> but not <see cref="Main.tileSolidTop"/>. The tile can be sloped as long as the side being anchored to isn't sloped. </summary>
  	SolidSide = 8,
  	Tree = 0x10,
 +	/// <summary> The tile is contained in <see cref="ObjectData.TileObjectData.AnchorAlternateTiles"/> </summary>

--- a/patches/tModLoader/Terraria/ID/SlopeType.cs
+++ b/patches/tModLoader/Terraria/ID/SlopeType.cs
@@ -3,8 +3,12 @@ namespace Terraria.ID;
 public enum SlopeType
 {
 	Solid = 0,
+	/// <summary> Only the bottom and left sides are solid. </summary>
 	SlopeDownLeft = 1,
+	/// <summary> Only the bottom and right sides are solid. </summary>
 	SlopeDownRight = 2,
+	/// <summary> Only the top and left sides are solid. </summary>
 	SlopeUpLeft = 3,
+	/// <summary> Only the top and right sides are solid. </summary>
 	SlopeUpRight = 4,
 }

--- a/patches/tModLoader/Terraria/Tile.TML.cs
+++ b/patches/tModLoader/Terraria/Tile.TML.cs
@@ -90,22 +90,22 @@ public readonly partial struct Tile
 	public bool IsHalfBlock { get => Get<TileWallWireStateData>().IsHalfBlock; set => Get<TileWallWireStateData>().IsHalfBlock = value; }
 
 	/// <summary>
-	/// Whether a tile's <see cref="Slope"/> has a solid top side (<see cref="SlopeType.SlopeDownLeft"/> or <see cref="SlopeType.SlopeDownRight"/>).<br/>
+	/// If the top side of a tile is sloped (<see cref="Slope"/>), meaning the bottom side is solid. (<see cref="SlopeType.SlopeDownLeft"/> or <see cref="SlopeType.SlopeDownRight"/>).<br/>
 	/// Legacy/vanilla equivalent is <see cref="topSlope"/>.
 	/// </summary>
 	public bool TopSlope => Slope == SlopeType.SlopeDownLeft || Slope == SlopeType.SlopeDownRight;
 	/// <summary>
-	/// Whether a tile's <see cref="Slope"/> has a solid bottom side (<see cref="SlopeType.SlopeUpLeft"/> or <see cref="SlopeType.SlopeUpRight"/>).<br/>
+	/// If the bottom side of a tile is sloped (<see cref="Slope"/>), meaning the top side is solid. (<see cref="SlopeType.SlopeUpLeft"/> or <see cref="SlopeType.SlopeUpRight"/>).<br/>
 	/// Legacy/vanilla equivalent is <see cref="bottomSlope"/>.
 	/// </summary>
 	public bool BottomSlope => Slope == SlopeType.SlopeUpLeft || Slope == SlopeType.SlopeUpRight;
 	/// <summary>
-	/// Whether a tile's <see cref="Slope"/> has a solid left side (<see cref="SlopeType.SlopeDownRight"/> or <see cref="SlopeType.SlopeUpRight"/>).<br/>
+	/// If the left side of a tile is sloped (<see cref="Slope"/>), meaning the right side is solid. (<see cref="SlopeType.SlopeDownRight"/> or <see cref="SlopeType.SlopeUpRight"/>).<br/>
 	/// Legacy/vanilla equivalent is <see cref="leftSlope"/>.
 	/// </summary>
 	public bool LeftSlope => Slope == SlopeType.SlopeDownRight || Slope == SlopeType.SlopeUpRight;
 	/// <summary>
-	/// Whether a tile's <see cref="Slope"/> has a solid right side (<see cref="SlopeType.SlopeDownLeft"/> or <see cref="SlopeType.SlopeUpLeft"/>).<br/>
+	/// If the right side of a tile is sloped (<see cref="Slope"/>), meaning the left side is solid. (<see cref="SlopeType.SlopeDownLeft"/> or <see cref="SlopeType.SlopeUpLeft"/>).<br/>
 	/// Legacy/vanilla equivalent is <see cref="rightSlope"/>.
 	/// </summary>
 	public bool RightSlope => Slope == SlopeType.SlopeDownLeft || Slope == SlopeType.SlopeUpLeft;

--- a/patches/tModLoader/Terraria/TileObject.cs.patch
+++ b/patches/tModLoader/Terraria/TileObject.cs.patch
@@ -36,6 +36,14 @@
  						flag4 = true;
  
  					if (flag4 || flag2 || flag3) {
+@@ -330,6 +_,7 @@
+ 									flag5 = true;
+ 							}
+ 							else if (Main.tileSolid[tileSafely.type] && Main.tileSolidTop[tileSafely.type]) {
++								// This is buggy since it doesn't check TopSlope and HalfBrick like WorldGen.SolidTileAllowBottomSlope does, causing issues with placing ontop of hammerable tiles like MetalBar. This bug left in until vanilla fix since it might be complicated.
+ 								flag5 = true;
+ 							}
+ 						}
 @@ -373,7 +_,7 @@
  					Tile tileSafely = Framing.GetTileSafely(num8 + num29, num9 + num28);
  					bool flag6 = false;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -3039,6 +3039,17 @@
  			if (Main.tile[num15, num16].type == 2) {
  				if (genRand.Next(2) == 0)
  					flag4 = true;
+@@ -51041,6 +_,10 @@
+ 		return true;
+ 	}
+ 
++	/// <summary>
++	/// Returns true if there is a solid tile at the provided tile coordinates suitable for a tile to be anchored above.
++	/// <br/><br/> Specifically, this checks that the tile is active, unactuated, is <see cref="Main.tileSolid"/> or <see cref="Main.tileSolidTop"/>, isn't a half block, and it has a solid top side (top isn't sloped).
++	/// </summary>
+ 	public static bool SolidTileAllowBottomSlope(int i, int j)
+ 	{
+ 		try {
 @@ -52049,9 +_,20 @@
  
  	public static void UpdateWorld()


### PR DESCRIPTION
Basically just fixes them being able to be supported below by another hammered bar tile, uses the same method vanilla does for the bar tiles.

Needs a comment to explain what it's doing, I omitted it because I'm unsure what other placement scenarios this may affect.