### PR TITLE
add ProjectileID.Sets.MinionCannotBeFreed and add example

### DIFF
--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -105,6 +105,9 @@ namespace ExampleMod.Content.Projectiles.Minions
 
 			ProjectileID.Sets.MinionSacrificable[Projectile.type] = true; // This is needed so your minion can properly spawn when summoned and replaced when other minions are summoned
 			ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true; // Make the cultist resistant to this projectile, as it's resistant to all homing projectiles.
+
+			// If you want your minion to not be replaced when resummoning, you can write it like this:
+			// ProjectileID.Sets.MinionCannotBeFreed[Projectile.type] = true;
 		}
 
 		public sealed override void SetDefaults() {

--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -105,9 +105,6 @@ namespace ExampleMod.Content.Projectiles.Minions
 
 			ProjectileID.Sets.MinionSacrificable[Projectile.type] = true; // This is needed so your minion can properly spawn when summoned and replaced when other minions are summoned
 			ProjectileID.Sets.CultistIsResistantTo[Projectile.type] = true; // Make the cultist resistant to this projectile, as it's resistant to all homing projectiles.
-
-			// If you want your minion to not be replaced when resummoning, you can write it like this:
-			// ProjectileID.Sets.MinionCannotBeFreed[Projectile.type] = true;
 		}
 
 		public sealed override void SetDefaults() {

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -16,12 +16,10 @@ partial class ProjectileID
 		public static bool[] FiresFewerFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
 
 		/// <summary>
-		/// If <see langword="true"/> for a given projectile type (<see cref="Projectile.type"/>), then this projectile will not be replaced when resummoning.
+		/// If <see langword="true"/> for a given projectile type (<see cref="Projectile.type"/>), then this minion will not be replaced when resummoning.
+		/// <br/><br/> Defaults to <see langword="false"/>. Vanilla examples: <see cref="StardustGuardian"/>, <see cref="StardustDragon1"/>, <see cref="StardustDragon4"/>
 		/// </summary>
-		/// <remarks>
-		/// Vanilla examples: <see cref="ProjectileID.StardustGuardian"/>, <see cref="ProjectileID.StardustDragon1"/>, <see cref="ProjectileID.StardustDragon4"/>
-		/// </remarks>
-		public static bool[] MinionCannotBeFreed = Factory.CreateBoolSet(false, 623, 625, 628);
+		public static bool[] MinionCannotBeFreed = Factory.CreateBoolSet(false, StardustGuardian, StardustDragon1, StardustDragon4);
 
 		/// <summary>
 		/// Used to scale down summon tag damage for fast hitting minions and sentries. 

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -16,6 +16,14 @@ partial class ProjectileID
 		public static bool[] FiresFewerFromDaedalusStormbow = Factory.CreateBoolSet(false, 91, 4, 5, 41);
 
 		/// <summary>
+		/// If <see langword="true"/> for a given projectile type (<see cref="Projectile.type"/>), then this projectile will not be replaced when resummoning.
+		/// </summary>
+		/// <remarks>
+		/// Vanilla examples: <see cref="ProjectileID.StardustGuardian"/>, <see cref="ProjectileID.StardustDragon1"/>, <see cref="ProjectileID.StardustDragon4"/>
+		/// </remarks>
+		public static bool[] MinionCannotBeFreed = Factory.CreateBoolSet(false, 623, 625, 628);
+
+		/// <summary>
 		/// Used to scale down summon tag damage for fast hitting minions and sentries. 
 		/// </summary>
 		public static float[] SummonTagDamageMultiplier = Factory.CreateFloatSet(1f,

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -8080,7 +8080,7 @@
  			pulley = false;
  			pulleyDir = 1;
  			if (controlRight)
-@@ -39780,7 +_,10 @@
+@@ -39780,11 +_,15 @@
  			}
  
  			for (int l = 0; l < list.Count; l++) {
@@ -8091,6 +8091,12 @@
  					break;
  
  				int type2 = Main.projectile[list[l]].type;
+-				if (type2 == num4 || type2 == 625 || type2 == 628 || type2 == 623)
++				// if (type2 == num4 || type2 == 625 || type2 == 628 || type2 == 623)
++				if (type2 == num4 || ProjectileID.Sets.MinionCannotBeFreed[type2])
+ 					continue;
+ 
+ 				if (type2 == 388 && num4 == 387)
 @@ -39836,6 +_,9 @@
  
  	private void ApplyPotionDelay(Item sItem)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -8080,7 +8080,7 @@
  			pulley = false;
  			pulleyDir = 1;
  			if (controlRight)
-@@ -39780,11 +_,15 @@
+@@ -39780,11 +_,17 @@
  			}
  
  			for (int l = 0; l < list.Count; l++) {
@@ -8091,8 +8091,9 @@
  					break;
  
  				int type2 = Main.projectile[list[l]].type;
--				if (type2 == num4 || type2 == 625 || type2 == 628 || type2 == 623)
-+				// if (type2 == num4 || type2 == 625 || type2 == 628 || type2 == 623)
++				/*
+ 				if (type2 == num4 || type2 == 625 || type2 == 628 || type2 == 623)
++				*/
 +				if (type2 == num4 || ProjectileID.Sets.MinionCannotBeFreed[type2])
  					continue;
  


### PR DESCRIPTION
### What is the new feature?
Added `ProjectileID.Sets.MinionCannotBeFreed`, which prevents minions from being replaced when resummoned, and integrated the original special cases from vanilla into this array.

### Why should this be part of tModLoader?
Requires an IL edit otherwise. It can be helpful for programming worm-like minions([Stardust Dragon Staff](https://terraria.wiki.gg/wiki/Stardust_Dragon_Staff)).

### Are there alternative designs?
No

### Sample usage for the new feature
None for now. This is an advanced use-case and could use an example, but that would require a complex minion.

### ExampleMod updates
None