### PR TITLE
Additional sound fixes, VariantsAreIndependent support

### DIFF
--- a/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
@@ -78,7 +78,8 @@
 +			return;
 +		}
 +
- 		SoundEffectInstance soundEffectInstance = Style.GetRandomSound().CreateInstance();
+-		SoundEffectInstance soundEffectInstance = Style.GetRandomSound().CreateInstance();
++		SoundEffectInstance soundEffectInstance = Style.GetSoundEffect().CreateInstance();
  		soundEffectInstance.Pitch += Style.GetRandomPitch();
  		Pitch = soundEffectInstance.Pitch;
 +		soundEffectInstance.IsLooped = Style.IsLooped;

--- a/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/ActiveSound.cs.patch
@@ -52,8 +52,9 @@
  		Volume = 1f;
  		Pitch = style.PitchVariance;
 -		IsGlobal = false;
+-		Style = style;
 +		//IsGlobal = false;
- 		Style = style;
++		Style = style.WithSelectedVariant(style.SelectedVariant); // Select a variant if for some reason not set at this point.
 +		Callback = updateCallback;
 +		
  		Play();

--- a/patches/tModLoader/Terraria/Audio/LegacySoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/LegacySoundPlayer.cs.patch
@@ -60,6 +60,14 @@
  	}
  
  	private SoundEffectInstance CreateInstance(Asset<SoundEffect> asset)
+@@ -470,6 +_,7 @@
+ 							case 103:
+ 							case 156:
+ 							case 162:
++								// The preceding ItemX SoundStyle all need MaxInstances = 0 in SoundID.TML.cs
+ 								break;
+ 						}
+ 						SoundInstanceItem[num] = SoundItem[num].Value.CreateInstance();
 @@ -855,6 +_,7 @@
  						break;
  					default:

--- a/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundEngine.cs.patch
@@ -22,7 +22,7 @@
  	}
  
  	public static void Load(IServiceProvider services)
-@@ -29,6 +_,15 @@
+@@ -29,12 +_,22 @@
  
  	public static void Update()
  	{
@@ -38,6 +38,13 @@
  		if (IsAudioSupported) {
  			if (Main.audioSystem != null)
  				Main.audioSystem.UpdateAudioEngine();
+ 
+ 			SoundInstanceGarbageCollector.Update();
+ 			bool flag = (!Main.hasFocus || Main.gamePaused) && Main.netMode == 0;
++			// TODO: Issue #3091, pause cuts off all sounds. Vanilla seems to only pause tracked sounds originally
+ 			if (!AreSoundsPaused && flag)
+ 				SoundPlayer.PauseAll();
+ 			else if (AreSoundsPaused && !flag)
 @@ -56,6 +_,8 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.TML.cs
@@ -14,12 +14,36 @@ partial class SoundPlayer
 	public bool TryGetActiveSound(SlotId id, [NotNullWhen(true)] out ActiveSound? result)
 		=> _trackedSounds.TryGetValue(id, out result);
 
+	/// <summary>
+	/// Stops all sounds matching the provided <see cref="SoundStyle"/>. Use <see cref="StopAll(in SoundStyle, int)"/> instead if stopping just a specific variant is desired.
+	/// </summary>
 	public void StopAll(in SoundStyle style)
 	{
 		List<SlotVector<ActiveSound>.ItemPair> stopped = new();
 
 		foreach (SlotVector<ActiveSound>.ItemPair item in (IEnumerable<SlotVector<ActiveSound>.ItemPair>)_trackedSounds) {
-			if (style.IsTheSameAs(item.Value.Style)) {
+			if (style.IsVariantOf(item.Value.Style)) {
+				item.Value.Stop();
+				stopped.Add(item);
+			}
+		}
+
+		foreach (var item in stopped) {
+			_trackedSounds.Remove(item.Id);
+		}
+	}
+
+	/// <summary>
+	/// Stops all sounds matching the provided <see cref="SoundStyle"/> and variant choice. Use <see cref="StopAll(in SoundStyle)"/> instead if stopping all variants is desired.
+	/// </summary>
+	public void StopAll(in SoundStyle style, int variant)
+	{
+		var checkStyle = style with { RandomChoice = variant };
+
+		List<SlotVector<ActiveSound>.ItemPair> stopped = new();
+
+		foreach (SlotVector<ActiveSound>.ItemPair item in (IEnumerable<SlotVector<ActiveSound>.ItemPair>)_trackedSounds) {
+			if (checkStyle.IsTheSameAs(item.Value.Style)) {
 				item.Value.Stop();
 				stopped.Add(item);
 			}

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.TML.cs
@@ -38,7 +38,7 @@ partial class SoundPlayer
 	/// </summary>
 	public void StopAll(in SoundStyle style, int variant)
 	{
-		var checkStyle = style with { RandomChoice = variant };
+		var checkStyle = style with { SelectedVariant = variant };
 
 		List<SlotVector<ActiveSound>.ItemPair> stopped = new();
 

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Audio/SoundPlayer.cs
 +++ src/tModLoader/Terraria/Audio/SoundPlayer.cs
-@@ -2,24 +_,84 @@
+@@ -2,24 +_,86 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Utilities;
  
@@ -48,8 +48,10 @@
 +	// The part that HAS to run on the main thread.
 +	private SlotId Play_Inner(in SoundStyle style, Vector2? position, SoundUpdateCallback? updateCallback)
 +	{
++		SoundStyle chosenStyle = style.WithChosenRandom();
++
 +		// Handle the MaxInstances & RestartIfPlaying properties
-+		int maxInstances = style.MaxInstances;
++		int maxInstances = chosenStyle.MaxInstances;
 +
 +		if (maxInstances > 0) {
 +			int instanceCount = 0;
@@ -57,11 +59,11 @@
 +			foreach (var pair in _trackedSounds) {
 +				var activeSound = pair.Value;
 +
-+				if (!activeSound.IsPlaying || !style.IsTheSameAs(activeSound.Style) || ++instanceCount < maxInstances) {
++				if (!activeSound.IsPlaying || !chosenStyle.IsTheSameAs(activeSound.Style) || ++instanceCount < maxInstances) {
 +					continue;
 +				}
 +
-+				switch (style.SoundLimitBehavior) {
++				switch (chosenStyle.SoundLimitBehavior) {
 +					case SoundLimitBehavior.ReplaceOldest: //TODO: Make this actually true to its name -- replace the *oldest* sound.
 +						activeSound.Sound?.Stop(true);
 +						break;
@@ -71,10 +73,10 @@
 +			}
 +		}
 +
-+		SoundStyle styleCopy = style;
++		SoundStyle styleCopy = chosenStyle;
 +
 +		// Handle 'UsesMusicPitch'.. This property is a weird solution for keeping vanilla's old instruments' behavior alive, and is currently internal.
-+		if (style.UsesMusicPitch) {
++		if (chosenStyle.UsesMusicPitch) {
 +			styleCopy.Pitch += Main.musicPitch;
 +		}
  

--- a/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
+++ b/patches/tModLoader/Terraria/Audio/SoundPlayer.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Audio/SoundPlayer.cs
 +++ src/tModLoader/Terraria/Audio/SoundPlayer.cs
-@@ -2,24 +_,86 @@
+@@ -2,24 +_,84 @@
  using Microsoft.Xna.Framework;
  using ReLogic.Utilities;
  
@@ -48,7 +48,7 @@
 +	// The part that HAS to run on the main thread.
 +	private SlotId Play_Inner(in SoundStyle style, Vector2? position, SoundUpdateCallback? updateCallback)
 +	{
-+		SoundStyle chosenStyle = style.WithChosenRandom();
++		SoundStyle chosenStyle = style.WithSelectedVariant();
 +
 +		// Handle the MaxInstances & RestartIfPlaying properties
 +		int maxInstances = chosenStyle.MaxInstances;
@@ -73,15 +73,13 @@
 +			}
 +		}
 +
-+		SoundStyle styleCopy = chosenStyle;
-+
 +		// Handle 'UsesMusicPitch'.. This property is a weird solution for keeping vanilla's old instruments' behavior alive, and is currently internal.
 +		if (chosenStyle.UsesMusicPitch) {
-+			styleCopy.Pitch += Main.musicPitch;
++			chosenStyle.Pitch += Main.musicPitch;
 +		}
  
 -		ActiveSound value = new ActiveSound(style, position);
-+		ActiveSound value = new ActiveSound(styleCopy, position, updateCallback);
++		ActiveSound value = new ActiveSound(chosenStyle, position, updateCallback);
  		return _trackedSounds.Add(value);
  	}
  

--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -35,6 +35,7 @@ public record struct SoundStyle
 	private float pitchVariance = 0f;
 	private Asset<SoundEffect>? effectCache = null;
 	private Asset<SoundEffect>?[]? variantsEffectCache = null;
+	private int random = -1;
 
 	/// <summary> The sound effect to play. </summary>
 	public string SoundPath { get; set; }
@@ -56,6 +57,11 @@ public record struct SoundStyle
 
 	/// <summary> Determines what the action taken when the max amount of sound instances is reached. </summary>
 	public SoundLimitBehavior SoundLimitBehavior { get; set; } = SoundLimitBehavior.ReplaceOldest;
+
+	/// <summary>
+	/// If true, then variants are treated as different sounds for the purposes of <see cref="SoundLimitBehavior"/> and <see cref="MaxInstances"/>. Defaults to false, meaning that all variants share the same sound instance limitations.
+	/// </summary>
+	public bool VariantsAreIndependent { get; set; } = false; // true might be a better default? Need to check.
 
 	/// <summary> If true, this sound won't play if the game's window isn't selected. </summary>
 	public bool PlayOnlyIfFocused { get; set; } = false;
@@ -111,6 +117,11 @@ public record struct SoundStyle
 			variantsWeights = value.ToArray();
 			totalVariantWeight = null;
 		}
+	}
+
+	public int RandomChoice {
+		get => random;
+		set => random = value;
 	}
 
 	/// <summary> The volume multiplier to play sounds with. </summary>
@@ -211,8 +222,11 @@ public record struct SoundStyle
 	// To be optimized, improved.
 	public bool IsTheSameAs(SoundStyle style)
 	{
-		if (Identifier != null && Identifier == style.Identifier)
-			return true;
+		if (VariantsAreIndependent && RandomChoice != -1 && RandomChoice != style.RandomChoice)
+			return false;
+
+		if (Identifier != null || style.Identifier != null)
+			return Identifier == style.Identifier;
 
 		if (SoundPath == style.SoundPath)
 			return true;
@@ -254,8 +268,20 @@ public record struct SoundStyle
 	public SoundStyle WithPitchOffset(float offset)
 		=> this with { Pitch = Pitch + offset };
 
+	public SoundStyle WithChosenRandom(int random = -1)
+	{
+		if (variants == null || variants.Length == 0)
+			return this;
+		return this with { RandomChoice = random == -1 ? GetRandomVariantIndex() : random };
+	}
+
 	private int GetRandomVariantIndex()
 	{
+		if (this.random != -1) {
+			// Use existing random decision if already made.
+			return this.random;
+		}
+
 		if (variantsWeights == null) {
 			// Simple random.
 			return Random.Next(variants!.Length);

--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -160,7 +160,7 @@ public record struct SoundStyle
 	/// </summary>
 	public (float minPitch, float maxPitch) PitchRange {
 		get {
-			float halfVariance = PitchVariance;
+			float halfVariance = PitchVariance / 2;
 			float minPitch = Pitch - halfVariance;
 			float maxPitch = Pitch + halfVariance;
 

--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -35,7 +35,6 @@ public record struct SoundStyle
 	private float pitchVariance = 0f;
 	private Asset<SoundEffect>? effectCache = null;
 	private Asset<SoundEffect>?[]? variantsEffectCache = null;
-	private int random = -1;
 
 	/// <summary> The sound effect to play. </summary>
 	public string SoundPath { get; set; }
@@ -120,10 +119,7 @@ public record struct SoundStyle
 		}
 	}
 
-	internal int RandomChoice {
-		get => random;
-		set => random = value;
-	}
+	internal int? SelectedVariant { get; set; };
 
 	/// <summary> The volume multiplier to play sounds with. </summary>
 	public float Volume {
@@ -226,7 +222,7 @@ public record struct SoundStyle
 	/// </summary>
 	public bool IsTheSameAs(SoundStyle style)
 	{
-		if (LimitsArePerVariant && RandomChoice != style.RandomChoice)
+		if (LimitsArePerVariant && SelectedVariant != style.SelectedVariant)
 			return false;
 
 		if (Identifier != null || style.Identifier != null)
@@ -260,7 +256,7 @@ public record struct SoundStyle
 			asset = effectCache ??= ModContent.Request<SoundEffect>(SoundPath, AssetRequestMode.ImmediateLoad);
 		}
 		else {
-			int variantIndex = GetRandomVariantIndex();
+			int variantIndex = SelectedVariant ?? GetRandomVariantIndex();
 			int variant = variants[variantIndex];
 
 			Array.Resize(ref variantsEffectCache, variants.Length);
@@ -286,20 +282,15 @@ public record struct SoundStyle
 	public SoundStyle WithPitchOffset(float offset)
 		=> this with { Pitch = Pitch + offset };
 
-	internal SoundStyle WithSelectedVariant(int random = -1)
+	internal SoundStyle WithSelectedVariant(int? random = null)
 	{
 		if (variants == null || variants.Length == 0)
 			return this;
-		return this with { RandomChoice = random == -1 ? GetRandomVariantIndex() : random };
+		return this with { SelectedVariant = random ?? GetRandomVariantIndex() };
 	}
 
 	private int GetRandomVariantIndex()
 	{
-		if (this.random != -1) {
-			// Use existing random decision if already made.
-			return this.random;
-		}
-
 		if (variantsWeights == null) {
 			// Simple random.
 			return Random.Next(variants!.Length);

--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -51,7 +51,8 @@ public record struct SoundStyle
 
 	/// <summary>
 	/// The max amount of sound instances that this style will allow creating, before stopping a playing sound or refusing to play a new one.
-	/// <br/> Set to 0 for no limits.
+	/// <br/><br/> If using variants, use <see cref="LimitsArePerVariant"/> to allow <see cref="MaxInstances"/> to apply to each variant individually rather than to all variants as a group.
+	/// <br/><br/> Set to 0 for no limits.
 	/// </summary>
 	public int MaxInstances { get; set; } = 1;
 
@@ -61,7 +62,7 @@ public record struct SoundStyle
 	/// <summary>
 	/// If true, then variants are treated as different sounds for the purposes of <see cref="SoundLimitBehavior"/> and <see cref="MaxInstances"/>. Defaults to false, meaning that all variants share the same sound instance limitations.
 	/// </summary>
-	public bool VariantsAreIndependent { get; set; } = false; // true might be a better default? Need to check.
+	public bool LimitsArePerVariant { get; set; } = false;
 
 	/// <summary> If true, this sound won't play if the game's window isn't selected. </summary>
 	public bool PlayOnlyIfFocused { get; set; } = false;
@@ -119,7 +120,7 @@ public record struct SoundStyle
 		}
 	}
 
-	public int RandomChoice {
+	internal int RandomChoice {
 		get => random;
 		set => random = value;
 	}
@@ -220,11 +221,28 @@ public record struct SoundStyle
 	}
 
 	// To be optimized, improved.
+	/// <summary>
+	/// Checks if this SoundStyle is the same as another SoundStyle. This method takes into account differences in chosen variants if <see cref="LimitsArePerVariant"/> is true.
+	/// </summary>
 	public bool IsTheSameAs(SoundStyle style)
 	{
-		if (VariantsAreIndependent && RandomChoice != -1 && RandomChoice != style.RandomChoice)
+		if (LimitsArePerVariant && RandomChoice != style.RandomChoice)
 			return false;
 
+		if (Identifier != null || style.Identifier != null)
+			return Identifier == style.Identifier;
+
+		if (SoundPath == style.SoundPath)
+			return true;
+
+		return false;
+	}
+
+	/// <summary>
+	/// Same as <see cref="IsTheSameAs(SoundStyle)"/> except it doesn't take into account differences in chosen variants.
+	/// </summary>
+	public bool IsVariantOf(SoundStyle style)
+	{
 		if (Identifier != null || style.Identifier != null)
 			return Identifier == style.Identifier;
 
@@ -268,7 +286,7 @@ public record struct SoundStyle
 	public SoundStyle WithPitchOffset(float offset)
 		=> this with { Pitch = Pitch + offset };
 
-	public SoundStyle WithChosenRandom(int random = -1)
+	internal SoundStyle WithSelectedVariant(int random = -1)
 	{
 		if (variants == null || variants.Length == 0)
 			return this;

--- a/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
+++ b/patches/tModLoader/Terraria/Audio/SoundStyle.TML.cs
@@ -248,7 +248,10 @@ public record struct SoundStyle
 		return false;
 	}
 
-	public SoundEffect GetRandomSound()
+	[Obsolete("Renamed to GetSoundEffect")]
+	public SoundEffect GetRandomSound() => GetSoundEffect();
+
+	public SoundEffect GetSoundEffect()
 	{
 		Asset<SoundEffect> asset;
 

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -37,7 +37,7 @@ partial class SoundID
 	public static readonly SoundStyle MenuClose = new($"{Prefix}Menu_Close");
 	public static readonly SoundStyle MenuTick = new($"{Prefix}Menu_Tick") { PlayOnlyIfFocused = true };
 	public static readonly SoundStyle Shatter = new($"{Prefix}Shatter");
-	public static readonly SoundStyle ZombieMoan = new($"{Prefix}Zombie_", 0, 3) { Identifier = "Terraria/ZombieMoan", Volume = 0.4f };
+	public static readonly SoundStyle ZombieMoan = new($"{Prefix}Zombie_", 0, 3) { Identifier = "Terraria/ZombieMoan", Volume = 0.4f, MaxInstances = 0 };
 	public static readonly SoundStyle SandShark = new($"{Prefix}Zombie_7") { Volume = 0.4f }; // New field
 	public static readonly SoundStyle BloodZombie = new($"{Prefix}Zombie_", 21, 3) { Identifier = "Terraria/BloodZombie", Volume = 0.4f }; // New field
 	public static readonly SoundStyle Roar = new($"{Prefix}Roar_0") { Identifier = "Terraria/Roar", SoundLimitBehavior = IgnoreNew };
@@ -133,7 +133,7 @@ partial class SoundID
 	public static readonly SoundStyle Clown = new($"{Prefix}Zombie_", 121, 3) { Identifier = "Terraria/Clown", Volume = 0.45f, PitchVariance = 0.15f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle Cockatiel = new($"{Prefix}Zombie_", 118, 3) { Identifier = "Terraria/Cockatiel", Volume = 0.3f, PitchVariance = 0.05f };
 	public static readonly SoundStyle Macaw = new($"{Prefix}Zombie_", 126, 3) { Identifier = "Terraria/Macaw", Volume = 0.22f, PitchVariance = 0.05f };
-	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.05f };
+	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.05f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
 	// End of replaced IDs.
 
 	public static readonly SoundStyle NPCHit1 = NPCHitSound(1);

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -23,8 +23,8 @@ partial class SoundID
 	private const string PrefixCustom = "Terraria/Sounds/Custom/";
 
 	// Start of IDs that used to be 'int' typed.
-	public static readonly SoundStyle Dig = new($"{Prefix}Dig_", 0, 3) { PitchVariance = 0.2f, VariantsAreIndependent = true };
-	public static readonly SoundStyle PlayerHit = new($"{Prefix}Player_Hit_", 0, 3) { VariantsAreIndependent = true };
+	public static readonly SoundStyle Dig = new($"{Prefix}Dig_", 0, 3) { PitchVariance = 0.2f, LimitsArePerVariant = true };
+	public static readonly SoundStyle PlayerHit = new($"{Prefix}Player_Hit_", 0, 3) { LimitsArePerVariant = true };
 	public static readonly SoundStyle Item = new($"{Prefix}Item_");
 	//public static readonly SoundStyle NPCHit = new($"{Prefix}NPC_Hit");
 	//public static readonly SoundStyle NPCKilled = new($"{Prefix}NPC_Killed");
@@ -54,8 +54,8 @@ partial class SoundID
 	public static readonly SoundStyle Shimmer2 = new($"{Prefix}Splash_3") { Volume = 0.75f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle ShimmerWeak1 = new($"{Prefix}Splash_4") { Identifier = "Terraria/ShimmerWeak", Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle ShimmerWeak2 = new($"{Prefix}Splash_5") { Identifier = "Terraria/ShimmerWeak", Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle FemaleHit = new($"{Prefix}Female_Hit_", 0, 3) { VariantsAreIndependent = true };
-	public static readonly SoundStyle Tink = new($"{Prefix}Tink_", 0, 3) { VariantsAreIndependent = true };
+	public static readonly SoundStyle FemaleHit = new($"{Prefix}Female_Hit_", 0, 3) { LimitsArePerVariant = true };
+	public static readonly SoundStyle Tink = new($"{Prefix}Tink_", 0, 3) { LimitsArePerVariant = true };
 	public static readonly SoundStyle Unlock = new($"{Prefix}Unlock");
 	public static readonly SoundStyle Drown = new($"{Prefix}Drown");
 	public static readonly SoundStyle Chat = new($"{Prefix}Chat") { MaxInstances = 0 };
@@ -78,7 +78,7 @@ partial class SoundID
 		MaxInstances = 0
 	}; // Not yet handled: PitchRange should be (-0.4, 0.2) for variant 12 and should also be IgnoreNew.
 	public static readonly SoundStyle Frog = new($"{Prefix}Zombie_13", SoundType.Ambient) { Volume = 0.35f, PitchRange = (-0.4f, 0.2f), MaxInstances = 0 };
-	public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", [14, 16, 17, 18, 19], SoundType.Ambient) { Identifier = "Terraria/Bird", Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
+	public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", [14, 16, 17, 18, 19], SoundType.Ambient) { Identifier = "Terraria/Bird", Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew, LimitsArePerVariant = true };
 	public static readonly SoundStyle Bird14 = Bird with { Variants = [14] };
 	public static readonly SoundStyle Bird16 = Bird with { Variants = [16] };
 	public static readonly SoundStyle Bird17 = Bird with { Variants = [17] };
@@ -128,13 +128,13 @@ partial class SoundID
 	public static readonly SoundStyle DrumKick = new($"{Prefix}Item_146") { Volume = 0.7f, Identifier = "Terraria/Drums" };
 	public static readonly SoundStyle DrumTamaSnare = new($"{Prefix}Item_147") { Volume = 0.7f, Identifier = "Terraria/Drums" };
 	public static readonly SoundStyle DrumFloorTom = new($"{Prefix}Item_148") { Volume = 0.7f, Identifier = "Terraria/Drums" };
-	public static readonly SoundStyle Research = new($"{Prefix}Research_", 1, 3) { VariantsAreIndependent = true };
+	public static readonly SoundStyle Research = new($"{Prefix}Research_", 1, 3) { LimitsArePerVariant = true };
 	public static readonly SoundStyle ResearchComplete = new($"{Prefix}Research_0");
 	public static readonly SoundStyle QueenSlime = new($"{Prefix}Zombie_", 115, 3) { Identifier = "Terraria/QueenSlime", Volume = 0.5f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle Clown = new($"{Prefix}Zombie_", 121, 3) { Identifier = "Terraria/Clown", Volume = 0.45f, PitchVariance = 0.3f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle Cockatiel = new($"{Prefix}Zombie_", 118, 3, SoundType.Ambient) { Identifier = "Terraria/Cockatiel", Volume = 0.3f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
-	public static readonly SoundStyle Macaw = new($"{Prefix}Zombie_", 126, 3, SoundType.Ambient) { Identifier = "Terraria/Macaw", Volume = 0.22f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
-	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2, SoundType.Ambient) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
+	public static readonly SoundStyle Cockatiel = new($"{Prefix}Zombie_", 118, 3, SoundType.Ambient) { Identifier = "Terraria/Cockatiel", Volume = 0.3f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, LimitsArePerVariant = true };
+	public static readonly SoundStyle Macaw = new($"{Prefix}Zombie_", 126, 3, SoundType.Ambient) { Identifier = "Terraria/Macaw", Volume = 0.22f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, LimitsArePerVariant = true };
+	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2, SoundType.Ambient) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, LimitsArePerVariant = true };
 	// End of replaced IDs.
 
 	public static readonly SoundStyle NPCHit1 = NPCHitSound(1);

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -61,7 +61,7 @@ partial class SoundID
 	public static readonly SoundStyle Chat = new($"{Prefix}Chat") { MaxInstances = 0 };
 	public static readonly SoundStyle MaxMana = new($"{Prefix}MaxMana") { MaxInstances = 0 };
 	public static readonly SoundStyle Mummy = new($"{Prefix}Zombie_", 3, 2) { Identifier = "Terraria/Mummy", Volume = 0.9f, PitchVariance = 0.2f, MaxInstances = 0 };
-	public static readonly SoundStyle Pixie = new($"{Prefix}Pixie") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew }; // Not yet handled: should adjust pitch/pan/volume of playing instance rather than just IgnoreNew.
+	public static readonly SoundStyle Pixie = new($"{Prefix}Pixie") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew }; // Not yet handled: should adjust pitch/pan/volume of playing instance rather than just IgnoreNew, but even that will sound bad with multiple sources playing the sound so no need to fix yet.
 	public static readonly SoundStyle Mech = new($"{Prefix}Mech_0") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 
 	//public static readonly SoundStyle Zombie = new($"{Prefix}Zombie_", 3, 2);
@@ -94,7 +94,7 @@ partial class SoundID
 	public static readonly SoundStyle Drip = new($"{Prefix}Drip_", 0, 2, SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f, MaxInstances = 0 };
 	public static readonly SoundStyle DripSplash = new($"{Prefix}Drip_2", SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f, MaxInstances = 0 };
 	public static readonly SoundStyle Camera = new($"{Prefix}Camera");
-	//TODO: Might need special distance falloff rules.
+	// Note: Vanilla logic has special distance falloff rules, but this sound is unused.
 	public static readonly SoundStyle MoonLord = new($"{Prefix}NPC_Killed_10") { PitchVariance = 0.2f, MaxInstances = 0 };
 	public static readonly SoundStyle Thunder = new($"{Prefix}Thunder_", 0, 7, SoundType.Ambient) { MaxInstances = 7, PitchVariance = 0.2f, };
 	public static readonly SoundStyle Seagull = new($"{Prefix}Zombie_", 106, 3, SoundType.Ambient) { Identifier = "Terraria/Seagull", Volume = 0.2f, PitchRange = (-0.7f, 0f), MaxInstances = 0 };

--- a/patches/tModLoader/Terraria/ID/SoundID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/SoundID.TML.cs
@@ -23,8 +23,8 @@ partial class SoundID
 	private const string PrefixCustom = "Terraria/Sounds/Custom/";
 
 	// Start of IDs that used to be 'int' typed.
-	public static readonly SoundStyle Dig = new($"{Prefix}Dig_", 0, 3) { PitchVariance = 0.2f };
-	public static readonly SoundStyle PlayerHit = new($"{Prefix}Player_Hit_", 0, 3) { PitchVariance = 0.2f };
+	public static readonly SoundStyle Dig = new($"{Prefix}Dig_", 0, 3) { PitchVariance = 0.2f, VariantsAreIndependent = true };
+	public static readonly SoundStyle PlayerHit = new($"{Prefix}Player_Hit_", 0, 3) { VariantsAreIndependent = true };
 	public static readonly SoundStyle Item = new($"{Prefix}Item_");
 	//public static readonly SoundStyle NPCHit = new($"{Prefix}NPC_Hit");
 	//public static readonly SoundStyle NPCKilled = new($"{Prefix}NPC_Killed");
@@ -38,30 +38,30 @@ partial class SoundID
 	public static readonly SoundStyle MenuTick = new($"{Prefix}Menu_Tick") { PlayOnlyIfFocused = true };
 	public static readonly SoundStyle Shatter = new($"{Prefix}Shatter");
 	public static readonly SoundStyle ZombieMoan = new($"{Prefix}Zombie_", 0, 3) { Identifier = "Terraria/ZombieMoan", Volume = 0.4f, MaxInstances = 0 };
-	public static readonly SoundStyle SandShark = new($"{Prefix}Zombie_7") { Volume = 0.4f }; // New field
-	public static readonly SoundStyle BloodZombie = new($"{Prefix}Zombie_", 21, 3) { Identifier = "Terraria/BloodZombie", Volume = 0.4f }; // New field
+	public static readonly SoundStyle SandShark = new($"{Prefix}Zombie_7") { Volume = 0.4f, MaxInstances = 0 }; // New field
+	public static readonly SoundStyle BloodZombie = new($"{Prefix}Zombie_", 21, 3) { Identifier = "Terraria/BloodZombie", Volume = 0.4f, MaxInstances = 0 }; // New field
 	public static readonly SoundStyle Roar = new($"{Prefix}Roar_0") { Identifier = "Terraria/Roar", SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle WormDig = new($"{Prefix}Roar_1") { SoundLimitBehavior = IgnoreNew }; // New field
 	public static readonly SoundStyle WormDigQuiet = WormDig with { Volume = 0.25f }; // New field
 	public static readonly SoundStyle ScaryScream = new($"{Prefix}Roar_2") { SoundLimitBehavior = IgnoreNew }; // New field
 	public static readonly SoundStyle DoubleJump = new($"{Prefix}Double_Jump") { PitchVariance = 0.2f };
 	public static readonly SoundStyle Run = new($"{Prefix}Run") { PitchVariance = 0.2f };
-	public static readonly SoundStyle Coins = new($"{Prefix}Coins");
+	public static readonly SoundStyle Coins = new($"{Prefix}Coins") { MaxInstances = 0 };
 	public static readonly SoundStyle Splash = new($"{Prefix}Splash_0") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle SplashWeak = new($"{Prefix}Splash_1") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	// Adjust these names if you have better ideas
 	public static readonly SoundStyle Shimmer1 = new($"{Prefix}Splash_2") { Volume = 0.75f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle Shimmer2 = new($"{Prefix}Splash_3") { Volume = 0.75f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle ShimmerWeak1 = new($"{Prefix}Splash_4") { Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle ShimmerWeak2 = new($"{Prefix}Splash_5") { Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle FemaleHit = new($"{Prefix}Female_Hit_", 0, 3);
-	public static readonly SoundStyle Tink = new($"{Prefix}Tink_", 0, 3);
+	public static readonly SoundStyle ShimmerWeak1 = new($"{Prefix}Splash_4") { Identifier = "Terraria/ShimmerWeak", Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
+	public static readonly SoundStyle ShimmerWeak2 = new($"{Prefix}Splash_5") { Identifier = "Terraria/ShimmerWeak", Volume = 0.75f, Pitch = -0.1f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
+	public static readonly SoundStyle FemaleHit = new($"{Prefix}Female_Hit_", 0, 3) { VariantsAreIndependent = true };
+	public static readonly SoundStyle Tink = new($"{Prefix}Tink_", 0, 3) { VariantsAreIndependent = true };
 	public static readonly SoundStyle Unlock = new($"{Prefix}Unlock");
 	public static readonly SoundStyle Drown = new($"{Prefix}Drown");
-	public static readonly SoundStyle Chat = new($"{Prefix}Chat");
-	public static readonly SoundStyle MaxMana = new($"{Prefix}MaxMana");
-	public static readonly SoundStyle Mummy = new($"{Prefix}Zombie_", 3, 2) { Identifier = "Terraria/Mummy", Volume = 0.9f, PitchVariance = 0.2f };
-	public static readonly SoundStyle Pixie = new($"{Prefix}Pixie") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
+	public static readonly SoundStyle Chat = new($"{Prefix}Chat") { MaxInstances = 0 };
+	public static readonly SoundStyle MaxMana = new($"{Prefix}MaxMana") { MaxInstances = 0 };
+	public static readonly SoundStyle Mummy = new($"{Prefix}Zombie_", 3, 2) { Identifier = "Terraria/Mummy", Volume = 0.9f, PitchVariance = 0.2f, MaxInstances = 0 };
+	public static readonly SoundStyle Pixie = new($"{Prefix}Pixie") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew }; // Not yet handled: should adjust pitch/pan/volume of playing instance rather than just IgnoreNew.
 	public static readonly SoundStyle Mech = new($"{Prefix}Mech_0") { PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 
 	//public static readonly SoundStyle Zombie = new($"{Prefix}Zombie_", 3, 2);
@@ -74,12 +74,12 @@ partial class SoundID
 	}, SoundType.Ambient) {
 		Identifier = "Terraria/Duck",
 		Volume = 0.75f,
-		PitchRange = (-0.7f, 0.0f)
-	};
-	public static readonly SoundStyle Frog = new($"{Prefix}Zombie_13", SoundType.Ambient) { Volume = 0.35f, PitchRange = (-0.4f, 0.2f) };
-	public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", 14, 5, SoundType.Ambient) { Identifier = "Terraria/Bird", Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew };
+		PitchRange = (-0.7f, 0.0f),
+		MaxInstances = 0
+	}; // Not yet handled: PitchRange should be (-0.4, 0.2) for variant 12 and should also be IgnoreNew.
+	public static readonly SoundStyle Frog = new($"{Prefix}Zombie_13", SoundType.Ambient) { Volume = 0.35f, PitchRange = (-0.4f, 0.2f), MaxInstances = 0 };
+	public static readonly SoundStyle Bird = new($"{Prefix}Zombie_", [14, 16, 17, 18, 19], SoundType.Ambient) { Identifier = "Terraria/Bird", Volume = 0.15f, PitchRange = (-0.7f, 0.26f), SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
 	public static readonly SoundStyle Bird14 = Bird with { Variants = [14] };
-	public static readonly SoundStyle Bird15 = Bird with { Variants = [15] };
 	public static readonly SoundStyle Bird16 = Bird with { Variants = [16] };
 	public static readonly SoundStyle Bird17 = Bird with { Variants = [17] };
 	public static readonly SoundStyle Bird18 = Bird with { Variants = [18] };
@@ -87,18 +87,18 @@ partial class SoundID
 	public static readonly SoundStyle Critter = new($"{Prefix}Zombie_15", SoundType.Ambient) { Volume = 0.2f, PitchRange = (-0.1f, 0.3f), SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle Waterfall = new($"{Prefix}Liquid_0", SoundType.Ambient) { Volume = 0.2f, SoundLimitBehavior = IgnoreNew };
 	public static readonly SoundStyle Lavafall = new($"{Prefix}Liquid_1", SoundType.Ambient) { Volume = 0.65f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle ForceRoar = new($"{Prefix}Roar_0") { MaxInstances = 0 };
+	public static readonly SoundStyle ForceRoar = new($"{Prefix}Roar_0") { Identifier = "Terraria/Roar", MaxInstances = 0 };
 	public static readonly SoundStyle ForceRoarPitched = ForceRoar with { Pitch = 0.6f };
-	public static readonly SoundStyle Meowmere = new($"{Prefix}Item_", 57, 2) { Identifier = "Terraria/Meowmere", PitchVariance = 0.8f };
-	public static readonly SoundStyle CoinPickup = new($"{Prefix}Coin_", 0, 5) { PitchVariance = 0.16f };
-	public static readonly SoundStyle Drip = new($"{Prefix}Drip_", 0, 2, SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f };
-	public static readonly SoundStyle DripSplash = new($"{Prefix}Drip_2", SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f };
+	public static readonly SoundStyle Meowmere = new($"{Prefix}Item_", 57, 2) { Identifier = "Terraria/Meowmere", PitchVariance = 0.8f, MaxInstances = 0 };
+	public static readonly SoundStyle CoinPickup = new($"{Prefix}Coin_", 0, 5) { PitchVariance = 0.16f, MaxInstances = 0 };
+	public static readonly SoundStyle Drip = new($"{Prefix}Drip_", 0, 2, SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f, MaxInstances = 0 };
+	public static readonly SoundStyle DripSplash = new($"{Prefix}Drip_2", SoundType.Ambient) { Volume = 0.5f, PitchVariance = 0.6f, MaxInstances = 0 };
 	public static readonly SoundStyle Camera = new($"{Prefix}Camera");
 	//TODO: Might need special distance falloff rules.
-	public static readonly SoundStyle MoonLord = new($"{Prefix}NPC_Killed_10") { PitchVariance = 0.2f };
+	public static readonly SoundStyle MoonLord = new($"{Prefix}NPC_Killed_10") { PitchVariance = 0.2f, MaxInstances = 0 };
 	public static readonly SoundStyle Thunder = new($"{Prefix}Thunder_", 0, 7, SoundType.Ambient) { MaxInstances = 7, PitchVariance = 0.2f, };
-	public static readonly SoundStyle Seagull = new($"{Prefix}Zombie_", 106, 3) { Identifier = "Terraria/Seagull", Volume = 0.2f, PitchRange = (-0.7f, 0f) };
-	public static readonly SoundStyle Dolphin = new($"{Prefix}Zombie_109") { Volume = 0.3f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
+	public static readonly SoundStyle Seagull = new($"{Prefix}Zombie_", 106, 3, SoundType.Ambient) { Identifier = "Terraria/Seagull", Volume = 0.2f, PitchRange = (-0.7f, 0f), MaxInstances = 0 };
+	public static readonly SoundStyle Dolphin = new($"{Prefix}Zombie_109", SoundType.Ambient) { Volume = 0.3f, PitchVariance = 0.2f, SoundLimitBehavior = IgnoreNew };
 	// There is a 1 in 300 chance for an owl to play one of 3 easter egg sound variants.
 	public static readonly SoundStyle Owl = new($"{Prefix}Zombie_", stackalloc (int, float)[] {
 		(110, (299f / 300f) * (1f / 2f)),
@@ -106,8 +106,9 @@ partial class SoundID
 		(112, (1.0f / 300f) * (1f / 3f)),
 		(113, (1.0f / 300f) * (1f / 3f)),
 		(114, (1.0f / 300f) * (1f / 3f)),
-	}) {
+	}, SoundType.Ambient) {
 		Identifier = "Terraria/Owl",
+		Volume = 0.9f,
 		PitchVariance = 0.2f,
 		SoundLimitBehavior = IgnoreNew,
 	};
@@ -127,13 +128,13 @@ partial class SoundID
 	public static readonly SoundStyle DrumKick = new($"{Prefix}Item_146") { Volume = 0.7f, Identifier = "Terraria/Drums" };
 	public static readonly SoundStyle DrumTamaSnare = new($"{Prefix}Item_147") { Volume = 0.7f, Identifier = "Terraria/Drums" };
 	public static readonly SoundStyle DrumFloorTom = new($"{Prefix}Item_148") { Volume = 0.7f, Identifier = "Terraria/Drums" };
-	public static readonly SoundStyle Research = new($"{Prefix}Research_", 1, 3);
+	public static readonly SoundStyle Research = new($"{Prefix}Research_", 1, 3) { VariantsAreIndependent = true };
 	public static readonly SoundStyle ResearchComplete = new($"{Prefix}Research_0");
 	public static readonly SoundStyle QueenSlime = new($"{Prefix}Zombie_", 115, 3) { Identifier = "Terraria/QueenSlime", Volume = 0.5f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle Clown = new($"{Prefix}Zombie_", 121, 3) { Identifier = "Terraria/Clown", Volume = 0.45f, PitchVariance = 0.15f, SoundLimitBehavior = IgnoreNew };
-	public static readonly SoundStyle Cockatiel = new($"{Prefix}Zombie_", 118, 3) { Identifier = "Terraria/Cockatiel", Volume = 0.3f, PitchVariance = 0.05f };
-	public static readonly SoundStyle Macaw = new($"{Prefix}Zombie_", 126, 3) { Identifier = "Terraria/Macaw", Volume = 0.22f, PitchVariance = 0.05f };
-	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.05f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
+	public static readonly SoundStyle Clown = new($"{Prefix}Zombie_", 121, 3) { Identifier = "Terraria/Clown", Volume = 0.45f, PitchVariance = 0.3f, SoundLimitBehavior = IgnoreNew };
+	public static readonly SoundStyle Cockatiel = new($"{Prefix}Zombie_", 118, 3, SoundType.Ambient) { Identifier = "Terraria/Cockatiel", Volume = 0.3f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
+	public static readonly SoundStyle Macaw = new($"{Prefix}Zombie_", 126, 3, SoundType.Ambient) { Identifier = "Terraria/Macaw", Volume = 0.22f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
+	public static readonly SoundStyle Toucan = new($"{Prefix}Zombie_", 129, 2, SoundType.Ambient) { Identifier = "Terraria/Toucan", Volume = 0.2f, PitchVariance = 0.1f, SoundLimitBehavior = IgnoreNew, VariantsAreIndependent = true };
 	// End of replaced IDs.
 
 	public static readonly SoundStyle NPCHit1 = NPCHitSound(1);
@@ -267,8 +268,8 @@ partial class SoundID
 	public static readonly SoundStyle Item6 = ItemSound(6);
 	public static readonly SoundStyle Item7 = ItemSound(7);
 	public static readonly SoundStyle Item8 = ItemSound(8);
-	public static readonly SoundStyle Item9 = ItemSound(9);
-	public static readonly SoundStyle Item10 = ItemSound(10);
+	public static readonly SoundStyle Item9 = ItemSound(9) with { MaxInstances = 0 };
+	public static readonly SoundStyle Item10 = ItemSound(10) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item11 = ItemSound(11);
 	public static readonly SoundStyle Item12 = ItemSound(12);
 	public static readonly SoundStyle Item13 = ItemSound(13);
@@ -282,9 +283,9 @@ partial class SoundID
 	public static readonly SoundStyle Item21 = ItemSound(21);
 	public static readonly SoundStyle Item22 = ItemSound(22);
 	public static readonly SoundStyle Item23 = ItemSound(23);
-	public static readonly SoundStyle Item24 = ItemSound(24);
+	public static readonly SoundStyle Item24 = ItemSound(24) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item25 = ItemSound(25);
-	public static readonly SoundStyle Item26 = ItemSound(26) with { Volume = 0.75f, PitchVariance = 0f, UsesMusicPitch = true };
+	public static readonly SoundStyle Item26 = ItemSound(26) with { Volume = 0.75f, PitchVariance = 0f, UsesMusicPitch = true, MaxInstances = 0 };
 	public static readonly SoundStyle Item27 = ItemSound(27);
 	public static readonly SoundStyle Item28 = ItemSound(28);
 	public static readonly SoundStyle Item29 = ItemSound(29);
@@ -292,7 +293,7 @@ partial class SoundID
 	public static readonly SoundStyle Item31 = ItemSound(31);
 	public static readonly SoundStyle Item32 = ItemSound(32);
 	public static readonly SoundStyle Item33 = ItemSound(33);
-	public static readonly SoundStyle Item34 = ItemSound(34);
+	public static readonly SoundStyle Item34 = ItemSound(34) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item35 = ItemSound(35) with { Volume = 0.75f, PitchVariance = 0f, UsesMusicPitch = true };
 	public static readonly SoundStyle Item36 = ItemSound(36);
 	public static readonly SoundStyle Item37 = ItemSound(37) with { Volume = 0.5f };
@@ -301,7 +302,7 @@ partial class SoundID
 	public static readonly SoundStyle Item40 = ItemSound(40);
 	public static readonly SoundStyle Item41 = ItemSound(41);
 	public static readonly SoundStyle Item42 = ItemSound(42);
-	public static readonly SoundStyle Item43 = ItemSound(43);
+	public static readonly SoundStyle Item43 = ItemSound(43) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item44 = ItemSound(44);
 	public static readonly SoundStyle Item45 = ItemSound(45);
 	public static readonly SoundStyle Item46 = ItemSound(46);
@@ -361,7 +362,7 @@ partial class SoundID
 	public static readonly SoundStyle Item100 = ItemSound(100);
 	public static readonly SoundStyle Item101 = ItemSound(101);
 	public static readonly SoundStyle Item102 = ItemSound(102);
-	public static readonly SoundStyle Item103 = ItemSound(103);
+	public static readonly SoundStyle Item103 = ItemSound(103) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item104 = ItemSound(104);
 	public static readonly SoundStyle Item105 = ItemSound(105);
 	public static readonly SoundStyle Item106 = ItemSound(106);
@@ -414,13 +415,13 @@ partial class SoundID
 	public static readonly SoundStyle Item153 = ItemSound(153) with { PitchVariance = 0.3f };
 	public static readonly SoundStyle Item154 = ItemSound(154);
 	public static readonly SoundStyle Item155 = ItemSound(155);
-	public static readonly SoundStyle Item156 = ItemSound(156) with { Volume = 0.6f, PitchVariance = 0.2f };
+	public static readonly SoundStyle Item156 = ItemSound(156) with { Volume = 0.6f, PitchVariance = 0.2f, MaxInstances = 0 };
 	public static readonly SoundStyle Item157 = ItemSound(157) with { Volume = 0.7f };
 	public static readonly SoundStyle Item158 = ItemSound(158) with { Volume = 0.8f };
 	public static readonly SoundStyle Item159 = ItemSound(159) with { Volume = 0.75f, SoundLimitBehavior = IgnoreNew, };
 	public static readonly SoundStyle Item160 = ItemSound(160);
 	public static readonly SoundStyle Item161 = ItemSound(161);
-	public static readonly SoundStyle Item162 = ItemSound(162);
+	public static readonly SoundStyle Item162 = ItemSound(162) with { MaxInstances = 0 };
 	public static readonly SoundStyle Item163 = ItemSound(163);
 	public static readonly SoundStyle Item164 = ItemSound(164);
 	public static readonly SoundStyle Item165 = ItemSound(165);
@@ -435,7 +436,7 @@ partial class SoundID
 	public static readonly SoundStyle Item173 = ItemSound(173);
 	public static readonly SoundStyle Item174 = ItemSound(174);
 	public static readonly SoundStyle Item175 = ItemSound(175);
-	public static readonly SoundStyle Item176 = ItemSound(176);
+	public static readonly SoundStyle Item176 = ItemSound(176) with { Volume = 0.9f };
 	public static readonly SoundStyle Item177 = ItemSound(177);
 	public static readonly SoundStyle Item178 = ItemSound(178);
 	// ZombieX sound styles are new, and weren't present in vanilla neither as int nor SoundStyle fields. 


### PR DESCRIPTION
**Note: This is a PR to another PR, not to the 1.4.4 branch**

This PR addresses a remaining TODO of #2566, "A lot of sounds need `MaxInstances` of 0.". The big ones are Coins, CoinPickup, and ZombieMoan, these were very obvious sound glitches. 

Many item sounds such as FallingStar/Star Cannon, meowmere, gem staffs, and flamethrower cut off the playing sound when triggered again. These have been fixed.

This PR also fixes many ambient sounds that were not marked as ambient.

This PR also found several PitchVariance values which were wrong and fixed them.

This PR also fixes the `PitchRange` getter, it was mistakenly doubling the value. The getter is unused in vanilla code, but it is good to have it corrected.

`Bird15` was removed and `Bird` will no longer play the `Critter` (Zombie_15) sound as a variant option.

`PlayerHit` no longer has `PitchVariance`. I could not find where that came from in the vanilla source code.

`ShimmerWeak1` and `ShimmerWeak2` now share an identifier to prevent them from playing at the same time, as intended.

The big change of this PR is the addition of `SoundStyle.VariantsAreIndependent` to indicate if the variants of a SoundStyle should be considered as separate sounds rather than the same sound. For example, Clown does not use this, only 1 random sound can be playing at a time, but the vanilla logic for Toucan says that each of the random sound variants can be playing at once, as if they were separate sounds.

To implement `VariantsAreIndependent`, the random choice decision had to be moved earlier in the logic to precede the `IsTheSameAs` check. 

`IsTheSameAs` has been overhauled. Previously 2 sounds with different `Identifier`s but the same `SoundPath` would both evaluate to true ("the same"). This logic is incorrect, an `Identifier` should indicate that 2 SoundStyles are separate even if their `SoundPath` matches. This bug would mistakenly prevent sounds using the `SoundPath` of "{Prefix}Zombie_" (but different `Identifier`s) from playing at the same time. Also, the random choice is also taken into account during `IsTheSameAs` if `VariantsAreIndependent` is also true. 2 `VariantsAreIndependent` `SoundStyle` with different random choice shouldn't be seen as "the same", allowing them both to coexist.

Comments have been added for some remaining issues to address, including pausing the game interrupting the MenuOpen sound, Duck having unique pitches per variant, and the Pixie sound not properly updating position and volume as the pixie moves around the game world.

# Discussions

1. These changes technically change some existing behavior for mods, such as `IsTheSameAs` mistakenly seeing 2 sounds with unique `Identifier` as the same, but I think the fixes shouldn't be an issue since the current behavior is buggy and it is rare for a mod to reuse a `SoundPath` like that.

2. It's possible that `VariantsAreIndependent` should default to true. It is a change to existing behavior for existing mods, however. I don't know how many mods are using the variants option, but it might affect some mods. Only `Clown` and `QueenSlime` sounds have variants but aren't unlimited (`MaxInstances = 0`) and only allow a single variant at a time (`VariantsAreIndependent = true`)


