### PR TITLE
Fix UIScrollbar hovering when obscured by another element

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIScrollbar.cs.patch
@@ -18,3 +18,13 @@
  	{
  		spriteBatch.Draw(texture, new Rectangle(dimensions.X, dimensions.Y - 6, dimensions.Width, 6), new Rectangle(0, 0, texture.Width, 6), color);
  		spriteBatch.Draw(texture, new Rectangle(dimensions.X, dimensions.Y, dimensions.Width, dimensions.Height), new Rectangle(0, 6, texture.Width, 4), color);
+@@ -83,7 +_,8 @@
+ 		Rectangle handleRectangle = GetHandleRectangle();
+ 		Vector2 mousePosition = UserInterface.ActiveInstance.MousePosition;
+ 		bool isHoveringOverHandle = _isHoveringOverHandle;
++		// tML: Added IsMouseHovering to account for obstructing UI elements such as popups
+-		_isHoveringOverHandle = handleRectangle.Contains(new Point((int)mousePosition.X, (int)mousePosition.Y));
++		_isHoveringOverHandle = IsMouseHovering && handleRectangle.Contains(new Point((int)mousePosition.X, (int)mousePosition.Y));
+ 		if (!isHoveringOverHandle && _isHoveringOverHandle && Main.hasFocus)
+ 			SoundEngine.PlaySound(12);
+ 


### PR DESCRIPTION
### What is the bug?
`UIScrollbar` handle acts like it is hovered even if an element is blocking it.

### How did you fix the bug?
By checking if the entire `UIScrollbar` is hovered as well instead of just the handle.

### Are there alternatives to your fix?
No.

Video demo here:
https://discord.com/channels/103110554649894912/445276626352209920/1416600331856515122