### PR TITLE
Fixes #3633: Negative NPCIDs now compatible with NPCDefinition

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
@@ -147,10 +147,12 @@ public class NPCDefinition : EntityDefinition
 	public static readonly Func<TagCompound, NPCDefinition> DESERIALIZER = Load;
 
 	public override bool IsUnloaded
-		=> !(Mod == "Terraria" && Name == "None" || Mod == "" && Name == "") && !(NPCID.Search.TryGetId(Mod != "Terraria" ? $"{Mod}/{Name}" : Name, out int id));
+		=> Type <= NPCID.NegativeIDCount && !(Mod == "Terraria" && Name == "None" || Mod == "" && Name == "");
 
-	// TODO: doesn't handle negative I think?
-	public override int Type => NPCID.Search.TryGetId(Mod != "Terraria" ? $"{Mod}/{Name}" : Name, out int id) ? id : -1;
+	/// <summary>
+	/// The NPCID of the NPC this NPCDefinition represents. Will be -66 (<see cref="NPCID.NegativeIDCount"/>) for <see cref="IsUnloaded"/> NPCDefinition.
+	/// </summary>
+	public override int Type => NPCID.Search.TryGetId(Mod != "Terraria" ? $"{Mod}/{Name}" : Name, out int id) ? id : NPCID.NegativeIDCount;
 
 	public NPCDefinition() : base() { }
 	/// <summary><b>Note: </b>As ModConfig loads before other content, make sure to only use <see cref="NPCDefinition(string, string)"/> for modded content in ModConfig classes. </summary>

--- a/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/EntityDefinition.cs
@@ -146,6 +146,9 @@ public class NPCDefinition : EntityDefinition
 {
 	public static readonly Func<TagCompound, NPCDefinition> DESERIALIZER = Load;
 
+	public override bool IsUnloaded
+		=> !(Mod == "Terraria" && Name == "None" || Mod == "" && Name == "") && !(NPCID.Search.TryGetId(Mod != "Terraria" ? $"{Mod}/{Name}" : Name, out int id));
+
 	// TODO: doesn't handle negative I think?
 	public override int Type => NPCID.Search.TryGetId(Mod != "Terraria" ? $"{Mod}/{Name}" : Name, out int id) ? id : -1;
 

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/NPCDefinitionElement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/NPCDefinitionElement.cs
@@ -21,7 +21,7 @@ internal class NPCDefinitionElement : DefinitionElement<NPCDefinition>
 		OptionScale = 0.8f;
 		var options = new List<DefinitionOptionElement<NPCDefinition>>();
 
-		for (int i = 0; i < NPCLoader.NPCCount; i++) {
+		for (int i = NPCID.NegativeIDCount + 1; i < NPCLoader.NPCCount; i++) {
 			var optionElement = new NPCDefinitionOptionElement(new NPCDefinition(i), OptionScale);
 			optionElement.OnLeftClick += (a, b) => {
 				Value = optionElement.Definition;
@@ -72,7 +72,7 @@ internal class NPCDefinitionOptionElement : DefinitionOptionElement<NPCDefinitio
 		spriteBatch.Draw(BackgroundTexture.Value, dimensions.Position(), null, Color.White, 0f, Vector2.Zero, Scale, SpriteEffects.None, 0f);
 
 		if (Definition != null) {
-			int type = Unloaded ? 0 : Type;
+			int type = Unloaded ? 0 : NPCID.FromNetId(Type);
 			if (TextureAssets.Npc[type].State == AssetState.NotLoaded)
 				Main.Assets.Request<Texture2D>(TextureAssets.Npc[type].Name, AssetRequestMode.AsyncLoad);
 			Texture2D npcTexture = TextureAssets.Npc[type].Value;


### PR DESCRIPTION
Fixes #3633

### What is the bug?
Negative NPCIDs, like those of Pinky, would not register as loaded under `NPCDefinition` when checking a mods config.

### How did you fix the bug?
I expanded the size of for loop that creates the options list in NPCDefinitionElements. I changed the declaration of type in DrawSelf() so that it takes in the netID of the NPC. Finally, for NPCDefinition I overloaded IsUnloaded so that it no longer views any ID less than zero to be unloaded

### Are there alternatives to your fix?
Most likely. I have little experience with C# and this is my first time contributing so there may be a few issues. One part I am unhappy with is how I overloaded IsUnloaded by using the NPCID.Search.TryGetId() method in place of Type < 0;

# Porting Notes

- Due to some negative values now being valid for `NPCDefinition.Type`, the `NPCDefinition.Type` for an "unloaded" `NPCDefinition` has changed from `-1` to `-66`. If you have code checking `NPCDefinition.Type == -1`, it would be better to check `NPCDefinition.IsUnloaded` instead.