### PR TITLE
[Fix] `DrawTileInWater` IOOB - Liquid Slopes Hotfix 1

### DIFF
--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6543,6 +6543,21 @@
  			TilesRenderer.DrawLiquidBehindTiles(waterStyle);
  
  		LiquidRenderer.Instance.DrawNormalLiquids(spriteBatch, drawOffset, waterStyle, Alpha, bg);
+@@ -47337,6 +_,14 @@
+ 
+ 	public static void DrawTileInWater(Vector2 drawOffset, int x, int y)
+ 	{
++		// TML(liquid-slopes): There seems to be an IOOB being thrown here,
++		// presumably due to tile coordinates being stored as relative XY
++		// positions as a result of the merger with the shimmer draw cache.
++		// For now, just add a safety check here.  We can keep this even if
++		// it's properly addressed.
++		if (!WorldGen.InWorld(x, y))
++			return;
++
+ 		if (Main.tile[x, y] != null && Main.tile[x, y].active() && Main.tile[x, y].type == 518) {
+ 			instance.LoadTiles(Main.tile[x, y].type);
+ 			Tile tile = Main.tile[x, y];
 @@ -47776,6 +_,7 @@
  			}
  		}


### PR DESCRIPTION
Early return in `DrawTileInWater` to prevent an issue with exceptions being thrown due to attempting to render tiles out of the world.

Haven't seen anyone else report it but it happens to me, will receive a better fix in a follow-up PR once I address some more issues, but this is free to cherrypick for now.