### PR TITLE
tModCodeAssist: BadIDType diagnostic, bindings improvements

### DIFF
--- a/patches/tModLoader/Terraria/ID/LiquidID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/LiquidID.cs.patch
@@ -1,0 +1,14 @@
+--- src/TerrariaNetCore/Terraria/ID/LiquidID.cs
++++ src/tModLoader/Terraria/ID/LiquidID.cs
+@@ -1,3 +_,5 @@
++using ReLogic.Reflection;
++
+ namespace Terraria.ID;
+ 
+ public static class LiquidID
+@@ -7,4 +_,5 @@
+ 	public const short Honey = 2;
+ 	public const short Shimmer = 3;
+ 	public static readonly short Count = 4;
++	public static readonly IdDictionary Search = IdDictionary.Create(typeof(PaintID), typeof(short)); // Added By TML
+ }

--- a/patches/tModLoader/Terraria/ID/PaintID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/PaintID.cs.patch
@@ -1,0 +1,14 @@
+--- src/TerrariaNetCore/Terraria/ID/PaintID.cs
++++ src/tModLoader/Terraria/ID/PaintID.cs
+@@ -1,3 +_,5 @@
++using ReLogic.Reflection;
++
+ namespace Terraria.ID;
+ 
+ public static class PaintID
+@@ -35,4 +_,5 @@
+ 	public const byte NegativePaint = 30;
+ 	public const byte IlluminantPaint = 31;
+ 	public const byte Old_IlluminantPaint = 31;
++	public static readonly IdDictionary Search = IdDictionary.Create(typeof(PaintID), typeof(byte)); // Added By TML
+ }

--- a/tModCodeAssist/tModCodeAssist.CodeFixes/CodeFixes/ChangeMagicNumberToIDCodeFixProvider.cs
+++ b/tModCodeAssist/tModCodeAssist.CodeFixes/CodeFixes/ChangeMagicNumberToIDCodeFixProvider.cs
@@ -13,8 +13,6 @@ using tModCodeAssist.Analyzers;
 
 namespace tModCodeAssist.CodeFixes;
 
-// TODO: handle multiple names for same id
-
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Diagnostics.ChangeMagicNumberToID)), Shared]
 public sealed class ChangeMagicNumberToIDCodeFixProvider() : AbstractCodeFixProvider(nameof(Diagnostics.ChangeMagicNumberToID))
 {
@@ -29,6 +27,7 @@ public sealed class ChangeMagicNumberToIDCodeFixProvider() : AbstractCodeFixProv
 
 			if (!parameters.Diagnostic.Properties.ContainsKey("ShortIdType"))
 				return Task.CompletedTask; // Conflict with Diagnostic registered by old tModLoader.CodeAssist
+
 			var properties = ChangeMagicNumberToIDAnalyzer.Properties.FromImmutable(parameters.Diagnostic.Properties);
 			var (shortIdType, fullIdType, name) = properties;
 

--- a/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
@@ -1,0 +1,69 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AnalyzerVerifier = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>;
+
+namespace tModCodeAssist.Tests.Analyzers;
+
+[TestClass]
+public class BadIDTypeUnitTest
+{
+	[TestMethod]
+	public async Task Test_Assignment()
+	{
+		await AnalyzerVerifier.Run(
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			var item = new Item();
+			item.type = {|BadIDType:TileID.Dirt|};
+			int a = 420;
+			item.type = a;
+			const int b = 420;
+			item.type = b;
+			"""
+			);
+	}
+
+	[TestMethod]
+	public async Task Test_Binary()
+	{
+		await AnalyzerVerifier.Run(
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			_ = new Item().type == {|BadIDType:TileID.Dirt|};
+			"""
+			);
+	}
+
+	[TestMethod]
+	public async Task Test_Invocation()
+	{
+		await AnalyzerVerifier.Run(
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			var recipe = Recipe.Create(ItemID.CobaltBrickWall);
+			recipe.AddIngredient({|BadIDType:TileID.Dirt|});
+			"""
+			);
+	}
+
+	[TestMethod]
+	public async Task Test_CaseSwitchLabel()
+	{
+		await AnalyzerVerifier.Run(
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			switch (new NPC().type) {
+				case {|BadIDType:TileID.Dirt|}:
+					break;
+			}
+			""");
+	}
+}

--- a/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using AnalyzerVerifier = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>;
+using VerifyCS = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>;
 
 namespace tModCodeAssist.Tests.Analyzers;
 
@@ -10,7 +10,7 @@ public class BadIDTypeUnitTest
 	[TestMethod]
 	public async Task Test_Assignment()
 	{
-		await AnalyzerVerifier.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 			using Terraria.ID;
@@ -28,7 +28,7 @@ public class BadIDTypeUnitTest
 	[TestMethod]
 	public async Task Test_Binary()
 	{
-		await AnalyzerVerifier.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 			using Terraria.ID;
@@ -41,7 +41,7 @@ public class BadIDTypeUnitTest
 	[TestMethod]
 	public async Task Test_Invocation()
 	{
-		await AnalyzerVerifier.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 			using Terraria.ID;
@@ -55,7 +55,7 @@ public class BadIDTypeUnitTest
 	[TestMethod]
 	public async Task Test_CaseSwitchLabel()
 	{
-		await AnalyzerVerifier.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 			using Terraria.ID;

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using CodeFixer = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>.CodeFixer<tModCodeAssist.CodeFixes.ChangeMagicNumberToIDCodeFixProvider>;
+using VerifyCS = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>.CodeFixer<tModCodeAssist.CodeFixes.ChangeMagicNumberToIDCodeFixProvider>;
 
 namespace tModCodeAssist.Tests.CodeFixes;
 
@@ -10,7 +10,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_Assignment()
 	{
-		await CodeFixer.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 
@@ -67,7 +67,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_Binary()
 	{
-		await CodeFixer.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 
@@ -86,7 +86,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_Invocation()
 	{
-		await CodeFixer.Run(
+		await VerifyCS.Run(
 			"""
 			using Microsoft.Xna.Framework;
 			using Terraria;
@@ -122,7 +122,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_CaseSwitchLabel()
 	{
-		await CodeFixer.Run(
+		await VerifyCS.Run(
 			"""
 			using Terraria;
 

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>.CodeFixer<tModCodeAssist.CodeFixes.ChangeMagicNumberToIDCodeFixProvider>;
+using CodeFixer = tModCodeAssist.Tests.Verifier.Analyzer<tModCodeAssist.Analyzers.ChangeMagicNumberToIDAnalyzer>.CodeFixer<tModCodeAssist.CodeFixes.ChangeMagicNumberToIDCodeFixProvider>;
 
 namespace tModCodeAssist.Tests.CodeFixes;
 
@@ -10,7 +10,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_Assignment()
 	{
-		await VerifyCS.Run(
+		await CodeFixer.Run(
 			"""
 			using Terraria;
 
@@ -28,9 +28,13 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			modTile.DustType = [|1|];
 			Terraria.ModLoader.ModWall modWall = null;
 			modWall.DustType = [|2|];
-
-			Main.tile[10, 20].TileType = [|490|];
-			Main.tile[20, 30].WallType = [|276|];
+			
+			var tile = Main.tile[10, 20];
+			tile.TileType = [|490|];
+			tile.WallType = [|276|];
+			tile.TileColor = [|1|];
+			tile.WallColor = [|1|];
+			tile.LiquidType = [|1|];
 			""",
 			"""
 			using Terraria;
@@ -51,15 +55,19 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			Terraria.ModLoader.ModWall modWall = null;
 			modWall.DustType = DustID.Grass;
 
-			Main.tile[10, 20].TileType = TileID.WeatherVane;
-			Main.tile[20, 30].WallType = WallID.Corruption1Echo;
+			var tile = Main.tile[10, 20];
+			tile.TileType = TileID.WeatherVane;
+			tile.WallType = WallID.Corruption1Echo;
+			tile.TileColor = PaintID.RedPaint;
+			tile.WallColor = PaintID.RedPaint;
+			tile.LiquidType = LiquidID.Lava;
 			""");
 	}
 
 	[TestMethod]
 	public async Task Test_Binary()
 	{
-		await VerifyCS.Run(
+		await CodeFixer.Run(
 			"""
 			using Terraria;
 
@@ -78,7 +86,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_Invocation()
 	{
-		await VerifyCS.Run(
+		await CodeFixer.Run(
 			"""
 			using Microsoft.Xna.Framework;
 			using Terraria;
@@ -114,7 +122,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	[TestMethod]
 	public async Task Test_CaseSwitchLabel()
 	{
-		await VerifyCS.Run(
+		await CodeFixer.Run(
 			"""
 			using Terraria;
 

--- a/tModCodeAssist/tModCodeAssist.Tests/Verifier.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Verifier.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,6 +28,7 @@ public static  class Verifier
 
 					FixedCode = fixedCode.ReplaceLineEndings();
 
+					MarkupOptions = MarkupOptions.UseFirstDescriptor;
 					ExpectedDiagnostics.AddRange(expected);
 
 					NumberOfFixAllIterations = 1;
@@ -76,6 +78,7 @@ public static  class Verifier
 				TestCode = testCode.ReplaceLineEndings();
 				TestState.OutputKind = OutputKind.ConsoleApplication;
 
+				MarkupOptions = MarkupOptions.UseFirstDescriptor;
 				ExpectedDiagnostics.AddRange(expected);
 			}
 

--- a/tModCodeAssist/tModCodeAssist.Tests/Verifier.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Verifier.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -11,7 +10,7 @@ using tModCodeAssist.Tests.Verifiers;
 
 namespace tModCodeAssist.Tests;
 
-public static  class Verifier
+public static class Verifier
 {
 	public static class Analyzer<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
 	{
@@ -22,7 +21,7 @@ public static  class Verifier
 				public Test(string testCode, string fixedCode, IEnumerable<DiagnosticResult> expected) : base()
 				{
 					ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
-
+					
 					TestCode = testCode.ReplaceLineEndings();
 					TestState.OutputKind = OutputKind.ConsoleApplication;
 

--- a/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
+++ b/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\tModCodeAssist\tModCodeAssist.csproj" />
     <ProjectReference Include="..\tModCodeAssist.CodeFixes\tModCodeAssist.CodeFixes.csproj" />
+    <Analyzer Remove="$(tMLLibraryPath)\tModCodeAssist\**\*.dll" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />

--- a/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
+++ b/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
@@ -7,13 +6,12 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
-using ReLogic.Reflection;
-using Terraria.ID;
+using tModCodeAssist.Bindings;
 
 namespace tModCodeAssist.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer(Diagnostics.ChangeMagicNumberToID)
+public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer(Diagnostics.ChangeMagicNumberToID, Diagnostics.BadIDType)
 {
 	public readonly record struct Properties(in string ShortIdType, in string FullIdType, in string Name)
 	{
@@ -36,129 +34,9 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 		}
 	}
 
-	// TODO: Switch to attributes in source instead of using bindings
-	#region Bindings
-	private abstract class Binding(Binding.CreationContext context)
-	{
-		public readonly record struct CreationContext(
-			in string OwningClassName,
-			in string MemberName,
-			in string ShortIdType,
-			in string FullIdType,
-			in IdDictionary Search
-		);
-
-		public string ShortIdType => context.ShortIdType;
-		public string FullIdType => context.FullIdType;
-		public IdDictionary Search => context.Search;
-	}
-	private sealed class FieldBinding(Binding.CreationContext context) : Binding(context)
-	{
-	}
-	private sealed class MethodParameterBinding(Binding.CreationContext context, int parameterOrder) : Binding(context)
-	{
-		public int ParameterOrder => parameterOrder;
-	}
-
-	private Dictionary<string, Dictionary<string, Binding>> bindingByMemberByOwningClass;
-
-	private void AddBinding(string owningClassName, string memberName, Func<Binding.CreationContext, Binding> func, string shortIdType, string fullIdType, IdDictionary search)
-	{
-		var context = new Binding.CreationContext(owningClassName, memberName, shortIdType, fullIdType, search);
-		var binding = func(context);
-
-		if (bindingByMemberByOwningClass.TryGetValue(owningClassName, out var bindingByMember)) {
-			bindingByMember.Add(memberName, binding);
-		}
-		else {
-			bindingByMemberByOwningClass[owningClassName] = new() { [memberName] = binding };
-		}
-	}
-
-	private bool TryGetBinding(ISymbol symbol, out Binding binding)
-	{
-		binding = null;
-
-		static string BuildQualifiedName(ISymbol symbol)
-		{
-			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-		}
-
-		if (symbol is IFieldSymbol fieldSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out Dictionary<string, Binding> bindingByMember)) {
-			if (bindingByMember.TryGetValue(fieldSymbol.MetadataName, out binding)) {
-				return true;
-			}
-		}
-		else if (symbol is IPropertySymbol propertySymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
-			if (bindingByMember.TryGetValue(propertySymbol.MetadataName, out binding)) {
-				return true;
-			}
-		}
-		else if (symbol is IMethodSymbol methodSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
-			var qualifiedName = methodSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat
-				.WithMemberOptions(SymbolDisplayMemberOptions.None)
-				.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
-				.WithParameterOptions(SymbolDisplayParameterOptions.None)
-			);
-			if (bindingByMember.TryGetValue(qualifiedName, out binding)) {
-				return true;
-			}
-
-			qualifiedName = methodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
-				.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
-				.WithMemberOptions(SymbolDisplayMemberOptions.IncludeParameters)
-				.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
-				.WithParameterOptions(SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeExtensionThis)
-			);
-			if (bindingByMember.TryGetValue(qualifiedName, out binding)) {
-				return true;
-			}
-		}
-		else if (symbol is IParameterSymbol parameterSymbol) {
-			if (TryGetBinding(parameterSymbol.ContainingSymbol, out binding) && parameterSymbol.Ordinal == ((MethodParameterBinding)binding).ParameterOrder) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-	#endregion
-
 	protected override void InitializeWorker(AnalysisContext ctx)
 	{
-		bindingByMemberByOwningClass = [];
-		AddBinding("Terraria.Item", "createTile", (ctx) => new FieldBinding(ctx), nameof(TileID), typeof(TileID).FullName, TileID.Search);
-		AddBinding("Terraria.Item", "type", (ctx) => new FieldBinding(ctx), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.Player", "cursorItemIconID", (ctx) => new FieldBinding(ctx), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.Item", "shoot", (ctx) => new FieldBinding(ctx), nameof(ProjectileID), typeof(ProjectileID).FullName, ProjectileID.Search);
-		AddBinding("Terraria.Item", "useStyle", (ctx) => new FieldBinding(ctx), nameof(ItemUseStyleID), typeof(ItemUseStyleID).FullName, ItemUseStyleID.Search);
-		AddBinding("Terraria.Item", "rare", (ctx) => new FieldBinding(ctx), nameof(ItemRarityID), typeof(ItemRarityID).FullName, ItemRarityID.Search);
-		AddBinding("Terraria.NPC", "type", (ctx) => new FieldBinding(ctx), nameof(NPCID), typeof(NPCID).FullName, NPCID.Search);
-		AddBinding("Terraria.Main", "netMode", (ctx) => new FieldBinding(ctx), nameof(NetmodeID), typeof(NetmodeID).FullName, NetmodeID.Search);
-		AddBinding("Terraria.Projectile", "type", (ctx) => new FieldBinding(ctx), nameof(ProjectileID), typeof(ProjectileID).FullName, ProjectileID.Search);
-
-		AddBinding("Terraria.ModLoader.ModBlockType", "DustType", (ctx) => new FieldBinding(ctx), nameof(DustID), typeof(DustID).FullName, DustID.Search);
-		AddBinding("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldBinding(ctx), nameof(DustID), typeof(DustID).FullName, DustID.Search);
-		AddBinding("Terraria.Tile", "TileType", (ctx) => new FieldBinding(ctx), nameof(TileID), typeof(TileID).FullName, TileID.Search);
-		AddBinding("Terraria.Tile", "WallType", (ctx) => new FieldBinding(ctx), nameof(WallID), typeof(WallID).FullName, WallID.Search);
-		//AddBinding("Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx), nameof(PaintID), typeof(PaintID).FullName, PaintID.Search);
-		//AddBinding("Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx), nameof(PaintID), typeof(PaintID).FullName, PaintID.Search);
-		//AddBinding("Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx), nameof(LiquidID), typeof(LiquidID).FullName, LiquidID.Search);
-
-		AddBinding("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.NetMessage", "SendData", (ctx) => new MethodParameterBinding(ctx, 0), nameof(MessageID), typeof(MessageID).FullName, MessageID.Search);
-		AddBinding("Terraria.Dust", "NewDust", (ctx) => new MethodParameterBinding(ctx, 3), nameof(DustID), typeof(DustID).FullName, DustID.Search);
-		AddBinding("Terraria.Dust", "NewDustDirect", (ctx) => new MethodParameterBinding(ctx, 3), nameof(DustID), typeof(DustID).FullName, DustID.Search);
-		AddBinding("Terraria.Dust", "NewDustPerfect", (ctx) => new MethodParameterBinding(ctx, 1), nameof(DustID), typeof(DustID).FullName, DustID.Search);
-
-		AddBinding("Terraria.Recipe", "Create", (ctx) => new MethodParameterBinding(ctx, 0), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.Recipe", "AddTile", (ctx) => new MethodParameterBinding(ctx, 0), nameof(TileID), typeof(TileID).FullName, TileID.Search);
-		AddBinding("Terraria.Recipe", "AddIngredient", (ctx) => new MethodParameterBinding(ctx, 0), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.Recipe", "HasResult", (ctx) => new MethodParameterBinding(ctx, 0), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.ModLoader.Mod", "CreateRecipe", (ctx) => new MethodParameterBinding(ctx, 0), nameof(ItemID), typeof(ItemID).FullName, ItemID.Search);
-		AddBinding("Terraria.Projectile", "NewProjectile(Terraria.DataStructures.IEntitySource, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Vector2, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 3), nameof(ProjectileID), typeof(ProjectileID).FullName, ProjectileID.Search);
-		AddBinding("Terraria.Projectile", "NewProjectile(Terraria.DataStructures.IEntitySource, float, float, float, float, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 5), nameof(ProjectileID), typeof(ProjectileID).FullName, ProjectileID.Search);
-		AddBinding("Terraria.Projectile", "NewProjectileDirect(Terraria.DataStructures.IEntitySource, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Vector2, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 3), nameof(ProjectileID), typeof(ProjectileID).FullName, ProjectileID.Search);
+		MagicNumberBindings.PopulateBindings();
 
 		/*
 			item.type = 1;
@@ -171,16 +49,24 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			var node = (AssignmentExpressionSyntax)ctx.Node;
 
 			var leftSymbolInfo = ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken);
-			if (leftSymbolInfo.Symbol is not { } leftSymbol || !TryGetBinding(leftSymbol, out var binding)) return;
+			if (leftSymbolInfo.Symbol is not { } leftSymbol || !MagicNumberBindings.TryGetBinding(leftSymbol, out var binding)) return;
 
-			if (!node.Right.IsKind(SyntaxKind.NumericLiteralExpression)) return;
+			if (node.Right.IsKind(SyntaxKind.NumericLiteralExpression)) {
+				var constant = ctx.SemanticModel.GetConstantValue(node.Right, ctx.CancellationToken);
+				if (!constant.HasValue)
+					return;
 
-			var constant = ctx.SemanticModel.GetConstantValue(node.Right, ctx.CancellationToken);
-			if (!constant.HasValue) return;
+				int id = Convert.ToInt32(constant.Value);
 
-			int id = Convert.ToInt32(constant.Value);
+				ReportDiagnostic(ctx.ReportDiagnostic, node.Right, binding, id);
+			}
+			else if (ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken) is { Symbol: var rightSymbol } && rightSymbol is IFieldSymbol { IsConst: true }) {
+				var displayString = rightSymbol.ContainingType.ToDisplayString();
+				if (!displayString.StartsWith("Terraria.") || binding.FullIdType.Equals(displayString, StringComparison.InvariantCulture))
+					return;
 
-			ReportDiagnostic(ctx.ReportDiagnostic, node.Right, binding, id);
+				ReportBadTypeDiagnostic(ctx.ReportDiagnostic, node.Right, binding);
+			}
 		}, SyntaxKind.SimpleAssignmentExpression);
 
 		/*
@@ -197,13 +83,13 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 		ctx.RegisterSyntaxNodeAction(ctx => {
 			var node = (BinaryExpressionSyntax)ctx.Node;
 
-			Binding binding;
+			MagicNumberBindings.Binding binding;
 			SyntaxNode literalNode;
 			Optional<object> constant;
 
 			if (node.Left.IsKind(SyntaxKind.NumericLiteralExpression)) {
 				var rightSymbolInfo = ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken);
-				if (rightSymbolInfo.Symbol is not { } rightSymbol || !TryGetBinding(rightSymbol, out binding))
+				if (rightSymbolInfo.Symbol is not { } rightSymbol || !MagicNumberBindings.TryGetBinding(rightSymbol, out binding))
 					return;
 
 				literalNode = node.Left;
@@ -211,13 +97,42 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			}
 			else if (node.Right.IsKind(SyntaxKind.NumericLiteralExpression)) {
 				var leftSymbolInfo = ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken);
-				if (leftSymbolInfo.Symbol is not { } leftSymbol || !TryGetBinding(leftSymbol, out binding))
+				if (leftSymbolInfo.Symbol is not { } leftSymbol || !MagicNumberBindings.TryGetBinding(leftSymbol, out binding))
 					return;
 
 				literalNode = node.Right;
 				constant = ctx.SemanticModel.GetConstantValue(node.Right, ctx.CancellationToken);
 			}
 			else {
+				var leftSymbolInfo = ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken);
+				var rightSymbolInfo = ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken);
+
+				var nodeToReport = default(SyntaxNode);
+				ISymbol a = null, b = null;
+
+				if (leftSymbolInfo.Symbol is IFieldSymbol { IsConst: true }) {
+					nodeToReport = node.Left;
+					a = rightSymbolInfo.Symbol;
+					b = leftSymbolInfo.Symbol;
+				}
+
+				if (rightSymbolInfo.Symbol is IFieldSymbol { IsConst: true }) {
+					nodeToReport = node.Right;
+					a = leftSymbolInfo.Symbol;
+					b = rightSymbolInfo.Symbol;
+				}
+
+				if (a != null && b != null) {
+					if (!MagicNumberBindings.TryGetBinding(a, out binding))
+						return;
+
+					var displayString = b.ContainingType.ToDisplayString();
+					if (!displayString.StartsWith("Terraria.") || binding.FullIdType.Equals(displayString, StringComparison.InvariantCulture))
+						return;
+
+					ReportBadTypeDiagnostic(ctx.ReportDiagnostic, nodeToReport, binding);
+				}
+
 				return;
 			}
 
@@ -241,19 +156,31 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 
 			if (ctx.SemanticModel.GetSymbolInfo(node, ctx.CancellationToken).Symbol as IMethodSymbol is not { } invokedMethodSymbol) return;
 
-			if (!TryGetBinding(invokedMethodSymbol, out _)) return;
+			if (!MagicNumberBindings.TryGetBinding(invokedMethodSymbol, out _)) return;
 
 			for (int i = 0; i < node.ArgumentList.Arguments.Count; i++) {
 				var argument = node.ArgumentList.Arguments[i];
-				if (!argument.Expression.IsKind(SyntaxKind.NumericLiteralExpression)) continue;
-				
-				var argumentOperation = (IArgumentOperation)ctx.SemanticModel.GetOperation(argument, ctx.CancellationToken);
-				if (!TryGetBinding(argumentOperation.Parameter, out var binding)) continue;
+				if (argument.Expression.IsKind(SyntaxKind.NumericLiteralExpression)) {
+					var argumentOperation = (IArgumentOperation)ctx.SemanticModel.GetOperation(argument, ctx.CancellationToken);
+					if (!MagicNumberBindings.TryGetBinding(argumentOperation.Parameter, out var binding))
+						continue;
 
-				int id = Convert.ToInt32(argumentOperation.Value.ConstantValue.Value);
+					int id = Convert.ToInt32(argumentOperation.Value.ConstantValue.Value);
 
-				ReportDiagnostic(ctx.ReportDiagnostic, argument.Expression, binding, id);
-				break; // with the way bindings currently work, only 1 argument can be binded, thus immediately terminate loop once found.
+					ReportDiagnostic(ctx.ReportDiagnostic, argument.Expression, binding, id);
+					break; // with the way bindings currently work, only 1 argument can be binded, thus immediately terminate loop once found.
+				}
+				else if (ctx.SemanticModel.GetSymbolInfo(argument.Expression, ctx.CancellationToken) is { Symbol: var rightSymbol } && rightSymbol is IFieldSymbol { IsConst: true }) {
+					var argumentOperation = (IArgumentOperation)ctx.SemanticModel.GetOperation(argument, ctx.CancellationToken);
+					if (!MagicNumberBindings.TryGetBinding(argumentOperation.Parameter, out var binding))
+						continue;
+
+					var displayString = rightSymbol.ContainingType.ToDisplayString();
+					if (!displayString.StartsWith("Terraria.") || binding.FullIdType.Equals(displayString, StringComparison.InvariantCulture))
+						return;
+
+					ReportBadTypeDiagnostic(ctx.ReportDiagnostic, argument.Expression, binding);
+				}
 			}
 		}, SyntaxKind.InvocationExpression);
 
@@ -282,18 +209,25 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			operatedExpression = ((SwitchStatementSyntax)operatedExpression).Expression;
 
 			if (ctx.SemanticModel.GetSymbolInfo(operatedExpression, ctx.CancellationToken).Symbol is not { } operatedSymbol) return;
-			if (!TryGetBinding(operatedSymbol, out var binding)) return;
+			if (!MagicNumberBindings.TryGetBinding(operatedSymbol, out var binding)) return;
 
-			if (!node.Value.IsKind(SyntaxKind.NumericLiteralExpression) || node.Value is not LiteralExpressionSyntax literalExpressionSyntax)
-				return;
+			if (node.Value.IsKind(SyntaxKind.NumericLiteralExpression) && node.Value is LiteralExpressionSyntax literalExpressionSyntax) {
+				int id = Convert.ToInt32(literalExpressionSyntax.Token.Value);
 
-			int id = Convert.ToInt32(literalExpressionSyntax.Token.Value);
+				ReportDiagnostic(ctx.ReportDiagnostic, node.Value, binding, id);
+			}
+			else if (ctx.SemanticModel.GetSymbolInfo(node.Value, ctx.CancellationToken) is { Symbol: var rightSymbol } && rightSymbol is IFieldSymbol { IsConst: true }) {
+				var displayString = rightSymbol.ContainingType.ToDisplayString();
+				if (!displayString.StartsWith("Terraria.") || binding.FullIdType.Equals(displayString, StringComparison.InvariantCulture))
+					return;
 
-			ReportDiagnostic(ctx.ReportDiagnostic, node.Value, binding, id);
+				ReportBadTypeDiagnostic(ctx.ReportDiagnostic, node.Value, binding);
+			}
+
 		}, SyntaxKind.CaseSwitchLabel);
 	}
 
-	private void ReportDiagnostic(Action<Diagnostic> report, SyntaxNode literalNode, Binding binding, int id)
+	private void ReportDiagnostic(Action<Diagnostic> report, SyntaxNode literalNode, MagicNumberBindings.Binding binding, int id)
 	{
 		Debug.Assert(literalNode is LiteralExpressionSyntax);
 
@@ -312,6 +246,15 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			literalNode.GetLocation(),
 			properties.ToImmutable(),
 			args
+		));
+	}
+
+	private void ReportBadTypeDiagnostic(Action<Diagnostic> report, SyntaxNode expressionNode, MagicNumberBindings.Binding expected)
+	{
+		report(Diagnostic.Create(
+			Diagnostics.BadIDType,
+			expressionNode.GetLocation(),
+			[expressionNode.ToString(), expected.ShortIdType]
 		));
 	}
 }

--- a/tModCodeAssist/tModCodeAssist/Analyzers/Diagnostics.cs
+++ b/tModCodeAssist/tModCodeAssist/Analyzers/Diagnostics.cs
@@ -20,6 +20,16 @@ public static class Diagnostics
 		isEnabledByDefault: true
 	);
 
+	public static readonly DiagnosticDescriptor BadIDType = new(
+		id: nameof(BadIDType),
+		title: CreateResourceString(nameof(Resources.BadIDTypeTitle)),
+		messageFormat: CreateResourceString(nameof(Resources.BadIDTypeMessageFormat)),
+		description: CreateResourceString(nameof(Resources.BadIDTypeDescription)),
+		category: Categories.Maintenance,
+		defaultSeverity: DiagnosticSeverity.Error,
+		isEnabledByDefault: true
+	);
+
 	public static readonly DiagnosticDescriptor SimplifyUnifiedRandom = new(
 		id: nameof(SimplifyUnifiedRandom),
 		title: CreateResourceString(nameof(Resources.SimplifyUnifiedRandomTitle)),

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -73,9 +73,9 @@ public static class MagicNumberBindings
 			AddBinding<DustID>("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldBinding(ctx));
 			AddBinding<TileID>("Terraria.Tile", "TileType", (ctx) => new FieldBinding(ctx));
 			AddBinding<WallID>("Terraria.Tile", "WallType", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx), typeof(byte));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx), typeof(byte));
-			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx), typeof(short));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx));
 
 			AddBinding<ItemID>("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0));
 			AddBinding<MessageID>("Terraria.NetMessage", "SendData", (ctx) => new MethodParameterBinding(ctx, 0));

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -73,9 +73,9 @@ public static class MagicNumberBindings
 			AddBinding<DustID>("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldBinding(ctx));
 			AddBinding<TileID>("Terraria.Tile", "TileType", (ctx) => new FieldBinding(ctx));
 			AddBinding<WallID>("Terraria.Tile", "WallType", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx), typeof(byte));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx), typeof(byte));
+			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx), typeof(short));
 
 			AddBinding<ItemID>("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0));
 			AddBinding<MessageID>("Terraria.NetMessage", "SendData", (ctx) => new MethodParameterBinding(ctx, 0));
@@ -98,12 +98,20 @@ public static class MagicNumberBindings
 		AddBinding(typeof(T), owningClassName, memberName, func);
 	}
 
-	private static void AddBinding(Type idClass, string owningClassName, string memberName, Func<Binding.CreationContext, Binding> func)
+	private static void AddBinding(Type idClass, string owningClassName, string memberName, Func<Binding.CreationContext, Binding> func, Type idType = null)
 	{
 		if (!searchCache.TryGetValue(idClass, out var search)) {
 			var field = idClass.GetField("Search", (BindingFlags)(-1));
-			Debug.Assert(field != null);
-			searchCache[idClass] = search = (IdDictionary)field.GetValue(null);
+			if (field != null) {
+				Debug.Assert(idType == null, "This idClass has a Search IdDictionary, please remove the idType argument");
+				search = (IdDictionary)field.GetValue(null);
+			}
+			else {
+				Debug.Assert(idType != null, "idType must be provided for classes without a Search IdDictionary");
+				search = IdDictionary.Create(idClass, idType);
+			}
+			Debug.Assert(search != null);
+			searchCache[idClass] = search;
 		}
 
 		var context = new Binding.CreationContext(owningClassName, memberName, idClass.Name, idClass.FullName, search);

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using ReLogic.Reflection;
+using Terraria.ID;
+
+namespace tModCodeAssist.Bindings;
+
+public static class MagicNumberBindings
+{
+	public abstract class Binding(Binding.CreationContext context)
+	{
+		public readonly record struct CreationContext(
+			in string OwningClassName,
+			in string MemberName,
+			in string ShortIdType,
+			in string FullIdType,
+			in IdDictionary Search
+		);
+
+		public string ShortIdType => context.ShortIdType;
+		public string FullIdType => context.FullIdType;
+		public IdDictionary Search => context.Search;
+	}
+	private sealed class FieldBinding(Binding.CreationContext context) : Binding(context)
+	{
+	}
+	private sealed class MethodParameterBinding(Binding.CreationContext context, int parameterOrder) : Binding(context)
+	{
+		public int ParameterOrder => parameterOrder;
+	}
+
+	// Foo
+	private static readonly SymbolDisplayFormat MethodNameOnlyDisplayFormat = SymbolDisplayFormat.MinimallyQualifiedFormat
+		.WithMemberOptions(SymbolDisplayMemberOptions.None)
+		.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
+		.WithParameterOptions(SymbolDisplayParameterOptions.None);
+
+	// Foo(int, System.Collections.Generic.List<int>)
+	private static readonly SymbolDisplayFormat MethodWithQualifiedParametersDisplayFormat = SymbolDisplayFormat.FullyQualifiedFormat
+		.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
+		.WithMemberOptions(SymbolDisplayMemberOptions.IncludeParameters)
+		.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
+		.WithParameterOptions(SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeExtensionThis);
+
+	private static readonly object @lock = new();
+	private static ConcurrentDictionary<Type, IdDictionary> searchCache;
+	private static ConcurrentDictionary<string, Dictionary<string, Binding>> bindingByMemberByOwningClass;
+
+	public static void PopulateBindings()
+	{
+		lock (@lock) {
+			if (bindingByMemberByOwningClass != null)
+				return;
+
+			searchCache = [];
+			bindingByMemberByOwningClass = [];
+
+			AddBinding<TileID>("Terraria.Item", "createTile", (ctx) => new FieldBinding(ctx));
+			AddBinding<ItemID>("Terraria.Item", "type", (ctx) => new FieldBinding(ctx));
+			AddBinding<ItemID>("Terraria.Player", "cursorItemIconID", (ctx) => new FieldBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.Item", "shoot", (ctx) => new FieldBinding(ctx));
+			AddBinding<ItemUseStyleID>("Terraria.Item", "useStyle", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(ItemRarityID), "Terraria.Item", "rare", (ctx) => new FieldBinding(ctx));
+			AddBinding<NPCID>("Terraria.NPC", "type", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(NetmodeID), "Terraria.Main", "netMode", (ctx) => new FieldBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.Projectile", "type", (ctx) => new FieldBinding(ctx));
+			AddBinding<DustID>("Terraria.ModLoader.ModBlockType", "DustType", (ctx) => new FieldBinding(ctx));
+			AddBinding<DustID>("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldBinding(ctx));
+			AddBinding<TileID>("Terraria.Tile", "TileType", (ctx) => new FieldBinding(ctx));
+			AddBinding<WallID>("Terraria.Tile", "WallType", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx));
+			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx));
+
+			AddBinding<ItemID>("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<MessageID>("Terraria.NetMessage", "SendData", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<DustID>("Terraria.Dust", "NewDust", (ctx) => new MethodParameterBinding(ctx, 3));
+			AddBinding<DustID>("Terraria.Dust", "NewDustDirect", (ctx) => new MethodParameterBinding(ctx, 3));
+			AddBinding<DustID>("Terraria.Dust", "NewDustPerfect", (ctx) => new MethodParameterBinding(ctx, 1));
+			AddBinding<ItemID>("Terraria.Recipe", "Create", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<TileID>("Terraria.Recipe", "AddTile", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<ItemID>("Terraria.Recipe", "AddIngredient", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<ItemID>("Terraria.Recipe", "HasResult", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<ItemID>("Terraria.ModLoader.Mod", "CreateRecipe", (ctx) => new MethodParameterBinding(ctx, 0));
+			AddBinding<ProjectileID>("Terraria.Projectile", "NewProjectile(Terraria.DataStructures.IEntitySource, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Vector2, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 3));
+			AddBinding<ProjectileID>("Terraria.Projectile", "NewProjectile(Terraria.DataStructures.IEntitySource, float, float, float, float, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 5));
+			AddBinding<ProjectileID>("Terraria.Projectile", "NewProjectileDirect(Terraria.DataStructures.IEntitySource, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Vector2, int, int, float, int, float, float, float)", (ctx) => new MethodParameterBinding(ctx, 3));
+		}
+	}
+
+	private static void AddBinding<T>(string owningClassName, string memberName, Func<Binding.CreationContext, Binding> func)
+	{
+		AddBinding(typeof(T), owningClassName, memberName, func);
+	}
+
+	private static void AddBinding(Type idClass, string owningClassName, string memberName, Func<Binding.CreationContext, Binding> func)
+	{
+		if (!searchCache.TryGetValue(idClass, out var search)) {
+			var field = idClass.GetField("Search", (BindingFlags)(-1));
+			Debug.Assert(field != null);
+			searchCache[idClass] = search = (IdDictionary)field.GetValue(null);
+		}
+
+		var context = new Binding.CreationContext(owningClassName, memberName, idClass.Name, idClass.FullName, search);
+		var binding = func(context);
+
+		if (bindingByMemberByOwningClass.TryGetValue(owningClassName, out var bindingByMember)) {
+			bindingByMember.Add(memberName, binding);
+		}
+		else {
+			bindingByMemberByOwningClass[owningClassName] = new() { [memberName] = binding };
+		}
+	}
+
+	public static bool TryGetBinding(ISymbol symbol, out Binding binding)
+	{
+		binding = null;
+
+		static string BuildQualifiedName(ISymbol symbol)
+		{
+			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+		}
+
+		if (symbol is IFieldSymbol fieldSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out Dictionary<string, Binding> bindingByMember)) {
+			if (bindingByMember.TryGetValue(fieldSymbol.MetadataName, out binding)) {
+				return true;
+			}
+		}
+		else if (symbol is IPropertySymbol propertySymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
+			if (bindingByMember.TryGetValue(propertySymbol.MetadataName, out binding)) {
+				return true;
+			}
+		}
+		else if (symbol is IMethodSymbol methodSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
+			if (bindingByMember.TryGetValue(methodSymbol.ToDisplayString(MethodNameOnlyDisplayFormat), out binding)) {
+				return true;
+			}
+
+			if (bindingByMember.TryGetValue(methodSymbol.ToDisplayString(MethodWithQualifiedParametersDisplayFormat), out binding)) {
+				return true;
+			}
+		}
+		else if (symbol is IParameterSymbol parameterSymbol) {
+			if (TryGetBinding(parameterSymbol.ContainingSymbol, out binding) && parameterSymbol.Ordinal == ((MethodParameterBinding)binding).ParameterOrder) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/tModCodeAssist/tModCodeAssist/Resources.Designer.cs
+++ b/tModCodeAssist/tModCodeAssist/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace tModCodeAssist {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Errors when incorrect ID type is used.
+        /// </summary>
+        internal static string BadIDTypeDescription {
+            get {
+                return ResourceManager.GetString("BadIDTypeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The expression &quot;{0}&quot; is not type of {1}.
+        /// </summary>
+        internal static string BadIDTypeMessageFormat {
+            get {
+                return ResourceManager.GetString("BadIDTypeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Incorrect ID type is used.
+        /// </summary>
+        internal static string BadIDTypeTitle {
+            get {
+                return ResourceManager.GetString("BadIDTypeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changes magic numbers into appropriate ID values.
         /// </summary>
         internal static string ChangeMagicNumberToIDDescription {

--- a/tModCodeAssist/tModCodeAssist/Resources.de.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.de.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.es.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.es.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.fr.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.fr.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.it.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.it.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.pl.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.pl.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.pt.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.pt.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BadIDTypeDescription" xml:space="preserve">
+    <value>Errors when incorrect ID type is used</value>
+  </data>
+  <data name="BadIDTypeMessageFormat" xml:space="preserve">
+    <value>The expression "{0}" is not type of {1}</value>
+  </data>
+  <data name="BadIDTypeTitle" xml:space="preserve">
+    <value>Incorrect ID type is used</value>
+  </data>
   <data name="ChangeMagicNumberToIDDescription" xml:space="preserve">
     <value>Changes magic numbers into appropriate ID values</value>
   </data>

--- a/tModCodeAssist/tModCodeAssist/Resources.ru.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.ru.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/Resources.zh.resx
+++ b/tModCodeAssist/tModCodeAssist/Resources.zh.resx
@@ -1,101 +1,120 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
 </root>

--- a/tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj
+++ b/tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj
@@ -36,10 +36,12 @@
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemRarityID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemUseStyleID.cs" LinkBase="$(SourceIDsPath)" />
+    <Compile Include="$(TMLSourcePath)\Terraria\ID\LiquidID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\MessageID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\MessageID.TML.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\NetmodeID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\NPCID.cs" LinkBase="$(SourceIDsPath)" />
+    <Compile Include="$(TMLSourcePath)\Terraria\ID\PaintID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ProjectileID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\TileID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\WallID.cs" LinkBase="$(SourceIDsPath)" />


### PR DESCRIPTION
##
adds analyzer for detecting "bad id types", e.g. `AddIngredient(TileID.Dirt)`, closes #4738
<img width="611" height="154" alt="BadIDType: The expression ItemID.OrichalcumAnvil is not type of TileID" src="https://github.com/user-attachments/assets/f19d43aa-b7a1-425f-8e78-73561953161a" />

not 100% sure whether or not cases such as this should be reported too:
```cs
const int a = 420;

item.type = a;
```
(`UnknownIDType` diagnostic perhaps? would require ID type attributes at very least)

##
additionally moves bindings stuff to its own file and re-adds bindings for `Tile.TileColor`, `Tile.WallColor` and `Tile.LiquidType` from https://github.com/tModLoader/tModLoader/commit/dbb8a6b4682f68373e544a9df41d8fc77b3952f1#diff-22928eba7d35b676db7176f2ec2c6ab674b5ef194eec9f4ac81a2f7fcde4b6cfR144-R146
