### PR TITLE
tModCodeAssist: Easy to follow AddBinding commit example

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleSwingingEnergySwordProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleSwingingEnergySwordProjectile.cs
@@ -242,7 +242,7 @@ namespace ExampleMod.Content.Projectiles
 
 		// Copied from Main.DrawPrettyStarSparkle() which is private
 		private static void DrawPrettyStarSparkle(float opacity, SpriteEffects dir, Vector2 drawPos, Color drawColor, Color shineColor, float flareCounter, float fadeInStart, float fadeInEnd, float fadeOutStart, float fadeOutEnd, float rotation, Vector2 scale, Vector2 fatness) {
-			Texture2D sparkleTexture = TextureAssets.Extra[98].Value;
+			Texture2D sparkleTexture = TextureAssets.Extra[ExtrasID.SharpTears].Value;
 			Color bigColor = shineColor * opacity * 0.5f;
 			bigColor.A = 0;
 			Vector2 origin = sparkleTexture.Size() / 2f;

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -152,6 +152,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 		await VerifyCS.Run(
 			"""
 			using Terraria;
+			using Terraria.GameContent;
 			using Terraria.ID;
 
 			ItemID.Sets.StaffMinionSlotsRequired[[|1309|]] = 2f;
@@ -161,9 +162,11 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			TileID.Sets.Conversion.Sand[[|461|]] = true;
 			WallID.Sets.Transparent[[|12|]] = true;
 			WallID.Sets.Conversion.Grass[[|65|]] = true;
+			_ = TextureAssets.Extra[[|98|]].Value;
 			""",
 			"""
 			using Terraria;
+			using Terraria.GameContent;
 			using Terraria.ID;
 			
 			ItemID.Sets.StaffMinionSlotsRequired[ItemID.SlimeStaff] = 2f;
@@ -173,6 +176,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			TileID.Sets.Conversion.Sand[TileID.SandDrip] = true;
 			WallID.Sets.Transparent[WallID.CopperBrick] = true;
 			WallID.Sets.Conversion.Grass[WallID.FlowerUnsafe] = true;
+			_ = TextureAssets.Extra[ExtrasID.SharpTears].Value;
 			""");
 	}
 }

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -77,6 +77,7 @@ public static class MagicNumberBindings
 			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx));
 			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx));
 			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx));
+			AddBinding<ExtrasID>("Terraria.GameContent.TextureAssets", "Extra", (ctx) => new FieldBinding(ctx), typeof(short));
 
 			AddBinding<ItemID>("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0));
 			AddBinding<MessageID>("Terraria.NetMessage", "SendData", (ctx) => new MethodParameterBinding(ctx, 0));

--- a/tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj
+++ b/tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj
@@ -33,6 +33,7 @@
     <!-- All ID classes from original Code Assist. TODO: Expand and include all ID classes from Terraria/ID/ directory -->
     <Compile Include="$(TMLSourcePath)\Terraria\ID\DustID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\DustID.TML.cs" LinkBase="$(SourceIDsPath)" />
+    <Compile Include="$(TMLSourcePath)\Terraria\ID\ExtrasID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemRarityID.cs" LinkBase="$(SourceIDsPath)" />
     <Compile Include="$(TMLSourcePath)\Terraria\ID\ItemUseStyleID.cs" LinkBase="$(SourceIDsPath)" />


### PR DESCRIPTION
___

This pull request serves as an example of adding new capabilities to the `ChangeMagicNumberToID` code fix in the `tModCodeAssist` code analyzer. The goal is that a modder can consult this PR to make their own PR to add a feature to `tModCodeAssist` by following the changes shown. The code changes are explained in more details on [the tModCodeAssist wiki page](https://github.com/tModLoader/tModLoader/wiki/tModCodeAssist#contributing-new-features-to-tmodcodeassist).

___

### What is the new feature?
Adds support to change `TextureAssets.Extra[int]` accesses to their corresponding `ExtrasID` entry.

### Why should this be part of tModLoader?
Modders adapting vanilla code might copy over usages of `TextureAssets.Extra`, the code fix will make the adapted code more readable.

### Are there alternative designs?
No.

### Sample usage for the new feature
```diff
-Texture2D sparkleTexture = TextureAssets.Extra[98].Value;
+Texture2D sparkleTexture = TextureAssets.Extra[ExtrasID.SharpTears].Value;
```

<img width="1428" height="216" alt="image" src="https://github.com/user-attachments/assets/caa021b6-bded-4df7-a6f4-cff22900a61b" />
