### PR TITLE
WIP: Allow screen shaders when using Retro/Trippy lighting modes. (And additionally on the main menu.)

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
@@ -1,0 +1,14 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Capture/CaptureCamera.cs
++++ src/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs
+@@ -131,8 +_,9 @@
+ 		Monitor.Enter(_captureLock);
+ 		if (_activeSettings == null)
+ 			return;
+-
+-		bool notRetro = Lighting.NotRetro;
++		
++		// Always allow capturing with screen shaders.
++		bool notRetro = true;
+ 		if (_renderQueue.Count > 0) {
+ 			CaptureChunk captureChunk = _renderQueue.Dequeue();
+ 			_graphics.SetRenderTarget(null);

--- a/patches/tModLoader/Terraria/Graphics/Effects/FilterManager.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Effects/FilterManager.cs.patch
@@ -1,9 +1,28 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Effects/FilterManager.cs
 +++ src/tModLoader/Terraria/Graphics/Effects/FilterManager.cs
-@@ -194,4 +_,13 @@
+@@ -2,6 +_,7 @@
+ using System.Collections.Generic;
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Graphics;
++using Terraria;
+ using Terraria.IO;
+ 
+ namespace Terraria.Graphics.Effects;
+@@ -149,7 +_,8 @@
+ 						graphicsDevice.Clear(clearColor);
+ 						Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend);
+ 						filter.Apply();
+-						Main.spriteBatch.Draw(renderTarget2D2, Vector2.Zero, Main.ColorOfTheSkies);
++						// Use white when retro lighting is active otherwise the result has Main.ColorOfTheSkies applied many times.
++						Main.spriteBatch.Draw(renderTarget2D2, Vector2.Zero, Lighting.UpdateEveryFrame ? Color.White : Main.ColorOfTheSkies);
+ 						Main.spriteBatch.End();
+ 						renderTarget2D2 = ((renderTarget2D2 != screenTarget1) ? screenTarget1 : screenTarget2);
+ 					}
+@@ -193,5 +_,14 @@
+ 			return this.OnPostDraw != null;
  
  		return true;
- 	}
++	}
 +
 +	// Added by TML.
 +	internal void DeactivateAll()
@@ -12,5 +31,5 @@
 +			if (this[key].IsActive())
 +				this[key].Deactivate(Array.Empty<object>());
 +		}
-+	}
+ 	}
  }

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -671,4 +671,51 @@ public partial class Main
 			ConfigManager.OnChangedAll();
 		}
 	}
+	
+	// Forces Main.screenTarget, and Main.screenTargetSwap to be initialized when starting with retro lighting enabled.
+	private static bool screenTargetsSet = false;
+	
+	// Initializes Main.screenTarget, and Main.screenTargetSwap whilst disabling others; similar to to Main.ReleaseTargets in that effect.
+	private static void InitScreenTargets()
+	{
+		if (screenTargetsSet)
+            return;
+		
+        if (Main.targetSet) {
+            ReleaseNonScreenTargets();
+			Main.targetSet = false;
+			screenTargetsSet = true;
+		}
+
+        Main.targetSet = false;
+
+        GraphicsDevice device = Main.graphics.GraphicsDevice;
+
+        int width = device.PresentationParameters.BackBufferWidth;
+        int height = device.PresentationParameters.BackBufferHeight;
+
+        Main.screenTarget = new(device, width, height, false, device.PresentationParameters.BackBufferFormat, DepthFormat.None);
+        Main.screenTargetSwap = new(device, width, height, false, device.PresentationParameters.BackBufferFormat, DepthFormat.None);
+
+        screenTargetsSet = true;
+
+        return;
+	}
+	
+	private static void ReleaseNonScreenTargets()
+	{
+		Main.drawToScreen = true;
+        Main.offScreenRange = 0;
+
+        Main.waterTarget?.Dispose();
+        Main.instance.backWaterTarget.Dispose();
+        Main.instance.blackTarget?.Dispose();
+        Main.instance.tileTarget?.Dispose();
+        Main.instance.tile2Target?.Dispose();
+        Main.instance.wallTarget?.Dispose();
+        Main.instance.backgroundTarget?.Dispose();
+		
+		// Unsure if this should be invoked here.
+        //Main.OnRenderTargetsReleased?.Invoke();
+	}
 }

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -687,8 +687,6 @@ public partial class Main
 			screenTargetsSet = true;
 		}
 
-        Main.targetSet = false;
-
         GraphicsDevice device = Main.graphics.GraphicsDevice;
 
         int width = device.PresentationParameters.BackBufferWidth;
@@ -697,7 +695,9 @@ public partial class Main
         Main.screenTarget = new(device, width, height, false, device.PresentationParameters.BackBufferFormat, DepthFormat.None);
         Main.screenTargetSwap = new(device, width, height, false, device.PresentationParameters.BackBufferFormat, DepthFormat.None);
 
-        screenTargetsSet = true;
+		Main.targetSet = false;
+
+		screenTargetsSet = true;
 
         return;
 	}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6705,34 +6705,33 @@
  			_isDrawingOrUpdating = false;
  		}
  	}
-@@ -50802,17 +_,23 @@
- 			DrawToMap();
+@@ -50803,17 +_,19 @@
  			TimeLogger.DetailedDrawTime(1);
  		}
--
+ 
 -		if (Lighting.UpdateEveryFrame)
-+		
 +		if (Lighting.UpdateEveryFrame) {
  			drawToScreen = true;
 +			// The screen target(s) should be the only active target(s) when Retro/Trippy lighting is enabled.
 +			InitScreenTargets();
-+			goto SkipTargetInitialization;
 +		}
  		else
++		{
  			drawToScreen = false;
--
-+		
- 		if (drawToScreen && targetSet)
- 			ReleaseTargets();
--
-+		
- 		if (!drawToScreen && !targetSet)
- 			InitTargets();
-+		
-+		SkipTargetInitialization:
  
+-		if (drawToScreen && targetSet)
+-			ReleaseTargets();
+-
+-		if (!drawToScreen && !targetSet)
+-			InitTargets();
+-
++			if (!targetSet)
++				InitTargets();
++		}
++		
  		fpsCount++;
  		if (!base.IsActive)
+ 			maxQ = true;
 @@ -50898,19 +_,22 @@
  				renderCount = 99;
  			}
@@ -6805,11 +6804,11 @@
  
 +		// Additionally remove the restrictions of the Retro/Trippy lighing modes and allow for screen shaders.
 -		bool flag2 = !(drawToScreen || netMode == 2 || flag) && !mapFullscreen && Lighting.NotRetro && Terraria.Graphics.Effects.Filters.Scene.CanCapture();
-+		bool flag2 = !(drawToScreen || netMode == 2 /*|| flag*/) && !mapFullscreen && /*Lighting.NotRetro &&*/ Terraria.Graphics.Effects.Filters.Scene.CanCapture();
++		bool flag2 = !(/*drawToScreen ||*/ netMode == 2 /*|| flag*/) && !mapFullscreen && /*Lighting.NotRetro &&*/ Terraria.Graphics.Effects.Filters.Scene.CanCapture();
  		if (flag2)
  			Terraria.Graphics.Effects.Filters.Scene.BeginCapture(screenTarget, Microsoft.Xna.Framework.Color.Black);
  
-@@ -51170,7 +_,7 @@
+@@ -51170,19 +_,25 @@
  		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, Rasterizer, null, GameViewMatrix.TransformationMatrix);
  		DrawBackgroundBlackFill();
  		spriteBatch.End();
@@ -6818,6 +6817,25 @@
  		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, Rasterizer, null, UIScaleMatrix);
  		if (gameMenu || netMode == 2) {
  			spriteBatch.End();
++
++			// End the screen capture BEFORE drawing UI.
++			if (flag2)
++				Terraria.Graphics.Effects.Filters.Scene.EndCapture(null, screenTarget, screenTargetSwap, Microsoft.Xna.Framework.Color.Black);
++
+ 			PreDrawMenu(out var screenSizeCache, out var screenSizeCacheAfterScaling);
+ 			spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, Rasterizer, null, UIScaleMatrix);
+ 			DrawMenu(gameTime);
+ 			PostDrawMenu(screenSizeCache, screenSizeCacheAfterScaling);
+ 			TimeLogger.MenuDrawTime(stopwatch.Elapsed.TotalMilliseconds);
+ 			TimeLogger.EndDrawFrame();
++			/*
+ 			if (flag2)
+ 				Terraria.Graphics.Effects.Filters.Scene.EndCapture(null, screenTarget, screenTargetSwap, Microsoft.Xna.Framework.Color.Black);
+-
++			*/
+ 			return;
+ 		}
+ 
 @@ -51282,6 +_,9 @@
  
  		TimeLogger.DetailedDrawReset();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6705,6 +6705,34 @@
  			_isDrawingOrUpdating = false;
  		}
  	}
+@@ -50802,17 +_,23 @@
+ 			DrawToMap();
+ 			TimeLogger.DetailedDrawTime(1);
+ 		}
+-
+-		if (Lighting.UpdateEveryFrame)
++		
++		if (Lighting.UpdateEveryFrame) {
+ 			drawToScreen = true;
++			// The screen target(s) should be the only active target(s) when Retro/Trippy lighting is enabled.
++			InitScreenTargets();
++			goto SkipTargetInitialization;
++		}
+ 		else
+ 			drawToScreen = false;
+-
++		
+ 		if (drawToScreen && targetSet)
+ 			ReleaseTargets();
+-
++		
+ 		if (!drawToScreen && !targetSet)
+ 			InitTargets();
++		
++		SkipTargetInitialization:
+ 
+ 		fpsCount++;
+ 		if (!base.IsActive)
 @@ -50898,19 +_,22 @@
  				renderCount = 99;
  			}
@@ -6765,6 +6793,22 @@
  		if (gameMenu || player[myPlayer].gravDir == 1f)
  			Rasterizer = RasterizerState.CullCounterClockwise;
  		else
+@@ -51098,10 +_,14 @@
+ 			Terraria.Graphics.Effects.Filters.Scene.Deactivate("Sepia");
+ 		}
+ 
++		/*
++		 * Allow screen shaders to take effect while on the main menu, (must be activated by the modder manually.)
+ 		if (Terraria.Graphics.Effects.Filters.Scene["Sepia"].IsInUse())
+ 			flag = false;
++		*/
+ 
++		// Additionally remove the restrictions of the Retro/Trippy lighing modes and allow for screen shaders.
+-		bool flag2 = !(drawToScreen || netMode == 2 || flag) && !mapFullscreen && Lighting.NotRetro && Terraria.Graphics.Effects.Filters.Scene.CanCapture();
++		bool flag2 = !(drawToScreen || netMode == 2 /*|| flag*/) && !mapFullscreen && /*Lighting.NotRetro &&*/ Terraria.Graphics.Effects.Filters.Scene.CanCapture();
+ 		if (flag2)
+ 			Terraria.Graphics.Effects.Filters.Scene.BeginCapture(screenTarget, Microsoft.Xna.Framework.Color.Black);
+ 
 @@ -51170,7 +_,7 @@
  		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, Rasterizer, null, GameViewMatrix.TransformationMatrix);
  		DrawBackgroundBlackFill();


### PR DESCRIPTION
### What is the bug(s)?
1. Retro/Trippy lighting modes as of current disable all screen shaders, causing buggy functionality. (This is likely intentional by Relogic however.)
2. Screen shaders -- other than Terraria's 'Sepia' filter -- currently do not work on the main menu; this fix is similar to the [proposal by Tyfyter](https://github.com/tModLoader/tModLoader/pull/4716#issuecomment-3300875862) on Ebonfly's ['New drawing-related hooks for ModMenus' PR](https://github.com/tModLoader/tModLoader/pull/4716), see below for more details as to possible implementations.
3. Screen shaders on the main menu apply over top of the UI.

### How did you fix the bug(s)?
This initial pass takes from my mods [Retro Lighting Fix](https://github.com/ZenTheMod/FixRetroLighting) and [Zen's Sky](https://github.com/ZenTheMod/ZensSky/blob/main/Common/Systems/CaptureInMenuSystem.cs), to allow for use of screen shaders with both Retro/Trippy lighting modes and on the main menu*.
The current implementation does not currently allow modded screen shaders on the menu currently as `Main.ClearVisualPostProcessEffects` is ran every frame. I'm unsure of the best way to handle deactivating modded filters whilst allowing some to be active on the main menu (I'm open to suggestions here).

### Are there alternatives to your fix?
There are definitely safer ways to patch the methods I've changed here, and likely a vastly better way to handle what I run in Main.TML.InitScreenTargets.