### PR TITLE
Fix escape not working while inputting text on platforms other than Windows

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2850,6 +2850,17 @@
  			if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z) && !oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z)) {
  				text = "";
  			}
+@@ -15866,6 +_,10 @@
+ 					text2 = PasteTextIn(allowMultiLine, text2);
+ 			}
+ 
++			// `WinImm32Ime` sends escape as an input character, but `FnaIme` does not, so we need to do this for escape to work on platforms other that Windows.
++			if (inputText.IsKeyDown(Keys.Escape) && !oldInputText.IsKeyDown(Keys.Escape))
++				inputTextEscape = true;
++
+ 			for (int i = 0; i < keyCount; i++) {
+ 				int num = keyInt[i];
+ 				string text3 = keyString[i];
 @@ -15938,11 +_,16 @@
  		MouseText(cursorText, null, rare, diff, hackedMouseX, hackedMouseY, hackedScreenWidth, hackedScreenHeight, pushWidthX, noOverride: true);
  	}


### PR DESCRIPTION
Note: This is a vanilla bug.

`WinImm32Ime` receives input characters via `WM_CHAR` messages, which are posted even for control characters (including escape). On the other hand, `FnaIme` receives characters through FNA's `TextInputEXT::TextInput` event, which does *not* include escape.

As a result, `GetInputText` sets `inputTextEscape` when escape is pressed on Windows, but not on other platforms. In the bestiary, for example, pressing escape does not deselect the search bar.

This PR just explicitly checks in `GetInputText` whether the escape key has been pressed. This could also probably be solved by modifying `FnaIme` to detect escape explicitly, but it's not obvious to me the best way to do that.