### PR TITLE
Add opt-out of mod building in tModLoader.targets

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -1,27 +1,36 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- Build Defaults -->
+	<!-- Set the default value for BuildMod -->
 	<PropertyGroup>
+		<BuildMod Condition="'$(BuildMod)' == ''">true</BuildMod>
+	</PropertyGroup>
+
+	<!-- Build Defaults -->
+	<PropertyGroup Condition="'$(BuildMod)' == 'true'">
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
-		<!-- legacy property -->
+		<!-- Legacy property name for tMLSteamPath -->
 		<TerrariaSteamPath>$(MSBuildThisFileDirectory)</TerrariaSteamPath>
 		<tMLSteamPath>$(MSBuildThisFileDirectory)</tMLSteamPath>
 		<tMLLibraryPath>$(tMLSteamPath)Libraries</tMLLibraryPath>
 		<tMLName>tModLoader</tMLName>
 		<tMLPath>$(tMLName).dll</tMLPath>
 		<tMLServerPath>$(tMLPath) -server</tMLServerPath>
-    	<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
-    	<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
-    	<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
+		<!-- The below comment gets replaced in the build script with <DefineConstant> -->
 		<!-- TML stable version define placeholder -->
 	</PropertyGroup>
-	
-	<ItemGroup>
+
+	<PropertyGroup Condition="'$(BuildMod)' == 'true'">
+		<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
+		<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
+		<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(BuildMod)' == 'true'">
 		<AdditionalFiles Include="**/*.hjson" />
 		<AdditionalFiles Include="**/*.txt" />
 		<AdditionalFiles Include="**/*.png" />
@@ -29,6 +38,9 @@
 		<!-- Remove the txt files that can be found in build folders, causing them to appear in the editor -->
 		<AdditionalFiles Remove="bin/**" />
 		<AdditionalFiles Remove="obj/**" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Reference Include="$(tMLSteamPath)$(tMLPath)" />
 		<Reference Include="$(tMLLibraryPath)/**/*.dll" />
 		<Reference Remove="$(tMLLibraryPath)/Native/**" />
@@ -39,7 +51,7 @@
 		<Analyzer Include="$(tMLLibraryPath)/tModCodeAssist/1.0.0/tModCodeAssist.CodeFixes.dll" />
 	</ItemGroup>
 
-	<Target Name="BuildMod" AfterTargets="Build">
+	<Target Name="BuildMod" AfterTargets="Build" Condition="'$(BuildMod)' == 'true'">
 		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
 	</Target>
 

--- a/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
+++ b/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <BuildMod>false</BuildMod>
+  </PropertyGroup>
+
   <Import Project="../../src/WorkspaceInfo.targets" />
   <Import Project="$(tModLoaderSteamPath)/tMLMod.targets" />
 
@@ -24,8 +28,5 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
   </ItemGroup>
-  
-  <Target Name="BuildMod">
-  </Target>
-  
+
 </Project>

--- a/tModPorter/tModPorter.Tests/TestData/TestData.csproj
+++ b/tModPorter/tModPorter.Tests/TestData/TestData.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <BuildMod>false</BuildMod>
+  </PropertyGroup>
+
   <Import Project="../../../src/WorkspaceInfo.targets" />
   <Import Project="$(tModLoaderSteamPath)/tMLMod.targets" />
   <PropertyGroup>

--- a/tModPorter/tModPorter.Tests/TestData/TestDataExpected.csproj
+++ b/tModPorter/tModPorter.Tests/TestData/TestDataExpected.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <BuildMod>false</BuildMod>
+  </PropertyGroup>
+
   <Import Project="../../../src/WorkspaceInfo.targets" />
   <Import Project="$(tModLoaderSteamPath)/tMLMod.targets" />
   <PropertyGroup>


### PR DESCRIPTION
### What is the new feature?
Projects can import `tModLoader.targets` to reference tML without being built as a mod by setting the property `BuildMod` instead of redefining the target that would build a mod.

### Why should this be part of tModLoader?
So tools libraries/tools that aren't necessarily mods can easily reference tMLs code. [TerraUtil](https://github.com/Destructor-Ben/TerraUtil) is one example that I made (and never finished unfortunately, but the build system does work).

### Are there alternative designs?
Making another tModLoader.targets file, but this would require more effort. and would require splitting tMLMod.targets into multiple files which is probably worse for maintainability.

### Sample usage for the new feature
See porting notes.

### Porting Notes
If you previously redefined the `BuildMod` target like this: `<Target Name="BuildMod"></Target>`
You can opt-in to disabling mod building by putting this in your `.csproj`:
```csproj
<!-- This must go before tModLoader.targets is imported -->
<PropertyGroup>
    <BuildMod>false</BuildMod>
</PropertyGroup>

<Import Project="..\tModLoader.targets" />
```
This will also disable setting PlatformTarget, TargetFramework, and LangVersion to their default values, as well as setting DotNetName and adding files to AdditionalFiles.
