### PR TITLE
Optimize Collision.CanHitLine, TupleHitLine and TupleHitLineWall by replacing float remainder

### DIFF
--- a/patches/tModLoader/Terraria/Collision.cs.patch
+++ b/patches/tModLoader/Terraria/Collision.cs.patch
@@ -8,6 +8,60 @@
  
  namespace Terraria;
  
+@@ -527,7 +_,7 @@
+ 					case 2: {
+ 						num9 += num7;
+ 						int num17 = (int)num9;
+-						num9 %= 1f;
++						num9 -= num17;
+ 						for (int j = 0; j < num17; j++) {
+ 							if (Main.tile[num, num2 - 1] == null)
+ 								return false;
+@@ -563,7 +_,7 @@
+ 					case 1: {
+ 						num10 += num8;
+ 						int num16 = (int)num10;
+-						num10 %= 1f;
++						num10 -= num16;
+ 						for (int i = 0; i < num16; i++) {
+ 							if (Main.tile[num - 1, num2] == null)
+ 								return false;
+@@ -664,7 +_,7 @@
+ 					case 2: {
+ 						num5 += num3;
+ 						int num13 = (int)num5;
+-						num5 %= 1f;
++						num5 -= num13;
+ 						for (int j = 0; j < num13; j++) {
+ 							if (Main.tile[value, value2 - 1] == null) {
+ 								col = new Tuple<int, int>(value, value2 - 1);
+@@ -715,7 +_,7 @@
+ 					case 1: {
+ 						num6 += num4;
+ 						int num12 = (int)num6;
+-						num6 %= 1f;
++						num6 -= num12;
+ 						for (int i = 0; i < num12; i++) {
+ 							if (Main.tile[value - 1, value2] == null) {
+ 								col = new Tuple<int, int>(value - 1, value2);
+@@ -855,7 +_,7 @@
+ 					case 2: {
+ 						num9 += num7;
+ 						int num17 = (int)num9;
+-						num9 %= 1f;
++						num9 -= num17;
+ 						for (int j = 0; j < num17; j++) {
+ 							_ = Main.tile[num, num2];
+ 							if (HitWallSubstep(num, num2))
+@@ -880,7 +_,7 @@
+ 					case 1: {
+ 						num10 += num8;
+ 						int num16 = (int)num10;
+-						num10 %= 1f;
++						num10 -= num16;
+ 						for (int i = 0; i < num16; i++) {
+ 							_ = Main.tile[num, num2];
+ 							if (HitWallSubstep(num, num2))
 @@ -1030,7 +_,7 @@
  		if (tile == null || !tile.active() || tile.inActive() || !Main.tileSolid[tile.type])
  			return false;


### PR DESCRIPTION
### What is the bug?
`Collision.CanHitLine`, `Collision.TupleHitLine` and `Collision.TupleHitLineWall` all cast a float to an integer and then proceed to use: `val %= 1f` within the main loop. This is slower than reusing the cast and performing subtraction.

### How did you fix the bug?
The fix replaces the expensive:
```
float val;
int something = (int)val;
val %= 1f
```
with its arithmetically identical and significantly faster equivalent:
```cs
float val;
int something = (int)val;
val -= something;
```

This reuses the cast from the previous line and uses subtraction to achieve the same result as the ~modulo~ remainder operation. The change is a simple optimization and has no impact on any output, the results are identical. This only works for positive numbers. All three functions are using positive numbers where the optimization is applied.

After [benchmarking](https://github.com/tModLoader/tModLoader/pull/4696#issuecomment-3054197236), the speedup is ~50% for `Collision.CanHitLine`. I have not benchmarked the Tuple versions so I don't have any numbers to share for them.

### Are there alternatives to your fix?
Yes. Leave the original implementation as is and live with the unoptimized code.
