### PR TITLE
fix(bug): Fix the issue of deleting the environment on first run

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -29,6 +29,9 @@ LaunchLogs="$root_dir/tModLoader-Logs"
 
 if [ ! -d "$LaunchLogs" ]; then
 	mkdir -p "$LaunchLogs"
+	is_first_run=true
+else
+	is_first_run=false
 fi
 
 LogFile="$LaunchLogs/Launch.log"
@@ -54,10 +57,9 @@ echo "This may take a few moments."
 source ./DotNetVersion.sh
 
 # Attempt to fix first time Crash To Desktop due to dotnet install failure
-if [[ ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" ]]; then
+if [[ ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" && ! "$is_first_run" ]]; then
 	echo "Last Run Attempt Failed to Start tModLoader. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 	rm -rf "$dotnet_dir"
-	mkdir "$dotnet_dir"
 fi
 
 # Dotnet binaries Fixes (Proton, AppleSilicon)
@@ -65,18 +67,19 @@ if [[ "$_uname" == *"_NT"* ]]; then
 	if [[ -f "$dotnet_dir/dotnet" ]]; then
 		echo "A non-Windows dotnet executable was detected. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
-		mkdir "$dotnet_dir"
 	fi
 else
 	if [[ -f "$dotnet_dir/dotnet.exe" ]]; then
 		echo "A Windows dotnet executable was detected, possibly from a previous Proton launch. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
-		mkdir "$dotnet_dir"
 	elif [ "$_uname" = Darwin ] && [[ "$_arch" != "arm64" ]] && [[ "$(file "$dotnet_dir/dotnet")" == *"arm64"* ]]; then
 		echo "An arm64 install of dotnet was detected. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 		rm -rf "$dotnet_dir"
-		mkdir "$dotnet_dir"
 	fi
+fi
+
+if [ ! -d "$dotnet_dir" ]; then
+	mkdir -p "$dotnet_dir"
 fi
 
 # Installing Dotnet

--- a/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
+++ b/patches/tModLoader/Terraria/release_extras/LaunchUtils/ScriptCaller.sh
@@ -57,7 +57,7 @@ echo "This may take a few moments."
 source ./DotNetVersion.sh
 
 # Attempt to fix first time Crash To Desktop due to dotnet install failure
-if [[ ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" && ! "$is_first_run" ]]; then
+if [[ ! "$is_first_run" && ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" ]]; then
 	echo "Last Run Attempt Failed to Start tModLoader. Deleting dotnet_dir and resetting"  2>&1 | tee -a "$LogFile"
 	rm -rf "$dotnet_dir"
 fi


### PR DESCRIPTION
### What is the bug?
The issue occurs in `ScriptCaller.sh` which is called by `start-tModLoaderServer.sh`. During the first run, the script incorrectly deletes the prepared `dotnet_dir` environment. This happens because the script checks for the existence of log files (`client.log` and `server.log`) to determine if the previous run failed. Since these log files don't exist on the first run, the condition is met and the environment is unnecessarily deleted and reset.

### How did you fix the bug?
I enhanced the existing log directory check by adding a first-run flag mechanism:

1. When the script runs, it first checks if the `LaunchLogs` directory exists
2. If the directory doesn't exist (indicating first run), it creates the directory and sets `is_first_run=true`
3. If the directory exists, it sets `is_first_run=false`
4. Modified the environment deletion condition to check both the absence of log files AND that it's not the first run: ```sh if [[ ! -f "$LaunchLogs/client.log" && ! -f "$LaunchLogs/server.log" && ! "$is_first_run" ]]; then ```

This ensures that on the first run, even though the log files don't exist, the environment won't be deleted, allowing the script to use the existing environment.

### Are there alternatives to your fix?
Yes, alternative approaches include:
- Checking for specific error patterns in existing log files to more accurately detect actual failures
- Creating placeholder log files during first run to prevent the deletion condition from being met
- Using a separate flag file to track successful runs

However, the first-run flag approach is the most straightforward and maintains the existing logic while simply adding a necessary exception for initial execution. It doesn't complicate the code and provides a clear solution to the problem.