### PR TITLE
Properly support manually setting bestiary stars (Fix #4687)

### DIFF
--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -101,6 +101,8 @@ namespace ExampleMod.Content.NPCs
 				new Profiles.DefaultNPCProfile(Texture + "_Shimmer", ShimmerHeadIndex, Texture + "_Shimmer_Party")
 			);
 
+			ContentSamples.NpcBestiaryRarityStars[Type] = 3; // We can override the default bestiary star count calculation by setting this.
+
 			UpgradedText = this.GetLocalization("Upgraded");
 		}
 

--- a/patches/tModLoader/Terraria/ID/ContentSamples.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ContentSamples.cs.patch
@@ -65,7 +65,7 @@
  				Item item = new Item();
  				item.SetDefaults(i);
  				list.Add(item);
-@@ -719,26 +_,86 @@
+@@ -719,26 +_,87 @@
  		public static int GetBestiaryStarsPriority(NPC npc) => NpcBestiaryRarityStars[npc.type];
  	}
  
@@ -125,7 +125,8 @@
 +
 +	/// <summary>
 +	/// The number of stars a given NPC type (<see cref="NPC.type"/>) shows in the Bestiary.
-+	/// <br/> Set in <see cref="ModNPC.SetBestiary(BestiaryDatabase, BestiaryEntry)"/> or <see cref="GlobalNPC.SetBestiary(NPC, BestiaryDatabase, BestiaryEntry)"/>.
++	/// <br/><br/> Defaults to the result of <see cref="GetNPCBestiaryRarityStarsCount"/>. Read the <see href="https://github.com/tModLoader/tModLoader/wiki/Bestiary-Stars">Bestiary Stars wiki page</see> to learn more about the default calculations.
++	/// <br/><br/> Set in SetStaticDefaults to override that logic.
 +	/// </summary>
  	public static Dictionary<int, int> NpcBestiaryRarityStars = new Dictionary<int, int>();
 +
@@ -182,12 +183,15 @@
  	{
  		for (int i = 0; i < itemsThatWillResearchTheItemToUnlock.Length; i++) {
  			AddItemResearchOverride_Inner(itemsThatWillResearchTheItemToUnlock[i], itemTypeToUnlock);
-@@ -955,7 +_,7 @@
+@@ -955,7 +_,10 @@
  		NPCSpawnParams nPCSpawnParams = default(NPCSpawnParams);
  		nPCSpawnParams.gameModeData = Main.RegisteredGameModes[0];
  		NPCSpawnParams spawnparams = nPCSpawnParams;
 -		for (int i = -65; i < NPCID.Count; i++) {
 +		for (int i = -65; i < NPCLoader.NPCCount; i++) {
++			if (NpcBestiaryRarityStars.ContainsKey(i)) // Fix #4687, let modders set stars manually in SetStaticDefaults.
++				continue;
++
  			NPC nPC = new NPC();
  			nPC.SetDefaults(i, spawnparams);
  			NpcBestiaryRarityStars[i] = GetNPCBestiaryRarityStarsCount(nPC);

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -102,6 +102,8 @@ public static class NPCLoader
 			Main.npcFrameCount[k] = 1;
 			Lang._npcNameCache[k] = LocalizedText.Empty;
 		}
+
+		ContentSamples.NpcBestiaryRarityStars.Clear();
 	}
 
 	internal static void FinishSetup()


### PR DESCRIPTION
As mentioned in #4687 , manually setting bestiary stars doesn't work correctly. Modders can work around this by finding and swapping out the `NPCPortraitInfoElement` entry in `bestiaryEntry.Info`, but that is complicated. This PR adds logic to allow modders to set bestiary star value in `SetStaticDefaults`. This is much more in-line with expectations.

I considered adding a `GetNPCBestiaryRarityStarsCount(ref float stars)` hook to `GlobalNPC` as well to allow modders to make global changes to the calculations that go into rarity stars, but since no one has actually asked for a hook like that I left it out and went with this approach for now.

By accident, it is possible to use `GlobalNPC.SetBestiary` to set `ContentSamples.NpcBestiaryRarityStars`, despite SetBestiary running after NpcBestiaryRarityStars is calculated and used to populate NPCPortraitInfoElement. This works because mods aren't checking for npc.type in SetBestiary, so when it is run for NPCID.Slime those mods are assigning NpcBestiaryRarityStars for future npcids. This disconnect between how SetBestiary works for ModNPC and GlobalNPC is undesirable. Mods using this approach are technically being inefficient as well, running the full set of assignments for each npc type. 

# Porting Notes
- Mods setting `ContentSamples.NpcBestiaryRarityStars` in `GlobalNPC.SetBestiary` currently work by accident, but we recommend setting `ContentSamples.NpcBestiaryRarityStars` in `SetStaticDefaults` instead. It is technically more efficient as well.

