### PR TITLE
Feature: allow mods to specify whether or not to show content count baubles

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -55,6 +55,10 @@ public partial class Mod
 	public string SourceFolder { get; internal set; }
 
 	/// <summary>
+	/// Whether or not this mod will show its content count baubles in the mod list.
+	/// </summary>
+	public bool ShowContentCountBaubles { get; init; } = true;
+	/// <summary>
 	/// Whether or not this mod will autoload content by default. Autoloading content means you do not need to manually add content through methods.
 	/// </summary>
 	public bool ContentAutoloadingEnabled { get; init; } = true;

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -305,6 +305,8 @@ internal class UIModItem : UIPanel
 						Left = { Pixels = xOffset, Percent = 1f }
 					};
 
+					// If this mod decides not to show its content count baubles, return early and do not append.
+					if (!loadedMod.ShowContentCountBaubles) return;
 					Append(_keyImage);
 					xOffset -= 18;
 				}


### PR DESCRIPTION
### What is the new feature?

Adds a bool in the ``Mod`` class that allows developers to decide whether or not their mods display the content count "baubles".

### Why should this be part of tModLoader?

With the increase in popularity of custom mod list item designs (pictured below), i feel it would be a nice QOL feature to be able to decide whether or not these show. Even if a mod does not have any custom panel design, it would be nice to be able to disable it and reduce clutter.

<img width="616" height="108" alt="image" src="https://github.com/user-attachments/assets/ae21913f-ab7f-4337-93fa-93fdbeaef452" />
<img width="619" height="109" alt="image" src="https://github.com/user-attachments/assets/f28cfad6-4464-4beb-bcd6-a03131f72902" />
<img width="622" height="109" alt="image" src="https://github.com/user-attachments/assets/d3adfbce-8af6-4c00-a797-8072cff40c4d" />

### Are there alternative designs?
N/A

### Sample usage for the new feature
```csharp
class MyMod : Mod {
    public MyMod() {
        ShowContentCountBaubles = false;
    }
}
```

### ExampleMod updates
N/A

