### PR TITLE
Add hook for when a tile is being replaced via block swap

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -344,6 +344,11 @@ public abstract class GlobalTile : GlobalBlockType
 		return true;
 	}
 
+	/// <inheritdoc cref="ModTile.ReplaceTile(int, int, int, int)"/>
+	public virtual void ReplaceTile(int i, int j, int type, int targetType, int targetStyle)
+	{
+	}
+
 	/// <summary>
 	/// Can be used to adjust tile merge related things that are not possible to do in <see cref="ModBlockType.SetStaticDefaults"/> due to timing.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -691,6 +691,15 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Called when this tile at the given coordinates is being replaced via the block swap feature. For supported multi-tiles, the coordinates will be the top left corner. <paramref name="targetType"/> and <paramref name="targetStyle"/> are the tile type and style that will replace the current tile.
+	/// <br/><br/> An implementation of this method might end up duplicating some custom KillMultiTile or KillTile code, but not all. For example, for a chest or dresser tile you wouldn't want to call Chest.DestroyChest.
+	/// <br/><br/> Called on local, server, and remote clients.
+	/// </summary>
+	public virtual void ReplaceTile(int i, int j, int targetType, int targetStyle)
+	{
+	}
+
+	/// <summary>
 	/// Customizes a tile drawn using <see cref="GameContent.Drawing.TileDrawing.AddSpecialPoint"/> with <see cref="GameContent.Drawing.TileDrawing.TileCounterType.MultiTileVine"/>, specifically how the tile reacts to wind and player interactions.
 	/// <para/> The parameters are as follows:
 	/// <br/> <b><paramref name="overrideWindCycle"/>:</b> <inheritdoc cref="AdjustMultiTileVineParameters" path="/param[@name='overrideWindCycle']"/>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -90,6 +90,7 @@ public static class TileLoader
 	private static DelegateTileFrame[] HookTileFrame;
 	private static Func<int, int, int, bool>[] HookCanPlace;
 	private static Func<int, int, int, int, bool>[] HookCanReplace;
+	private static Action<int, int, int, int, int>[] HookReplaceTile;
 	private static Func<int, int[]>[] HookAdjTiles;
 	private static Action<int, int, int>[] HookRightClick;
 	private static Action<int, int, int>[] HookMouseOver;
@@ -244,6 +245,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateTileFrame>(ref HookTileFrame, globalTiles, g => g.TileFrame);
 		ModLoader.BuildGlobalHook(ref HookCanPlace, globalTiles, g => g.CanPlace);
 		ModLoader.BuildGlobalHook(ref HookCanReplace, globalTiles, g => g.CanReplace);
+		ModLoader.BuildGlobalHook(ref HookReplaceTile, globalTiles, g => g.ReplaceTile);
 		ModLoader.BuildGlobalHook(ref HookAdjTiles, globalTiles, g => g.AdjTiles);
 		ModLoader.BuildGlobalHook(ref HookRightClick, globalTiles, g => g.RightClick);
 		ModLoader.BuildGlobalHook(ref HookMouseOver, globalTiles, g => g.MouseOver);
@@ -1004,6 +1006,14 @@ public static class TileLoader
 			}
 		}
 		return GetTile(type)?.CanReplace(i, j, tileTypeBeingPlaced) ?? true;
+	}
+
+	public static void ReplaceTile(int i, int j, int type, int targetType, int targetStyle)
+	{
+		foreach (var hook in HookReplaceTile) {
+			hook(i, j, type, targetType, targetStyle);
+		}
+		GetTile(type)?.ReplaceTile(i, j, targetType, targetStyle); // Do we want the reverse as well?
 	}
 
 	public static void AdjTiles(Player player, int type)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6196,7 +6196,7 @@
  			else if (TileObjectData.CustomPlace(tileToCreate, previewPlaceStyle) && tileToCreate != 82 && tileToCreate != 227) {
  				newObjectType = true;
  				canPlace = TileObject.CanPlace(tileTargetX, tileTargetY, (ushort)tileToCreate, previewPlaceStyle, direction, out objectData, onlyCheck: false, forcedRandom);
-@@ -30757,9 +_,15 @@
+@@ -30757,14 +_,23 @@
  			if (!WorldGen.IsTileReplacable(tileTargetX, tileTargetY))
  				return false;
  
@@ -6209,11 +6209,20 @@
  			if (0 == 0) {
  				if (hitReplace.AddDamage(num, pickaxeDamage) < 100) {
 -					int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile);
-+					int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile, tileTargetX, tileTargetY);
++					/*int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile, tileTargetX, tileTargetY);
  					for (int i = 0; i < num2; i++) {
  						WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  					}
-@@ -30777,21 +_,22 @@
+ 
+-					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);
++					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);*/
++					
++					WorldGen.KillTile(tileTargetX, tileTargetY, fail: true);
++
+ 					if (HeldItem.consumable)
+ 						HeldItem.stack++;
+ 
+@@ -30777,21 +_,23 @@
  				ClearMiningCacheAt(tileTargetX, tileTargetY, 1);
  			}
  
@@ -6223,6 +6232,7 @@
 +			int[,] typeCaches = PlaceThing_Tiles_GetAutoAccessoryCache(TileObjectData.GetTileData(HeldItem.createTile, HeldItem.placeStyle), topLeft);
 +			int num3 = HeldItem.createTile;
  			int num4 = HeldItem.placeStyle;
++
  			if (UsingBiomeTorches && num3 == 4)
 -				num4 = BiomeTorchPlaceStyle(num4);
 +				BiomeTorchPlaceStyle(ref num3, ref num4);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6196,7 +6196,7 @@
  			else if (TileObjectData.CustomPlace(tileToCreate, previewPlaceStyle) && tileToCreate != 82 && tileToCreate != 227) {
  				newObjectType = true;
  				canPlace = TileObject.CanPlace(tileTargetX, tileTargetY, (ushort)tileToCreate, previewPlaceStyle, direction, out objectData, onlyCheck: false, forcedRandom);
-@@ -30757,14 +_,21 @@
+@@ -30757,9 +_,15 @@
  			if (!WorldGen.IsTileReplacable(tileTargetX, tileTargetY))
  				return false;
  
@@ -6213,12 +6213,6 @@
  					for (int i = 0; i < num2; i++) {
  						WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  					}
- 
- 					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);
-+
- 					if (HeldItem.consumable)
- 						HeldItem.stack++;
- 
 @@ -30777,21 +_,22 @@
  				ClearMiningCacheAt(tileTargetX, tileTargetY, 1);
  			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -6196,7 +6196,7 @@
  			else if (TileObjectData.CustomPlace(tileToCreate, previewPlaceStyle) && tileToCreate != 82 && tileToCreate != 227) {
  				newObjectType = true;
  				canPlace = TileObject.CanPlace(tileTargetX, tileTargetY, (ushort)tileToCreate, previewPlaceStyle, direction, out objectData, onlyCheck: false, forcedRandom);
-@@ -30757,14 +_,23 @@
+@@ -30757,14 +_,21 @@
  			if (!WorldGen.IsTileReplacable(tileTargetX, tileTargetY))
  				return false;
  
@@ -6209,20 +6209,17 @@
  			if (0 == 0) {
  				if (hitReplace.AddDamage(num, pickaxeDamage) < 100) {
 -					int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile);
-+					/*int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile, tileTargetX, tileTargetY);
++					int num2 = WorldGen.KillTile_GetTileDustAmount(fail: true, tile, tileTargetX, tileTargetY);
  					for (int i = 0; i < num2; i++) {
  						WorldGen.KillTile_MakeTileDust(tileTargetX, tileTargetY, tile);
  					}
  
--					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);
-+					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);*/
-+					
-+					WorldGen.KillTile(tileTargetX, tileTargetY, fail: true);
+ 					WorldGen.KillTile_PlaySounds(tileTargetX, tileTargetY, fail: true, tile);
 +
  					if (HeldItem.consumable)
  						HeldItem.stack++;
  
-@@ -30777,21 +_,23 @@
+@@ -30777,21 +_,22 @@
  				ClearMiningCacheAt(tileTargetX, tileTargetY, 1);
  			}
  
@@ -6232,7 +6229,6 @@
 +			int[,] typeCaches = PlaceThing_Tiles_GetAutoAccessoryCache(TileObjectData.GetTileData(HeldItem.createTile, HeldItem.placeStyle), topLeft);
 +			int num3 = HeldItem.createTile;
  			int num4 = HeldItem.placeStyle;
-+
  			if (UsingBiomeTorches && num3 == 4)
 -				num4 = BiomeTorchPlaceStyle(num4);
 +				BiomeTorchPlaceStyle(ref num3, ref num4);

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2523,10 +2523,14 @@
  			return false;
  
  		Tile tile = Main.tile[x, y];
-@@ -44606,7 +_,7 @@
+@@ -44606,7 +_,11 @@
  			return false;
  
  		MoveReplaceTileAnchor(ref x, ref y, targetType, tileSafely);
++
++		bool _f = false, _e = false, _n = false;
++		TileLoader.KillTile(x, y, tileSafely.type, ref _f, ref _e, ref _n);
++
 -		int num = KillTile_GetTileDustAmount(fail: false, tileSafely);
 +		int num = KillTile_GetTileDustAmount(fail: false, tileSafely, x, y);
  		for (int i = 0; i < num; i++) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2523,20 +2523,16 @@
  			return false;
  
  		Tile tile = Main.tile[x, y];
-@@ -44606,7 +_,11 @@
+@@ -44606,7 +_,7 @@
  			return false;
  
  		MoveReplaceTileAnchor(ref x, ref y, targetType, tileSafely);
-+
-+		bool _f = false, _e = false, _n = false;
-+		TileLoader.KillTile(x, y, tileSafely.type, ref _f, ref _e, ref _n);
-+
 -		int num = KillTile_GetTileDustAmount(fail: false, tileSafely);
 +		int num = KillTile_GetTileDustAmount(fail: false, tileSafely, x, y);
  		for (int i = 0; i < num; i++) {
  			KillTile_MakeTileDust(x, y, tileSafely);
  		}
-@@ -44631,7 +_,7 @@
+@@ -44631,12 +_,13 @@
  		else if (TileID.Sets.BasicDresser[targetType]) {
  			ReplaceTile_DoActualReplacement_Area(targetType, targetStyle, topLeftX, topLeftY, 3, 2);
  		}
@@ -2545,6 +2541,12 @@
  			ReplaceTile_DoActualReplacement_Area(targetType, targetStyle, topLeftX, topLeftY, 3, 2);
  		}
  		else {
+ 			ReplaceTile_DoActualReplacement_Single(targetType, targetStyle, topLeftX, topLeftY, t);
+ 		}
++		TileLoader.ReplaceTile(topLeftX, topLeftY, t.TileType, targetType, targetStyle);
+ 	}
+ 
+ 	private static void ReplaceTile_DoActualReplacement_Single(ushort targetType, int targetStyle, int topLeftX, int topLeftY, Tile t)
 @@ -44647,7 +_,7 @@
  		if (TileID.Sets.Platforms[t.type])
  			t.frameY = (short)(targetStyle * 18);


### PR DESCRIPTION
### What is the bug?
As per #4674, there is no hook to act upon a tile being replaced by the block swap feature. Fixes #4674 

### How did you fix the bug?

A `ReplaceTile` hook has been added.

### Are there alternatives to your fix?

Other options were explored, but would lead to inconsistent behavior. A new hook was needed.

#### Side Note: 
This is my first contribution, so I don't really know what I am doing, and I feel like I am creating a solution that might change some intended functionality --- please tell me if I did anything wrong and what I can fix.

