### PR TITLE
Fix tML Launch Config for Rider

### DIFF
--- a/patches/tModLoader/Terraria/Properties/launchSettings.json.patch
+++ b/patches/tModLoader/Terraria/Properties/launchSettings.json.patch
@@ -4,7 +4,7 @@
    "profiles": {
      "Terraria": {
        "commandName": "Executable",
-+      "executablePath": "dotnet",
++      "executablePath": "$(DotNetName)",
 -      "executablePath": "$(TerrariaSteamPath)/$(OutputName).exe",
 +      "commandLineArgs": "$(OutputName).dll",
 -      "workingDirectory": "$(TerrariaSteamPath)"
@@ -12,26 +12,27 @@
      },
      "Terraria Server": {
        "commandName": "Executable",
-       "executablePath": "dotnet",
+-      "executablePath": "dotnet",
++      "executablePath": "$(DotNetName)",
        "commandLineArgs": "$(OutputName).dll -server",
 -      "workingDirectory": "$(TerrariaSteamPath)"
 +      "workingDirectory": "$(tModLoaderSteamPath)"
 +    },
 +    "Terraria GoG": {
 +      "commandName": "Executable",
-+      "executablePath": "dotnet",
++      "executablePath": "$(DotNetName)",
 +      "commandLineArgs": "$(OutputName).dll -nosteam",
 +      "workingDirectory": "$(tModLoaderSteamPath)"
 +    },
 +    "Terraria Steam Server": {
 +      "commandName": "Executable",
-+      "executablePath": "dotnet",
++      "executablePath": "$(DotNetName)",
 +      "commandLineArgs": "$(OutputName).dll -server -steam -lobby friends -friendsoffriends",
 +      "workingDirectory": "$(tModLoaderSteamPath)"
 +    },
 +    "tModPorter ExampleMod.csproj": {
 +      "commandName": "Executable",
-+      "executablePath": "dotnet",
++      "executablePath": "$(DotNetName)",
 +      "commandLineArgs": "$(OutputName).dll -tModPorter \"$(ProjectDir)/../../../ExampleMod/ExampleMod.csproj\"",
 +      "workingDirectory": "$(tModLoaderSteamPath)"
      }

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -8,7 +8,7 @@
  
  	<!-- General -->
  	<PropertyGroup>
-@@ -11,59 +_,90 @@
+@@ -11,59 +_,94 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -33,6 +33,10 @@
  		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
  		<CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
 +		<ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
++
++		<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
++		<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
++		<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
 +	</PropertyGroup>
 +
 +	<!-- Versioning -->


### PR DESCRIPTION
### What is the bug?
Rider cannot launch tML without modifying `launchSettings.json` because `dotnet.exe` needs to be run instead of `dotnet`.

### How did you fix the bug?
By adding `$(DotNetName)` to `launchSettings.json` and `Terraria.csproj` (copied from `tMLMod.targets`).

### Are there alternatives to your fix?
No.
