### PR TITLE
Fix very minor typos

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Templates/{{ModName}}.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/{{ModName}}.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria.ModLoader;
 
-namespace {{ModName }}
+namespace {{ModName}}
 {
 	// Please read https://github.com/tModLoader/tModLoader/wiki/Basic-tModLoader-Modding-Guide#mod-skeleton-contents for more information about the various files in a mod.
 	public class {{ModName}} : Mod

--- a/tModPorter/tModPorter.Tests/TestData/TestData.csproj
+++ b/tModPorter/tModPorter.Tests/TestData/TestData.csproj
@@ -8,9 +8,7 @@
     <LangVersion>latest</LangVersion>
     <DefineConstants>COMPILE_ERROR</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="**/*.Expected.cs" />
     <Compile Remove="**/*.Out.cs" />

--- a/tModPorter/tModPorter.Tests/TestData/TestDataExpected.csproj
+++ b/tModPorter/tModPorter.Tests/TestData/TestDataExpected.csproj
@@ -7,9 +7,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="tModLoader.CodeAssist" Version="0.1.*" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="**/*.cs" />
     <Compile Include="Common/*.cs" />


### PR DESCRIPTION
### What is the bug?
`{{ModName}}.cs` has an extra space in the templating logic and the tModPorter test projects were importing the old tModLoader.CodeAssist, even though tMLMod would handle that anyway, and it uses the new analyzers now.

### How did you fix the bug?
Remove the extra space/package references.

### Are there alternatives to your fix?
No.
