### PR TITLE
Add ModSystem.PostWorldLoad and TileID.Sets.ClearedOnWorldLoad

### DIFF
--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -184,6 +184,11 @@ partial class TileID
 		/// </summary>
 		public static bool[] NegatesFallDamage = Factory.CreateBoolSet(Cloud, RainCloud, SnowCloud, PoopBlock);
 
+		/// <summary>
+		/// If true, the tile will be destroyed after the world is loaded, before it is entered. Can be used to get rid of temporary tiles such as the block created by <see href="https://terraria.wiki.gg/wiki/Ice_Rod">Ice Rod</see>
+		/// </summary>
+		public static bool[] ClearedOnWorldLoad = Factory.CreateBoolSet(127, 504);
+
 		/// Functions to simplify modders adding a tile to the crimson, corruption, or jungle regardless of a remix world or not. Can still add manually as needed.
 		public static void AddCrimsonTile(ushort type, int strength = 1)
 		{

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -186,11 +186,12 @@ partial class TileID
 
 		// Values taken from WorldFile.ClearTempTiles
 		/// <summary>
-		/// If true, the tile will be destroyed after the world is loaded, before it is entered. Can be used to get rid of temporary tiles such as the block created by <see href="https://terraria.wiki.gg/wiki/Ice_Rod">Ice Rod</see>
-		/// <br/> The tile will NOT drop it's associated item, but it will trigger any effects invoked through <see cref="GlobalTile.KillTile(int, int, int, ref bool, ref bool, ref bool)"/> and <see cref="ModTile.KillTile(int, int, ref bool, ref bool, ref bool)"/>
-		/// <br/> The tile will NOT get destroyed in cases where certain tiles - such as non-empty chests - anchor onto it
+		/// If true, the tile will be destroyed after the world is loaded, before it is entered. Can be used to get rid of temporary tiles such as the block created by <see href="https://terraria.wiki.gg/wiki/Ice_Rod">Ice Rod</see>.
+		/// <br/><br/> The tile will NOT drop it's associated item, but it will trigger any effects invoked through <see cref="GlobalTile.KillTile(int, int, int, ref bool, ref bool, ref bool)"/> and <see cref="ModTile.KillTile(int, int, ref bool, ref bool, ref bool)"/>.
+		/// <br/><br/> The tile will NOT get destroyed in cases where certain tiles - such as non-empty chests - anchor onto it.
+		/// <br/><br/> Defaults to <see langword="false"/>.
 		/// </summary>
-		public static bool[] ClearedOnWorldLoad = Factory.CreateBoolSet(127, 504);
+		public static bool[] ClearedOnWorldLoad = Factory.CreateBoolSet(MagicalIceBlock, MysticSnakeRope);
 
 		/// Functions to simplify modders adding a tile to the crimson, corruption, or jungle regardless of a remix world or not. Can still add manually as needed.
 		public static void AddCrimsonTile(ushort type, int strength = 1)

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -184,8 +184,11 @@ partial class TileID
 		/// </summary>
 		public static bool[] NegatesFallDamage = Factory.CreateBoolSet(Cloud, RainCloud, SnowCloud, PoopBlock);
 
+		// Values taken from WorldFile.ClearTempTiles
 		/// <summary>
 		/// If true, the tile will be destroyed after the world is loaded, before it is entered. Can be used to get rid of temporary tiles such as the block created by <see href="https://terraria.wiki.gg/wiki/Ice_Rod">Ice Rod</see>
+		/// <br/> The tile will NOT drop it's associated item, but it will trigger any effects invoked through <see cref="GlobalTile.KillTile(int, int, int, ref bool, ref bool, ref bool)"/> and <see cref="ModTile.KillTile(int, int, ref bool, ref bool, ref bool)"/>
+		/// <br/> The tile will NOT get destroyed in cases where certain tiles - such as non-empty chests - anchor onto it
 		/// </summary>
 		public static bool[] ClearedOnWorldLoad = Factory.CreateBoolSet(127, 504);
 

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -58,17 +58,20 @@
  		}
  
  		return null;
-@@ -433,7 +_,10 @@
+@@ -433,8 +_,13 @@
  	{
  		for (int i = 0; i < Main.maxTilesX; i++) {
  			for (int j = 0; j < Main.maxTilesY; j++) {
 +				/*
  				if (Main.tile[i, j].type == 127 || Main.tile[i, j].type == 504)
-+				*/
-+				if (TileID.Sets.ClearedOnWorldLoad[Main.tile[i, j].type])
  					WorldGen.KillTile(i, j);
++				*/
++				// TML: noItem: true added to KillTile. Vanilla tiles in that set do not drop items, but modded ones might
++				if (TileID.Sets.ClearedOnWorldLoad[Main.tile[i, j].type])
++					WorldGen.KillTile(i, j, noItem: true);
  			}
  		}
+ 	}
 @@ -446,6 +_,8 @@
  		Main.checkXMas();
  		Main.checkHalloween();

--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -58,6 +58,17 @@
  		}
  
  		return null;
+@@ -433,7 +_,10 @@
+ 	{
+ 		for (int i = 0; i < Main.maxTilesX; i++) {
+ 			for (int j = 0; j < Main.maxTilesY; j++) {
++				/*
+ 				if (Main.tile[i, j].type == 127 || Main.tile[i, j].type == 504)
++				*/
++				if (TileID.Sets.ClearedOnWorldLoad[Main.tile[i, j].type])
+ 					WorldGen.KillTile(i, j);
+ 			}
+ 		}
 @@ -446,6 +_,8 @@
  		Main.checkXMas();
  		Main.checkHalloween();
@@ -78,6 +89,14 @@
  				if (num3 != 0)
  					WorldGen.loadFailed = true;
  				else
+@@ -502,6 +_,7 @@
+ 
+ 				ConvertOldTileEntities();
+ 				ClearTempTiles();
++				SystemLoader.PostWorldLoad();
+ 				WorldGen.gen = true;
+ 				GenVars.waterLine = Main.maxTilesY;
+ 				Liquid.QuickWater(2);
 @@ -652,6 +_,9 @@
  		if (Main.worldPathName == null)
  			return;

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -96,7 +96,7 @@ public abstract partial class ModSystem : ModType
 	/// <summary>
 	/// Called whenever a world is loaded, after <see cref="LoadWorldData"/>. <br/>
 	/// At this point, the world is ready to be entered by players, and all modded world data is loaded. <br/>
-	/// Can be used to migrate modded world data across different <see cref="ModSystem"/>s, or to modify <see cref="Main.tile"/>. For deleting tiles, use <see cref="TileID.Sets.ClearedOnWorldLoad"/> instead.
+	/// Can be used to migrate modded world data across different <see cref="ModSystem"/>s, or to modify <see cref="Main.tile"/>. For deleting temporary tiles, use <see cref="TileID.Sets.ClearedOnWorldLoad"/> instead.
 	/// </summary>
 	public virtual void PostWorldLoad() { }
 

--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -94,6 +94,13 @@ public abstract partial class ModSystem : ModType
 	public virtual void OnWorldLoad() { }
 
 	/// <summary>
+	/// Called whenever a world is loaded, after <see cref="LoadWorldData"/>. <br/>
+	/// At this point, the world is ready to be entered by players, and all modded world data is loaded. <br/>
+	/// Can be used to migrate modded world data across different <see cref="ModSystem"/>s, or to modify <see cref="Main.tile"/>. For deleting tiles, use <see cref="TileID.Sets.ClearedOnWorldLoad"/> instead.
+	/// </summary>
+	public virtual void PostWorldLoad() { }
+
+	/// <summary>
 	/// Called whenever a world is unloaded.
 	/// </summary>
 	public virtual void OnWorldUnload() { }

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.HookLists.cs
@@ -61,6 +61,8 @@ partial class SystemLoader
 
 	private static HookList HookOnWorldLoad = AddHook<Action>(s => s.OnWorldLoad);
 
+	private static HookList HookPostWorldLoad = AddHook<Action>(s => s.PostWorldLoad);
+
 	private static HookList HookOnWorldUnload = AddHook<Action>(s => s.OnWorldUnload);
 
 	private static HookList HookClearWorld = AddHook<Action>(s => s.ClearWorld);

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -167,7 +167,7 @@ public static partial class SystemLoader
 
 	public static void PostWorldLoad()
 	{
-		foreach (var system in HookOnWorldLoad.Enumerate()) {
+		foreach (var system in HookPostWorldLoad.Enumerate()) {
 			try {
 				system.PostWorldLoad();
 			}

--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -165,6 +165,18 @@ public static partial class SystemLoader
 		}
 	}
 
+	public static void PostWorldLoad()
+	{
+		foreach (var system in HookOnWorldLoad.Enumerate()) {
+			try {
+				system.PostWorldLoad();
+			}
+			catch (Exception e) {
+				throw new CustomModDataException(system.Mod, e.Message, e);
+			}
+		}
+	}
+
 	public static void OnWorldUnload()
 	{
 		foreach (var system in HookOnWorldUnload.Enumerate()) {


### PR DESCRIPTION
### What is the new feature?

Two related features:
`ModSystem.PostWorldLoad` and `TileID.Sets.ClearedOnWorldLoad`

### Why should this be part of tModLoader?
`TileID.Sets.ClearedOnWorldLoad` is simply allowing modders to specify tiles that should be cleared on world load. Vanilla precedent are the tiles placed by Ice Rod and Snake Charmer's Flute.

`ModSystem.PostWorldLoad` is a more general application of the former, mainly for the timing, as `ModSystem.OnWorldLoad` may be too early. The use cases are:
1. Acting on fully loaded data across all `ModSystem`s for the purposes of migration/refactoring
2. Acting on fully loaded world including modded tiles and walls (such as https://discord.com/channels/103110554649894912/534215632795729922/1413723137702498458 which I saw 1 day after creating this PR)
3. Other modifications to the world beyond what `TileID.Sets.ClearedOnWorldLoad` provides 

### Are there alternative designs?
`TileID.Sets.ClearedOnWorldLoad` has a few caveats which I documented. First, since tiles in this set will get `WorldGen.KillTile` called on them, if they have a registered item drop, that item will drop. Moreso, the hooks for `Global/Modtile.KillTile` will get called aswell. Since the hook is supposed to be used for temporary tiles only, the modder likely will not specify an item drop for it in the first place. But if this is used for debugging purposes, or used by a third-party mod to i.e. remove tiles from another mod, this will be handy, so I added `noItem: true`. As said before, this does not affect vanilla behavior as the tiles that are in this set don't have an item drop in the first place.
The `KillTile` hook call should not be a downside, given that many times, important code is inside `KillTile` intended to be ran by the modder if the tile is destroyed. An alternative would be to reset the tile directly, but that has implications on behaviors related to indestructible tiles that depend on the tile in question being active, such as a placed chest or mannequin.

Temporary tiles would need to manually insert themselves into `AnchorInvalidTiles` of all `TileObjectData`s which also contains `MagicalIceBlock` to avoid the above mentioned issue of anchoring for chests and such, which is cumbersome from a modder's perspective, so a follow-up PR may be necessary if there is interest.

Maybe an oversight in vanilla, but `WorldGen.KillTile` is called on the tile regardless if it's active/`HasTile` or not, maybe the check should be added?

`ModSystem.PostWorldLoad` is called immediately after `WorldGen.ClearTempTiles`, when that isn't actually the last step before the world finishes loading. Things like liquid settling, and various weather/environment flags are also set afterwards. The hook could be moved to the invocation site of `WorldFile.OnWorldLoad` instead. However, an argument can be made that since liquids depend on the tiles, modifications to tiles should happen before liquids settle.

One may argue that subscribing to `WorldFile.OnWorldLoad` is sufficient, but such hooks exist in TML despite similar events existing in vanilla, such as `OnEnterWorld`. The main benefit is removal for the need to manually unsubscribe from the event, thus reducing boilerplate.

### Sample usage for the new feature
```cs
//ModTile
public override void SetStaticDefaults() => TileID.Sets.ClearedOnWorldLoad[Type] = true;

//Tile conversion example
//ModSystem
public override void PostWorldLoad() {
	for (int x = 0; x < Main.maxTilesX; x++) {
		for (int y = 0; y < Main.maxTilesY; y++) {
			Tile t = Main.tile[x, y];
			if (t.TileType == TileID.Tin) {
				//assuming framing matches
				t.TileType = (ushort)ModContent.TileType<ExampleOre>();
			}
		}
	}
}

//Data migration between ModSystems example
//ModSystem1
//Mirrors the tag loaded in LoadWorldData
public static TagCompound LoadedTag { get; private set; }
public override void LoadWorldData(TagCompound tag) => LoadedTag = tag;

//ModSystem2
public override void PostLoadWorld() => HandleMigration(ModSystem1.LoadedTag);
public void HandleMigration(TagCompound tag) => myNewData = tag.Get("myOldData");
```

### ExampleMod updates
ExampleMod has no temporary tiles or features that would use such.

### Porting Notes
Nothing, besides modders previously implementing this via detours, IL editing, or subscribing and unsubscribing to `WorldFile.OnWorldLoad`, they can get rid of that and use the new features in this PR instead.
