### PR TITLE
TmodFile.GetStream Conditional branching order

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/TmodFile.cs
@@ -98,15 +98,15 @@ public class TmodFile : IEnumerable<TmodFile.FileEntry>
 		if (entry.cachedBytes != null) {
 			stream = entry.cachedBytes.ToMemoryStream();
 		}
-		else if (fileStream == null) {
-			throw new IOException($"File not open: {path}");
-		}
-		else if (newFileStream) {
+  		else if (newFileStream) {
 			var ers = new EntryReadStream(this, entry, File.OpenRead(path), false);
 			lock (independentEntryReadStreams) { // todo, make this a set? maybe?
 				independentEntryReadStreams.Add(ers);
 			}
 			stream = ers;
+		}
+		else if (fileStream == null) {
+			throw new IOException($"File not open: {path}");
 		}
 		else if (sharedEntryReadStream != null) {
 			throw new IOException($"Previous entry read stream not closed: {sharedEntryReadStream.Name}");


### PR DESCRIPTION
### What is the bug?
#4672 

### How did you fix the bug?
Adjust the branch sequence

### Are there alternatives to your fix?

I used reflection and conducted the test in the same operation mode as within this branch, and it ran normally
```cs
Type type = typeof(ModLoader).Assembly.GetType("Terraria.ModLoader.Core.EntryReadStream")!;
var ersCtor = type.GetConstructor([
    typeof(TmodFile),
    typeof(TmodFile.FileEntry),
    typeof(Stream),
    typeof(bool)
]);

var BIN = BindingFlags.Instance | BindingFlags.NonPublic;
var indep = (IList)typeof(TmodFile).GetField("independentEntryReadStreams", BIN)!.GetValue(ThisTModFile)!;
var fileStream = (Stream)ersCtor!.Invoke([ThisTModFile, fileEntry, File.OpenRead(ThisTModFile.path), false]);
//var fileStream = ThisTModFile.GetStream(fileEntry, true);
indep.Add(fileStream);

string fileContent = GetText(fileStream, fileEntry.IsCompressed) ?? "";
fileStream.Close();

```