### PR TITLE
Add example of modifying Player.statLifeMax2 in equipment

### DIFF
--- a/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleBreastplate.cs
@@ -11,6 +11,7 @@ namespace ExampleMod.Content.Items.Armor
 	public class ExampleBreastplate : ModItem
 	{
 		public static readonly int MaxManaIncrease = 20;
+		public static readonly int MaxLifeIncrease = 20;
 		public static readonly int MaxMinionIncrease = 1;
 
 		public override LocalizedText Tooltip => base.Tooltip.WithFormatArgs(MaxManaIncrease, MaxMinionIncrease);
@@ -27,6 +28,9 @@ namespace ExampleMod.Content.Items.Armor
 			player.buffImmune[BuffID.OnFire] = true; // Make the player immune to Fire
 			player.statManaMax2 += MaxManaIncrease; // Increase how many mana points the player can have by 20
 			player.maxMinions += MaxMinionIncrease; // Increase how many minions the player can have by one
+
+			// Some effects are applied in ExampleBreastplatePlayer below.
+			player.GetModPlayer<ExampleBreastplatePlayer>().exampleBreastplate = true;
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
@@ -34,6 +38,19 @@ namespace ExampleMod.Content.Items.Armor
 			CreateRecipe().AddIngredient<ExampleItem>()
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
+		}
+	}
+
+	public class ExampleBreastplatePlayer : ModPlayer
+	{
+		public bool exampleBreastplate = false;
+
+		public override void ResetEffects() {
+			if (exampleBreastplate) {
+				// Player.statLifeMax2 needs to be modified in ResetEffects due to the order that player life max code is executed.
+				Player.statLifeMax2 += ExampleBreastplate.MaxLifeIncrease;
+			}
+			exampleBreastplate = false;
 		}
 	}
 }

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -301,6 +301,7 @@ Mods: {
 					This is a modded body armor.
 					Immunity to 'On Fire!'
 					{$CommonItemTooltip.IncreasesMaxManaBy}
+					{$CommonItemTooltip.IncreasesMaxLifeBy}
 					{$CommonItemTooltip.IncreasesMaxMinionsBy@1}
 					'''
 			}

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -566,7 +566,7 @@
  	public bool fireWalk;
  	public bool channel;
  	public int step = -1;
-@@ -961,38 +_,124 @@
+@@ -961,38 +_,125 @@
  	public int golferScoreAccumulated;
  	public int bartenderQuestLog;
  	public bool downedDD2EventAnyDifficulty;
@@ -593,18 +593,19 @@
 +
 +	/// <summary>
 +	/// The maximum health this player can have without adjustment.
-+	/// <br/> You should <strong>not</strong> modify this value. If you need to increase max health for equipment, modify <see cref="statLifeMax2"/>. If you need to increase max health for a permanent stat boost, use <see cref="ModPlayer.ModifyMaxStats(out StatModifier, out StatModifier)"/>.
++	/// <br/><br/> You should <strong>not</strong> modify this value. If you need to increase max health for equipment, modify <see cref="statLifeMax2"/>. If you need to increase max health for a permanent stat boost, use <see cref="ModPlayer.ModifyMaxStats(out StatModifier, out StatModifier)"/>.
 +	/// </summary>
  	public int statLifeMax = 100;
 +
 +	/// <summary>
-+	/// The maximum health this player can have, adjusted by buffs and equipment.
++	/// The maximum health this player can have, adjusted by buffs and equipment. 
++	/// <br/><br/> To avoid issues arising from code execution ordering, the most compatible place to modify this value is in <see cref="ModPlayer.ResetEffects"/>.
 +	/// </summary>
  	public int statLifeMax2 = 100;
 +
 +	/// <summary>
 +	/// The current health of this player. Capped at <see cref="statLifeMax2"/>.
-+	/// <br/> If you increase this value, be sure to respect the cap.
++	/// <br/><br/> If you increase this value, be sure to respect the cap.
 +	/// </summary>
 +	/// <remarks>
 +	/// If you want to heal the player with the green text effect, use <see cref="Player.Heal(int)"/>.
@@ -614,7 +615,7 @@
 +
 +	/// <summary>
 +	/// The current mana of this player. Capped at <see cref="statManaMax2"/>.
-+	/// <br/> If you increase this value, be sure to respect the cap.
++	/// <br/><br/> If you increase this value, be sure to respect the cap.
 +	/// </summary>
 +	/// <remarks>
 +	/// If you want to use mana, use <see cref="Player.CheckMana(Item, int, bool, bool)"/> or its overload.
@@ -623,7 +624,7 @@
 +
 +	/// <summary>
 +	/// The maximum mana this player can have without adjustment.
-+	/// <br/> You should <strong>not</strong> modify this value. If you need to increase max mana for equipment, modify <see cref="statManaMax2"/>. If you need to increase max mana for a permanent stat boost, use <see cref="ModPlayer.ModifyMaxStats(out StatModifier, out StatModifier)"/>.
++	/// <br/><br/> You should <strong>not</strong> modify this value. If you need to increase max mana for equipment, modify <see cref="statManaMax2"/>. If you need to increase max mana for a permanent stat boost, use <see cref="ModPlayer.ModifyMaxStats(out StatModifier, out StatModifier)"/>.
 +	/// </summary>
  	public int statManaMax;
 +


### PR DESCRIPTION
It has been brought up that modifying `Player.statLifeMax2` outside of `ResetEffects` can lead to some buggy logic. This is because various vanilla effects in `UpdateBuffs` and `UpdateEquips` are checking the current value in the same place that other effects might be adjusting the current value. Technically, I think the lifeforce and frozen turtle shell interaction can be incorrect depending on if the life force potion is taken after the IceBarrier buff is applied or before.

Since there are many examples of vanilla equipment adjusting `Player.statManaMax2` directly in `UpdateEquips`, modders might assume that adjusting `statLifeMax2` in the same manner is also compatible, but these vanilla effects might have incorrect logic if modders are doing that. 

While we could just ignore these slight issues with these buffs activating, there are mods that might be emulating them in similar logic leading to compounding issues. 

The current PR adjusts the documentation and provides and example of doing it "correctly". We may, however, want to find some other solution as it is a bit strange that this particular stat must be modified in a specific manner.

```
Player.Update
Line 21255	UpdateBuffs -- IceBarrier (Frozen Turtle Shell) checks it, Lifeforce increases it.	

	else if (buffType[j] == 113) {
		lifeForce = true;
		statLifeMax2 += statLifeMax / 5 / 20 * 20;
	}	
        else if (buffType[j] == 62) {
	        if ((double)statLife <= (double)statLifeMax2 * 0.5) {
		        Lighting.AddLight((int)(base.Center.X / 16f), (int)(base.Center.Y / 16f), 0.1f, 0.2f, 0.45f);
		        iceBarrier = true;
		        endurance += 0.25f;
		        iceBarrierFrameCounter++;
		        if (iceBarrierFrameCounter > 2) {
			        iceBarrierFrameCounter = 0;
			        iceBarrierFrame++;
			        if (iceBarrierFrame >= 12)
				        iceBarrierFrame = 0;
		        }
	        }
	        else {
		        DelBuff(j);
		        j--;
	        }
        }

Line 21319	UpdateEquips/ApplyEquipFunctional -- PaladinShield and FrozenTurtleShield both check statLifeMax2 for gameplay logic

      if (currentItem.type == 938 || currentItem.type == 3997 || currentItem.type == 3998) {
	      noKnockback = true;
	      if ((float)statLife > (float)statLifeMax2 * 0.25f) {
		      hasPaladinShield = true;
		      if (whoAmI != Main.myPlayer && miscCounter % 10 == 0) {
			      int myPlayer = Main.myPlayer;
			      if (Main.player[myPlayer].team == team && team != 0) {
				      float num = position.X - Main.player[myPlayer].position.X;
				      float num2 = position.Y - Main.player[myPlayer].position.Y;
				      if ((float)Math.Sqrt(num * num + num2 * num2) < 800f)
					      Main.player[myPlayer].AddBuff(43, 20);
			      }
		      }
	      }
      }
      if ((currentItem.type == 1253 || currentItem.type == 3997) && (double)statLife <= (double)statLifeMax2 * 0.5)
	      AddBuff(62, 5);

Line 21591	UpdateLifeRegen -- uses statlifeMax2 to calculate natural life regen

      float num7 = (float)statLifeMax2 / 400f * 0.85f + 0.15f;
      num5 *= num7;
      lifeRegen += (int)Math.Round(num5);
      
Line 22350, 21338, 22129  --  MountFishronSpecial  -- uses statLifeMax2 to adjust mount speed and effects
	public bool MountFishronSpecial {
		get {
			if (statLife >= statLifeMax2 / 2 && (!wet || lavaWet || honeyWet) && !dripping && !(MountFishronSpecialCounter > 0f)) {
				if (Main.raining)
					return WorldGen.InAPlaceWithWind(position, width, height);

				return false;
			}

			return true;
		}
	}
```