### PR TITLE
Better portable storage support (Port of #1978)

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleDresser.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleDresser.cs
@@ -98,8 +98,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 					}
 				}
 				else {
-					player.piggyBankProjTracker.Clear();
-					player.voidLensChest.Clear();
+					player.ClearPortableBankProjectileTrackers();
 					int chestIndex = Chest.FindChest(left, top);
 					if (chestIndex != -1) {
 						Main.stackSplit = 600;

--- a/patches/tModLoader/Terraria/ID/BankID.cs
+++ b/patches/tModLoader/Terraria/ID/BankID.cs
@@ -1,0 +1,12 @@
+﻿namespace Terraria.ID;
+
+/// <summary>
+/// Values used to identify special banks with the <see cref="Player.chest"></see> field
+/// </summary>
+public static class BankID
+{
+	public const int PiggyBank = -2;
+	public const int Safe = -3;
+	public const int DefendersForge = -4;
+	public const int VoidVault = 5;
+}

--- a/patches/tModLoader/Terraria/ID/BankID.cs
+++ b/patches/tModLoader/Terraria/ID/BankID.cs
@@ -1,12 +1,17 @@
 ﻿namespace Terraria.ID;
 
 /// <summary>
-/// Values used to identify special banks with the <see cref="Player.chest"></see> field
+/// Values used to identify special banks ("personal storage") with the <see cref="Player.chest"></see> field.
 /// </summary>
 public static class BankID
 {
+	public const int None = -1;
+	/// <summary> For the corresponding items, see <see cref="Player.bank"/> </summary>
 	public const int PiggyBank = -2;
+	/// <summary> For the corresponding items, see <see cref="Player.bank2"/> </summary>
 	public const int Safe = -3;
+	/// <summary> For the corresponding items, see <see cref="Player.bank3"/> </summary>
 	public const int DefendersForge = -4;
-	public const int VoidVault = 5;
+	/// <summary> For the corresponding items, see <see cref="Player.bank4"/> </summary>
+	public const int VoidVault = -5;
 }

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -85,5 +85,7 @@ partial class ProjectileID
 		/// <br/><br/> Defaults to false. Vanilla entries include <see cref="FlyingPiggyBank"/>, <see cref="VoidLens"/>, and <see cref="ChesterPet"/>.
 		/// </summary>
 		public static bool[] IsInteractable = Factory.CreateBoolSet(false, 525, 734, 960);
+
+		public static int[] CountAsBank = Factory.CreateIntSet(-1, 525, -2, 960, -2, 734, -5);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -86,6 +86,10 @@ partial class ProjectileID
 		/// </summary>
 		public static bool[] IsInteractable = Factory.CreateBoolSet(false, 525, 734, 960);
 
-		public static int[] CountAsBank = Factory.CreateIntSet(-1, 525, -2, 960, -2, 734, -5);
+		/// <summary>
+		/// Maps projectile types to the the <see cref="BankID"/> of the personal storage this projectile provides access to.
+		/// <br/><br/> Defaults to -1 (<see cref="BankID.None"/>.
+		/// </summary>
+		public static int[] CountAsBank = Factory.CreateIntSet(-1, FlyingPiggyBank, BankID.PiggyBank, ChesterPet, BankID.PiggyBank, VoidLens, BankID.VoidVault);
 	}
 }

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -666,4 +666,9 @@ public partial class Main
 			ConfigManager.OnChangedAll();
 		}
 	}
+
+	private static bool TrySyncingMyPlayer_TMLSyncBankFields(Player player)
+	{
+		return Main.player[myPlayer].safeProjTracker != player.safeProjTracker || Main.player[myPlayer].defendersForgeProjTracker != player.defendersForgeProjTracker;
+	}
 }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -2691,6 +2691,15 @@
  			syncedAnyInventoryContents = true;
  			NetMessage.SendData(5, -1, -1, null, myPlayer, PlayerItemSlotID.TrashItem, (int)Main.player[myPlayer].trashItem.prefix);
  		}
+@@ -14055,7 +_,7 @@
+ 		if (Main.player[myPlayer].talkNPC != player.talkNPC)
+ 			NetMessage.SendData(40, -1, -1, null, myPlayer);
+ 
+-		if (false | (Main.player[myPlayer].voidLensChest != player.voidLensChest) | (Main.player[myPlayer].piggyBankProjTracker != player.piggyBankProjTracker))
++		if (Main.player[myPlayer].voidLensChest != player.voidLensChest || Main.player[myPlayer].piggyBankProjTracker != player.piggyBankProjTracker || TrySyncingMyPlayer_TMLSyncBankFields(player))
+ 			NetMessage.SendData(142, -1, -1, null, myPlayer);
+ 
+ 		if (LocalPlayer.tileEntityAnchor.interactEntityID != player.tileEntityAnchor.interactEntityID && LocalPlayer.tileEntityAnchor.interactEntityID < 0)
 @@ -14077,6 +_,9 @@
  		if ((byte)Main.player[myPlayer].zone5 != (byte)player.zone5)
  			flag = true;

--- a/patches/tModLoader/Terraria/MessageBuffer.cs.patch
+++ b/patches/tModLoader/Terraria/MessageBuffer.cs.patch
@@ -814,6 +814,15 @@
  				float torchLuck = reader.ReadSingle();
  				byte luckPotion = reader.ReadByte();
  				bool hasGardenGnomeNearby = reader.ReadBoolean();
+@@ -3543,6 +_,8 @@
+ 				Player obj = Main.player[num18];
+ 				obj.piggyBankProjTracker.TryReading(reader);
+ 				obj.voidLensChest.TryReading(reader);
++				obj.safeProjTracker.TryReading(reader);
++				obj.defendersForgeProjTracker.TryReading(reader);
+ 				if (Main.netMode == 2)
+ 					NetMessage.TrySendData(142, -1, whoAmI, null, num18);
+ 
 @@ -3587,6 +_,35 @@
  
  				break;

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -474,4 +474,11 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	public virtual void EmitEnchantmentVisualsAt(Vector2 boxPosition, int boxWidth, int boxHeight)
 	{
 	}
+
+	/// <summary>
+	/// If this projectile is a portable bank (like the Money Trough), this is called when the storage UI is closed. It is recommended that you play a sound here, as it is not done automatically.
+	/// </summary>
+	public virtual void PlayBankCloseSound()
+	{
+	}
 }

--- a/patches/tModLoader/Terraria/NetMessage.cs.patch
+++ b/patches/tModLoader/Terraria/NetMessage.cs.patch
@@ -361,6 +361,15 @@
  					break;
  				}
  				case 134: {
+@@ -1411,6 +_,8 @@
+ 					Player obj = Main.player[number];
+ 					obj.piggyBankProjTracker.Write(writer);
+ 					obj.voidLensChest.Write(writer);
++					obj.safeProjTracker.Write(writer);
++					obj.defendersForgeProjTracker.Write(writer);
+ 					break;
+ 				}
+ 				case 146:
 @@ -1440,6 +_,16 @@
  				throw new Exception("Maximum packet length exceeded. id: " + msgType + " length: " + num21);
  

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -670,10 +670,10 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 
 	private void HandleBeingInChestRange_TMLCheckFields()
 	{
-		if (chest != -3)
+		if (chest != BankID.Safe)
 			safeProjTracker.Clear();
 
-		if (chest != -4)
+		if (chest != BankID.DefendersForge)
 			defendersForgeProjTracker.Clear();
 	}
 

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -687,52 +687,29 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 
 	private void HandleBeingInChestRange_TMLBankLogic(ref bool flag)
 	{
-		// Safe
-		int safeIndex = safeProjTracker.ProjectileLocalIndex;
-		if (safeIndex >= 0) {
-			flag = true;
-			if (!Main.projectile[safeIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[safeIndex].type] != BankID.Safe) {
-				InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
-				chest = -1;
-				Recipe.FindRecipes();
-			}
-			else {
-				int num = (int)(((double)position.X + (double)width * 0.5) / 16.0);
-				int num2 = (int)(((double)position.Y + (double)height * 0.5) / 16.0);
-				Vector2 vector = Main.projectile[safeIndex].Hitbox.ClosestPointInRect(base.Center);
-				chestX = (int)vector.X / 16;
-				chestY = (int)vector.Y / 16;
-				if (num < chestX - tileRangeX || num > chestX + tileRangeX + 1 || num2 < chestY - tileRangeY || num2 > chestY + tileRangeY + 1) {
-					if (chest != -1)
-						InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
-
+		(TrackedProjectileReference TrackedProjectileReference, int bankID)[] banks = [(safeProjTracker, BankID.Safe), (defendersForgeProjTracker, BankID.DefendersForge)];
+		foreach (var bank in banks) {
+			int index = bank.TrackedProjectileReference.ProjectileLocalIndex;
+			if (index >= 0) {
+				flag = true;
+				if (!Main.projectile[index].active || ProjectileID.Sets.CountAsBank[Main.projectile[index].type] != bank.bankID) {
+					InteractiveProjectileOpenCloseSound2(Main.projectile[index]);
 					chest = -1;
 					Recipe.FindRecipes();
 				}
-			}
-		}
+				else {
+					int num = (int)(((double)position.X + (double)width * 0.5) / 16.0);
+					int num2 = (int)(((double)position.Y + (double)height * 0.5) / 16.0);
+					Vector2 vector = Main.projectile[index].Hitbox.ClosestPointInRect(base.Center);
+					chestX = (int)vector.X / 16;
+					chestY = (int)vector.Y / 16;
+					if (num < chestX - tileRangeX || num > chestX + tileRangeX + 1 || num2 < chestY - tileRangeY || num2 > chestY + tileRangeY + 1) {
+						if (chest != -1)
+							InteractiveProjectileOpenCloseSound2(Main.projectile[index]);
 
-		// Defenders Forge
-		int defendersForgeIndex = defendersForgeProjTracker.ProjectileLocalIndex;
-		if (defendersForgeIndex >= 0) {
-			flag = true;
-			if (!Main.projectile[defendersForgeIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[defendersForgeIndex].type] != BankID.DefendersForge) {
-				InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
-				chest = -1;
-				Recipe.FindRecipes();
-			}
-			else {
-				int num = (int)(((double)position.X + (double)width * 0.5) / 16.0);
-				int num2 = (int)(((double)position.Y + (double)height * 0.5) / 16.0);
-				Vector2 vector = Main.projectile[defendersForgeIndex].Hitbox.ClosestPointInRect(base.Center);
-				chestX = (int)vector.X / 16;
-				chestY = (int)vector.Y / 16;
-				if (num < chestX - tileRangeX || num > chestX + tileRangeX + 1 || num2 < chestY - tileRangeY || num2 > chestY + tileRangeY + 1) {
-					if (chest != -1)
-						InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
-
-					chest = -1;
-					Recipe.FindRecipes();
+						chest = -1;
+						Recipe.FindRecipes();
+					}
 				}
 			}
 		}

--- a/patches/tModLoader/Terraria/Player.TML.cs
+++ b/patches/tModLoader/Terraria/Player.TML.cs
@@ -98,6 +98,9 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 
 	public HashSet<int> NearbyModTorch { get; private set; } = new HashSet<int>();
 
+	public TrackedProjectileReference safeProjTracker;
+	public TrackedProjectileReference defendersForgeProjTracker;
+
 	// Get
 
 	/// <summary> Gets the instance of the specified ModPlayer type. This will throw exceptions on failure. </summary>
@@ -663,5 +666,93 @@ public partial class Player : IEntityWithInstances<ModPlayer>
 
 		if (anyJumpCancelled)
 			jump = 0;
+	}
+
+	private void HandleBeingInChestRange_TMLCheckFields()
+	{
+		if (chest != -3)
+			safeProjTracker.Clear();
+
+		if (chest != -4)
+			defendersForgeProjTracker.Clear();
+	}
+
+	private void InteractiveProjectileOpenCloseSound2(Projectile projectile)
+	{
+		if (projectile.type < ProjectileID.Count) // For vanilla projectiles
+			Main.PlayInteractiveProjectileOpenCloseSound(projectile.type, open: false);
+		else if (projectile.ModProjectile != null) // For modded projectiles
+			projectile.ModProjectile.PlayBankCloseSound();
+	}
+
+	private void HandleBeingInChestRange_TMLBankLogic(ref bool flag)
+	{
+		// Safe
+		int safeIndex = safeProjTracker.ProjectileLocalIndex;
+		if (safeIndex >= 0) {
+			flag = true;
+			if (!Main.projectile[safeIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[safeIndex].type] != BankID.Safe) {
+				InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
+				chest = -1;
+				Recipe.FindRecipes();
+			}
+			else {
+				int num = (int)(((double)position.X + (double)width * 0.5) / 16.0);
+				int num2 = (int)(((double)position.Y + (double)height * 0.5) / 16.0);
+				Vector2 vector = Main.projectile[safeIndex].Hitbox.ClosestPointInRect(base.Center);
+				chestX = (int)vector.X / 16;
+				chestY = (int)vector.Y / 16;
+				if (num < chestX - tileRangeX || num > chestX + tileRangeX + 1 || num2 < chestY - tileRangeY || num2 > chestY + tileRangeY + 1) {
+					if (chest != -1)
+						InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
+
+					chest = -1;
+					Recipe.FindRecipes();
+				}
+			}
+		}
+
+		// Defenders Forge
+		int defendersForgeIndex = defendersForgeProjTracker.ProjectileLocalIndex;
+		if (defendersForgeIndex >= 0) {
+			flag = true;
+			if (!Main.projectile[defendersForgeIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[defendersForgeIndex].type] != BankID.DefendersForge) {
+				InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
+				chest = -1;
+				Recipe.FindRecipes();
+			}
+			else {
+				int num = (int)(((double)position.X + (double)width * 0.5) / 16.0);
+				int num2 = (int)(((double)position.Y + (double)height * 0.5) / 16.0);
+				Vector2 vector = Main.projectile[defendersForgeIndex].Hitbox.ClosestPointInRect(base.Center);
+				chestX = (int)vector.X / 16;
+				chestY = (int)vector.Y / 16;
+				if (num < chestX - tileRangeX || num > chestX + tileRangeX + 1 || num2 < chestY - tileRangeY || num2 > chestY + tileRangeY + 1) {
+					if (chest != -1)
+						InteractiveProjectileOpenCloseSound2(Main.projectile[safeIndex]);
+
+					chest = -1;
+					Recipe.FindRecipes();
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Clears all the portable storage projectile trackers
+	/// (<see cref="Player.piggyBankProjTracker"/>, <see cref="Player.safeProjTracker"/>, <see cref="Player.defendersForgeProjTracker"/>, <see cref="Player.voidLensChest"/>)
+	/// </summary>
+	public void ClearPortableBankProjectileTrackers()
+	{
+		piggyBankProjTracker.Clear();
+		voidLensChest.Clear();
+		safeProjTracker.Clear();
+		defendersForgeProjTracker.Clear();
+	}
+
+	private void clientClone_TMLCloneBankProjTrackers(Player player)
+	{
+		player.safeProjTracker = safeProjTracker;
+		player.defendersForgeProjTracker = defendersForgeProjTracker;
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4799,6 +4799,51 @@
  		if (wings == 32)
  			num27 = 3;
  
+@@ -23250,11 +_,13 @@
+ 			if (chest != -5)
+ 				voidLensChest.Clear();
+ 
++			HandleBeingInChestRange_TMLCheckFields();
++
+ 			bool flag = false;
+ 			int projectileLocalIndex = piggyBankProjTracker.ProjectileLocalIndex;
+ 			if (projectileLocalIndex >= 0) {
+ 				flag = true;
+-				if (!Main.projectile[projectileLocalIndex].active || (Main.projectile[projectileLocalIndex].type != 525 && Main.projectile[projectileLocalIndex].type != 960)) {
++				if (!Main.projectile[projectileLocalIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex].type] != -2) {
+ 					Main.PlayInteractiveProjectileOpenCloseSound(Main.projectile[projectileLocalIndex].type, open: false);
+ 					chest = -1;
+ 					Recipe.FindRecipes();
+@@ -23278,7 +_,7 @@
+ 			int projectileLocalIndex2 = voidLensChest.ProjectileLocalIndex;
+ 			if (projectileLocalIndex2 >= 0) {
+ 				flag = true;
+-				if (!Main.projectile[projectileLocalIndex2].active || Main.projectile[projectileLocalIndex2].type != 734) {
++				if (!Main.projectile[projectileLocalIndex2].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex2].type] != -5) {
+ 					SoundEngine.PlaySound(SoundID.Item130);
+ 					chest = -1;
+ 					Recipe.FindRecipes();
+@@ -23299,6 +_,8 @@
+ 				}
+ 			}
+ 
++			HandleBeingInChestRange_TMLBankLogic(ref flag);
++
+ 			if (flag)
+ 				return;
+ 
+@@ -23316,8 +_,11 @@
+ 			}
+ 		}
+ 		else {
++			ClearPortableBankProjectileTrackers();
++			/*
+ 			piggyBankProjTracker.Clear();
+ 			voidLensChest.Clear();
++			*/
+ 		}
+ 	}
+ 
 @@ -23333,7 +_,7 @@
  		if (TileID.Sets.BasicChest[tile.type] || tile.type == 97)
  			r = new Rectangle(chestPointX * 16, chestPointY * 16, 32, 32);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1048,9 +1048,9 @@
  	public TrackedProjectileReference piggyBankProjTracker;
  	public TrackedProjectileReference voidLensChest;
 +	/// <summary>
-+	/// Represents the chest the player currently has open. If -1, the player has no chest open.<br/>
-+	/// Positive values indicate the index of the chest in <see cref="Main.chest"/> the player currently has open.<br/>
-+	/// Negative values are used to indicate additional inventories: Piggy Bank (-2), Safe (-3), Defender's Forge (-4), Void Vault (-5)
++	/// Represents the chest the player currently has open. If -1, the player has no chest open.
++	/// <br/><br/> Positive values indicate the index of the chest in <see cref="Main.chest"/> the player currently has open.
++	/// <br/><br/> Negative values are used to indicate additional inventories: Piggy Bank (-2), Safe (-3), Defender's Forge (-4), Void Vault (-5). These ID values are found in <see cref="BankID"/> as well.
 +	/// </summary>
  	public int chest = -1;
  	public int chestX;
@@ -4810,7 +4810,7 @@
  			if (projectileLocalIndex >= 0) {
  				flag = true;
 -				if (!Main.projectile[projectileLocalIndex].active || (Main.projectile[projectileLocalIndex].type != 525 && Main.projectile[projectileLocalIndex].type != 960)) {
-+				if (!Main.projectile[projectileLocalIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex].type] != -2) {
++				if (!Main.projectile[projectileLocalIndex].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex].type] != BankID.PiggyBank) {
  					Main.PlayInteractiveProjectileOpenCloseSound(Main.projectile[projectileLocalIndex].type, open: false);
  					chest = -1;
  					Recipe.FindRecipes();
@@ -4819,7 +4819,7 @@
  			if (projectileLocalIndex2 >= 0) {
  				flag = true;
 -				if (!Main.projectile[projectileLocalIndex2].active || Main.projectile[projectileLocalIndex2].type != 734) {
-+				if (!Main.projectile[projectileLocalIndex2].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex2].type] != -5) {
++				if (!Main.projectile[projectileLocalIndex2].active || ProjectileID.Sets.CountAsBank[Main.projectile[projectileLocalIndex2].type] != BankID.VoidVault) {
  					SoundEngine.PlaySound(SoundID.Item130);
  					chest = -1;
  					Recipe.FindRecipes();
@@ -5031,6 +5031,18 @@
  				flag2 = true;
  				if (WorldGen.CloseDoor(myX, myY))
  					NetMessage.SendData(19, -1, -1, null, 1, myX, myY, direction);
+@@ -24873,8 +_,11 @@
+ 						}
+ 					}
+ 					else {
++						ClearPortableBankProjectileTrackers();
++						/*
+ 						piggyBankProjTracker.Clear();
+ 						voidLensChest.Clear();
++						*/
+ 						int num47 = Chest.FindChest(num45, num46);
+ 						if (num47 != -1) {
+ 							Main.stackSplit = 600;
 @@ -25004,7 +_,10 @@
  				if (flag12)
  					NetMessage.SendTileSquare(-1, num62, num63, 2, 2);
@@ -8671,7 +8683,12 @@
  		player.extraAccessory = extraAccessory;
  		player.MinionRestTargetPoint = MinionRestTargetPoint;
  		player.MinionAttackTargetNPC = MinionAttackTargetNPC;
-@@ -41771,34 +_,34 @@
+@@ -41767,38 +_,39 @@
+ 		player.talkNPC = talkNPC;
+ 		player.piggyBankProjTracker = piggyBankProjTracker;
+ 		player.voidLensChest = voidLensChest;
++		clientClone_TMLCloneBankProjTrackers(player);
+ 		player.hideVisibleAccessory = hideVisibleAccessory;
  		player.hideMisc = hideMisc;
  		player.shieldRaised = shieldRaised;
  		for (int i = 0; i < 59; i++) {
@@ -9234,6 +9251,18 @@
  			adjTile[n] = false;
  			oldAdjTile[n] = false;
  		}
+@@ -43084,8 +_,11 @@
+ 		hitReplace = new HitTile();
+ 		mount = new Mount();
+ 		talkNPC = -1;
++		ClearPortableBankProjectileTrackers();
++		/*
+ 		piggyBankProjTracker.Clear();
+ 		voidLensChest.Clear();
++		*/
+ 		creativeTracker = new CreativeUnlocksTracker();
+ 		builderAccStatus[0] = 1;
+ 	}
 @@ -43304,6 +_,9 @@
  			if ((settings.avoidWalls && tileSafely.wall > 0) || (settings.avoidAnyLiquid && Collision.WetCollision(vector, num4, height)) || (settings.avoidLava && Collision.LavaCollision(vector, num4, height)) || (settings.avoidHurtTiles && Collision.AnyHurtingTiles(vector, num4, height)) || Collision.SolidCollision(vector, num4, height) || num6 >= settings.maximumFallDistanceFromOrignalPoint - 1)
  				continue;


### PR DESCRIPTION
**Note: I was unable to get Git to open the original branch to resolve conflicts in the original PR. This PR is a port of #1978. The initial work was all done by @pbone64 .**

### What is the new feature?
Added better portable storage support, by introducing a tracker (similar to the void lens and piggy banks) for Safes and Defenders Forges, adding a set that lets you count a projectile as a portable storage projectile, and added the `BankID` class to easily reference special bank ids.

### Why should this be part of tModLoader?
1.4.3 greatly improved the portable storage system, but it still wasn't at the point where mods could easily add their own without IL editing. This saves mods from multiple annoying IL edits.

### Are there alternative designs?
Yes, probably. The way sounds are handled could be changed to deterministic, however I can't think of a good way to do that right now

### Sample usage for the new feature
Here is an example of a portable safe projectile:
```
public class Awa : ModProjectile
{
    public override void SetStaticDefaults()
    {
        ProjectileID.Sets.CountAsBank[Projectile.type] = BankID.Safe;
    }

    public bool init = false;

    public override void AI()
    {
        if (!init)
        {
            Player localPlayer = Main.player[Projectile.owner];

            localPlayer.chest = BankID.Safe;
            for (int i = 0; i < 40; i++)
            {
                ItemSlot.SetGlow(i, -1f, chest: true);
            }

            localPlayer.safeProjTracker.Set(Projectile);
            localPlayer.chestX = (int)Projectile.Center.X;
            localPlayer.chestY = (int)Projectile.Center.Y;
            localPlayer.SetTalkNPC(-1);
            Main.SetNPCShopIndex(0);
            Main.playerInventory = true;
            SoundEngine.PlaySound(SoundID.MenuOpen);
            Recipe.FindRecipes();

            init = true;
        }
    }

    public override void PlayBankCloseSound()
    {
        SoundEngine.PlaySound(SoundID.MenuClose);
    }
}
```
### ExampleMod updates
I did not update ExampleMod.

Side note: For some reason, an old commit was included in this. The old commit doesn't actually change anything, and I'm not sure why GitHub included it in this PR.
