### PR TITLE
Move ModAchievement.(Auto)SetStaticDefaults to FinishSetup

### DIFF
--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -141,7 +141,7 @@
 +		foreach (ModAchievement modAchievement in ModdedAchievements) {
 +			modAchievement.SetStaticDefaults();
 +			if (modAchievement.Achievement._conditions.Count == 0)
-+				throw BlameAchievementException(new Exception($"The ModAchievement '{modAchievement}' has no conditions, achievements must have at least one condition."));
++				throw BlameAchievementException(new Exception($"The ModAchievement '{modAchievement.Name}' has no conditions, achievements must have at least one condition."));
 +			modAchievement.AutoStaticDefaults();
 +
 +			var position = modAchievement.GetDefaultPosition();
@@ -164,7 +164,7 @@
 +					break;
 +				}
 +				default: {
-+					var ex = new ArgumentException($"ModMapLayer {modAchievement} has unknown Position {position}");
++					var ex = new ArgumentException($"ModAchievement {modAchievement} has unknown Position {position}");
 +					throw BlameAchievementException(ex);
 +				}
 +			}

--- a/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
+++ b/patches/tModLoader/Terraria/Achievements/AchievementManager.cs.patch
@@ -111,7 +111,7 @@
  	public Achievement GetAchievement(string achievementName)
  	{
  		if (_achievements.TryGetValue(achievementName, out var value))
-@@ -181,5 +_,93 @@
+@@ -181,5 +_,98 @@
  			return value;
  
  		return 0;
@@ -139,6 +139,11 @@
 +			sortingSlots[i] = [];
 +
 +		foreach (ModAchievement modAchievement in ModdedAchievements) {
++			modAchievement.SetStaticDefaults();
++			if (modAchievement.Achievement._conditions.Count == 0)
++				throw BlameAchievementException(new Exception($"The ModAchievement '{modAchievement}' has no conditions, achievements must have at least one condition."));
++			modAchievement.AutoStaticDefaults();
++
 +			var position = modAchievement.GetDefaultPosition();
 +
 +			switch (position) {

--- a/patches/tModLoader/Terraria/GameContent/Achievements/ItemPickupCondition.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Achievements/ItemPickupCondition.cs.patch
@@ -23,10 +23,18 @@
  	{
  		_itemIds = new short[1] {
  			itemId
-@@ -20,8 +_,20 @@
+@@ -20,8 +_,28 @@
  		ListenForPickup(this);
  	}
  
++	/// <summary>
++	/// Since this takes a short array, you may need to do something like this to convert a set:
++	/// <code>
++	/// int[] drillItems = ItemID.Sets.IsDrill.GetTrueIndexes().ToArray();
++	/// short[] drillItemsAsShort = Array.ConvertAll(drillItems, Convert.ToInt16);
++	/// AddCondition(new ItemPickupCondition(drillItemsAsShort));
++	/// </code>
++	/// </summary>
 -	private ItemPickupCondition(short[] itemIds)
 +	public ItemPickupCondition(short[] itemIds)
 -		: base("ITEM_PICKUP_" + itemIds[0])

--- a/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModAchievement.cs
@@ -159,10 +159,6 @@ public abstract class ModAchievement : ModType<Achievement, ModAchievement>, ILo
 
 	public override sealed void SetupContent()
 	{
-		SetStaticDefaults();
-		if (Achievement._conditions.Count == 0)
-			throw new Exception($"The ModAchievement '{Name}' has no conditions, achievements must have at least one condition.");
-		AutoStaticDefaults();
 		Main.Achievements.Register(Achievement);
 		Main.Achievements.RegisterIconIndex(Achievement.Name, Index);
 		Achievement.OnCompleted += OnCompleted;


### PR DESCRIPTION
### What is the new feature?
The current `ModAchievement` implementation doesn't take into concideration that most often, achievement conditions are based on existing content. These conditions were meant to be set up within the `SetupContent` part of the load process, which happens concurrently to other content.

This PR moves the condition (and tracker) code near the end of the loading process, commonly known as "`FinishSetup`", allowing it to capture existing and modified content properly.

### Why should this be part of tModLoader?
As it stands, if the modder wants to make conditions that are based on data which is set by other content within `SetStaticDefaults`, it is prone to out-of-order execution since it all happens in the same loading step. A basic example of such a content-dependent condition is shown in a section below.

### Are there alternative designs?
I simply moved the hooks, which are _usually_ called in SetupContent, to a later step. This does break (non-enforced) spec, but other content (such as IPlant or ModPylon) also has delayed invocation of these hooks. I did it that way as it will not be breaking mods (runtime or compile-time) except in rare cases where ModAchievement.SetStaticDefaults had to run in the original timing. I have tested this with an unreleased mod adding 43 new ModAchievements and experienced no such issues.

### Sample usage for the new feature
```cs
public class ObtainAllDrillsAchievement : ModAchievement
{
	public override void SetStaticDefaults()
	{
		//ModItem would do SetStaticDefaults() => ItemID.Sets.IsDrill[Type] = true;
		for (int i = 0; i < ItemLoader.ItemCount; i++) {
			if (ItemID.Sets.IsDrill[i])
				AddCondition(new ItemPickupCondition((short)i));
		}
	}
}
```

### ExampleMod updates
Nothing, it's rather straightforward, but if needed, can implement the sample usage.

### Porting Notes
Potential runtime breakage if code execution relied on SetupContent timing.
