### PR TITLE
Preserve backwards compatibility for MonoMod hooks when a method receives a new overload, inherit Obsolete from origin method

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -71,25 +71,12 @@ public static class MonoModHooks
 			}
 
 			Logging.tML.Debug(msg);
-
-			/*
-			// Issue, not actually called anymore since No-op
-			if(info.Entry.GetCustomAttribute<ObsoleteAttribute>() != null) {
-				Logging.tML.Error($"WARNING: The method {StringRep(info.Method.Method)} is Obsolete. Report this issue to the {owner.GetName().Name} author.");
-			}
-			*/
 		};
 
 		DetourManager.ILHookApplied += (info) => {
 			var owner = info.ManipulatorMethod.DeclaringType.Assembly;
 			GetDetourList(owner).ilHooks.Add(info);
 			Logging.tML.Debug($"ILHook {StringRep(info.Method.Method)} added by {owner.GetName().Name}");
-
-			/*
-			if (info.ManipulatorMethod.GetCustomAttribute<ObsoleteAttribute>() != null) {
-				Logging.tML.Error($"WARNING: The method {StringRep(info.Method.Method)} is Obsolete. Report this issue to the {owner.GetName().Name} author.");
-			}
-			*/
 		};
 		
 		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (MethodBase method, Delegate modded) => {

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -71,12 +71,30 @@ public static class MonoModHooks
 			}
 
 			Logging.tML.Debug(msg);
+
+			/*
+			// Issue, not actually called anymore since No-op
+			if(info.Entry.GetCustomAttribute<ObsoleteAttribute>() != null) {
+				Logging.tML.Error($"WARNING: The method {StringRep(info.Method.Method)} is Obsolete. Report this issue to the {owner.GetName().Name} author.");
+			}
+			*/
 		};
 
 		DetourManager.ILHookApplied += (info) => {
 			var owner = info.ManipulatorMethod.DeclaringType.Assembly;
 			GetDetourList(owner).ilHooks.Add(info);
 			Logging.tML.Debug($"ILHook {StringRep(info.Method.Method)} added by {owner.GetName().Name}");
+
+			/*
+			if (info.ManipulatorMethod.GetCustomAttribute<ObsoleteAttribute>() != null) {
+				Logging.tML.Error($"WARNING: The method {StringRep(info.Method.Method)} is Obsolete. Report this issue to the {owner.GetName().Name} author.");
+			}
+			*/
+		};
+
+		// Issue, type Action<> is defined in an assembly not imported
+		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (s) => {
+			Logging.tML.Debug($"OnObsoleteHookSubscribed {s}");
 		};
 
 		isInitialized = true;

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -91,11 +91,10 @@ public static class MonoModHooks
 			}
 			*/
 		};
-
-		// Issue, type Action<> is defined in an assembly not imported
-		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (s) => {
-			Logging.tML.Debug($"OnObsoleteHookSubscribed {s}");
-		};
+		  
+		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (MethodBase s) => {
+			Logging.tML.Debug($"OnObsoleteHookSubscribed {StringRep(s)}");
+		}; 
 
 		isInitialized = true;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MonoModHooks.cs
@@ -91,10 +91,11 @@ public static class MonoModHooks
 			}
 			*/
 		};
-		  
-		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (MethodBase s) => {
-			Logging.tML.Debug($"OnObsoleteHookSubscribed {StringRep(s)}");
-		}; 
+		
+		TerrariaHooks.Logging.OnObsoleteHookSubscribed += (MethodBase method, Delegate modded) => {
+			var owner = modded.Method.DeclaringType.Assembly;
+			Logging.tML.Error($"The method {StringRep(method)} is Obsolete. It was hooked by the {StringRep(modded.Method)} method of {owner.GetName().Name}");
+		};
 
 		isInitialized = true;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/OriginalOverloadAttribute.cs
+++ b/patches/tModLoader/Terraria/ModLoader/OriginalOverloadAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Terraria.ModLoader;
+
+/// <summary>
+/// Indicates that a method matching multiple overloads is the original method. This should be added to the original method when adding a 2nd overload to prevent breaking binary and source compatibility. The original method event will be generated as if there were not multiple overloads (in addition to the new fully qualified event), preserving the old simplified event name.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal class OriginalOverloadAttribute : Attribute
+{
+}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1930,7 +1930,7 @@
  			return false;
  
  		if (!InWorld(i, j, 2))
-@@ -39342,7 +_,31 @@
+@@ -39342,7 +_,32 @@
  		return true;
  	}
  
@@ -1938,6 +1938,7 @@
 +	// legacy overload for abi compat, remove in 1.4.5
 +	/// <inheritdoc cref="Convert(int, int, int, int, bool, bool)"/>
 +	[OriginalOverload]
++	[Obsolete("Use Convert(int, int, int, int, bool, bool) instead")]
 +	public static void Convert(int i, int j, int conversionType, int size) => Convert(i, j, conversionType, size, tiles: true, walls: true);
 +
 +	/// <summary>

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -1930,13 +1930,14 @@
  			return false;
  
  		if (!InWorld(i, j, 2))
-@@ -39342,7 +_,30 @@
+@@ -39342,7 +_,31 @@
  		return true;
  	}
  
 -	public static void Convert(int i, int j, int conversionType, int size = 4)
 +	// legacy overload for abi compat, remove in 1.4.5
 +	/// <inheritdoc cref="Convert(int, int, int, int, bool, bool)"/>
++	[OriginalOverload]
 +	public static void Convert(int i, int j, int conversionType, int size) => Convert(i, j, conversionType, size, tiles: true, walls: true);
 +
 +	/// <summary>

--- a/setup/Core/HookGenTask.cs
+++ b/setup/Core/HookGenTask.cs
@@ -27,6 +27,12 @@ namespace Terraria.ModLoader.Setup.Core
 				throw new FileNotFoundException($"\"{TmlAssemblyPath}\" does not exist.");
 			}
 
+			DateTime buildTimestamp = File.GetLastWriteTime(TmlAssemblyPath);
+			int buildDaysAgo = (DateTime.Now - buildTimestamp).Days;
+			if (buildDaysAgo > 1) {
+				throw new Exception($"tModLoader.dll was last modified on {buildTimestamp} ({buildDaysAgo} day(s) ago). HookGen is run on the release build, make sure to build release.");
+			}
+
 			// Hopefully this always works since we should be running on a system install of a .NET Core sdk
 			var dotnetPath = Path.GetFullPath(Path.GetDirectoryName(typeof(object).Assembly.Location) + "/../../..");
 			var dotnetRefsLocation = Path.Combine(dotnetPath, $"packs/Microsoft.NETCore.App.Ref/{Environment.Version}/ref/{DotnetTargetVersion}");

--- a/setup/Core/HookGenTask.cs
+++ b/setup/Core/HookGenTask.cs
@@ -80,6 +80,8 @@ namespace Terraria.ModLoader.Setup.Core
 				HookPrivate = true,
 			};
 
+			gen.GenerateObsoleteLogging();
+
 			foreach (var type in mm.Module.Types) {
 				cancellationToken.ThrowIfCancellationRequested();
 

--- a/setup/Core/HookGenTask.cs
+++ b/setup/Core/HookGenTask.cs
@@ -80,7 +80,7 @@ namespace Terraria.ModLoader.Setup.Core
 				HookPrivate = true,
 			};
 
-			gen.GenerateObsoleteLogging();
+			gen.GenerateObsoleteLogging(mm);
 
 			foreach (var type in mm.Module.Types) {
 				cancellationToken.ThrowIfCancellationRequested();
@@ -115,7 +115,7 @@ namespace Terraria.ModLoader.Setup.Core
 			type.Namespace = type.Namespace[Math.Min(3, type.Namespace.Length)..];
 		}
 
-		private class ProgressReportingMonoModder : MonoModder
+		public class ProgressReportingMonoModder : MonoModder
 		{
 			private IWorkItemProgress progress;
 

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -315,7 +315,8 @@ namespace MonoMod.RuntimeDetour.HookGen
             il = addHook.Body.GetILProcessor();
             if (obsolete) {
                 if (LogObsoleteHookSubscribed != null) {
-                    il.Emit(OpCodes.Ldstr, "Warning");
+                    il.Emit(OpCodes.Ldtoken, methodRef);
+                    il.Emit(OpCodes.Call, m_GetMethodFromHandle);
                     il.Emit(OpCodes.Call, LogObsoleteHookSubscribed);
                 }
                 il.Emit(OpCodes.Ret);
@@ -661,11 +662,11 @@ namespace MonoMod.RuntimeDetour.HookGen
             namespace TerrariaHooks {
                 public static class Logging
                 {
-                    public static Action<string> OnObsoleteHookSubscribed;
+                    public static Action<MethodBase> OnObsoleteHookSubscribed;
 
-                    public static void LogObsoleteHookSubscribed(string message) {
+                    public static void LogObsoleteHookSubscribed(MethodBase methodBase) {
                         if(OnObsoleteHookSubscribed != null) {
-                            OnObsoleteHookSubscribed.Invoke(message);
+                            OnObsoleteHookSubscribed.Invoke(methodBase);
                         }
                     }
                 }
@@ -675,7 +676,9 @@ namespace MonoMod.RuntimeDetour.HookGen
             var cls_Logging_0 = new TypeDefinition("TerrariaHooks", "Logging", TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed, OutputModule.TypeSystem.Object);
             OutputModule.Types.Add(cls_Logging_0);
 
-            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(modder.FindType("System.Action`1").Resolve().MakeGenericInstanceType(OutputModule.TypeSystem.String)));
+            OutputModule.ImportReference(modder.FindType("System.Reflection.MethodBase").Resolve());
+
+            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(modder.FindType("System.Action`1").Resolve().MakeGenericInstanceType(modder.FindType("System.Reflection.MethodBase").Resolve())));
             //var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(OutputModule.TypeSystem.String)); // Generated code that causes assembly reference issue
 
             cls_Logging_0.Fields.Add(fld_OnObsoleteHookSubscribed_1);
@@ -686,9 +689,9 @@ namespace MonoMod.RuntimeDetour.HookGen
             md_LogObsoleteHookSubscribed_2.Body.InitLocals = true;
             var il_LogObsoleteHookSubscribed_3 = md_LogObsoleteHookSubscribed_2.Body.GetILProcessor();
 
-            //Parameters of 'public static void LogObsoleteHookSubscribed(string message) {...'
-            var p_Message_4 = new ParameterDefinition("message", ParameterAttributes.None, OutputModule.TypeSystem.String);
-            md_LogObsoleteHookSubscribed_2.Parameters.Add(p_Message_4);
+            //Parameters of 'public static void LogObsoleteHookSubscribed(MethodBase methodBase) {...'
+            var p_MethodBase_4 = new ParameterDefinition("methodBase", ParameterAttributes.None, OutputModule.ImportReference(modder.FindType("System.Reflection.MethodBase").Resolve()));
+            md_LogObsoleteHookSubscribed_2.Parameters.Add(p_MethodBase_4);
 
             LogObsoleteHookSubscribed = md_LogObsoleteHookSubscribed_2; // Store reference for later
 
@@ -702,10 +705,10 @@ namespace MonoMod.RuntimeDetour.HookGen
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Brfalse, lbl_ElseEntryPoint_5);
             //if body
 
-            //OnObsoleteHookSubscribed.Invoke(message);
+            //OnObsoleteHookSubscribed.Invoke(methodBase);
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1);
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldarg_0);
-            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Callvirt, OutputModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.String>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.String")));
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Callvirt, OutputModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.Reflection.MethodBase>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.Reflection.MethodBase")));
             var lbl_ElseEnd_6 = il_LogObsoleteHookSubscribed_3.Create(OpCodes.Nop);
             il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEntryPoint_5);
             il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEnd_6);

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -235,6 +235,11 @@ namespace MonoMod.RuntimeDetour.HookGen
                 {
                     suffix = false;
                 }
+                if (skipOverloadSuffix) {
+                    if (overloads.Any(x => x.HasCustomAttribute("Terraria.ModLoader.OriginalOverloadAttribute"))) {
+                          throw new Exception($"Multiple overloads for {method.DeclaringType.Name}.{method.Name} with OriginalOverloadAttribute");
+                    }
+                }
             }
 
             if (suffix)

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -186,8 +186,11 @@ namespace MonoMod.RuntimeDetour.HookGen
 
             var add = false;
 
-            foreach (var method in type.Methods)
+            foreach (var method in type.Methods) {
                 add |= GenerateFor(hookType, hookILType, method);
+                if (method.HasCustomAttribute("Terraria.ModLoader.OriginalOverloadAttribute"))
+                    add |= GenerateFor(hookType, hookILType, method, skipOverloadSuffix: true);
+            }
 
             foreach (var nested in type.NestedTypes)
             {
@@ -205,7 +208,7 @@ namespace MonoMod.RuntimeDetour.HookGen
             }
         }
 
-        public bool GenerateFor(TypeDefinition hookType, TypeDefinition hookILType, MethodDefinition method)
+        public bool GenerateFor(TypeDefinition hookType, TypeDefinition hookILType, MethodDefinition method, bool skipOverloadSuffix = false)
         {
             if (method.HasGenericParameters ||
                 method.IsAbstract ||
@@ -228,7 +231,7 @@ namespace MonoMod.RuntimeDetour.HookGen
             if (suffix)
             {
                 overloads = method.DeclaringType.Methods.Where(other => !other.HasGenericParameters && HookGenerator.GetFriendlyName(other) == name && other != method);
-                if (!overloads.Any())
+                if (!overloads.Any() || skipOverloadSuffix)
                 {
                     suffix = false;
                 }

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -279,6 +279,8 @@ namespace MonoMod.RuntimeDetour.HookGen
                 name = nameTmp;
             }
 
+            bool obsolete = method.HasCustomAttribute("System.ObsoleteAttribute"); // Do we need to check if error is true?
+
             // TODO: Fix possible conflict when other members with the same names exist.
 
             var delOrig = GenerateDelegateFor(method);
@@ -310,13 +312,19 @@ namespace MonoMod.RuntimeDetour.HookGen
             addHook.Parameters.Add(new ParameterDefinition(null, ParameterAttributes.None, delHook));
             addHook.Body = new MethodBody(addHook);
             il = addHook.Body.GetILProcessor();
-            il.Emit(OpCodes.Ldtoken, methodRef);
-            il.Emit(OpCodes.Call, m_GetMethodFromHandle);
-            il.Emit(OpCodes.Ldarg_0);
-            endpointMethod = new GenericInstanceMethod(m_Add);
-            endpointMethod.GenericArguments.Add(delHook);
-            il.Emit(OpCodes.Call, endpointMethod);
-            il.Emit(OpCodes.Ret);
+            if (obsolete) {
+                // TODO: How to log mods using this method still?
+                il.Emit(OpCodes.Ret);
+            }
+            else {
+                il.Emit(OpCodes.Ldtoken, methodRef);
+                il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                il.Emit(OpCodes.Ldarg_0);
+                endpointMethod = new GenericInstanceMethod(m_Add);
+                endpointMethod.GenericArguments.Add(delHook);
+                il.Emit(OpCodes.Call, endpointMethod);
+                il.Emit(OpCodes.Ret);
+            }
             hookType.Methods.Add(addHook);
 
             var removeHook = new MethodDefinition(
@@ -327,13 +335,18 @@ namespace MonoMod.RuntimeDetour.HookGen
             removeHook.Parameters.Add(new ParameterDefinition(null, ParameterAttributes.None, delHook));
             removeHook.Body = new MethodBody(removeHook);
             il = removeHook.Body.GetILProcessor();
-            il.Emit(OpCodes.Ldtoken, methodRef);
-            il.Emit(OpCodes.Call, m_GetMethodFromHandle);
-            il.Emit(OpCodes.Ldarg_0);
-            endpointMethod = new GenericInstanceMethod(m_Remove);
-            endpointMethod.GenericArguments.Add(delHook);
-            il.Emit(OpCodes.Call, endpointMethod);
-            il.Emit(OpCodes.Ret);
+            if (obsolete) {
+                il.Emit(OpCodes.Ret);
+            }
+            else { 
+                il.Emit(OpCodes.Ldtoken, methodRef);
+                il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                il.Emit(OpCodes.Ldarg_0);
+                endpointMethod = new GenericInstanceMethod(m_Remove);
+                endpointMethod.GenericArguments.Add(delHook);
+                il.Emit(OpCodes.Call, endpointMethod);
+                il.Emit(OpCodes.Ret);
+            }
             hookType.Methods.Add(removeHook);
 
             var evHook = new EventDefinition(name, EventAttributes.None, delHook)
@@ -341,6 +354,9 @@ namespace MonoMod.RuntimeDetour.HookGen
                 AddMethod = addHook,
                 RemoveMethod = removeHook
             };
+            if (obsolete) {
+                evHook.CustomAttributes.Add(GenerateObsolete("The hooked method is Obsolete, this detour should not be used.", true));
+            }
             hookType.Events.Add(evHook);
 
             #endregion
@@ -355,13 +371,18 @@ namespace MonoMod.RuntimeDetour.HookGen
             addIL.Parameters.Add(new ParameterDefinition(null, ParameterAttributes.None, t_ILManipulator));
             addIL.Body = new MethodBody(addIL);
             il = addIL.Body.GetILProcessor();
-            il.Emit(OpCodes.Ldtoken, methodRef);
-            il.Emit(OpCodes.Call, m_GetMethodFromHandle);
-            il.Emit(OpCodes.Ldarg_0);
-            endpointMethod = new GenericInstanceMethod(m_Modify);
-            endpointMethod.GenericArguments.Add(delHook);
-            il.Emit(OpCodes.Call, endpointMethod);
-            il.Emit(OpCodes.Ret);
+            if (obsolete) {
+                il.Emit(OpCodes.Ret);
+            }
+            else {
+                il.Emit(OpCodes.Ldtoken, methodRef);
+                il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                il.Emit(OpCodes.Ldarg_0);
+                endpointMethod = new GenericInstanceMethod(m_Modify);
+                endpointMethod.GenericArguments.Add(delHook);
+                il.Emit(OpCodes.Call, endpointMethod);
+                il.Emit(OpCodes.Ret);
+            }
             hookILType.Methods.Add(addIL);
 
             var removeIL = new MethodDefinition(
@@ -372,13 +393,18 @@ namespace MonoMod.RuntimeDetour.HookGen
             removeIL.Parameters.Add(new ParameterDefinition(null, ParameterAttributes.None, t_ILManipulator));
             removeIL.Body = new MethodBody(removeIL);
             il = removeIL.Body.GetILProcessor();
-            il.Emit(OpCodes.Ldtoken, methodRef);
-            il.Emit(OpCodes.Call, m_GetMethodFromHandle);
-            il.Emit(OpCodes.Ldarg_0);
-            endpointMethod = new GenericInstanceMethod(m_Unmodify);
-            endpointMethod.GenericArguments.Add(delHook);
-            il.Emit(OpCodes.Call, endpointMethod);
-            il.Emit(OpCodes.Ret);
+            if (obsolete) {
+                il.Emit(OpCodes.Ret);
+            }
+            else {
+                il.Emit(OpCodes.Ldtoken, methodRef);
+                il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                il.Emit(OpCodes.Ldarg_0);
+                endpointMethod = new GenericInstanceMethod(m_Unmodify);
+                endpointMethod.GenericArguments.Add(delHook);
+                il.Emit(OpCodes.Call, endpointMethod);
+                il.Emit(OpCodes.Ret);
+            }
             hookILType.Methods.Add(removeIL);
 
             var evIL = new EventDefinition(name, EventAttributes.None, t_ILManipulator)
@@ -386,6 +412,9 @@ namespace MonoMod.RuntimeDetour.HookGen
                 AddMethod = addIL,
                 RemoveMethod = removeIL
             };
+            if (obsolete) {
+                evIL.CustomAttributes.Add(GenerateObsolete("The hooked method is Obsolete, this IL edit should not be used.", true));
+            }
             hookILType.Events.Add(evIL);
 
             #endregion

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -1,13 +1,14 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+using MonoMod.Utils;
 
 // Man, I just want these warnings gone. This needs to be entirely rewritten anyway.
 #pragma warning disable CA1051 // Do not declare visible instance fields
@@ -313,7 +314,10 @@ namespace MonoMod.RuntimeDetour.HookGen
             addHook.Body = new MethodBody(addHook);
             il = addHook.Body.GetILProcessor();
             if (obsolete) {
-                // TODO: How to log mods using this method still?
+                if (LogObsoleteHookSubscribed != null) {
+                    il.Emit(OpCodes.Ldstr, "Warning");
+                    il.Emit(OpCodes.Call, LogObsoleteHookSubscribed);
+                }
                 il.Emit(OpCodes.Ret);
             }
             else {
@@ -646,6 +650,181 @@ namespace MonoMod.RuntimeDetour.HookGen
             return attrib;
         }
 
+        MethodDefinition LogObsoleteHookSubscribed;
+
+        public void GenerateObsoleteLogging()
+        {
+            var assembly = OutputModule.Assembly;
+
+            // Generated on https://cecilifier.me/
+            /*
+            using System;
+
+            namespace TerrariaHooks {
+                public static class Logging
+                {
+                    public static event Action<string> OnObsoleteHookSubscribed;
+
+                    public static void LogObsoleteHookSubscribed(string message){
+                        OnObsoleteHookSubscribed.Invoke(message);
+                    }
+                }
+            }
+            */
+
+            //Class : Logging
+            var cls_Logging_0 = new TypeDefinition("TerrariaHooks", "Logging", TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed, assembly.MainModule.TypeSystem.Object);
+            assembly.MainModule.Types.Add(cls_Logging_0);
+
+
+            //Event: OnObsoleteHookSubscribed
+            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Static | FieldAttributes.Private, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String));
+            cls_Logging_0.Fields.Add(fld_OnObsoleteHookSubscribed_1);
+            var md_Add_2 = new MethodDefinition("add_OnObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
+            md_Add_2.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
+            var mr_OpenCompExc_3 = assembly.MainModule.ImportReference(typeof(System.Threading.Interlocked).GetMethods().Single(m => m.Name == "CompareExchange" && m.IsGenericMethodDefinition));
+            var gi_CompExp_4 = new GenericInstanceMethod(mr_OpenCompExc_3);
+            gi_CompExp_4.GenericArguments.Add(fld_OnObsoleteHookSubscribed_1.FieldType);
+            md_Add_2.Body = new MethodBody(md_Add_2);
+            var il_Add_5 = md_Add_2.Body.GetILProcessor();
+            var lv_Add_6 = md_Add_2.Body.Instructions;
+            var lbl_LoopStart_7 = il_Add_5.Create(OpCodes.Ldloc_0);
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_0));
+            lv_Add_6.Add(lbl_LoopStart_7);
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldarg, 0));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Call, assembly.MainModule.ImportReference(typeof(Delegate).GetMethods().Single(m => m.Name == "Combine" && m.IsStatic && m.GetParameters().Length == 2))));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Castclass, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_2));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldsflda, fld_OnObsoleteHookSubscribed_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_2));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Call, gi_CompExp_4));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_0));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_0));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Bne_Un_S, lbl_LoopStart_7));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
+            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ret));
+            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Add_2.Body.InitLocals = true;
+            cls_Logging_0.Methods.Add(md_Add_2);
+            var md_Remove_8 = new MethodDefinition("remove_OnObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
+            md_Remove_8.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
+            var mr_OpenCompExc_9 = assembly.MainModule.ImportReference(typeof(System.Threading.Interlocked).GetMethods().Single(m => m.Name == "CompareExchange" && m.IsGenericMethodDefinition));
+            var gi_CompExp_10 = new GenericInstanceMethod(mr_OpenCompExc_9);
+            gi_CompExp_10.GenericArguments.Add(fld_OnObsoleteHookSubscribed_1.FieldType);
+            md_Remove_8.Body = new MethodBody(md_Remove_8);
+            var il_Remove_11 = md_Remove_8.Body.GetILProcessor();
+            var lv_Remove_12 = md_Remove_8.Body.Instructions;
+            var lbl_LoopStart_13 = il_Remove_11.Create(OpCodes.Ldloc_0);
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Nop));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_0));
+            lv_Remove_12.Add(lbl_LoopStart_13);
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldarg, 0));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Call, assembly.MainModule.ImportReference(typeof(Delegate).GetMethod("Remove"))));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Castclass, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_2));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Nop));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldsflda, fld_OnObsoleteHookSubscribed_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_2));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Call, gi_CompExp_10));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_0));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_0));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Bne_Un_S, lbl_LoopStart_13));
+            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ret));
+            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
+            md_Remove_8.Body.InitLocals = true;
+            cls_Logging_0.Methods.Add(md_Remove_8);
+            var evt_OnObsoleteHookSubscribed_14 = new EventDefinition("OnObsoleteHookSubscribed", EventAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String));
+            evt_OnObsoleteHookSubscribed_14.AddMethod = md_Add_2;
+            evt_OnObsoleteHookSubscribed_14.RemoveMethod = md_Remove_8;
+            cls_Logging_0.Events.Add(evt_OnObsoleteHookSubscribed_14);
+
+            //Method : LogObsoleteHookSubscribed
+            var md_LogObsoleteHookSubscribed_15 = new MethodDefinition("LogObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
+            cls_Logging_0.Methods.Add(md_LogObsoleteHookSubscribed_15);
+            md_LogObsoleteHookSubscribed_15.Body.InitLocals = true;
+            var il_LogObsoleteHookSubscribed_16 = md_LogObsoleteHookSubscribed_15.Body.GetILProcessor();
+
+            //Parameters of 'public static void LogObsoleteHookSubscribed(string message){...'
+            var p_Message_17 = new ParameterDefinition("message", ParameterAttributes.None, assembly.MainModule.TypeSystem.String);
+            md_LogObsoleteHookSubscribed_15.Parameters.Add(p_Message_17);
+
+            LogObsoleteHookSubscribed = md_LogObsoleteHookSubscribed_15; // Store reference for later
+
+            //OnObsoleteHookSubscribed.Invoke(message);
+            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ldfld, fld_OnObsoleteHookSubscribed_1); // Generator skipped this line
+            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ldarg_0);
+            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Callvirt, assembly.MainModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.String>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.String")));
+            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ret);
+
+            //** Constructor: Logging() **
+            var ctor_Logging_18 = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName, assembly.MainModule.TypeSystem.Void);
+            cls_Logging_0.Methods.Add(ctor_Logging_18);
+            var il_Ctor_Logging_19 = ctor_Logging_18.Body.GetILProcessor();
+            il_Ctor_Logging_19.Emit(OpCodes.Ldarg_0);
+            il_Ctor_Logging_19.Emit(OpCodes.Call, assembly.MainModule.ImportReference(TypeHelpers.DefaultCtorFor(cls_Logging_0.BaseType)));
+            il_Ctor_Logging_19.Emit(OpCodes.Ret);
+        }
+    }
+
+    public class TypeHelpers
+    {
+        public static MethodReference DefaultCtorFor(TypeReference type)
+        {
+            var resolved = type.Resolve();
+            if (resolved == null)
+                return null;
+
+            var ctor = resolved.Methods.SingleOrDefault(m => m.IsConstructor && m.Parameters.Count == 0 && !m.IsStatic);
+            if (ctor == null)
+                return DefaultCtorFor(resolved.BaseType);
+
+            return new MethodReference(".ctor", type.Module.TypeSystem.Void, type) { HasThis = true };
+        }
+
+        public static System.Reflection.MethodBase ResolveMethod(Type declaringType, string methodName, System.Reflection.BindingFlags bindingFlags, params string[] paramTypes)
+        {
+            if (methodName == ".ctor") {
+                var resolvedCtor = declaringType.GetConstructor(
+                    bindingFlags,
+                    null,
+                    paramTypes.Select(Type.GetType).ToArray(),
+                    null);
+
+                if (resolvedCtor == null) {
+                    throw new InvalidOperationException($"Failed to resolve ctor [{declaringType}({string.Join(',', paramTypes)})");
+                }
+
+                return resolvedCtor;
+            }
+
+            var resolvedMethod = declaringType.GetMethod(methodName,
+                bindingFlags,
+                null,
+                paramTypes.Select(Type.GetType).ToArray(),
+                null);
+
+            if (resolvedMethod == null) {
+                throw new InvalidOperationException($"Failed to resolve method {declaringType}.{methodName}({string.Join(',', paramTypes)})");
+            }
+
+            return resolvedMethod;
+        }
     }
 }
 

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -652,10 +652,8 @@ namespace MonoMod.RuntimeDetour.HookGen
 
         MethodDefinition LogObsoleteHookSubscribed;
 
-        public void GenerateObsoleteLogging()
+        public void GenerateObsoleteLogging(Terraria.ModLoader.Setup.Core.HookGenTask.ProgressReportingMonoModder modder)
         {
-            var assembly = OutputModule.Assembly;
-
             // Generated on https://cecilifier.me/
             /*
             using System;
@@ -663,122 +661,65 @@ namespace MonoMod.RuntimeDetour.HookGen
             namespace TerrariaHooks {
                 public static class Logging
                 {
-                    public static event Action<string> OnObsoleteHookSubscribed;
+                    public static Action<string> OnObsoleteHookSubscribed;
 
-                    public static void LogObsoleteHookSubscribed(string message){
-                        OnObsoleteHookSubscribed.Invoke(message);
+                    public static void LogObsoleteHookSubscribed(string message) {
+                        if(OnObsoleteHookSubscribed != null) {
+                            OnObsoleteHookSubscribed.Invoke(message);
+                        }
                     }
                 }
             }
             */
 
-            //Class : Logging
-            var cls_Logging_0 = new TypeDefinition("TerrariaHooks", "Logging", TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed, assembly.MainModule.TypeSystem.Object);
-            assembly.MainModule.Types.Add(cls_Logging_0);
+            var cls_Logging_0 = new TypeDefinition("TerrariaHooks", "Logging", TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed, OutputModule.TypeSystem.Object);
+            OutputModule.Types.Add(cls_Logging_0);
 
+            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(modder.FindType("System.Action`1").Resolve().MakeGenericInstanceType(OutputModule.TypeSystem.String)));
+            //var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(OutputModule.TypeSystem.String)); // Generated code that causes assembly reference issue
 
-            //Event: OnObsoleteHookSubscribed
-            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Static | FieldAttributes.Private, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String));
             cls_Logging_0.Fields.Add(fld_OnObsoleteHookSubscribed_1);
-            var md_Add_2 = new MethodDefinition("add_OnObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
-            md_Add_2.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
-            var mr_OpenCompExc_3 = assembly.MainModule.ImportReference(typeof(System.Threading.Interlocked).GetMethods().Single(m => m.Name == "CompareExchange" && m.IsGenericMethodDefinition));
-            var gi_CompExp_4 = new GenericInstanceMethod(mr_OpenCompExc_3);
-            gi_CompExp_4.GenericArguments.Add(fld_OnObsoleteHookSubscribed_1.FieldType);
-            md_Add_2.Body = new MethodBody(md_Add_2);
-            var il_Add_5 = md_Add_2.Body.GetILProcessor();
-            var lv_Add_6 = md_Add_2.Body.Instructions;
-            var lbl_LoopStart_7 = il_Add_5.Create(OpCodes.Ldloc_0);
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_0));
-            lv_Add_6.Add(lbl_LoopStart_7);
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldarg, 0));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Call, assembly.MainModule.ImportReference(typeof(Delegate).GetMethods().Single(m => m.Name == "Combine" && m.IsStatic && m.GetParameters().Length == 2))));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Castclass, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_2));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldsflda, fld_OnObsoleteHookSubscribed_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_2));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Call, gi_CompExp_4));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Stloc_0));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_0));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ldloc_1));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Bne_Un_S, lbl_LoopStart_7));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Nop));
-            lv_Add_6.Add(il_Add_5.Create(OpCodes.Ret));
-            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Add_2.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Add_2.Body.InitLocals = true;
-            cls_Logging_0.Methods.Add(md_Add_2);
-            var md_Remove_8 = new MethodDefinition("remove_OnObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
-            md_Remove_8.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
-            var mr_OpenCompExc_9 = assembly.MainModule.ImportReference(typeof(System.Threading.Interlocked).GetMethods().Single(m => m.Name == "CompareExchange" && m.IsGenericMethodDefinition));
-            var gi_CompExp_10 = new GenericInstanceMethod(mr_OpenCompExc_9);
-            gi_CompExp_10.GenericArguments.Add(fld_OnObsoleteHookSubscribed_1.FieldType);
-            md_Remove_8.Body = new MethodBody(md_Remove_8);
-            var il_Remove_11 = md_Remove_8.Body.GetILProcessor();
-            var lv_Remove_12 = md_Remove_8.Body.Instructions;
-            var lbl_LoopStart_13 = il_Remove_11.Create(OpCodes.Ldloc_0);
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Nop));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_0));
-            lv_Remove_12.Add(lbl_LoopStart_13);
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldarg, 0));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Call, assembly.MainModule.ImportReference(typeof(Delegate).GetMethod("Remove"))));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Castclass, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String)));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_2));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Nop));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldsflda, fld_OnObsoleteHookSubscribed_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_2));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Call, gi_CompExp_10));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Stloc_0));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_0));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ldloc_1));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Bne_Un_S, lbl_LoopStart_13));
-            lv_Remove_12.Add(il_Remove_11.Create(OpCodes.Ret));
-            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Remove_8.Body.Variables.Add(new VariableDefinition(fld_OnObsoleteHookSubscribed_1.FieldType));
-            md_Remove_8.Body.InitLocals = true;
-            cls_Logging_0.Methods.Add(md_Remove_8);
-            var evt_OnObsoleteHookSubscribed_14 = new EventDefinition("OnObsoleteHookSubscribed", EventAttributes.None, assembly.MainModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(assembly.MainModule.TypeSystem.String));
-            evt_OnObsoleteHookSubscribed_14.AddMethod = md_Add_2;
-            evt_OnObsoleteHookSubscribed_14.RemoveMethod = md_Remove_8;
-            cls_Logging_0.Events.Add(evt_OnObsoleteHookSubscribed_14);
 
             //Method : LogObsoleteHookSubscribed
-            var md_LogObsoleteHookSubscribed_15 = new MethodDefinition("LogObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig, assembly.MainModule.TypeSystem.Void);
-            cls_Logging_0.Methods.Add(md_LogObsoleteHookSubscribed_15);
-            md_LogObsoleteHookSubscribed_15.Body.InitLocals = true;
-            var il_LogObsoleteHookSubscribed_16 = md_LogObsoleteHookSubscribed_15.Body.GetILProcessor();
+            var md_LogObsoleteHookSubscribed_2 = new MethodDefinition("LogObsoleteHookSubscribed", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig, OutputModule.TypeSystem.Void);
+            cls_Logging_0.Methods.Add(md_LogObsoleteHookSubscribed_2);
+            md_LogObsoleteHookSubscribed_2.Body.InitLocals = true;
+            var il_LogObsoleteHookSubscribed_3 = md_LogObsoleteHookSubscribed_2.Body.GetILProcessor();
 
-            //Parameters of 'public static void LogObsoleteHookSubscribed(string message){...'
-            var p_Message_17 = new ParameterDefinition("message", ParameterAttributes.None, assembly.MainModule.TypeSystem.String);
-            md_LogObsoleteHookSubscribed_15.Parameters.Add(p_Message_17);
+            //Parameters of 'public static void LogObsoleteHookSubscribed(string message) {...'
+            var p_Message_4 = new ParameterDefinition("message", ParameterAttributes.None, OutputModule.TypeSystem.String);
+            md_LogObsoleteHookSubscribed_2.Parameters.Add(p_Message_4);
 
-            LogObsoleteHookSubscribed = md_LogObsoleteHookSubscribed_15; // Store reference for later
+            LogObsoleteHookSubscribed = md_LogObsoleteHookSubscribed_2; // Store reference for later
+
+            //if(OnObsoleteHookSubscribed != null) {...
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldnull);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ceq);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldc_I4_0);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ceq);
+            var lbl_ElseEntryPoint_5 = il_LogObsoleteHookSubscribed_3.Create(OpCodes.Nop);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Brfalse, lbl_ElseEntryPoint_5);
+            //if body
 
             //OnObsoleteHookSubscribed.Invoke(message);
-            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ldfld, fld_OnObsoleteHookSubscribed_1); // Generator skipped this line
-            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ldarg_0);
-            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Callvirt, assembly.MainModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.String>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.String")));
-            il_LogObsoleteHookSubscribed_16.Emit(OpCodes.Ret);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldarg_0);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Callvirt, OutputModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.String>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.String")));
+            var lbl_ElseEnd_6 = il_LogObsoleteHookSubscribed_3.Create(OpCodes.Nop);
+            il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEntryPoint_5);
+            il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEnd_6);
+            md_LogObsoleteHookSubscribed_2.Body.OptimizeMacros();
+            // end if (if(OnObsoleteHookSubscribed != null) {...)
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ret);
 
             //** Constructor: Logging() **
-            var ctor_Logging_18 = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName, assembly.MainModule.TypeSystem.Void);
-            cls_Logging_0.Methods.Add(ctor_Logging_18);
-            var il_Ctor_Logging_19 = ctor_Logging_18.Body.GetILProcessor();
-            il_Ctor_Logging_19.Emit(OpCodes.Ldarg_0);
-            il_Ctor_Logging_19.Emit(OpCodes.Call, assembly.MainModule.ImportReference(TypeHelpers.DefaultCtorFor(cls_Logging_0.BaseType)));
-            il_Ctor_Logging_19.Emit(OpCodes.Ret);
+            var ctor_Logging_7 = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName, OutputModule.TypeSystem.Void);
+            cls_Logging_0.Methods.Add(ctor_Logging_7);
+            var il_Ctor_Logging_8 = ctor_Logging_7.Body.GetILProcessor();
+            il_Ctor_Logging_8.Emit(OpCodes.Ldarg_0);
+            il_Ctor_Logging_8.Emit(OpCodes.Call, OutputModule.ImportReference(TypeHelpers.DefaultCtorFor(cls_Logging_0.BaseType)));
+            il_Ctor_Logging_8.Emit(OpCodes.Ret);
         }
     }
 

--- a/setup/Core/Utilities/HookGenerator.cs
+++ b/setup/Core/Utilities/HookGenerator.cs
@@ -317,6 +317,7 @@ namespace MonoMod.RuntimeDetour.HookGen
                 if (LogObsoleteHookSubscribed != null) {
                     il.Emit(OpCodes.Ldtoken, methodRef);
                     il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                    il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Call, LogObsoleteHookSubscribed);
                 }
                 il.Emit(OpCodes.Ret);
@@ -377,6 +378,12 @@ namespace MonoMod.RuntimeDetour.HookGen
             addIL.Body = new MethodBody(addIL);
             il = addIL.Body.GetILProcessor();
             if (obsolete) {
+                if (LogObsoleteHookSubscribed != null) {
+                    il.Emit(OpCodes.Ldtoken, methodRef);
+                    il.Emit(OpCodes.Call, m_GetMethodFromHandle);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Call, LogObsoleteHookSubscribed);
+                }
                 il.Emit(OpCodes.Ret);
             }
             else {
@@ -658,15 +665,16 @@ namespace MonoMod.RuntimeDetour.HookGen
             // Generated on https://cecilifier.me/
             /*
             using System;
+            using System.Reflection;
 
             namespace TerrariaHooks {
                 public static class Logging
                 {
-                    public static Action<MethodBase> OnObsoleteHookSubscribed;
+                    public static Action<MethodBase, Delegate> OnObsoleteHookSubscribed;
 
-                    public static void LogObsoleteHookSubscribed(MethodBase methodBase) {
+                    public static void LogObsoleteHookSubscribed(MethodBase methodBase, Delegate methodDelegate) {
                         if(OnObsoleteHookSubscribed != null) {
-                            OnObsoleteHookSubscribed.Invoke(methodBase);
+                            OnObsoleteHookSubscribed.Invoke(methodBase, methodDelegate);
                         }
                     }
                 }
@@ -677,8 +685,9 @@ namespace MonoMod.RuntimeDetour.HookGen
             OutputModule.Types.Add(cls_Logging_0);
 
             OutputModule.ImportReference(modder.FindType("System.Reflection.MethodBase").Resolve());
+            OutputModule.ImportReference(modder.FindType("System.Delegate").Resolve());
 
-            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(modder.FindType("System.Action`1").Resolve().MakeGenericInstanceType(modder.FindType("System.Reflection.MethodBase").Resolve())));
+            var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(modder.FindType("System.Action`2").Resolve().MakeGenericInstanceType(modder.FindType("System.Reflection.MethodBase").Resolve(), modder.FindType("System.Delegate").Resolve())));
             //var fld_OnObsoleteHookSubscribed_1 = new FieldDefinition("OnObsoleteHookSubscribed", FieldAttributes.Public | FieldAttributes.Static, OutputModule.ImportReference(typeof(System.Action<>)).MakeGenericInstanceType(OutputModule.TypeSystem.String)); // Generated code that causes assembly reference issue
 
             cls_Logging_0.Fields.Add(fld_OnObsoleteHookSubscribed_1);
@@ -689,9 +698,11 @@ namespace MonoMod.RuntimeDetour.HookGen
             md_LogObsoleteHookSubscribed_2.Body.InitLocals = true;
             var il_LogObsoleteHookSubscribed_3 = md_LogObsoleteHookSubscribed_2.Body.GetILProcessor();
 
-            //Parameters of 'public static void LogObsoleteHookSubscribed(MethodBase methodBase) {...'
+            //Parameters of 'public static void LogObsoleteHookSubscribed(MethodBase methodBase, Delegate methodDelegate) {...'
             var p_MethodBase_4 = new ParameterDefinition("methodBase", ParameterAttributes.None, OutputModule.ImportReference(modder.FindType("System.Reflection.MethodBase").Resolve()));
             md_LogObsoleteHookSubscribed_2.Parameters.Add(p_MethodBase_4);
+            var p_MethodDelegate_5 = new ParameterDefinition("methodDelegate", ParameterAttributes.None, OutputModule.ImportReference(modder.FindType("System.Delegate").Resolve()));
+            md_LogObsoleteHookSubscribed_2.Parameters.Add(p_MethodDelegate_5);
 
             LogObsoleteHookSubscribed = md_LogObsoleteHookSubscribed_2; // Store reference for later
 
@@ -705,10 +716,11 @@ namespace MonoMod.RuntimeDetour.HookGen
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Brfalse, lbl_ElseEntryPoint_5);
             //if body
 
-            //OnObsoleteHookSubscribed.Invoke(methodBase);
+            //OnObsoleteHookSubscribed.Invoke(methodBase, methodDelegate);
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldsfld, fld_OnObsoleteHookSubscribed_1);
             il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldarg_0);
-            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Callvirt, OutputModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.Reflection.MethodBase>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.Reflection.MethodBase")));
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Ldarg_1);
+            il_LogObsoleteHookSubscribed_3.Emit(OpCodes.Callvirt, OutputModule.ImportReference(TypeHelpers.ResolveMethod(typeof(System.Action<System.Reflection.MethodBase, System.Delegate>), "Invoke", System.Reflection.BindingFlags.Default | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public, "System.Reflection.MethodBase", "System.Delegate")));
             var lbl_ElseEnd_6 = il_LogObsoleteHookSubscribed_3.Create(OpCodes.Nop);
             il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEntryPoint_5);
             il_LogObsoleteHookSubscribed_3.Append(lbl_ElseEnd_6);


### PR DESCRIPTION
Fixes #4771 

As described in the issue, adding a 2nd overload to a method will result in the TerrariaHooks.dll containing "fully qualified" events for each overload. This breaks compatibility with existing mods since the original simplified (no parameter suffix) event no longer exists in the referenced dll.

To solve this, HookGenerator now checks for a `[OriginalOverloadAttribute]`. If it finds it, it outputs an event for that method as if it were the sole overload. 

If we go with this approach, we'll need to remember to add this to any PR that adds a 2nd overload. I guess alternatively we could do this automatically through some checks against vanilla, but it would be complicated.

I tested the solution and verified the issue by adding a new overload to an existing method and having a monomod detour in ExampleMod. ExampleMod stopped loading as expected when hookgen was run without the attribute, but fixed itself once the attribute was added and hookgen run again. Both hooks seem to work together as well.

Note: MonoMod seems to have [`MonoModOriginal`](https://github.com/MonoMod/MonoMod/blob/reorganize/src/MonoMod.Patcher/Modifiers/MonoModOriginal.cs) and [`MonoModOriginalName`](https://github.com/MonoMod/MonoMod/blob/reorganize/src/MonoMod.Patcher/Modifiers/MonoModOriginalName.cs) attributes, but from what I can tell they are not related to this issue. I might be wrong though.

**In addition,** after giving the issue more thought, we realized that this situation is usually done as a result of making a new method and marking the old one as `Obsolete`. The old method is usually preserved as a forwarder and passes in any assumed default parameters when calling the new method. Mods still hooking the old method risk silently breaking as mods and tModLoader use the new method.

As such, we've decided that methods marked as `Obsolete` will now result in monomod hooks that are also `Obsolete`. This will result in build errors for any mods still hooking the old method signature, forcing mods to migrate to the correct hook. 

Existing mods hooking the now obsolete monomod hooks will still load, which will result in silent or inconsistent breakage of the features of that mod. Rather than allow inconsistent execution of the hooks, we've decided that the hooks should not run at all. Any existing mods hooking these methods will result in error messages logged to the logs, allowing users to report the issue to the original author.

<img width="1861" height="153" alt="VsDebugConsole_2025-10-06_17-21-06" src="https://github.com/user-attachments/assets/9c15b525-22b4-4d83-ba58-b814e462183d" />

Using monomod hooks for obsolete methods is now a compile time error
<img width="1112" height="380" alt="devenv_2025-09-29_11-14-17" src="https://github.com/user-attachments/assets/c9f7bdde-c6e8-4c97-ac51-b1d752aec386" />

The obsolete hooks are now "noops", aside from the logging.
<img width="1377" height="387" alt="image" src="https://github.com/user-attachments/assets/0e5faaa4-292c-4f69-ae74-42b5ec2e386d" />

# Porting Notes
- Several MonoMod hooks (Both Detours and IL Edits) are now marked as `Obsolete` since the corresponding method is also `Obsolete`. These will no longer function and will result in a compile error. Consult the error message to fix these to use the correct hook.
- Existing mods hooking these `Obsolete` methods that require a rebuild will be logged to the logs. If you see these error messages in other mods please inform the mod author.