### PR TITLE
[Build] Include tML-Provided References as Non-`Private`

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -41,8 +41,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="$(tMLSteamPath)$(tMLPath)" />
-		<Reference Include="$(tMLLibraryPath)/**/*.dll" />
+		<Reference Include="$(tMLSteamPath)$(tMLPath)" Private="false" />
+		<Reference Include="$(tMLLibraryPath)/**/*.dll" Private="false" />
 		<Reference Remove="$(tMLLibraryPath)/Native/**" />
 		<Reference Remove="$(tMLLibraryPath)/**/runtime*/**" />
 		<Reference Remove="$(tMLLibraryPath)/**/*.resources.dll" />


### PR DESCRIPTION
### What is the new feature?

Changes tML-provided references in MSBuild to be non-`Private`, meaning they no longer copy to the output directory of the mod.

### Why should this be part of tModLoader?

Heavily reduces build sizes and clutter on disk, just not impact packaged `.tmod`s.

