### PR TITLE
Fix wall blending (Main.wallBlend) issues for modded walls

### DIFF
--- a/ExampleMod/Content/Walls/ExampleWallAdvanced.cs
+++ b/ExampleMod/Content/Walls/ExampleWallAdvanced.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Content.Walls
 	{
 		public override void SetStaticDefaults() {
 			Main.wallHouse[Type] = true;
+			Main.wallBlend[Type] = WallID.CogWall; // Prevent black line being drawn between this and CogWall
 
 			DustType = DustID.Stone;
 

--- a/ExampleMod/Content/Walls/ExampleWallUnsafe.cs
+++ b/ExampleMod/Content/Walls/ExampleWallUnsafe.cs
@@ -1,5 +1,6 @@
 ﻿using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Walls
@@ -8,6 +9,7 @@ namespace ExampleMod.Content.Walls
 	{
 		public override void SetStaticDefaults() {
 			// As an example of an unsafe wall, "Main.wallHouse[Type] = true;" is omitted.
+			Main.wallBlend[Type] = ModContent.WallType<ExampleWall>(); // Lets these 2 walls "blend", preventing the game from drawing a dark line between this and ExampleWall.
 
 			DustType = ModContent.DustType<Sparkle>();
 

--- a/patches/tModLoader/Terraria/ID/WallID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/WallID.cs.patch
@@ -16,6 +16,16 @@
  		public static bool[] CanBeConvertedToGlowingMushroom = Factory.CreateBoolSet(64, 67, 15, 247);
  		public static bool[] AllowsUndergroundDesertEnemiesToSpawn = Factory.CreateBoolSet(187, 220, 222, 221, 216, 217, 219, 218);
  		public static bool[] Transparent = Factory.CreateBoolSet(88, 89, 90, 91, 92, 241);
+@@ -31,6 +_,9 @@
+ 		public static bool[] AllowsPlantsToGrow = Factory.CreateBoolSet(0, 150, 138, 145, 107, 152, 140, 139, 141, 106, 245, 315, 317, 63, 64, 65, 66, 67, 68, 69, 81, 70, 264, 268, 265, 74, 80);
+ 		public static bool[] CannotBeReplacedByWallSpread = Factory.CreateBoolSet(4, 40, 3, 87, 34);
+ 		public static bool[] WallSpreadStopsAtAir = Factory.CreateBoolSet(63, 62);
++		/// <summary>
++		/// <strong>Unused.</strong> Used to populate <see cref="Main.wallBlend"/> for vanilla walls. Not used for modded walls, use Main.wallBlend instead.
++		/// </summary>
+ 		public static int[] BlendType = Factory.CreateIntSet(-1, 66, 63, 68, 63, 65, 63, 16, 2, 59, 2, 261, 2, 284, 196, 285, 197, 286, 198, 287, 199, 256, 54, 257, 55, 258, 56, 259, 57, 260, 58, 262, 61, 274, 185, 300, 212, 301, 213, 302, 214, 303, 215, 296, 208, 297, 209, 298, 210, 299, 211, 48, 1, 49, 1, 50, 1, 51, 1, 52, 1, 53, 1, 250, 1, 251, 1, 252, 1, 253, 1, 254, 1, 255, 1, 69, 264, 3, 246, 217, 305, 220, 308, 188, 276, 189, 277, 190, 278, 191, 279, 81, 77, 268, 77, 83, 269, 218, 306, 221, 309, 192, 280, 193, 281, 194, 282, 195, 283, 70, 265, 28, 248, 219, 307, 222, 310, 200, 288, 201, 289, 202, 290, 203, 291, 15, 247, 64, 67, 204, 292, 205, 293, 206, 294, 207, 295, 86, 108, 87, 112, 40, 249, 71, 266, 216, 304, 187, 275, 62, 263, 80, 74, 180, 184, 178, 183, 79, 267, 20, 14, 7, 17, 94, 17, 95, 17, 8, 18, 98, 18, 99, 18, 9, 19, 96, 19, 97, 19);
+ 	}
+ 
 @@ -382,4 +_,8 @@
  	public const ushort VioletMossBlockWall = 345;
  	public const ushort RainbowMossBlockWall = 346;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -496,9 +496,9 @@
 +	/// </summary>
  	public static bool[] wallLight = new bool[WallID.Count];
 +	/// <summary>
-+	/// Set to a wall type to "blend" with that wall. By default, a faint black line is drawn between walls of different types to transition between them. Walls that blend will not have this line drawn. 
-+	/// <br/><br/> This is most commonly used to blend safe and unsafe wall variants, although there are some exceptions. All variants that should blend together should set this to a common shared base variant. The base variant does not need to set this. For example, <see cref="WallID.GreenDungeonUnsafe"/>, <see cref="WallID.GreenDungeonTileUnsafe"/>, and <see cref="WallID.GreenDungeonSlabUnsafe"/> all set this to <see cref="WallID.GreenDungeon"/> allowing all 4 to blend together.
-+	/// <br/><br/> Defaults to it's own wall type, meaning it does not blend with any other wall.
++	/// Set to a wall type to "blend" with that wall. All walls sharing the same value are considered to be the same wall type when blending. By default, a faint black line is drawn between walls of different types to transition between them. Walls that blend will not have this line drawn. 
++	/// <br/><br/> This is most commonly used to blend safe and unsafe wall variants, although there are some exceptions. All variants that should blend together should set this to a common shared base variant. The base variant does not need to set this. For example, <see cref="WallID.GreenDungeonUnsafe"/>, <see cref="WallID.GreenDungeonTileUnsafe"/>, and <see cref="WallID.GreenDungeonSlabUnsafe"/> all set this to <see cref="WallID.GreenDungeon"/> allowing all 4 wall types to be considered to be <see cref="WallID.GreenDungeon"/> and blend together.
++	/// <br/><br/> Defaults to it's own wall type, meaning it does not blend with any other wall (unless another wall is set to this wall's type.
 +	/// </summary>
  	public static int[] wallBlend = new int[WallID.Count];
  	public static bool[] tileStone = new bool[TileID.Count];

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -456,7 +456,7 @@
  	public static bool allChestStackHover;
  	public static bool inventorySortMouseOver;
  	public static float GraveyardVisualIntensity;
-@@ -829,44 +_,142 @@
+@@ -829,44 +_,147 @@
  	public static float ambientVolume = 1f;
  	public static float soundVolume = 1f;
  	public static ServerMode MenuServerMode = ServerMode.Lobby | ServerMode.FriendsCanJoin;
@@ -495,6 +495,11 @@
 +	/// If true, light flows in from the background, such as fences and glass.
 +	/// </summary>
  	public static bool[] wallLight = new bool[WallID.Count];
++	/// <summary>
++	/// Set to a wall type to "blend" with that wall. By default, a faint black line is drawn between walls of different types to transition between them. Walls that blend will not have this line drawn. 
++	/// <br/><br/> This is most commonly used to blend safe and unsafe wall variants, although there are some exceptions. All variants that should blend together should set this to a common shared base variant. The base variant does not need to set this. For example, <see cref="WallID.GreenDungeonUnsafe"/>, <see cref="WallID.GreenDungeonTileUnsafe"/>, and <see cref="WallID.GreenDungeonSlabUnsafe"/> all set this to <see cref="WallID.GreenDungeon"/> allowing all 4 to blend together.
++	/// <br/><br/> Defaults to it's own wall type, meaning it does not blend with any other wall.
++	/// </summary>
  	public static int[] wallBlend = new int[WallID.Count];
  	public static bool[] tileStone = new bool[TileID.Count];
 +	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModWall.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModWall.cs
@@ -10,6 +10,7 @@ namespace Terraria.ModLoader;
 
 /// <summary>
 /// This class represents a type of wall that can be added by a mod. Only one instance of this class will ever exist for each type of wall that is added. Any hooks that are called will be called by the instance corresponding to the wall type.
+/// <br/><br/> The <see href="https://github.com/tModLoader/tModLoader/wiki/Wall">Wall Guide</see> teaches the basics of making a modded wall.
 /// </summary>
 public abstract class ModWall : ModBlockType
 {

--- a/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/WallLoader.cs
@@ -91,6 +91,9 @@ public static class WallLoader
 		Array.Resize(ref Main.wallDungeon, nextWall);
 		Array.Resize(ref Main.wallLight, nextWall);
 		Array.Resize(ref Main.wallBlend, nextWall);
+		for (int k = WallID.Count; k < nextWall; k++) {
+			Main.wallBlend[k] = k;
+		}
 		Array.Resize(ref Main.wallLargeFrames, nextWall);
 		Array.Resize(ref Main.wallFrame, nextWall);
 		Array.Resize(ref Main.wallFrameCounter, nextWall);


### PR DESCRIPTION
Wall blending does not work correctly for modded walls. Currently, all modded walls blend together with each other because `Main.wallBlend[ModdedIDHere]` has a value of `0`. Every `ModWall` that does not manually set `Main.wallBlend` will blend with each other. Vanilla walls only blend with the specific wall they are intended to blend with by setting to a common WallID, but since modded walls all have a value of 0, they all share a common WallID.

What is blending? Blending is when the thin black line that is usually drawn between different wall types is **not** drawn. 

This PR does the following:

- Fix `Main.wallBlend` initial values so that modded tiles don't automatically blend with each other, the intended default.
- Adds documentation
- Adds example usages of `Main.wallBlend` showing blending with a vanilla and modded wall.

The following images show the issue and fixes, it might be hard to see, but there is a faint black line between walls:

The bottom 3 walls in this example are modded. Note how they blend even though blending is not intended. The fix restores the black border shown between the other wall borders.

| Bugged | Fixed |
|--------|--------|
| ![ModdedBlendingByDefault](https://github.com/user-attachments/assets/ea0d1232-cae4-4496-b996-1381fa2fd676) | ![FixedNoBlending](https://github.com/user-attachments/assets/91807a03-6bd3-4293-9b65-5e84251f5fc5) | 

Here that is as a gif:
![output](https://github.com/user-attachments/assets/9d5f1ccd-b742-476a-b5d8-f6577f3cdc72)

Here is another example. In this example you can see `ExampleWallAdvanced` incorrectly blending with `ExampleWall` and `ExampleWall` and `ExampleWallUnsafe` blending. After the fix, code was added to explicitly blend `ExampleWallAdvanced` and `WallID.CogWall` as well as `ExampleWall` and `ExampleWallUnsafe`. `ExampleWallAdvanced` and `ExampleWall` now correctly do **not** blend.

| Bugged | Fixed |
|--------|--------|
| ![WrongBlend](https://github.com/user-attachments/assets/aaa3749e-0a7c-4e44-92bb-c04e86982dc7) | ![FixedBlend](https://github.com/user-attachments/assets/6d72b494-06d2-48dd-8bd3-646bba1bbc27) | 

Here that is as a gif:
![output2](https://github.com/user-attachments/assets/1233dd5a-9014-4c9e-8ff7-164978492376)    

# Discussion
Since it was a bug, changing the behavior for modded walls should be fine, but it's possible that mods were relying on the existing buggy implementation. Given that `Main.wallBlend` and `WallID.Sets.BlendType` only came up once in the whole chat history of Discord and the bug was never reported, I think modders never even noticed the issue, so it should be fine to fix to match vanilla behavior.

# Porting Notes

- Add `Main.wallBlend[Type] = ModContent.WallType<OtherWall>();` to any `ModWall` where blending was intended. This only needs to be done on one of the walls in a pair, since this is indicating that this wall should be considered to be the other wall for the purposes of blending.
- `WallID.Sets.BlendType` never worked in the first place, despite being recommended on our wiki previously. If you were using it, remove it and use `Main.wallBlend` instead.