### PR TITLE
Forward port Item.material sensibility fixes from 1.4.5

### DIFF
--- a/patches/tModLoader/Terraria/ID/ContentSamples.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ContentSamples.cs.patch
@@ -192,6 +192,15 @@
  	{
  		for (int i = 0; i < itemsThatWillResearchTheItemToUnlock.Length; i++) {
  			AddItemResearchOverride_Inner(itemsThatWillResearchTheItemToUnlock[i], itemTypeToUnlock);
+@@ -805,7 +_,7 @@
+ 	public static void FixItemsAfterRecipesAreAdded()
+ 	{
+ 		foreach (KeyValuePair<int, Item> item in ItemsByType) {
+-			item.Value.material = ItemID.Sets.IsAMaterial[item.Key];
++			item.Value.Refresh(onlyIfVariantChanged: false);
+ 		}
+ 	}
+ 
 @@ -955,7 +_,10 @@
  		NPCSpawnParams nPCSpawnParams = default(NPCSpawnParams);
  		nPCSpawnParams.gameModeData = Main.RegisteredGameModes[0];

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1287,6 +1287,38 @@
  				return 0;
  		}
  	}
+@@ -3269,6 +_,7 @@
+ 				consumable = true;
+ 				createTile = 330;
+ 				noMelee = true;
++				material = false;
+ 				break;
+ 			case 72:
+ 				width = 10;
+@@ -3289,6 +_,7 @@
+ 				consumable = true;
+ 				createTile = 331;
+ 				noMelee = true;
++				material = false;
+ 				break;
+ 			case 73:
+ 				width = 10;
+@@ -3309,6 +_,7 @@
+ 				consumable = true;
+ 				createTile = 332;
+ 				noMelee = true;
++				material = false;
+ 				break;
+ 			case 74:
+ 				width = 12;
+@@ -3329,6 +_,7 @@
+ 				consumable = true;
+ 				createTile = 333;
+ 				noMelee = true;
++				material = false;
+ 				break;
+ 			case 75:
+ 				width = 18;
 @@ -7679,6 +_,8 @@
  				value = 300;
  				break;
@@ -1305,6 +1337,30 @@
  				useStyle = 5;
  				autoReuse = true;
  				useAnimation = 30;
+@@ -9158,6 +_,7 @@
+ 					consumable = true;
+ 					useAnimation = 45;
+ 					useTime = 45;
++					material = false;
+ 				}
+ 				maxStack = CommonMaxStack;
+ 				rare = 3;
+@@ -9294,6 +_,7 @@
+ 					consumable = true;
+ 					useAnimation = 45;
+ 					useTime = 45;
++					material = false;
+ 				}
+ 				maxStack = CommonMaxStack;
+ 				rare = 3;
+@@ -9306,6 +_,7 @@
+ 					consumable = true;
+ 					useAnimation = 45;
+ 					useTime = 45;
++					material = false;
+ 				}
+ 				maxStack = CommonMaxStack;
+ 				rare = 3;
 @@ -11396,6 +_,7 @@
  				knockBack = 6.5f;
  				melee = true;
@@ -1357,6 +1413,21 @@
  				return;
  			case 3612:
  				useStyle = 1;
+@@ -36121,8 +_,12 @@
+ 			case 3767:
+ 			case 3768:
+ 			case 3769:
+-				SetDefaults(198);
+-				this.type = type;
++				useStyle = 1;
++				knockBack = 3f;
++				width = 40;
++				height = 40;
++				UseSound = SoundID.Item15;
++				melee = true;
+ 				damage = 48;
+ 				useTime = 16;
+ 				useAnimation = 16;
 @@ -36886,6 +_,8 @@
  				shootSpeed = 17f;
  				return;
@@ -1393,6 +1464,37 @@
  	public void DefaultToGolfBall(int projid)
  	{
  		shoot = projid;
+@@ -38632,6 +_,7 @@
+ 				width = 12;
+ 				height = 12;
+ 				value = 100000;
++				material = false;
+ 				break;
+ 			case 4091:
+ 				DefaultToPlaceableTile((ushort)496, 0);
+@@ -38769,6 +_,7 @@
+ 				useTime = 28;
+ 				rare = 3;
+ 				value = sellPrice(0, 2);
++				material = false;
+ 				break;
+ 			case 4132:
+ 				width = 18;
+@@ -39568,8 +_,12 @@
+ 				melee = true;
+ 				break;
+ 			case 4259:
+-				SetDefaults(198);
+-				this.type = type;
++				useStyle = 1;
++				knockBack = 3f;
++				width = 40;
++				height = 40;
++				UseSound = SoundID.Item15;
++				melee = true;
+ 				damage = 48;
+ 				useTime = 16;
+ 				useAnimation = 16;
 @@ -43082,6 +_,8 @@
  				expert = true;
  				break;
@@ -1854,7 +1956,7 @@
  	{
  		useStyle = 1;
  		useTurn = true;
-@@ -47088,6 +_,28 @@
+@@ -47088,6 +_,30 @@
  		SetDefaults(Type, noMatCheck: false, null);
  	}
  
@@ -1869,6 +1971,7 @@
 +	{
 +		int originalType = type;
 +		int originalNetID = netID;
++		var originalMaterial = material;
 +		var originalModItem = ModItem;
 +		var originalGlobals = _globals;
 +
@@ -1876,6 +1979,7 @@
 +
 +		type = originalType;
 +		netID = originalNetID;
++		material = originalMaterial;
 +		ModItem = originalModItem;
 +		_globals = originalGlobals;
 +	}
@@ -1883,10 +1987,11 @@
  	public void SetDefaults(int Type, bool noMatCheck = false, ItemVariant variant = null)
  	{
  		if (Type < 0) {
-@@ -47101,8 +_,11 @@
+@@ -47101,8 +_,12 @@
  			playerIndexTheItemIsReservedFor = Main.myPlayer;
  
  		ResetStats(Type);
++		material = ItemID.Sets.IsAMaterial[type];
 +
 +		/*
  		if (type >= ItemID.Count)
@@ -1915,15 +2020,14 @@
  		if (hairDye != 0)
  			hairDye = GameShaders.Hair.GetShaderIdFromItemId(type);
  
-@@ -47297,19 +_,27 @@
+@@ -47297,19 +_,24 @@
  			maxStack = CommonMaxStack;
  
  		netID = type;
+-		if (!noMatCheck)
+-			material = ItemID.Sets.IsAMaterial[type];
 +
 +		ItemLoader.SetDefaults(this);
-+
- 		if (!noMatCheck)
- 			material = ItemID.Sets.IsAMaterial[type];
  
  		RebuildTooltip();
 -		if (type > 0 && type < ItemID.Count && ItemID.Sets.Deprecated[type]) {

--- a/patches/tModLoader/Terraria/ModLoader/NPCShopDatabase.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCShopDatabase.cs
@@ -86,7 +86,7 @@ public static partial class NPCShopDatabase
 			shop.FinishSetup();
 			// NPCShopDatabase.Initialize(); seems intentionally run before SetupRecipes, where IsAMaterial is populated, so we need to fix entries here.
 			foreach (var entry in shop.ActiveEntries) {
-				entry.Item.material = ItemID.Sets.IsAMaterial[entry.Item.type]; 
+				entry.Item.Refresh(onlyIfVariantChanged: false);
 			}
 		}
 

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -491,7 +491,7 @@
  	}
  
  	public static void UpdateItemVariants()
-@@ -620,8 +_,9 @@
+@@ -620,12 +_,14 @@
  		for (int i = 0; i < maxRecipes; i++) {
  			Recipe obj = Main.recipe[i];
  			obj.createItem.Refresh();
@@ -503,6 +503,19 @@
  				array[j].Refresh();
  			}
  		}
+ 
++		/*
+ 		if (Main.remixWorld && Main.getGoodWorld) {
+ 			ItemID.Sets.IsAMaterial[544] = true;
+ 			ItemID.Sets.IsAMaterial[556] = true;
+@@ -636,6 +_,7 @@
+ 			ItemID.Sets.IsAMaterial[556] = false;
+ 			ItemID.Sets.IsAMaterial[557] = false;
+ 		}
++		*/
+ 	}
+ 
+ 	public static void SetupRecipes()
 @@ -1727,12 +_,14 @@
  		currentRecipe.requiredItem[1].SetDefaults(316);
  		currentRecipe.requiredItem[2].SetDefaults(68);
@@ -587,46 +600,23 @@
  					RecipeGroup recipeGroup = RecipeGroup.recipeGroups[num];
  					if (recipeGroup.ValidItems.Contains(item.type))
  						requiredItemEntry2.itemIdOrRecipeGroup = recipeGroup.GetGroupFakeItemId();
-@@ -14575,8 +_,8 @@
+@@ -14575,27 +_,54 @@
  	private static void UpdateMaterialFieldForAllRecipes()
  	{
  		for (int i = 0; i < numRecipes; i++) {
 -			for (int j = 0; Main.recipe[i].requiredItem[j].type > 0; j++) {
 -				Main.recipe[i].requiredItem[j].material = ItemID.Sets.IsAMaterial[Main.recipe[i].requiredItem[j].type];
 +			foreach (Item item in Main.recipe[i].requiredItem) {
-+				item.material = ItemID.Sets.IsAMaterial[item.type];
++				item.Refresh(onlyIfVariantChanged: false);
  			}
  
- 			Main.recipe[i].createItem.material = ItemID.Sets.IsAMaterial[Main.recipe[i].createItem.type];
-@@ -14585,17 +_,47 @@
+-			Main.recipe[i].createItem.material = ItemID.Sets.IsAMaterial[Main.recipe[i].createItem.type];
++			Main.recipe[i].createItem.Refresh(onlyIfVariantChanged: false);
+ 		}
+ 	}
  
  	public static void UpdateWhichItemsAreMaterials()
  	{
-+		for (int i = 0; i < Recipe.numRecipes; i++) {
-+			if (Main.recipe[i].Disabled)
-+				continue;
-+
-+			foreach (Item item in Main.recipe[i].requiredItem) {
-+				ItemID.Sets.IsAMaterial[item.type] = true;
-+			}
-+		}
-+
-+		// TODO: Check that each group is used at least once?
-+		foreach (RecipeGroup recipeGroup in RecipeGroup.recipeGroups.Values) {
-+			foreach (var item in recipeGroup.ValidItems) {
-+				ItemID.Sets.IsAMaterial[item] = true;
-+			}
-+		}
-+
-+		// These come from the removed Item.checkMat. Coins and Void Bag. Void Bag is removed since it would be odd to have the Material tooltip appear on the open bag and not be present on the closed bag
-+		ItemID.Sets.IsAMaterial[71] = false;
-+		ItemID.Sets.IsAMaterial[72] = false;
-+		ItemID.Sets.IsAMaterial[73] = false;
-+		ItemID.Sets.IsAMaterial[74] = false;
-+		ItemID.Sets.IsAMaterial[4076] = false;
-+		ItemID.Sets.IsAMaterial[4131] = false;
-+		ItemID.Sets.IsAMaterial[5325] = false;
-+
 +		/*
  		for (int i = 0; i < ItemID.Count; i++) {
  			Item item = new Item();
@@ -635,6 +625,28 @@
  			ItemID.Sets.IsAMaterial[i] = item.material;
  		}
 +		*/
++
++		bool[] recipeGroupsUsed = new bool[RecipeGroup.nextRecipeGroupIndex];
++
++		for (int i = 0; i < numRecipes; i++) {
++			if (Main.recipe[i].Disabled)
++				continue;
++
++			foreach (Item item in Main.recipe[i].requiredItem)
++				ItemID.Sets.IsAMaterial[item.type] = true;
++
++			foreach (int g in Main.recipe[i].acceptedGroups)
++				if (g >= 0)
++					recipeGroupsUsed[g] = true;
++		}
++
++		foreach (RecipeGroup recipeGroup in RecipeGroup.recipeGroups.Values) {
++			if (!recipeGroupsUsed[recipeGroup.RegisteredId])
++				continue;
++
++			foreach (var item in recipeGroup.ValidItems)
++				ItemID.Sets.IsAMaterial[item] = true;
++		}
  	}
  
  	public static void UpdateWhichItemsAreCrafted()


### PR DESCRIPTION
### What is the new feature?

`ItemID.Sets.IsAMaterial` now only includes items which are used in a non-disabled recipe (or in a recipe group of a non disabled recipe), and is not updated after load time.

`Item.material` is now set at the start of `SetDefaults`, so mods can change it in `Mod/GlobalItem.SetDefaults`

### Why should this be part of tModLoader?

- #4805
- #4804 

And in general, the previous vanilla way of doing things was a mess.

### Are there alternative designs?

### Sample usage for the new feature

```cs
		public override void SetDefaults() {
			// To exclude an item from being treated as a material, despite being a recipe component
			Item.material = false;
			// If using the variant system to make items which are different depending on the world
			Item.material = Item.Variant == ItemVariants.EnabledVariant;
		}
```

### ExampleMod updates

None

### Porting Notes

If you were previously setting `ItemID.Sets.IsAMaterial`, leave it alone and follow the sample usage