### PR TITLE
fix linux WatchLocalization path

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/LocalizationLoader.cs
@@ -205,7 +205,7 @@ public static class LocalizationLoader
 				string translationFileContents = streamReader.ReadToEnd();
 
 				string modpath = Path.Combine(tModFile.Name, translationFile.Name).Replace('/', '\\');
-				if (!string.IsNullOrWhiteSpace(sourceFolder) && changedFiles.Select(x => Path.Join(x.Mod, x.fileName)).Contains(modpath)) {
+				if (!string.IsNullOrWhiteSpace(sourceFolder) && changedFiles.Select(x => Path.Join(x.Mod, x.fileName).Replace('/', '\\')).Contains(modpath)) {
 					// TODO: we could skip this for GetLocalizationCounts to be more accurate to the entries in the mod itself, but that is not needed since we don't allow publishing on the client if any changedFiles and the command line publish won't detect changedFiles unless hosting.
 					string path = Path.Combine(sourceFolder, translationFile.Name);
 					if (File.Exists(path)) {


### PR DESCRIPTION
### What is the bug?
On linux, the "hot reload" localization file feature (internally referred to as WatchLocalization) was not working correctly due to path separator discrepancies.

<img width="1505" height="305" alt="2025-10-30_22-10" src="https://github.com/user-attachments/assets/da2b6193-0e89-4388-933b-5aae0f010f7b" />

### How did you fix the bug?
replace path separators. It will continue working on windows as the separators it's replacing don't exist on windows in the first place

### Are there alternatives to your fix?
Do it the other way around