### PR TITLE
disable borderless option in windows (already disabled on other platforms)

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6246,6 +6246,25 @@
  	}
  
  	private static void PostDrawMenu(Microsoft.Xna.Framework.Point screenSizeCache, Microsoft.Xna.Framework.Point screenSizeCacheAfterScaling)
+@@ -42862,11 +_,18 @@
+ 
+ 	private static bool IsBorderlessDisplayAvailable()
+ 	{
++		// TML: Exclusive fullscreen is retired in favor of borderless
++		// fullscreen.  As such, the borderless option serves no purpose (and
++		// is ignored in practice).
++		return false;
++
++		/*
+ 		bool result = false;
+ 		if (Platform.IsWindows)
+ 			result = true;
+ 
+ 		return result;
++		*/
+ 	}
+ 
+ #if !NETCORE
 @@ -43330,9 +_,17 @@
  		float value = (float)((double)(screenPosition.Y - (float)(screenHeight / 2) + 200f) - rockLayer * 16.0) / 300f;
  		value = MathHelper.Clamp(value, 0f, 1f);


### PR DESCRIPTION
### What is the bug?

On Windows, there is an optional to configure whether borderless windows are used, which does nothing.

### How did you fix the bug?

Hide the option like on other platforms.

### Are there alternatives to your fix?

Re-introduce exclusive fullscreen and differentiate between borderless fullscreen and exclusive fullscreen (no).
