### PR TITLE
[Fix] Include missed LiquidEdgeRenderer case

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
@@ -286,7 +286,7 @@ public static class LiquidEdgeRenderer
 					}
 					if (slope is SlopeType.SlopeDownRight or SlopeType.SlopeUpRight) {
 						offset = new Vector2(0, depthPush);
-						if (WorldGen.SolidTile(tileRightCache)) {
+						if (WorldGen.SolidOrSlopedTile(tileRightCache)) {
 							size = (16, 16 - depthPush);
 						}
 						else {
@@ -296,7 +296,7 @@ public static class LiquidEdgeRenderer
 				}
 				else if (right) {
 					if (slope is SlopeType.SlopeDownLeft or SlopeType.SlopeUpLeft) {
-						if (WorldGen.SolidTile(tileLeftCache)) {
+						if (WorldGen.SolidOrSlopedTile(tileLeftCache)) {
 							offset = new Vector2(0, depthPush);
 							size = (16, 16 - depthPush);
 						}

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
@@ -286,13 +286,24 @@ public static class LiquidEdgeRenderer
 					}
 					if (slope is SlopeType.SlopeDownRight or SlopeType.SlopeUpRight) {
 						offset = new Vector2(0, depthPush);
-						size = (14, 16 - depthPush);
+						if (WorldGen.SolidTile(tileRightCache)) {
+							size = (16, 16 - depthPush);
+						}
+						else {
+							size = (14, 16 - depthPush);
+						}
 					}
 				}
 				else if (right) {
 					if (slope is SlopeType.SlopeDownLeft or SlopeType.SlopeUpLeft) {
-						offset = new Vector2(2, depthPush);
-						size = (14, 16 - depthPush);
+						if (WorldGen.SolidTile(tileLeftCache)) {
+							offset = new Vector2(0, depthPush);
+							size = (16, 16 - depthPush);
+						}
+						else {
+							offset = new Vector2(2, depthPush);
+							size = (14, 16 - depthPush);
+						}
 					}
 					if (slope is SlopeType.SlopeDownRight or SlopeType.SlopeUpRight) {
 						offset = new Vector2(14, depthPush);


### PR DESCRIPTION
Bug: Small gaps appear in sloped (and possibly full, not tested) tiles with water on perpendicular sides (left and down, up and right, etc.) where DrawBlack does not apply due to brightness.
Fix: Checks the solidity of the tile on the solid side of the slope in question, and extend the edge rectangle if so.

Current:
<img width="299" height="181" alt="image" src="https://github.com/user-attachments/assets/f54dfdd2-7fa5-4a65-b474-f82e8abbd191" />
Fixed:
<img width="354" height="251" alt="image" src="https://github.com/user-attachments/assets/9f8cc5b6-b6e4-4541-9367-2a9eed424dee" />