### PR TITLE
Fix equals expression for Tile properties

### DIFF
--- a/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
@@ -37,6 +37,7 @@ public class BadIDTypeUnitTest
 			using Terraria.ID;
 
 			_ = new Item().type == {|BadIDType:TileID.Dirt|};
+			_ = Main.tile[10, 20].TileType == {|BadIDType:ItemID.GoldOre|}; // ref property
 			"""
 			);
 	}

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -103,6 +103,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 
 			_ = new Item().type == [|1|];
 			_ = new Projectile().type == [|444|];
+			_ = Main.tile[10, 20].TileType == [|8|]; // ref property
 			""",
 			"""
 			using Terraria;
@@ -110,6 +111,7 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			
 			_ = new Item().type == ItemID.IronPickaxe;
 			_ = new Projectile().type == ProjectileID.Xenopopper;
+			_ = Main.tile[10, 20].TileType == TileID.Gold; // ref property
 			""");
 	}
 

--- a/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
+++ b/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
@@ -71,21 +71,21 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			var node = (BinaryExpressionSyntax)ctx.Node;
 
 			if (IsNumber(node.Right)) {
-				if (ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken).Symbol as IFieldSymbol is not { } leftSymbol) return;
+				if (ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken).Symbol is not { } leftSymbol) return;
 				if (!MagicNumberBindings.TryGetBinding(leftSymbol, out var binding)) return;
 
 				TryReportVariedDiagnostics(ctx.ReportDiagnostic, ctx.SemanticModel, node.Right, binding, ctx.CancellationToken);
 			}
 			else if (IsNumber(node.Left)) {
-				if (ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken).Symbol as IFieldSymbol is not { } rightSymbol) return;
+				if (ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken).Symbol is not { } rightSymbol) return;
 				if (!MagicNumberBindings.TryGetBinding(rightSymbol, out var binding)) return;
 
 				TryReportVariedDiagnostics(ctx.ReportDiagnostic, ctx.SemanticModel, node.Left, binding, ctx.CancellationToken);
 			}
 			else {
 				MagicNumberBindings.Binding leftBinding = null, rightBinding = null;
-				_ = ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken).Symbol as IFieldSymbol is { } leftSymbol && MagicNumberBindings.TryGetBinding(leftSymbol, out leftBinding);
-				_ = ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken).Symbol as IFieldSymbol is { } rightSymbol && MagicNumberBindings.TryGetBinding(rightSymbol, out rightBinding);
+				_ = ctx.SemanticModel.GetSymbolInfo(node.Left, ctx.CancellationToken).Symbol is { } leftSymbol && MagicNumberBindings.TryGetBinding(leftSymbol, out leftBinding);
+				_ = ctx.SemanticModel.GetSymbolInfo(node.Right, ctx.CancellationToken).Symbol is { } rightSymbol && MagicNumberBindings.TryGetBinding(rightSymbol, out rightBinding);
 
 				switch (leftBinding, rightBinding) {
 					case (not null, not null):


### PR DESCRIPTION
Fix for the following. Any `==`-style magic number fix wasn't working for Tile.Tile/WallType.

<img width="556" height="761" alt="NVIDIA_Share_2025-09-09_13-38-33" src="https://github.com/user-attachments/assets/29097d7b-7a39-4800-aeee-b21587de98bb" />

```cs

bool a = false;

Item item = new Item();
item.useStyle = 5;
if (item.useStyle == 5) { }
a = item.useStyle == 5;

Tile tile = Main.tile[3, 2];
tile.TileType = ItemID.GoldOre;
tile.TileType = 3;
if (tile.TileType == 3) { }
if (tile.TileType == ItemID.Acorn) { }
a = tile.TileType == 3;
a = tile.TileType == ItemID.GoldOre;

a = tile.WallType == 3;
a = tile.WallType == ItemID.GoldOre;
if (tile.WallType == WallID.EbonstoneUnsafe) { }
if (tile.WallType == ItemID.Acorn) { }

_ = Main.tile[10, 20].TileType == 27;
_ = Main.tile[10, 20].TileType != 27;

switch (tile.TileType) {
	case 3:
		break;
	case ItemID.Acorn:
		break;
}
```