### PR TITLE
ModPlayer.DrawPlayer hook to facilitate custom player "shadow" visuals

### DIFF
--- a/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.Graphics;
 using Terraria.ModLoader;
 
@@ -15,6 +16,7 @@ namespace ExampleMod.Common.Players
 		public int ShadowStyle = 0; // This is the shadow to use. Note that ExampleHood.ArmorSetShadows will only be called if the full armor set is visible.
 		public bool CustomShadow; // Indicates that our custom shadow should be used.
 		private int CustomShadowTimer; // Used in our custom shadow logic.
+		private Color CustomShadowColor = Color.White;
 
 		public override void ResetEffects() {
 			ExampleSetHood = false;
@@ -76,9 +78,13 @@ namespace ExampleMod.Common.Players
 				Vector2 drawPosition = playerPosition + new Vector2(0f, distanceFromPlayer).RotatedBy(rotation) * 25;
 				float shadow = 1 - Utils.Remap(Math.Abs(distanceFromPlayer), 0, 1, 0.1f, 0.4f, clamped: true);
 
-				// Main.PlayerRenderer.DrawPlayer handles drawing the player clone. 
+				// CustomShadowColor is used in TransformDrawData to apply a tint to the player clones.
+				CustomShadowColor = Color.Lerp(Color.Aqua, Color.Red, (float)i / (clones - 1));
+
+				// Main.PlayerRenderer.DrawPlayer handles drawing the player clone.
 				Main.PlayerRenderer.DrawPlayer(camera, Player, drawPosition, Player.fullRotation, Player.fullRotationOrigin, shadow);
 			}
+			CustomShadowColor = Color.White; // Reset CustomShadowColor so it doesn't affect normal drawing or other clones.
 
 			// Another common player effect is to draw the player at previous positions and slightly faded. Player.shadowPos/shadowRotation/shadowOrigin stores the last 3 positions and is used by shadow effects added to the game in early versions. Player.GetAdvancedShadow is a more recent addition and can be used for more advanced control and stores up to 60 previous positions.
 			/* 
@@ -90,6 +96,22 @@ namespace ExampleMod.Common.Players
 				Main.PlayerRenderer.DrawPlayer(camera, Player, advancedShadow.Position, advancedShadow.Rotation, advancedShadow.Origin, shadow);
 			}
 			*/
+		}
+
+		// TransformDrawData can be used to affect all PlayerDrawSet.DrawDataCache entries immediately before they are drawn.
+		public override void TransformDrawData(ref PlayerDrawSet drawInfo) {
+			// Check to only affect specific clones
+			if (CustomShadowColor == Color.White) {
+				return;
+			}
+
+			// Tint the clones with CustomShadowColor by modifying the draw color of every DrawData in drawInfo.DrawDataCache.
+			for (int i = 0; i < drawInfo.DrawDataCache.Count; i++) {
+				DrawData value = drawInfo.DrawDataCache[i];
+				// Multiply the colors to tint it rather than assign it directly since DrawData.color will likely already have some non-white color.
+				value.color = value.color.MultiplyRGBA(CustomShadowColor);
+				drawInfo.DrawDataCache[i] = value;
+			}
 		}
 	}
 }

--- a/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
+++ b/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs
@@ -1,16 +1,24 @@
-﻿using Terraria;
+﻿using Microsoft.Xna.Framework;
+using System;
+using Terraria;
+using Terraria.Graphics;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Common.Players
 {
-	// This ModPlayer facilitates a set bonus effect. This example shows how either ArmorSetBonusActivated or ArmorSetBonusHeld can be used depending on how you want the player to interact with the set bonus effect. 
+	// This ModPlayer facilitates a set bonus visual effect, also known as an armor set shadow effect. This example shows how either ArmorSetBonusActivated or ArmorSetBonusHeld can be used depending on how you want the player to interact with the set bonus effect.
+	// To test out these effects, wear ExampleHood, ExampleBreastplate, and ExampleLeggings.
+	// This example demonstrates using several vanilla armor set shadows toggled by double tapping the down key, as well as a completely custom armor set shadow toggled by holding the down key. "Shadow" effects in vanilla are also used for some dodges and dashes.
 	public class ExampleArmorSetBonusPlayer : ModPlayer
 	{
 		public bool ExampleSetHood; // Indicates if the ExampleSet with ExampleHood is the active armor set.
 		public int ShadowStyle = 0; // This is the shadow to use. Note that ExampleHood.ArmorSetShadows will only be called if the full armor set is visible.
+		public bool CustomShadow; // Indicates that our custom shadow should be used.
+		private int CustomShadowTimer; // Used in our custom shadow logic.
 
 		public override void ResetEffects() {
 			ExampleSetHood = false;
+			CustomShadow = false;
 		}
 
 		public override void ArmorSetBonusActivated() {
@@ -18,10 +26,10 @@ namespace ExampleMod.Common.Players
 				return;
 			}
 
-			if (ShadowStyle == 3) {
+			if (ShadowStyle == 4) {
 				ShadowStyle = 0;
 			}
-			ShadowStyle = (ShadowStyle + 1) % 3;
+			ShadowStyle = (ShadowStyle + 1) % 4;
 			ShowMessageForShadowStyle();
 		}
 
@@ -31,7 +39,7 @@ namespace ExampleMod.Common.Players
 			}
 
 			if (holdTime == 60) {
-				ShadowStyle = ShadowStyle == 3 ? 0 : 3;
+				ShadowStyle = ShadowStyle == 4 ? 0 : 4;
 				ShowMessageForShadowStyle();
 			}
 		}
@@ -41,9 +49,47 @@ namespace ExampleMod.Common.Players
 				1 => "armorEffectDrawShadow",
 				2 => "armorEffectDrawOutlines",
 				3 => "armorEffectDrawOutlinesForbidden",
+				4 => "CustomShadow",
 				_ => "None",
 			};
 			Main.NewText("Current shadow style: " + styleName);
+		}
+
+		// For implementing a custom armor set "shadow" visual effect, we use the DrawPlayer hook to render the player multiple times.
+		public override void DrawPlayer(Camera camera) {
+			if (!CustomShadow) {
+				return;
+			}
+
+			CustomShadowTimer++;
+			int clones = 3;
+			if (Player.statLife < Player.statLifeMax2 / 2) {
+				clones += 1;
+			}
+			Vector2 playerPosition = Player.position + new Vector2(0f, Player.gfxOffY);
+			// Draw the player 3 or 4 times
+			for (int i = 0; i < clones; i++) {
+				// This logic spins the clones around the player while pulsing them in and out.
+				// See Terraria.Graphics.Renderers.LegacyPlayerRenderer.DrawPlayerFull to see how other vanilla effects are implemented.
+				float rotation = CustomShadowTimer * 0.03f + i * (MathHelper.TwoPi / clones);
+				float distanceFromPlayer = MathF.Sin(CustomShadowTimer * 0.06f);
+				Vector2 drawPosition = playerPosition + new Vector2(0f, distanceFromPlayer).RotatedBy(rotation) * 25;
+				float shadow = 1 - Utils.Remap(Math.Abs(distanceFromPlayer), 0, 1, 0.1f, 0.4f, clamped: true);
+
+				// Main.PlayerRenderer.DrawPlayer handles drawing the player clone. 
+				Main.PlayerRenderer.DrawPlayer(camera, Player, drawPosition, Player.fullRotation, Player.fullRotationOrigin, shadow);
+			}
+
+			// Another common player effect is to draw the player at previous positions and slightly faded. Player.shadowPos/shadowRotation/shadowOrigin stores the last 3 positions and is used by shadow effects added to the game in early versions. Player.GetAdvancedShadow is a more recent addition and can be used for more advanced control and stores up to 60 previous positions.
+			/* 
+			int totalShadows = Math.Min(Player.availableAdvancedShadowsCount, 30);
+			int skip = 5;
+			for (int i = totalShadows - totalShadows % skip; i > 0; i -= skip) {
+				EntityShadowInfo advancedShadow = Player.GetAdvancedShadow(i);
+				float shadow = Utils.Remap((float)i / totalShadows, 0, 1, 0.5f, 1f, clamped: true);
+				Main.PlayerRenderer.DrawPlayer(camera, Player, advancedShadow.Position, advancedShadow.Rotation, advancedShadow.Origin, shadow);
+			}
+			*/
 		}
 	}
 }

--- a/ExampleMod/Content/Items/Armor/ExampleHood.cs
+++ b/ExampleMod/Content/Items/Armor/ExampleHood.cs
@@ -54,6 +54,9 @@ namespace ExampleMod.Content.Items.Armor
 			else if (exampleArmorSetBonusPlayer.ShadowStyle == 3) {
 				player.armorEffectDrawOutlinesForbidden = true;
 			}
+			else if (exampleArmorSetBonusPlayer.ShadowStyle == 4) {
+				exampleArmorSetBonusPlayer.CustomShadow = true;
+			}
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.

--- a/patches/tModLoader/Terraria/DataStructures/EntityShadowInfo.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/EntityShadowInfo.cs.patch
@@ -1,0 +1,12 @@
+--- src/TerrariaNetCore/Terraria/DataStructures/EntityShadowInfo.cs
++++ src/tModLoader/Terraria/DataStructures/EntityShadowInfo.cs
+@@ -2,6 +_,9 @@
+ 
+ namespace Terraria.DataStructures;
+ 
++/// <summary>
++/// Contains positioning data (position, rotation, direction, etc) from previous frames for this player. See <see cref="Player.availableAdvancedShadowsCount"/> and <see cref="Player.GetAdvancedShadow(int)"/> to use.
++/// </summary>
+ public struct EntityShadowInfo
+ {
+ 	public Vector2 Position;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.TML.cs
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.TML.cs
@@ -1,5 +1,10 @@
 namespace Terraria.DataStructures;
 
+/// <summary>
+/// Contains all the parameters defining how a particular player will be rendered in the current lighting, copied from the <see cref="drawPlayer"/>.
+/// <br/><br/> First, the color of each body part is calculated and all of the fields are populated. Next, this data is used by each <see cref="ModLoader.PlayerDrawLayer"/> to populate <see cref="DrawDataCache"/> with <see cref="DrawData"/> corresponding to each individual layer making up the visuals of the player. Finally, every <see cref="DrawDataCache"/> is actually drawn.
+/// <br/><br/> In terms of modded logic, <see cref="ModLoader.ModPlayer.DrawEffects"/> runs before body part color values are calculated, <see cref="ModLoader.ModPlayer.ModifyDrawInfo"/> runs right before each <see cref="ModLoader.PlayerDrawLayer"/> runs, then each <see cref="ModLoader.PlayerDrawLayer"/> runs, and finally <see cref="ModLoader.ModPlayer.TransformDrawData"/> runs.
+/// </summary>
 public partial struct PlayerDrawSet
 {
 	public bool headOnlyRender;

--- a/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/DataStructures/PlayerDrawSet.cs
 +++ src/tModLoader/Terraria/DataStructures/PlayerDrawSet.cs
-@@ -5,10 +_,11 @@
+@@ -5,11 +_,15 @@
  using Terraria.GameContent.Golf;
  using Terraria.Graphics.Shaders;
  using Terraria.ID;
@@ -11,8 +11,12 @@
 -public struct PlayerDrawSet
 +public partial struct PlayerDrawSet
  {
++	/// <summary>
++	/// Contains <see cref="DrawData"/> representing each individual layer, from back to front, comprising the full visuals of the player.
++	/// </summary>
  	public List<DrawData> DrawDataCache;
  	public List<int> DustCache;
+ 	public List<int> GoreCache;
 @@ -19,8 +_,19 @@
  	public int projectileDrawPosition;
  	public Vector2 ItemLocation;

--- a/patches/tModLoader/Terraria/Graphics/Renderers/IPlayerRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Renderers/IPlayerRenderer.cs.patch
@@ -1,0 +1,13 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Renderers/IPlayerRenderer.cs
++++ src/tModLoader/Terraria/Graphics/Renderers/IPlayerRenderer.cs
+@@ -9,5 +_,10 @@
+ 
+ 	void DrawPlayerHead(Camera camera, Player drawPlayer, Vector2 position, float alpha = 1f, float scale = 1f, Color borderColor = default(Color));
+ 
++	/// <summary>
++	/// Draws a player fully.
++	/// <br/><br/> When using this method for an armor set shadow effect, make sure shadow is never 0 so that only the main body renders with the item and other visual effects that are intended to only be drawn on the main body. A shadow value of 0 is fully opaque, while a value of 1 is fully transparent.
++	/// <br/><br/> When using this method outside of the game world, such as in a UI, setting <see cref="Player.isDisplayDollOrInanimate"/> to true will avoid world lighting values affecting how the player is drawn.
++	/// </summary>
+ 	void DrawPlayer(Camera camera, Player drawPlayer, Vector2 position, float rotation, Vector2 rotationOrigin, float shadow = 0f, float scale = 1f);
+ }

--- a/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
@@ -39,7 +39,7 @@
  		if (drawPlayer.ShouldNotDraw)
  			return;
  
-@@ -121,8 +_,30 @@
+@@ -121,12 +_,36 @@
  		_drawData.Clear();
  		_dust.Clear();
  		_gore.Clear();
@@ -70,6 +70,12 @@
  		PlayerDrawLayers.DrawPlayer_TransformDrawData(ref drawInfo);
  		if (scale != 1f)
  			PlayerDrawLayers.DrawPlayer_ScaleDrawData(ref drawInfo, scale);
+ 
++		PlayerLoader.TransformDrawData(ref drawInfo);
++
+ 		PlayerDrawLayers.DrawPlayer_RenderAllLayers(ref drawInfo);
+ 		if (!drawInfo.drawPlayer.mount.Active || !drawInfo.drawPlayer.UsingSuperCart)
+ 			return;
 @@ -263,6 +_,8 @@
  					}
  				}

--- a/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
@@ -70,3 +70,12 @@
  		PlayerDrawLayers.DrawPlayer_TransformDrawData(ref drawInfo);
  		if (scale != 1f)
  			PlayerDrawLayers.DrawPlayer_ScaleDrawData(ref drawInfo, scale);
+@@ -289,6 +_,8 @@
+ 					drawPlayer.invis = true;
+ 				}
+ 			}
++
++			PlayerLoader.DrawPlayer(drawPlayer, camera);
+ 
+ 			if (drawPlayer.armorEffectDrawOutlines) {
+ 				_ = drawPlayer.position;

--- a/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Renderers/LegacyPlayerRenderer.cs.patch
@@ -70,12 +70,12 @@
  		PlayerDrawLayers.DrawPlayer_TransformDrawData(ref drawInfo);
  		if (scale != 1f)
  			PlayerDrawLayers.DrawPlayer_ScaleDrawData(ref drawInfo, scale);
-@@ -289,6 +_,8 @@
- 					drawPlayer.invis = true;
+@@ -263,6 +_,8 @@
+ 					}
  				}
  			}
 +
 +			PlayerLoader.DrawPlayer(drawPlayer, camera);
  
- 			if (drawPlayer.armorEffectDrawOutlines) {
- 				_ = drawPlayer.position;
+ 			if (drawPlayer.armorEffectDrawShadowEOCShield) {
+ 				int num = drawPlayer.eocDash / 4;

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1134,11 +1134,19 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
-	/// Allows you to modify the drawing parameters of the player before drawing begins.
+	/// Allows you to modify the drawing parameters of the player before drawing begins (before every <see cref="PlayerDrawLayer"/> runs).
 	/// <para/> Called on local and remote clients.
 	/// </summary>
 	/// <param name="drawInfo"></param>
 	public virtual void ModifyDrawInfo(ref PlayerDrawSet drawInfo)
+	{
+	}
+
+	/// <summary>
+	/// Allows modifying player draw data after all <see cref="PlayerDrawLayer"/> have run (and added <see cref="PlayerDrawSet.DrawDataCache"/> entries) and immediately before the <see cref="PlayerDrawSet.DrawDataCache"/> entries are actually drawn.
+	/// <br/><br/> This can be used to modify all <see cref="PlayerDrawSet.DrawDataCache"/> entries, such as modifying the draw color of each entry. Vanilla uses this to apply the scale parameter of <see cref="Graphics.Renderers.IPlayerRenderer.DrawPlayer"/> and to customize how the First Fractal clones are rendered (unobtainable weapon).
+	/// </summary>
+	public virtual void TransformDrawData(ref PlayerDrawSet drawInfo)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria.DataStructures;
 using Terraria.GameInput;
+using Terraria.Graphics;
 using Terraria.ID;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.IO;
@@ -1415,6 +1416,14 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// <param name="oldLoadoutIndex">The old loadout index.</param>
 	/// <param name="loadoutIndex">The new loadout index.</param>
 	public virtual void OnEquipmentLoadoutSwitched(int oldLoadoutIndex, int loadoutIndex)
+	{
+	}
+
+	/// <summary>
+	/// Allows drawing additional copies of the player, usually to implement an armor set shadow visual effect, dodge effect, or dash effect. Use <c>Main.PlayerRenderer.DrawPlayer(...)</c> to draw the additional player copies. The normal player will be drawn after this method runs.
+	/// <br/><br/> Called during <see cref="Terraria.Graphics.Renderers.LegacyPlayerRenderer.DrawPlayerFull(Graphics.Camera, Player)"/>. 
+	/// </summary>
+	public virtual void DrawPlayer(Camera camera)
 	{
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1215,6 +1215,19 @@ public static class PlayerLoader
 		}
 	}
 
+	private delegate void DelegateTransformDrawData(ref PlayerDrawSet drawInfo);
+	private static HookList HookTransformDrawData = AddHook<DelegateTransformDrawData>(p => p.TransformDrawData);
+
+	public static void TransformDrawData(ref PlayerDrawSet drawInfo)
+	{
+		var player = drawInfo.drawPlayer;
+
+		foreach (var modPlayer in HookTransformDrawData.Enumerate(player)) {
+			try { modPlayer.TransformDrawData(ref drawInfo); }
+			catch { }
+		}
+	}
+
 	private static HookList HookModifyDrawLayerOrdering = AddHook<Action<IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position>>>(p => p.ModifyDrawLayerOrdering);
 
 	public static void ModifyDrawLayerOrdering(IDictionary<PlayerDrawLayer, PlayerDrawLayer.Position> positions)

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Runtime.InteropServices;
 using Terraria.DataStructures;
 using Terraria.GameInput;
+using Terraria.Graphics;
 using Terraria.ModLoader.Default;
 using HookList = Terraria.ModLoader.Core.HookList<Terraria.ModLoader.ModPlayer>;
 
@@ -1508,6 +1509,14 @@ public static class PlayerLoader
 	{
 		foreach (var modPlayer in HookOnEquipmentLoadoutSwitched.Enumerate(player)) {
 			modPlayer.OnEquipmentLoadoutSwitched(oldLoadoutIndex, loadoutIndex);
+		}
+	}
+
+	private static HookList HookDrawPlayer = AddHook<Action<Camera>>(p => p.DrawPlayer);
+
+	public static void DrawPlayer(Player player, Camera camera) {
+		foreach (var modPlayer in HookDrawPlayer.Enumerate(player)) {
+			modPlayer.DrawPlayer(camera);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -541,7 +541,7 @@
  	public bool controlDownHold;
  	public bool isOperatingAnotherEntity;
  	public bool autoReuseAllWeapons;
-@@ -930,10 +_,26 @@
+@@ -930,20 +_,49 @@
  	public bool delayUseItem;
  	public const int defaultWidth = 20;
  	public const int defaultHeight = 42;
@@ -568,8 +568,17 @@
  	public string cursorItemIconText = "";
  	public int runSoundDelay;
  	public float opacityForAnimation = 1f;
-@@ -943,7 +_,13 @@
+ 	public const int shadowMax = 3;
++	/// <summary>
++	/// Contains the player positioning data for the last 3 frames. Used by <see cref="armorEffectDrawShadow"/> and other similar effects.
++	/// <br/><br/> See <see cref="GetAdvancedShadow(int)"/> for a more flexible approach. 
++	/// </summary>
+ 	public Vector2[] shadowPos = new Vector2[3];
++	/// <inheritdoc cref="shadowPos"/>
+ 	public float[] shadowRotation = new float[3];
++	/// <inheritdoc cref="shadowPos"/>
  	public Vector2[] shadowOrigin = new Vector2[3];
++	/// <inheritdoc cref="shadowPos"/>
  	public int[] shadowDirection = new int[3];
  	public int shadowCount;
 +
@@ -582,6 +591,16 @@
  	public bool fireWalk;
  	public bool channel;
  	public int step = -1;
+@@ -952,6 +_,9 @@
+ 	public RabbitOrderFrameHelper rabbitOrderFrame;
+ 	public bool creativeGodMode;
+ 	private const int MaxAdvancedShadows = 60;
++	/// <summary>
++	/// The number of frames of previous positioning data available for use with <see cref="GetAdvancedShadow(int)"/>. This will max at 60. Teleporting and mounting are some ways the previous positioning data will be cleared.
++	/// </summary>
+ 	public int availableAdvancedShadowsCount;
+ 	private EntityShadowInfo[] _advancedShadows = new EntityShadowInfo[60];
+ 	private int _lastAddedAvancedShadow;
 @@ -961,38 +_,124 @@
  	public int golferScoreAccumulated;
  	public int bartenderQuestLog;
@@ -1379,6 +1398,18 @@
  	public Vector2 RotatedRelativePoint(Vector2 pos, bool reverseRotation = false, bool addGfxOffY = true)
  	{
  		float num = (reverseRotation ? (0f - fullRotation) : fullRotation);
+@@ -2282,6 +_,11 @@
+ 		return num;
+ 	}
+ 
++	/// <summary>
++	/// Returns positioning data for this player <paramref name="shadowIndex"/> frames ago, up to <see cref="availableAdvancedShadowsCount"/>.
++	/// <br/><br/> This can be used to draw trails that follow the movement of the player. You'll usually want to iterate from <see cref="availableAdvancedShadowsCount"/> down to 1 for proper draw layering and to skip index 0 which would be the current frame when using this to draw a trail.
++	/// <br/><br/> See <see href="https://github.com/tModLoader/tModLoader/blob/stable/ExampleMod/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs">ExampleArmorSetBonusPlayer.DrawPlayer</see> for an example of correctly using this.
++	/// </summary>
+ 	public EntityShadowInfo GetAdvancedShadow(int shadowIndex)
+ 	{
+ 		if (shadowIndex > availableAdvancedShadowsCount)
 @@ -2328,6 +_,7 @@
  	{
  		talkNPC = npcIndex;

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -257,7 +257,7 @@
  	public static Vector2 ClosestPointOnLine(this Vector2 P, Vector2 A, Vector2 B)
  	{
  		Vector2 value = P - A;
-@@ -1007,6 +_,7 @@
+@@ -1007,16 +_,24 @@
  	public static float DistanceSQ(this Vector2 Origin, Vector2 Target) => Vector2.DistanceSquared(Origin, Target);
  	public static Vector2 DirectionTo(this Vector2 Origin, Vector2 Target) => Vector2.Normalize(Target - Origin);
  	public static Vector2 DirectionFrom(this Vector2 Origin, Vector2 Target) => Vector2.Normalize(Origin - Target);
@@ -265,7 +265,16 @@
  	public static bool WithinRange(this Vector2 Origin, Vector2 Target, float MaxRange) => Vector2.DistanceSquared(Origin, Target) <= MaxRange * MaxRange;
  	public static Vector2 XY(this Vector4 vec) => new Vector2(vec.X, vec.Y);
  	public static Vector2 ZW(this Vector4 vec) => new Vector2(vec.Z, vec.W);
-@@ -1017,6 +_,7 @@
+ 	public static Vector3 XZW(this Vector4 vec) => new Vector3(vec.X, vec.Z, vec.W);
+ 	public static Vector3 YZW(this Vector4 vec) => new Vector3(vec.Y, vec.Z, vec.W);
++	/// <summary>
++	/// Multiplies each channel (except for the Alpha channel, which will be 1 in the result) of this Color with the provided color, resulting in a darker blended color. This is the "multiply blend mode" used by drawing programs.
++	/// </summary>
+ 	public static Color MultiplyRGB(this Color firstColor, Color secondColor) => new Color((byte)((float)(firstColor.R * secondColor.R) / 255f), (byte)((float)(firstColor.G * secondColor.G) / 255f), (byte)((float)(firstColor.B * secondColor.B) / 255f));
++	/// <summary>
++	/// Multiplies each channel of this Color with the provided color, resulting in a darker blended color. This is the "multiply blend mode" used by drawing programs.
++	/// </summary>
+ 	public static Color MultiplyRGBA(this Color firstColor, Color secondColor) => new Color((byte)((float)(firstColor.R * secondColor.R) / 255f), (byte)((float)(firstColor.G * secondColor.G) / 255f), (byte)((float)(firstColor.B * secondColor.B) / 255f), (byte)((float)(firstColor.A * secondColor.A) / 255f));
  	public static string Hex3(this Color color) => (color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2")).ToLower();
  	public static string Hex4(this Color color) => (color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2") + color.A.ToString("X2")).ToLower();
  


### PR DESCRIPTION
### What is the new feature?
Adds a `ModPlayer.DrawPlayer` hook that is called during `LegacyPlayerRenderer.DrawPlayerFull`. This hook is suitable for calling `Main.PlayerRenderer.DrawPlayer` to draw additional copies of the player, allowing mods to implement custom player "shadow" effects.

`ModPlayer.TransformDrawData` has also been added, allowing an effect to affect all `PlayerDrawLayer` immediately before being drawn. This can be used for tinting the clones or other transformations.

Lots of documentation. Some examples include Utils.MultiplyRGBA, new shadow related fields, LegacyPlayerRenderer.DrawPlayer, and PlayerDrawSet(.DrawDataCache).

### Why should this be part of tModLoader?
We have hooks for modifying how a player is rendered, but nothing that allows rendering the player multiple times. `ExampleArmorSetBonusPlayer` currently shows off re-using vanilla armor set shadow effects, but until now it was not possible to make a custom shadow effect through normal means.

### Are there alternative designs?
The current design seems reasonable as it closely matches how vanilla shadow effects are implemented. 

The only question is where should `PlayerLoader.DrawPlayer` be called and do we need any additional parameters:

Right now `PlayerLoader.DrawPlayer` is called only if the player is not a ghost. It is also called before all other vanilla shadow effects. Vanilla shadow effects don't seem to be mutually exclusive (can coexist and all will draw) aside from `Player.invis` which disables several shadow effects and `armorEffectDrawShadowBasilisk`/`armorEffectDrawShadow` which are mutually exclusive. I think it makes sense for `PlayerLoader.DrawPlayer` to be before the vanilla effects in case it needs to disable another vanilla effect, similar to what `Player.invis` does.

We could add a parameter to skip the drawing of the main body, if that would be useful.

### Sample usage for the new feature
To use this feature, override `ModPlayer.DrawPlayer` and call `Main.PlayerRenderer.DrawPlayer` for each "shadow" player. For example, the following could be used to implement an exact clone of the `Player.armorEffectDrawShadow` (Shadow Armor) visuals:

```cs
public bool MyCustomShadow; // Set this in ModItem.ArmorSetShadows, during dodge effects, during dashes, when on a specific mount, etc.

public override void ResetEffects() {
	MyCustomShadow = false;
}

public override void DrawPlayer(Camera camera) {
	if (!MyCustomShadow) {
		return;
	}

	for (int i = 0; i < 3; i++) {
		Main.PlayerRenderer.DrawPlayer(camera, Player, Player.shadowPos[i], Player.shadowRotation[i], Player.shadowOrigin[i], 0.5f + 0.2f * i);
	}
}
```

To use `ModPlayer.TransformDrawData`, iterate over `drawInfo.DrawDataCache` and modify/reassign as desired.

### ExampleMod updates
`ExampleArmorSetBonusPlayer` has been updated with a custom armor set shadow option. To test out the new effect, wear `ExampleHood`, `ExampleBreastplate`, and `ExampleLeggings`, then hold down the `down` key (or `up` if you have the reverse armor set hotkey setting toggled).


https://github.com/user-attachments/assets/63534ccb-05cb-4d11-b8ac-310d70cfd494

Note that the video shows the effect prior to adding colors. Current code has colored shadows as shown below:

<img width="287" height="228" alt="dotnet_2025-10-15_13-21-48" src="https://github.com/user-attachments/assets/10df9a17-df23-400e-9f7c-717b5267dda8" />


### Porting Notes
- Replace any relevant IL edits or detours of `LegacyPlayerRenderer.DrawPlayerFull` by using `ModPlayer.DrawPlayer`.
- Replace any relevant IL edits or detours of `LegacyPlayerRenderer.DrawPlayerInternal` by using `ModPlayer.TransformDrawData`.
