### PR TITLE
[CodeAssist] Allow For Multiple Bindings Per Member

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -3,6 +3,7 @@
 	<!-- Set the default value for BuildMod -->
 	<PropertyGroup>
 		<BuildMod Condition="'$(BuildMod)' == ''">true</BuildMod>
+		<OutputTmlReferences Condition="'$(OutputTmlReferences)' == ''">false</OutputTmlReferences>
 	</PropertyGroup>
 
 	<!-- Build Defaults -->
@@ -41,8 +42,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="$(tMLSteamPath)$(tMLPath)" Private="false" />
-		<Reference Include="$(tMLLibraryPath)/**/*.dll" Private="false" />
+		<Reference Include="$(tMLSteamPath)$(tMLPath)" Private="$(OutputTmlReferences)" />
+		<Reference Include="$(tMLLibraryPath)/**/*.dll" Private="$(OutputTmlReferences)" />
 		<Reference Remove="$(tMLLibraryPath)/Native/**" />
 		<Reference Remove="$(tMLLibraryPath)/**/runtime*/**" />
 		<Reference Remove="$(tMLLibraryPath)/**/*.resources.dll" />

--- a/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
@@ -38,6 +38,10 @@ public class BadIDTypeUnitTest
 
 			_ = new Item().type == {|BadIDType:TileID.Dirt|};
 			_ = Main.tile[10, 20].TileType == {|BadIDType:ItemID.GoldOre|}; // ref property
+
+			// https://github.com/tModLoader/tModLoader/issues/4849
+			_ == new Player().CountItem(ItemID.Dirt) < 10;
+			_ == Dust.NewDust(default, 0, 0, DustID.Dirt) == Main.maxDust;
 			"""
 			);
 	}

--- a/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/Analyzers/BadIDTypeUnitTest.cs
@@ -40,8 +40,7 @@ public class BadIDTypeUnitTest
 			_ = Main.tile[10, 20].TileType == {|BadIDType:ItemID.GoldOre|}; // ref property
 
 			// https://github.com/tModLoader/tModLoader/issues/4849
-			_ == new Player().CountItem(ItemID.Dirt) < 10;
-			_ == Dust.NewDust(default, 0, 0, DustID.Dirt) == Main.maxDust;
+			_ = Dust.NewDust(default, 0, 0, DustID.Dirt) == Main.maxDust;
 			"""
 			);
 	}

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -126,6 +126,9 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			_ = new Item().type == [|1|];
 			_ = new Projectile().type == [|444|];
 			_ = Main.tile[10, 20].TileType == [|8|]; // ref property
+
+			// https://github.com/tModLoader/tModLoader/issues/4849
+			_ = new Player().CountItem([|2|]) < 10;
 			""",
 			"""
 			using Terraria;
@@ -134,6 +137,9 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			_ = new Item().type == ItemID.IronPickaxe;
 			_ = new Projectile().type == ProjectileID.Xenopopper;
 			_ = Main.tile[10, 20].TileType == TileID.Gold; // ref property
+
+			// https://github.com/tModLoader/tModLoader/issues/4849
+			_ = new Player().CountItem(ItemID.DirtBlock) < 10;
 			""");
 	}
 

--- a/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
+++ b/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <BuildMod>false</BuildMod>
+    <OutputTmlReferences>true</OutputTmlReferences>
   </PropertyGroup>
 
   <Import Project="../../src/WorkspaceInfo.targets" />

--- a/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
+++ b/tModCodeAssist/tModCodeAssist/Analyzers/ChangeMagicNumberToIDAnalyzer.cs
@@ -114,7 +114,7 @@ public sealed class ChangeMagicNumberToIDAnalyzer() : AbstractDiagnosticAnalyzer
 			var node = (InvocationExpressionSyntax)ctx.Node;
 
 			if (ctx.SemanticModel.GetSymbolInfo(node, ctx.CancellationToken).Symbol as IMethodSymbol is not { } invokedMethodSymbol) return;
-			if (!MagicNumberBindings.TryGetBinding(invokedMethodSymbol, out _)) return;
+			if (!MagicNumberBindings.HasBindingsForSymbol(invokedMethodSymbol)) return;
 
 			for (int i = 0; i < node.ArgumentList.Arguments.Count; i++) {
 				ctx.CancellationToken.ThrowIfCancellationRequested();

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -43,8 +43,8 @@ public static class MagicNumberBindings
 	// Designates a method's return type as an ID type.
 	private sealed class MethodReturnBinding(Binding.CreationContext context) : Binding(context)
 	{
-		// No need to check whether names match; we need to support wildcard
-		// operators ('*') and filtering is handled prior to this call.
+		// No need to check whether names match; filtering is handled prior to
+		// this call.
 		// Be sure to filter out parameter symbols.
 		public override bool AppliesTo(ISymbol symbol) => symbol is IMethodSymbol;
 	}
@@ -55,9 +55,8 @@ public static class MagicNumberBindings
 		public int ParameterOrdinal => parameterOrdinal;
 
 		// We only want to match against parameters of the same ordinal.
-		// No need to check whether the method name is the same; wildcard
-		// operators aren't used here, but filtering is handled prior to this
-		// call regardless.
+		// No need to check whether the method name is the same; filtering is
+		// handled prior to this call.
 		public override bool AppliesTo(ISymbol symbol) =>
 			symbol is IParameterSymbol parameterSymbol && parameterSymbol.Ordinal == ParameterOrdinal;
 	}
@@ -239,11 +238,6 @@ public static class MagicNumberBindings
 		}
 
 		return false;
-
-		static string BuildQualifiedName(ISymbol symbol)
-		{
-			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-		}
 	}
 
 	public static bool TryGetBinding(ISymbol symbol, out Binding binding)
@@ -254,6 +248,37 @@ public static class MagicNumberBindings
 		}
 
 		return TryFindBinding(symbol, bindings, out binding);
+	}
+
+	// Whether the symbol or symbols within it (e.g. parameters of methods)
+	// contain any bindings.
+	public static bool HasBindingsForSymbol(ISymbol symbol)
+	{
+		if (symbol is IFieldSymbol fieldSymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out var bindingsByMember)) {
+			return bindingsByMember.ContainsKey(fieldSymbol.MetadataName)
+				|| bindingsByMember.ContainsKey("*");
+		}
+		else if (symbol is IPropertySymbol propertySymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingsByMember)) {
+			return bindingsByMember.ContainsKey(propertySymbol.MetadataName);
+		}
+		else if (symbol is IMethodSymbol methodSymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingsByMember)) {
+			// This includes parameters!  They only get filtered out in
+			// TryGetBinding(s).
+			return bindingsByMember.ContainsKey(methodSymbol.ToDisplayString(MethodNameOnlyDisplayFormat))
+				|| bindingsByMember.ContainsKey(methodSymbol.ToDisplayString(MethodWithQualifiedParametersDisplayFormat));
+		}
+		else if (symbol is IParameterSymbol parameterSymbol) {
+			// The parameter case is a bit of an edge case in this context but
+			// we can support it by treating it identically to its TryGet case.
+			return TryGetBindings(parameterSymbol, out _);
+		}
+
+		return false;
+	}
+
+	private static string BuildQualifiedName(ISymbol symbol)
+	{
+		return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
 	}
 
 	private static bool TryFindBinding(ISymbol symbol, IEnumerable<Binding> bindings, out Binding binding)

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using Microsoft.CodeAnalysis;
 using ReLogic.Reflection;
 using Terraria.ID;
-using static tModCodeAssist.Bindings.MagicNumberBindings;
 
 namespace tModCodeAssist.Bindings;
 

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis;
 using ReLogic.Reflection;
 using Terraria.ID;
+using static tModCodeAssist.Bindings.MagicNumberBindings;
 
 namespace tModCodeAssist.Bindings;
 
@@ -27,12 +28,17 @@ public static class MagicNumberBindings
 		public IdDictionary Search => context.Search;
 		public bool AllowNegativeIDs => context.AllowNegativeIDs;
 	}
-	private sealed class FieldBinding(Binding.CreationContext context) : Binding(context)
-	{
-	}
+
+	// Designates a field's type as an ID type.
+	private sealed class FieldBinding(Binding.CreationContext context) : Binding(context) { }
+
+	// Designates a method's return type as an ID type.
+	private sealed class MethodReturnBinding(Binding.CreationContext context) : Binding(context) { }
+
+	// Designates a method parameter's type as an ID type.
 	private sealed class MethodParameterBinding(Binding.CreationContext context, int parameterOrder) : Binding(context)
 	{
-		public int ParameterOrder => parameterOrder;
+		public int ParameterOrdinal => parameterOrder;
 	}
 
 	// Foo
@@ -50,16 +56,16 @@ public static class MagicNumberBindings
 
 	private static readonly object @lock = new();
 	private static ConcurrentDictionary<Type, IdDictionary> searchCache;
-	private static ConcurrentDictionary<string, Dictionary<string, Binding>> bindingByMemberByOwningClass;
+	private static ConcurrentDictionary<string, Dictionary<string, List<Binding>>> bindingsByMemberByOwningClass;
 
 	public static void PopulateBindings()
 	{
 		lock (@lock) {
-			if (bindingByMemberByOwningClass != null)
+			if (bindingsByMemberByOwningClass != null)
 				return;
 
 			searchCache = [];
-			bindingByMemberByOwningClass = [];
+			bindingsByMemberByOwningClass = [];
 
 			AddBinding<TileID>("Terraria.Item", "createTile", (ctx) => new FieldBinding(ctx));
 			AddBinding<ItemID>("Terraria.Item", "type", (ctx) => new FieldBinding(ctx));
@@ -167,52 +173,61 @@ public static class MagicNumberBindings
 		var context = new Binding.CreationContext(owningClassName, memberName, idClass.Name, idClass.FullName, search, AllowNegativeIDs: allowNegativeIDs);
 		var binding = func(context);
 
-		if (bindingByMemberByOwningClass.TryGetValue(owningClassName, out var bindingByMember)) {
-			bindingByMember.Add(memberName, binding);
+		if (bindingsByMemberByOwningClass.TryGetValue(owningClassName, out var bindingsByMember)) {
+			if (!bindingsByMember.TryGetValue(memberName, out var bindings))
+				bindingsByMember[memberName] = bindings = [];
+
+			bindings.Add(binding);
 		}
 		else {
-			bindingByMemberByOwningClass[owningClassName] = new() { [memberName] = binding };
+			bindingsByMemberByOwningClass[owningClassName] = new() { [memberName] = [binding] };
 		}
 	}
 
-	public static bool TryGetBinding(ISymbol symbol, out Binding binding)
+	public static bool TryGetBindings(ISymbol symbol, out Binding[] bindings)
 	{
-		binding = null;
+		bindings = null;
 
 		static string BuildQualifiedName(ISymbol symbol)
 		{
 			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
 		}
 
-		if (symbol is IFieldSymbol fieldSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out Dictionary<string, Binding> bindingByMember)) {
-			if (bindingByMember.TryGetValue(fieldSymbol.MetadataName, out binding)) {
+		if (symbol is IFieldSymbol fieldSymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out var bindingsByMember)) {
+			if (bindingsByMember.TryGetValue(fieldSymbol.MetadataName, out bindings)) {
 				return true;
 			}
 
-			if (bindingByMember.TryGetValue("*", out binding)) {
+			if (bindingsByMember.TryGetValue("*", out bindings)) {
 				return true;
 			}
 		}
-		else if (symbol is IPropertySymbol propertySymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
-			if (bindingByMember.TryGetValue(propertySymbol.MetadataName, out binding)) {
+		else if (symbol is IPropertySymbol propertySymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingsByMember)) {
+			if (bindingsByMember.TryGetValue(propertySymbol.MetadataName, out bindings)) {
 				return true;
 			}
 		}
-		else if (symbol is IMethodSymbol methodSymbol && bindingByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingByMember)) {
-			if (bindingByMember.TryGetValue(methodSymbol.ToDisplayString(MethodNameOnlyDisplayFormat), out binding)) {
+		else if (symbol is IMethodSymbol methodSymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out bindingsByMember)) {
+			if (bindingsByMember.TryGetValue(methodSymbol.ToDisplayString(MethodNameOnlyDisplayFormat), out bindings)) {
 				return true;
 			}
 
-			if (bindingByMember.TryGetValue(methodSymbol.ToDisplayString(MethodWithQualifiedParametersDisplayFormat), out binding)) {
+			if (bindingsByMember.TryGetValue(methodSymbol.ToDisplayString(MethodWithQualifiedParametersDisplayFormat), out bindings)) {
 				return true;
 			}
 		}
 		else if (symbol is IParameterSymbol parameterSymbol) {
-			if (TryGetBinding(parameterSymbol.ContainingSymbol, out binding) && parameterSymbol.Ordinal == ((MethodParameterBinding)binding).ParameterOrder) {
+			if (TryGetBinding(parameterSymbol.ContainingSymbol, out bindings) && parameterSymbol.Ordinal == ((MethodParameterBinding)bindings).ParameterOrdinal) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	public static bool TryGetBinding(ISymbol symbol, out Binding binding)
+	{
+		binding = null;
+
 	}
 }

--- a/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
+++ b/tModCodeAssist/tModCodeAssist/Bindings/MagicNumberBindings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using ReLogic.Reflection;
@@ -27,18 +28,38 @@ public static class MagicNumberBindings
 		public string FullIdType => context.FullIdType;
 		public IdDictionary Search => context.Search;
 		public bool AllowNegativeIDs => context.AllowNegativeIDs;
+
+		public abstract bool AppliesTo(ISymbol symbol);
 	}
 
-	// Designates a field's type as an ID type.
-	private sealed class FieldBinding(Binding.CreationContext context) : Binding(context) { }
+	// Designates a field or property's type as an ID type.
+	private sealed class FieldOrPropertyBinding(Binding.CreationContext context) : Binding(context)
+	{
+		// No need to check whether names match; we need to support wildcard
+		// operators ('*') and filtering is handled prior to this call.
+		public override bool AppliesTo(ISymbol symbol) => symbol is IFieldSymbol or IPropertySymbol;
+	}
 
 	// Designates a method's return type as an ID type.
-	private sealed class MethodReturnBinding(Binding.CreationContext context) : Binding(context) { }
+	private sealed class MethodReturnBinding(Binding.CreationContext context) : Binding(context)
+	{
+		// No need to check whether names match; we need to support wildcard
+		// operators ('*') and filtering is handled prior to this call.
+		// Be sure to filter out parameter symbols.
+		public override bool AppliesTo(ISymbol symbol) => symbol is IMethodSymbol;
+	}
 
 	// Designates a method parameter's type as an ID type.
-	private sealed class MethodParameterBinding(Binding.CreationContext context, int parameterOrder) : Binding(context)
+	private sealed class MethodParameterBinding(Binding.CreationContext context, int parameterOrdinal) : Binding(context)
 	{
-		public int ParameterOrdinal => parameterOrder;
+		public int ParameterOrdinal => parameterOrdinal;
+
+		// We only want to match against parameters of the same ordinal.
+		// No need to check whether the method name is the same; wildcard
+		// operators aren't used here, but filtering is handled prior to this
+		// call regardless.
+		public override bool AppliesTo(ISymbol symbol) =>
+			symbol is IParameterSymbol parameterSymbol && parameterSymbol.Ordinal == ParameterOrdinal;
 	}
 
 	// Foo
@@ -67,33 +88,33 @@ public static class MagicNumberBindings
 			searchCache = [];
 			bindingsByMemberByOwningClass = [];
 
-			AddBinding<TileID>("Terraria.Item", "createTile", (ctx) => new FieldBinding(ctx));
-			AddBinding<ItemID>("Terraria.Item", "type", (ctx) => new FieldBinding(ctx));
-			AddBinding<ItemID>("Terraria.Player", "cursorItemIconID", (ctx) => new FieldBinding(ctx));
-			AddBinding<ProjectileID>("Terraria.Item", "shoot", (ctx) => new FieldBinding(ctx));
-			AddBinding<ProjectileID>("Terraria.ModLoader.ModProjectile", "AIType", (ctx) => new FieldBinding(ctx));
-			AddBinding<ItemUseStyleID>("Terraria.Item", "useStyle", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(ItemRarityID), "Terraria.Item", "rare", (ctx) => new FieldBinding(ctx), allowNegativeIDs: true);
-			AddBinding<NPCAIStyleID>("Terraria.NPC", "aiStyle", (ctx) => new FieldBinding(ctx));
-			AddBinding<NPCID>("Terraria.NPC", "type", (ctx) => new FieldBinding(ctx));
-			AddBinding<NPCID>("Terraria.ModLoader.ModNPC", "AIType", (ctx) => new FieldBinding(ctx));
-			AddBinding<NPCID>("Terraria.ModLoader.ModNPC", "AnimationType", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(NetmodeID), "Terraria.Main", "netMode", (ctx) => new FieldBinding(ctx));
-			AddBinding<ProjAIStyleID>("Terraria.Projectile", "aiStyle", (ctx) => new FieldBinding(ctx));
-			AddBinding<ProjectileID>("Terraria.Projectile", "type", (ctx) => new FieldBinding(ctx));
-			AddBinding<DustID>("Terraria.ModLoader.ModBlockType", "DustType", (ctx) => new FieldBinding(ctx));
-			AddBinding<DustID>("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldBinding(ctx));
-			AddBinding<TileID>("Terraria.Tile", "TileType", (ctx) => new FieldBinding(ctx));
-			AddBinding<WallID>("Terraria.Tile", "WallType", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldBinding(ctx));
-			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldBinding(ctx));
-			AddBinding<ExtrasID>("Terraria.GameContent.TextureAssets", "Extra", (ctx) => new FieldBinding(ctx), typeof(short));
-			AddBinding<MountID>("Terraria.Item", "mountType", (ctx) => new FieldBinding(ctx));
-			AddBinding<MountID>("Terraria.Mount", "Type", (ctx) => new FieldBinding(ctx));
-			AddBinding<BuffID>("Terraria.Item", "buffType", (ctx) => new FieldBinding(ctx));
-			AddBinding<BuffID>("Terraria.Mount.MountData", "buff", (ctx) => new FieldBinding(ctx));
-			AddBinding<BuffID>("Terraria.Mount", "BuffType", (ctx) => new FieldBinding(ctx));
+			AddBinding<TileID>("Terraria.Item", "createTile", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ItemID>("Terraria.Item", "type", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ItemID>("Terraria.Player", "cursorItemIconID", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.Item", "shoot", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.ModLoader.ModProjectile", "AIType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ItemUseStyleID>("Terraria.Item", "useStyle", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding(typeof(ItemRarityID), "Terraria.Item", "rare", (ctx) => new FieldOrPropertyBinding(ctx), allowNegativeIDs: true);
+			AddBinding<NPCAIStyleID>("Terraria.NPC", "aiStyle", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<NPCID>("Terraria.NPC", "type", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<NPCID>("Terraria.ModLoader.ModNPC", "AIType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<NPCID>("Terraria.ModLoader.ModNPC", "AnimationType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding(typeof(NetmodeID), "Terraria.Main", "netMode", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ProjAIStyleID>("Terraria.Projectile", "aiStyle", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.Projectile", "type", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<DustID>("Terraria.ModLoader.ModBlockType", "DustType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<DustID>("Terraria.ModLoader.ModDust", "UpdateType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<TileID>("Terraria.Tile", "TileType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<WallID>("Terraria.Tile", "WallType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "TileColor", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding(typeof(PaintID), "Terraria.Tile", "WallColor", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding(typeof(LiquidID), "Terraria.Tile", "LiquidType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ExtrasID>("Terraria.GameContent.TextureAssets", "Extra", (ctx) => new FieldOrPropertyBinding(ctx), typeof(short));
+			AddBinding<MountID>("Terraria.Item", "mountType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<MountID>("Terraria.Mount", "Type", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<BuffID>("Terraria.Item", "buffType", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<BuffID>("Terraria.Mount.MountData", "buff", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<BuffID>("Terraria.Mount", "BuffType", (ctx) => new FieldOrPropertyBinding(ctx));
 
 			AddBinding<ItemID>("Terraria.Item", "CloneDefaults", (ctx) => new MethodParameterBinding(ctx, 0));
 			AddBinding<ItemID>("Terraria.Item", "netDefaults", (ctx) => new MethodParameterBinding(ctx, 0), allowNegativeIDs: true);
@@ -137,14 +158,14 @@ public static class MagicNumberBindings
 			AddBinding<BuffID>("Terraria.NPC", "FindBuffIndex", (ctx) => new MethodParameterBinding(ctx, 0));
 			AddBinding<BuffID>("Terraria.NPC", "HasBuff(int)", (ctx) => new MethodParameterBinding(ctx, 0));
 
-			AddBinding<ItemID>("Terraria.ID.ItemID.Sets", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<NPCID>("Terraria.ID.NPCID.Sets", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<ProjectileID>("Terraria.ID.ProjectileID.Sets", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<TileID>("Terraria.ID.TileID.Sets", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<TileID>("Terraria.ID.TileID.Sets.Conversion", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<WallID>("Terraria.ID.WallID.Sets", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<WallID>("Terraria.ID.WallID.Sets.Conversion", "*", (ctx) => new FieldBinding(ctx));
-			AddBinding<MountID>("Terraria.ID.MountID.Sets", "*", (ctx) => new FieldBinding(ctx));
+			AddBinding<ItemID>("Terraria.ID.ItemID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<NPCID>("Terraria.ID.NPCID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<ProjectileID>("Terraria.ID.ProjectileID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<TileID>("Terraria.ID.TileID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<TileID>("Terraria.ID.TileID.Sets.Conversion", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<WallID>("Terraria.ID.WallID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<WallID>("Terraria.ID.WallID.Sets.Conversion", "*", (ctx) => new FieldOrPropertyBinding(ctx));
+			AddBinding<MountID>("Terraria.ID.MountID.Sets", "*", (ctx) => new FieldOrPropertyBinding(ctx));
 		}
 	}
 
@@ -184,14 +205,9 @@ public static class MagicNumberBindings
 		}
 	}
 
-	public static bool TryGetBindings(ISymbol symbol, out Binding[] bindings)
+	public static bool TryGetBindings(ISymbol symbol, out List<Binding> bindings)
 	{
 		bindings = null;
-
-		static string BuildQualifiedName(ISymbol symbol)
-		{
-			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-		}
 
 		if (symbol is IFieldSymbol fieldSymbol && bindingsByMemberByOwningClass.TryGetValue(BuildQualifiedName(symbol.ContainingType), out var bindingsByMember)) {
 			if (bindingsByMember.TryGetValue(fieldSymbol.MetadataName, out bindings)) {
@@ -217,17 +233,32 @@ public static class MagicNumberBindings
 			}
 		}
 		else if (symbol is IParameterSymbol parameterSymbol) {
-			if (TryGetBinding(parameterSymbol.ContainingSymbol, out bindings) && parameterSymbol.Ordinal == ((MethodParameterBinding)bindings).ParameterOrdinal) {
+			if (TryGetBindings(parameterSymbol.ContainingSymbol, out bindings)) {
 				return true;
 			}
 		}
 
 		return false;
+
+		static string BuildQualifiedName(ISymbol symbol)
+		{
+			return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+		}
 	}
 
 	public static bool TryGetBinding(ISymbol symbol, out Binding binding)
 	{
-		binding = null;
+		if (!TryGetBindings(symbol, out var bindings)) {
+			binding = null;
+			return false;
+		}
 
+		return TryFindBinding(symbol, bindings, out binding);
+	}
+
+	private static bool TryFindBinding(ISymbol symbol, IEnumerable<Binding> bindings, out Binding binding)
+	{
+		binding = bindings.FirstOrDefault(x => x.AppliesTo(symbol));
+		return binding is not null;
 	}
 }


### PR DESCRIPTION
*Fixes #4849.*

`MagicNumberBinding` has been refactored to support multiple bindings per member name. Additionally, `MagicNumberBindings.Binding` has been extended with an API `AppliesTo` for simple filtering of symbol candidates in application.

These features have been used to properly decouple method parameter bindings from method return type bindings, allowing for multiple parameters of a single method to be decorated with binding information as well as the return type. In the process, #4849 has been fixed since this disambiguates return value comparison contexts.

Also fixes a regression from #4845 which caused tests to fail by introducing a new build property `OutputTmlReferences` which forces references to get copied again as needed.
