### PR TITLE
Prevent loading of libraries that are not needed on server

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -40,17 +40,18 @@ internal class ErrorReporting
 			Logging.tML.Fatal(message);
 
 		TerrariaSteamClient.Shutdown();
-		MessageBoxShow(message, fatal: true);
+		if (!Main.dedServ)
+		    MessageBoxShow(message, fatal: true);
 		Environment.Exit(1);
 	}
 
 	public static void FatalExit(string message, Exception e)
 	{
 		try {
-			if (SDL2.SDL.SDL_GetError() is string error && !string.IsNullOrWhiteSpace(error))
-				message += "\n\nSDL Error: " + error;
-		}
-		catch { }
+            if (!Main.dedServ && SDL2.SDL.SDL_GetError() is string error && !string.IsNullOrWhiteSpace(error))
+                message += "\n\nSDL Error: " + error;
+        }
+        catch { }
 
 		if (e.HelpLink != null) {
 			try {

--- a/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/ErrorReporting.cs
@@ -27,7 +27,8 @@ internal class ErrorReporting
 			// always write to console. Ideal for headless servers
 			Console.ForegroundColor = ConsoleColor.Red;
 			Console.Out.WriteLine(title + "\n" + message);
-			SDL2.SDL.SDL_ShowSimpleMessageBox(SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, IntPtr.Zero);
+			if (!Main.dedServ)
+				SDL2.SDL.SDL_ShowSimpleMessageBox(SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, IntPtr.Zero);
 		}
 		catch { }
 	}
@@ -40,8 +41,7 @@ internal class ErrorReporting
 			Logging.tML.Fatal(message);
 
 		TerrariaSteamClient.Shutdown();
-		if (!Main.dedServ)
-		    MessageBoxShow(message, fatal: true);
+		MessageBoxShow(message, fatal: true);
 		Environment.Exit(1);
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/FNALogging.cs
@@ -84,15 +84,18 @@ internal static class FNALogging
 
 		Logging.FNA.Debug("Querying linked library versions...");
 
-		SDL2.SDL.SDL_GetVersion(out var sdl_version);
-		Logging.FNA.Debug($"SDL v{sdl_version.major}.{sdl_version.minor}.{sdl_version.patch}");
+        if (!Main.dedServ)
+        {
+            SDL2.SDL.SDL_GetVersion(out var sdl_version);
+            Logging.FNA.Debug($"SDL v{sdl_version.major}.{sdl_version.minor}.{sdl_version.patch}");
 
-		uint fna3d_version = FNA3D.FNA3D_LinkedVersion();
-		Logging.FNA.Debug($"FNA3D v{fna3d_version / 10000}.{fna3d_version / 100 % 100}.{fna3d_version % 100}");
+            uint fna3d_version = FNA3D.FNA3D_LinkedVersion();
+            Logging.FNA.Debug($"FNA3D v{fna3d_version / 10000}.{fna3d_version / 100 % 100}.{fna3d_version % 100}");
 
-		uint faudio_version = FAudio.FAudioLinkedVersion();
-		Logging.FNA.Debug($"FAudio v{faudio_version / 10000}.{faudio_version / 100 % 100}.{faudio_version % 100}");
-	}
+            uint faudio_version = FAudio.FAudioLinkedVersion();
+            Logging.FNA.Debug($"FAudio v{faudio_version / 10000}.{faudio_version / 100 % 100}.{faudio_version % 100}");
+        }
+    }
 
 	public static void GraphicsInit(GraphicsDeviceManager graphics)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -94,7 +94,8 @@ public static class ModLoader
 		FileAssociationSupport.UpdateFileAssociation();
 		FolderShortcutSupport.UpdateFolderShortcuts();
 		MonoModHooks.Initialize();
-		FNAFixes.Init();
+		if (!Main.dedServ)
+		    FNAFixes.Init();
 		LoaderManager.AutoLoad();
 	}
 


### PR DESCRIPTION
### What is the bug?
these libraries are x86-64 only, so they cannot be loaded on arm and are unnecessary on server

### How did you fix the bug?
load the libraries only on client 

### Are there alternatives to your fix?
building all native libraries for multiple architectures which at least for Steamworks is currently not possible 
 
<br>
<br>
 
with this changes its possible to run tmodloader server on arm64 if you build MonoMod from [this pull request](https://github.com/MonoMod/MonoMod/pull/241) and build Steamworks.NET for arm64