### PR TITLE
Changes to liquid rendering fields to be both public and no longer readonly

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -38,7 +38,7 @@
  	private struct SpecialLiquidDrawCache
  	{
  		public int X;
-@@ -60,24 +_,51 @@
+@@ -60,43 +_,55 @@
  		public bool IsSurfaceLiquid;
  		public bool HasWall;
  	}
@@ -53,49 +53,49 @@
  	private const int ANIMATION_FRAME_COUNT = 16;
  	private const int CACHE_PADDING = 2;
  	private const int CACHE_PADDING_2 = 4;
+-	private static readonly int[] WATERFALL_LENGTH = new int[4] {
+-		10,
+-		3,
+-		2,
+-		10
+-	};
+-	private static readonly float[] DEFAULT_OPACITY = new float[4] {
+-		0.6f,
+-		0.95f,
+-		0.95f,
+-		0.75f
+-	};
+-	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
+-	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
+-		0,
+-		200,
+-		240,
+-		0,
+-		0
+-	};
 +	/// <summary>
 +	/// Liquids use this to control how many tiles long their liquidfall is. <br/>
 +	/// Liquidfalls are drawn whenever there is not a solid block underneath a liquid, most visible when a liquid is overtop of a half block. <br/>
 +	/// This makes liquids look less akward when falling downwards.
 +	/// </summary>
--	private static readonly int[] WATERFALL_LENGTH = new int[4] {
-+	public static int[] WATERFALL_LENGTH = new int[4] {
- 		10,
- 		3,
- 		2,
- 		10
- 	};
++	public static int[] WATERFALL_LENGTH = new int[LiquidID.Count];
 +	/// <summary>
 +	/// How strong a liquid's opacity. <br/>
 +	/// Liquids like lava and honey use this to make them look more viscous by making things inside the liquid less visible. <br/>
 +	/// </summary>
--	private static readonly float[] DEFAULT_OPACITY = new float[4] {
-+	public static float[] DEFAULT_OPACITY = new float[4] {
- 		0.6f,
- 		0.95f,
- 		0.95f,
- 		0.75f
- 	};
--	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
--	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
++	public static float[] DEFAULT_OPACITY = new float[LiquidID.Count];
 +	/// <summary>
 +	/// Modifies the colors of the liquid wavemask. <br/>
 +	/// Modifies the wave alpha. <br/>
 +	/// Vanilla leaves this array blank by default.
 +	/// </summary>
 +	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
-+
 +	/// <summary>
 +	/// This is how powerful the ripples are for liquids. <br/>
 +	/// Lava and honey use this to have ripples be less strong. <br/>
 +	/// Can cause weird visual issues with ripples if set to large numbers like 255.
 +	/// </summary>
-+	public static byte[] VISCOSITY_MASK = new byte[5] {
- 		0,
- 		200,
- 		240,
-@@ -86,17 +_,19 @@
- 	};
++	public static byte[] VISCOSITY_MASK = new byte[5];
  	public const float MIN_LIQUID_SIZE = 0.25f;
  	public static LiquidRenderer Instance;
 -	private readonly Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[15];
@@ -116,6 +116,37 @@
  
  	public event Action<Color[], Rectangle> WaveFilters;
  
+@@ -106,6 +_,30 @@
+ 		Instance.PrepareAssets();
+ 	}
+ 
++	public static void Initialize_LiquidData()
++	{
++		WATERFALL_LENGTH = new int[4] {
++			10,
++			3,
++			2,
++			10
++		};
++		DEFAULT_OPACITY = new float[4] {
++			0.6f,
++			0.95f,
++			0.95f,
++			0.75f
++		};
++		WAVE_MASK_STRENGTH = new byte[5];
++		VISCOSITY_MASK = new byte[5] {
++			0,
++			200,
++			240,
++			0,
++			0
++		};
++	}
++
+ 	private void PrepareAssets()
+ 	{
+ 		if (!Main.dedServ) {
 @@ -117,6 +_,9 @@
  
  	private unsafe void InternalPrepareDraw(Rectangle drawArea)

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -38,7 +38,7 @@
  	private struct SpecialLiquidDrawCache
  	{
  		public int X;
-@@ -60,24 +_,31 @@
+@@ -60,24 +_,51 @@
  		public bool IsSurfaceLiquid;
  		public bool HasWall;
  	}
@@ -53,6 +53,11 @@
  	private const int ANIMATION_FRAME_COUNT = 16;
  	private const int CACHE_PADDING = 2;
  	private const int CACHE_PADDING_2 = 4;
++	/// <summary>
++	/// Liquids use this to control how many tiles long their liquidfall is. <br/>
++	/// Liquidfalls are drawn whenever there is not a solid block underneath a liquid, most visible when a liquid is overtop of a half block. <br/>
++	/// This makes liquids look less akward when falling downwards.
++	/// </summary>
 -	private static readonly int[] WATERFALL_LENGTH = new int[4] {
 +	public static int[] WATERFALL_LENGTH = new int[4] {
  		10,
@@ -60,6 +65,10 @@
  		2,
  		10
  	};
++	/// <summary>
++	/// How strong a liquid's opacity. <br/>
++	/// Liquids like lava and honey use this to make them look more viscous by making things inside the liquid less visible. <br/>
++	/// </summary>
 -	private static readonly float[] DEFAULT_OPACITY = new float[4] {
 +	public static float[] DEFAULT_OPACITY = new float[4] {
  		0.6f,
@@ -68,8 +77,19 @@
  		0.75f
  	};
 -	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
-+	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
 -	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
++	/// <summary>
++	/// Modifies the colors of the liquid wavemask. <br/>
++	/// Modifies the wave alpha. <br/>
++	/// Vanilla leaves this array blank by default.
++	/// </summary>
++	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
++
++	/// <summary>
++	/// This is how powerful the ripples are for liquids. <br/>
++	/// Lava and honey use this to have ripples be less strong. <br/>
++	/// Can cause weird visual issues with ripples if set to large numbers like 255.
++	/// </summary>
 +	public static byte[] VISCOSITY_MASK = new byte[5] {
  		0,
  		200,

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -38,7 +38,7 @@
  	private struct SpecialLiquidDrawCache
  	{
  		public int X;
-@@ -60,43 +_,75 @@
+@@ -60,23 +_,58 @@
  		public bool IsSurfaceLiquid;
  		public bool HasWall;
  	}
@@ -53,49 +53,40 @@
  	private const int ANIMATION_FRAME_COUNT = 16;
  	private const int CACHE_PADDING = 2;
  	private const int CACHE_PADDING_2 = 4;
--	private static readonly int[] WATERFALL_LENGTH = new int[4] {
--		10,
--		3,
--		2,
--		10
--	};
--	private static readonly float[] DEFAULT_OPACITY = new float[4] {
--		0.6f,
--		0.95f,
--		0.95f,
--		0.75f
--	};
--	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
--	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
 +	/// <summary>
 +	/// Liquids use this to control how many tiles long their liquidfall is. <br/>
 +	/// Liquidfalls are drawn whenever there is not a solid block underneath a liquid, most visible when a liquid is overtop of a half block. <br/>
 +	/// This makes liquids look less akward when falling downwards.
 +	/// </summary>
 +	public static int[] WATERFALL_LENGTH = new int[LiquidID.Count];
-+	/*public static readonly int[] WATERFALL_LENGTH = new int[4] { 
-+		10, 
-+		3, 
-+		2, 
-+		10 
-+	};*/
++	/*
+ 	private static readonly int[] WATERFALL_LENGTH = new int[4] {
+ 		10,
+ 		3,
+ 		2,
+ 		10
+ 	};
++	*/
 +	/// <summary>
 +	/// How strong a liquid's opacity. <br/>
 +	/// Liquids like lava and honey use this to make them look more viscous by making things inside the liquid less visible. <br/>
 +	/// </summary>
 +	public static float[] DEFAULT_OPACITY = new float[LiquidID.Count];
-+	/*public static readonly float[] DEFAULT_OPACITY = new float[4] {
-+		0.6f, 
-+		0.95f, 
-+		0.95f, 
-+		0.75f 
-+	};*/
++	/*
+ 	private static readonly float[] DEFAULT_OPACITY = new float[4] {
+ 		0.6f,
+ 		0.95f,
+ 		0.95f,
+ 		0.75f
+ 	};
++	*/
 +	/// <summary>
 +	/// Modifies the colors of the liquid wavemask. <br/>
 +	/// Modifies the wave alpha. <br/>
 +	/// Vanilla leaves this array blank by default.
 +	/// </summary>
 +	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
+-	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
 +	//private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
 +	/// <summary>
 +	/// This is how powerful the ripples are for liquids. <br/>
@@ -103,14 +94,15 @@
 +	/// Can cause weird visual issues with ripples if set to large numbers like 255.
 +	/// </summary>
 +	public static byte[] VISCOSITY_MASK = new byte[5];
-+	/*private static readonly byte[] VISCOSITY_MASK = new byte[5] { 
++	/*
+ 	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
  		0,
  		200,
- 		240,
+@@ -84,19 +_,22 @@
  		0,
  		0
--	};
-+	};*/
+ 	};
++	*/
  	public const float MIN_LIQUID_SIZE = 0.25f;
  	public static LiquidRenderer Instance;
 -	private readonly Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[15];

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -38,7 +38,7 @@
  	private struct SpecialLiquidDrawCache
  	{
  		public int X;
-@@ -60,43 +_,55 @@
+@@ -60,43 +_,75 @@
  		public bool IsSurfaceLiquid;
  		public bool HasWall;
  	}
@@ -67,35 +67,50 @@
 -	};
 -	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
 -	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
--		0,
--		200,
--		240,
--		0,
--		0
--	};
 +	/// <summary>
 +	/// Liquids use this to control how many tiles long their liquidfall is. <br/>
 +	/// Liquidfalls are drawn whenever there is not a solid block underneath a liquid, most visible when a liquid is overtop of a half block. <br/>
 +	/// This makes liquids look less akward when falling downwards.
 +	/// </summary>
 +	public static int[] WATERFALL_LENGTH = new int[LiquidID.Count];
++	/*public static readonly int[] WATERFALL_LENGTH = new int[4] { 
++		10, 
++		3, 
++		2, 
++		10 
++	};*/
 +	/// <summary>
 +	/// How strong a liquid's opacity. <br/>
 +	/// Liquids like lava and honey use this to make them look more viscous by making things inside the liquid less visible. <br/>
 +	/// </summary>
 +	public static float[] DEFAULT_OPACITY = new float[LiquidID.Count];
++	/*public static readonly float[] DEFAULT_OPACITY = new float[4] {
++		0.6f, 
++		0.95f, 
++		0.95f, 
++		0.75f 
++	};*/
 +	/// <summary>
 +	/// Modifies the colors of the liquid wavemask. <br/>
 +	/// Modifies the wave alpha. <br/>
 +	/// Vanilla leaves this array blank by default.
 +	/// </summary>
 +	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
++	//private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
 +	/// <summary>
 +	/// This is how powerful the ripples are for liquids. <br/>
 +	/// Lava and honey use this to have ripples be less strong. <br/>
 +	/// Can cause weird visual issues with ripples if set to large numbers like 255.
 +	/// </summary>
 +	public static byte[] VISCOSITY_MASK = new byte[5];
++	/*private static readonly byte[] VISCOSITY_MASK = new byte[5] { 
+ 		0,
+ 		200,
+ 		240,
+ 		0,
+ 		0
+-	};
++	};*/
  	public const float MIN_LIQUID_SIZE = 0.25f;
  	public static LiquidRenderer Instance;
 -	private readonly Asset<Texture2D>[] _liquidTextures = new Asset<Texture2D>[15];

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -38,7 +38,7 @@
  	private struct SpecialLiquidDrawCache
  	{
  		public int X;
-@@ -60,17 +_,24 @@
+@@ -60,24 +_,31 @@
  		public bool IsSurfaceLiquid;
  		public bool HasWall;
  	}
@@ -54,17 +54,26 @@
  	private const int CACHE_PADDING = 2;
  	private const int CACHE_PADDING_2 = 4;
 -	private static readonly int[] WATERFALL_LENGTH = new int[4] {
-+	public static readonly int[] WATERFALL_LENGTH = new int[4] {
++	public static int[] WATERFALL_LENGTH = new int[4] {
  		10,
  		3,
  		2,
  		10
  	};
 -	private static readonly float[] DEFAULT_OPACITY = new float[4] {
-+	public static readonly float[] DEFAULT_OPACITY = new float[4] {
++	public static float[] DEFAULT_OPACITY = new float[4] {
  		0.6f,
  		0.95f,
  		0.95f,
+ 		0.75f
+ 	};
+-	private static readonly byte[] WAVE_MASK_STRENGTH = new byte[5];
++	private static byte[] WAVE_MASK_STRENGTH = new byte[5];
+-	private static readonly byte[] VISCOSITY_MASK = new byte[5] {
++	public static byte[] VISCOSITY_MASK = new byte[5] {
+ 		0,
+ 		200,
+ 		240,
 @@ -86,17 +_,19 @@
  	};
  	public const float MIN_LIQUID_SIZE = 0.25f;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1908,6 +1908,14 @@
  		ClientInitialize();
  		base.Initialize();
  	}
+@@ -5213,6 +_,7 @@
+ 		Initialize_TileAndNPCData1();
+ 		Initialize_TileAndNPCData2();
+ 		Initialize_Items();
++		LiquidRenderer.Initialize_LiquidData();
+ 		for (int i = 1; i < ProjectileID.Count; i++) {
+ 			Projectile obj = new Projectile();
+ 			obj.SetDefaults(i);
 @@ -5239,11 +_,18 @@
  		}
  


### PR DESCRIPTION
### What is the new feature?

Changes the `LiquidRenderer` class to have `WATERFALL_LENGTH`, `DEFAULT_OPACITY`, `WAVE_MASK_STRENGTH` and `VISCOSITY_MASK` to be both public and to no longer be readonly. This is so these fields can be edited and used by mods.

This also gives each of the fields documentation on how they're used and resets their contents on initialization similar to arrays found in ``Main`` such as ``projFrames``.

### Why should this be part of tModLoader?

Currently (as of v2025.09) only `WATERFALL_LENGTH` and `DEFAULT_OPACITY` are public while all four fields are also set as readonly. This prevents mod's from being able to easily modify certain rendering settings for vanilla liquids.
This is already a planned change for ModLiquid, as it will be required to be changed so modded liquids can add their own rendering settings

### Are there alternative designs?

Creating dedicated fields/properties for each field in `LiquidRenderer` that both get and set the data of `WATERFALL_LENGTH`, `DEFAULT_OPACITY`, `WAVE_MASK_STRENGTH` and `VISCOSITY_MASK`.

### Sample usage for the new feature

```
public override void Load()
{
    LiquidRenderer.VISCOSITY_MASK[LiquidID.Honey] = 100;
}
```