### PR TITLE
Gamepad menu support

### DIFF
--- a/ExampleMod/Common/UI/ExampleFullscreenUI/ExampleFullscreenUI.cs
+++ b/ExampleMod/Common/UI/ExampleFullscreenUI/ExampleFullscreenUI.cs
@@ -3,16 +3,20 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Terraria;
 using Terraria.Audio;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Config;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace ExampleMod.Common.UI.ExampleFullscreenUI
 {
@@ -40,10 +44,15 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 		private static Asset<Texture2D> SomeBoolToggleTexture { get; set; }
 
 		private UIText itemDefinitionMessage;
+		private UITextPanel<LocalizedText> randomizeButton;
+		private UITextPanel<LocalizedText> openConfigAButton;
 		private UICycleImage onlyChangeableDuringNightToggle;
 		private UIText onlyChangeableDuringNightMessage;
 		private UIText someNumberMessage;
+		private UITextPanel<LocalizedText> openConfigBButton;
+		private UITextPanel<LocalizedText> saveConfigBButton;
 		private UIText ConfigSaveStatusMessage;
+		private UITextPanel<LocalizedText> backButton;
 
 		private ModConfigShowcaseDataTypes configA;
 		private ModConfigShowcaseAcceptClientChanges configB;
@@ -109,7 +118,7 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			panel.Append(itemDefinitionMessage);
 			top += 60;
 
-			var randomizeButton = new UITextPanel<LocalizedText>(RandomizeItemText, 0.7f) {
+			randomizeButton = new UITextPanel<LocalizedText>(RandomizeItemText, 0.7f) {
 				Top = new(top, 0f),
 				Width = new(-10f, 1 / 3f),
 				Height = new(30f, 0f)
@@ -117,13 +126,15 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			randomizeButton.HAlign = 0f;
 			randomizeButton.WithFadedMouseOver();
 			randomizeButton.OnLeftClick += RandomizeButton_OnLeftClick;
+			randomizeButton.SetSnapPoint("Randomize", 0);
 			panel.Append(randomizeButton);
 
-			var openConfigAButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModsOpenConfig"), 0.7f);
+			openConfigAButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModsOpenConfig"), 0.7f);
 			openConfigAButton.CopyStyle(randomizeButton);
 			openConfigAButton.HAlign = 0.5f;
 			openConfigAButton.WithFadedMouseOver();
 			openConfigAButton.OnLeftClick += OpenConfigAButton_OnLeftClick;
+			openConfigAButton.SetSnapPoint("OpenConfigAButton", 0);
 			panel.Append(openConfigAButton);
 			top += 40;
 
@@ -134,6 +145,7 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 				Top = new(top, 0f),
 			};
 			onlyChangeableDuringNightToggle.OnLeftClick += OnlyChangeableDuringNightToggle_OnLeftClick;
+			onlyChangeableDuringNightToggle.SetSnapPoint("OnlyChangeableDuringNightToggle", 0);
 			panel.Append(onlyChangeableDuringNightToggle);
 
 			onlyChangeableDuringNightMessage = new UIText(GetOnlyChangeableDuringNightMessageText()) {
@@ -155,7 +167,7 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			panel.Append(someNumberMessage);
 			top += 32;
 
-			var openConfigBButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModsOpenConfig"), 0.7f) {
+			openConfigBButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModsOpenConfig"), 0.7f) {
 				Top = new(top, 0f),
 				Width = new(-10f, 1 / 3f),
 				Height = new(30f, 0f)
@@ -163,14 +175,16 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			openConfigBButton.HAlign = 0.5f;
 			openConfigBButton.WithFadedMouseOver();
 			openConfigBButton.OnLeftClick += OpenConfigBButton_OnLeftClick;
+			openConfigBButton.SetSnapPoint("OpenConfigBButton", 0);
 			panel.Append(openConfigBButton);
 
-			var saveConfigBButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModConfigSaveConfig"), 0.7f);
+			saveConfigBButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.ModConfigSaveConfig"), 0.7f);
 			saveConfigBButton.CopyStyle(openConfigBButton);
 			saveConfigBButton.HAlign = 1f;
 			saveConfigBButton.BackgroundColor = Color.Purple * 0.7f;
 			saveConfigBButton.WithFadedMouseOver(Color.Purple, Color.Purple * 0.7f);
 			saveConfigBButton.OnLeftClick += SaveConfigBButton_OnLeftClick;
+			saveConfigBButton.SetSnapPoint("SaveConfigBButton", 0);
 			panel.Append(saveConfigBButton);
 			top += 40;
 
@@ -185,7 +199,7 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			panel.Append(ConfigSaveStatusMessage);
 			top += 30;
 
-			var backButton = new UITextPanel<LocalizedText>(Language.GetText("UI.Back"), 0.7f) {
+			backButton = new UITextPanel<LocalizedText>(Language.GetText("UI.Back"), 0.7f) {
 				TextColor = Color.Red,
 				Top = new(top, 0f),
 				Width = new(-10f, 1 / 3f),
@@ -193,6 +207,7 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			};
 			backButton.WithFadedMouseOver();
 			backButton.OnLeftClick += BackButton_OnLeftClick;
+			backButton.SetSnapPoint("BackButton", 0);
 			panel.Append(backButton);
 			top += 40;
 
@@ -213,6 +228,9 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 			RefreshContents();
 
 			UpdateConfigSaveStatusMessage("", Color.White);
+
+			// When this UI is opened, place the gamepad at the 1st element, which for various reasons should be GamepadPointID.FancyUI0 + 2 for fullscreen UI using IngameFancyUI.
+			UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2);
 		}
 
 		public void RefreshContents() {
@@ -314,6 +332,62 @@ namespace ExampleMod.Common.UI.ExampleFullscreenUI
 		private string GetSomeNumberMessageText() {
 			string configEntryLabel = Language.GetTextValue(configB.GetLocalizationKey($"{nameof(configB.SomeNumber)}.Label"));
 			return SaveValueText.Format(configEntryLabel, configB.SomeNumber);
+		}
+
+		public override void Draw(SpriteBatch spriteBatch) {
+			base.Draw(spriteBatch);
+
+			SetupGamepadPoints(spriteBatch);
+		}
+
+		// This method is in charge of adding gamepad support for this UI.
+		private void SetupGamepadPoints(SpriteBatch spriteBatch) {
+			UIGamepadHelper helper;
+			// Due to various reasons, fullscreen UI using IngameFancyUI should start at GamepadPointID.FancyUI0 + 2
+			int startID = GamepadPointID.FancyUI0 + 2;
+			int currentID = startID;
+
+			// Here we declare the "links" between each interactable UIElement in our UI.
+			// First, we assign each UIElement a UILinkPoint, which represents a gamepad interaction location.
+			// Each interactable UIElement needs to use the SetSnapPoint method for GetLinkPoint to be useable.
+			UILinkPoint randomizeButtonLP = helper.GetLinkPoint(currentID++, randomizeButton);
+			UILinkPoint openConfigAButtonLP = helper.GetLinkPoint(currentID++, openConfigAButton);
+			UILinkPoint onlyChangeableDuringNightToggleLP = helper.GetLinkPoint(currentID++, onlyChangeableDuringNightToggle);
+			UILinkPoint openConfigBButtonLP = helper.GetLinkPoint(currentID++, openConfigBButton);
+			UILinkPoint saveConfigBButtonLP = helper.GetLinkPoint(currentID++, saveConfigBButton);
+			UILinkPoint backButtonLP = helper.GetLinkPoint(currentID++, backButton);
+
+			// Then, we declare the bi-directional and one-way links.
+			// For example, the "Randomize Item" and "Click to open config" buttons are side by side, so they get paired left and right. Pressing to the right and left on the gamepad will navigate between them.
+			// The "Only Changeable During Night" button is below the "Randomize Item" button, and it is also the best option for a down press from the "Click to open config" button. In this case, "Only Changeable During Night" button and "Randomize Item" button get paired up and down, meaning pressing up and down navigates between them, but the "Click to open config" button has its down link set to the "Only Changeable During Night" button, causing a one-way travel from "Click to open config" to "Only Changeable During Night" when the user presses down.
+			helper.PairLeftRight(randomizeButtonLP, openConfigAButtonLP);
+			helper.PairUpDown(randomizeButtonLP, onlyChangeableDuringNightToggleLP);
+			openConfigAButtonLP.Down = onlyChangeableDuringNightToggleLP.ID;
+			// Similar logic for other buttons according to their placement in the UI.
+			helper.PairUpDown(onlyChangeableDuringNightToggleLP, openConfigBButtonLP);
+			saveConfigBButtonLP.Up = onlyChangeableDuringNightToggleLP.ID;
+			helper.PairLeftRight(openConfigBButtonLP, saveConfigBButtonLP);
+			helper.PairUpDown(openConfigBButtonLP, backButtonLP);
+			saveConfigBButtonLP.Down = backButtonLP.ID;
+
+			// Note that helper (UIGamepadHelper) has many helper methods that make setting up gamepad links much simpler for more common layouts. For example, the CreateUILinkPointGrid method can create links between UIElements arranged in a grid pattern, and CreateUILinkStripVertical/Horizontal can link elements together one after the other.
+			// This example demonstrated manually setting bi-directional and one-way links, but gamepad support should be more easily implemented and straightforward than this example for the majority of modded UI.
+
+			// For example, a UI with 2 rows and 3 columns, with no element in the last position could be implemented like this:
+			/*
+			// Gather the UIElements that should link to each other
+			UIElement[] buttons = [
+				row0Col0, row0Col1, row0Col2,
+				row1Col0, row1Col1, null,
+			];
+			// Gather their SnapPoints
+			List<SnapPoint> snapPoints = buttons.Select(x => x.GetSnapPoint(out SnapPoint point) ? point : null).ToList();
+			// Link them together
+			UILinkPoint[,] linkPoints = helper.CreateUILinkPointGrid(ref currentID, snapPoints, 3, null, null, null, null);
+			// Optionally add in missing links. In this case row0Col2 should travel to row1Col1 on a down press.
+			linkPoints[2, 0].Down = linkPoints[1, 1].ID;
+			*/
+			// Also, the GetSnapPoints method can be used rather than listing out each UIElement reference directly.
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs.patch
@@ -1,5 +1,22 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/States/UIGamepadHelper.cs
 +++ src/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs
+@@ -10,9 +_,16 @@
+ 
+ namespace Terraria.GameContent.UI.States;
+ 
++/// <summary>
++/// Contains various helper methods for setting up gamepad link points, especially dynamically changing link points.
++/// <br/><br/> Despite this being a struct, this contains no fields and all the methods can be considered to be static methods in behavior.
++/// </summary>
+ [StructLayout(LayoutKind.Sequential, Size = 1)]
+ public struct UIGamepadHelper
+ {
++	/// <summary>
++	/// Links each element in <paramref name="pointsForGrid"/> to each other in all directions as if they were in a grid <paramref name="pointsPerLine"/> elements wide. <paramref name="topLinkPoint"/>, <paramref name="leftLinkPoint"/>, <paramref name="rightLinkPoint"/>, and <paramref name="bottomLinkPoint"/>, if not null, will be linked with points along the edges of the grid in those directions.
++	/// </summary>
+ 	public UILinkPoint[,] CreateUILinkPointGrid(ref int currentID, List<SnapPoint> pointsForGrid, int pointsPerLine, UILinkPoint topLinkPoint, UILinkPoint leftLinkPoint, UILinkPoint rightLinkPoint, UILinkPoint bottomLinkPoint)
+ 	{
+ 		int num = (int)Math.Ceiling((float)pointsForGrid.Count / (float)pointsPerLine);
 @@ -20,7 +_,9 @@
  		for (int i = 0; i < pointsForGrid.Count; i++) {
  			int num2 = i % pointsPerLine;
@@ -11,3 +28,96 @@
  		}
  
  		for (int j = 0; j < array.GetLength(0); j++) {
+@@ -58,6 +_,9 @@
+ 		return array;
+ 	}
+ 
++	/// <summary>
++	/// Links elements left and right from <paramref name="stripOnLeft"/> to the corresponding element in <paramref name="stripOnRight"/>. Excess elements in one list will link in one direction to the last element in the shorter list.
++	/// </summary>
+ 	public void LinkVerticalStrips(UILinkPoint[] stripOnLeft, UILinkPoint[] stripOnRight, int leftStripStartOffset)
+ 	{
+ 		if (stripOnLeft == null || stripOnRight == null)
+@@ -137,6 +_,9 @@
+ 			PairUpDown(strip[strip.Length - 1], theSingle);
+ 	}
+ 
++	/// <summary>
++	/// Links the provided SnapPoints (<paramref name="currentStrip"/>) together in order from top to bottom.
++	/// </summary>
+ 	public UILinkPoint[] CreateUILinkStripVertical(ref int currentID, List<SnapPoint> currentStrip)
+ 	{
+ 		UILinkPoint[] array = new UILinkPoint[currentStrip.Count];
+@@ -190,6 +_,10 @@
+ 			UILinkPointNavigator.ChangePoint(uILinkPoint.ID);
+ 	}
+ 
++	/// <summary>
++	/// Returns the SnapPoints in <paramref name="pts"/> with <see cref="SnapPoint.Name"/> equal to <paramref name="name"/> ordered by <see cref="SnapPoint.Id"/>.
++	/// <br/><br/> Useful for lists or grids with list elements that have multiple interaction points. This method would be called on each of those named interaction points. This method is usually followed up by calling <see cref="CreateUILinkStripVertical"/> or <see cref="CreateUILinkPointGrid"/> to link together the resulting SnapPoints.
++	/// </summary>
+ 	public List<SnapPoint> GetOrderedPointsByCategoryName(List<SnapPoint> pts, string name)
+ 	{
+ 		return (from x in pts
+@@ -198,6 +_,9 @@
+ 				select x).ToList();
+ 	}
+ 
++	/// <summary>
++	/// Creates a bi-directional link from <paramref name="leftSide"/> to <paramref name="rightSide"/>.
++	/// </summary>
+ 	public void PairLeftRight(UILinkPoint leftSide, UILinkPoint rightSide)
+ 	{
+ 		if (leftSide != null && rightSide != null) {
+@@ -206,6 +_,9 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Creates a bi-directional link from <paramref name="upSide"/> to <paramref name="downSide"/>.
++	/// </summary>
+ 	public void PairUpDown(UILinkPoint upSide, UILinkPoint downSide)
+ 	{
+ 		if (upSide != null && downSide != null) {
+@@ -214,6 +_,9 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Retrieves and populates a <see cref="UILinkPoint"/> with the given <paramref name="id"/> (<see cref="UILinkPoint.ID"/>, <see cref="GamepadPointID"/>) from the provided <see cref="SnapPoint"/> (<paramref name="snap"/>). The returned UILinkPoint will have its position set and all directional links reset to nothing.
++	/// </summary>
+ 	public UILinkPoint MakeLinkPointFromSnapPoint(int id, SnapPoint snap)
+ 	{
+ 		UILinkPointNavigator.SetPosition(id, snap.Position);
+@@ -222,6 +_,10 @@
+ 		return uILinkPoint;
+ 	}
+ 
++	/// <summary>
++	/// Retrieves and populates a <see cref="UILinkPoint"/> with the given <paramref name="id"/> (<see cref="UILinkPoint.ID"/>, <see cref="GamepadPointID"/>) from the provided <see cref="UIElement"/>. Returns null if the <see cref="SnapPoint"/> of the UIElement has not been assigned (<see cref="UIElement.SetSnapPoint"/>).
++	/// <br/><br/> This is the typical way of getting a UILinkPoint to set up gamepad links for a solitary UIElement not in a grid or list arrangement.
++	/// </summary>
+ 	public UILinkPoint GetLinkPoint(int id, UIElement element)
+ 	{
+ 		if (element.GetSnapPoint(out var point))
+@@ -248,6 +_,10 @@
+ 		return result;
+ 	}
+ 
++	/// <summary>
++	/// If the currently selected gamepad link point (<see cref="UILinkPoint"/>) is not within the provided range (<paramref name="idRangeStartInclusive"/> to <paramref name="idRangeEndExclusive"/>), the gamepad location will be moved to the link point within that range that is closest to the current gamepad location.
++	/// <br/><br/> This is useful for navigating to a sensible gamepad location when a specific UI becomes activated.
++	/// </summary>
+ 	public void MoveToVisuallyClosestPoint(int idRangeStartInclusive, int idRangeEndExclusive)
+ 	{
+ 		if (UILinkPointNavigator.CurrentPoint >= idRangeStartInclusive && UILinkPointNavigator.CurrentPoint < idRangeEndExclusive)
+@@ -268,6 +_,9 @@
+ 			UILinkPointNavigator.ChangePoint(uILinkPoint.ID);
+ 	}
+ 
++	/// <summary>
++	/// Removes all SnapPoints from the provided list that are outside the bounds of <paramref name="container"/>. This is most typically used when working with scrolling elements like <see cref="Elements.UIList"/> to limit interaction to visible elements.
++	/// </summary>
+ 	public void CullPointsOutOfElementArea(SpriteBatch spriteBatch, List<SnapPoint> pointsAtMiddle, UIElement container)
+ 	{
+ 		float num = 1f / Main.UIScale;

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs.patch
@@ -1,0 +1,13 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/States/UIGamepadHelper.cs
++++ src/tModLoader/Terraria/GameContent/UI/States/UIGamepadHelper.cs
+@@ -20,7 +_,9 @@
+ 		for (int i = 0; i < pointsForGrid.Count; i++) {
+ 			int num2 = i % pointsPerLine;
+ 			int num3 = i / pointsPerLine;
++			int id = currentID++;
++			if (pointsForGrid[i] != null) // Support null inputs. Consume id for reliable arithmetic.
+-			array[num2, num3] = MakeLinkPointFromSnapPoint(currentID++, pointsForGrid[i]);
++				array[num2, num3] = MakeLinkPointFromSnapPoint(id, pointsForGrid[i]);
+ 		}
+ 
+ 		for (int j = 0; j < array.GetLength(0); j++) {

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorkshopHub.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorkshopHub.TML.cs
@@ -3,6 +3,7 @@ using Terraria.Audio;
 using Terraria.Localization;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace Terraria.GameContent.UI.States;
 
@@ -116,5 +117,9 @@ partial class UIWorkshopHub : IHaveBackButtonCommand
 	private UIElement MakeFancyButtonMod(string path, string textKey)
 	{
 		return MakeFancyButton_Inner(ModLoader.ModLoader.ManifestAssets.Request<Texture2D>(path), textKey);
+	}
+
+	public override void OnActivate() {
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2); // Mods button.
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIWorkshopHub.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIWorkshopHub.cs.patch
@@ -1,9 +1,12 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/States/UIWorkshopHub.cs
 +++ src/tModLoader/Terraria/GameContent/UI/States/UIWorkshopHub.cs
-@@ -1,6 +_,7 @@
+@@ -1,6 +_,10 @@
  using System;
++using System.Collections.Generic;
++using System.Linq;
  using Microsoft.Xna.Framework;
  using Microsoft.Xna.Framework.Graphics;
++using Microsoft.Xna.Framework.Input;
 +using ReLogic.Content;
  using Terraria.Audio;
  using Terraria.GameContent.UI.Elements;
@@ -130,23 +133,32 @@
  		SoundEngine.PlaySound(11);
  	}
  
-@@ -333,7 +_,11 @@
- 
+@@ -334,8 +_,11 @@
  	private void SetupGamepadPoints(SpriteBatch spriteBatch)
  	{
-+		//TODO: Add workshop mod gamepad link point
-+
  		UILinkPointNavigator.Shortcuts.BackButtonCommand = 7;
 +
-+		/*
  		int num = 3000;
++		num += 2; // adjust for default being 3002
  		int idRangeEndExclusive = num;
++		/*
  		UILinkPoint linkPoint = _helper.GetLinkPoint(idRangeEndExclusive++, _buttonUseResourcePacks);
-@@ -350,6 +_,7 @@
+ 		UILinkPoint linkPoint2 = _helper.GetLinkPoint(idRangeEndExclusive++, _buttonPublishResourcePacks);
+ 		UILinkPoint linkPoint3 = _helper.GetLinkPoint(idRangeEndExclusive++, _buttonImportWorlds);
+@@ -350,6 +_,16 @@
  		_helper.PairUpDown(linkPoint4, linkPoint5);
  		_helper.PairUpDown(linkPoint2, linkPoint6);
  		_helper.MoveToVisuallyClosestPoint(num, idRangeEndExclusive);
 +		*/
++
++		UIElement[] buttons = [
++			_buttonMods, _buttonModSources,
++			_buttonModBrowser, _buttonModPack,
++			_buttonImportWorlds, _buttonUseResourcePacks,
++			_buttonBack, _buttonLogs
++		];
++		List<SnapPoint> snapPoints = buttons.Select(x => x.GetSnapPoint(out SnapPoint point) ? point : null).ToList();
++		UILinkPoint[,] linkPoints = _helper.CreateUILinkPointGrid(ref idRangeEndExclusive, snapPoints, 2, null, null, null, null);
  	}
  
  	static UIWorkshopHub()

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfig.cs
@@ -1,20 +1,22 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Newtonsoft.Json;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Newtonsoft.Json;
 using Terraria.Audio;
 using Terraria.GameContent;
+using Terraria.GameContent.RGB;
 using Terraria.GameContent.UI.Elements;
 using Terraria.GameContent.UI.States;
+using Terraria.GameInput;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader.UI;
 using Terraria.UI;
 using Terraria.UI.Gamepad;
-using Terraria.Localization;
 using tModPorter;
 
 namespace Terraria.ModLoader.Config.UI;
@@ -51,7 +53,9 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 	internal ModConfig pendingConfig; // the clone we modify.
 	private bool updateNeeded;
 	private bool preserveNotificationMessage;
+	private bool preserveFilterText;
 	private UIFocusInputTextField filterTextField;
+	private UIImageButton clearTextFilterButton;
 	internal string scrollToOption = null;
 	internal bool centerScrolledOption = false;
 
@@ -81,6 +85,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		textBoxBackground.Left.Set(-190, 1f);
 		textBoxBackground.Width.Set(180, 0f);
 		textBoxBackground.Height.Set(30, 0f);
+		textBoxBackground.WithFadedMouseOver();
 		uIElement.Append(textBoxBackground);
 
 		filterTextField.SetText("");
@@ -94,7 +99,18 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		filterTextField.OnRightClick += (a, b) => {
 			filterTextField.SetText("");
 		};
+		filterTextField.OnLeftClick += LeftClickTextBox;
+		filterTextField.SetSnapPoint("FilterTextField", 0);
 		textBoxBackground.Append(filterTextField);
+
+		clearTextFilterButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/SearchCancel")) {
+			HAlign = 1f,
+			VAlign = 0.5f,
+			Left = new StyleDimension(-2f, 0f)
+		};
+		clearTextFilterButton.OnLeftClick += (a, b) => filterTextField.SetText("");
+		clearTextFilterButton.SetSnapPoint("ClearTextFilter", 0);
+		textBoxBackground.Append(clearTextFilterButton);
 
 		// TODO: ModConfig Localization support
 		message = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModConfigNotification"));//"Notification: "
@@ -136,6 +152,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		previousConfigButton.HAlign = 0f;
 		previousConfigButton.WithFadedMouseOver();
 		previousConfigButton.OnLeftClick += PreviousConfig;
+		previousConfigButton.SetSnapPoint("PreviousConfig", 0);
 		//uIElement.Append(previousConfigButton);
 
 		nextConfigButton = new UITextPanel<string>(">", 1f, false);
@@ -143,6 +160,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		nextConfigButton.WithFadedMouseOver();
 		nextConfigButton.HAlign = 1f;
 		nextConfigButton.OnLeftClick += NextConfig;
+		nextConfigButton.SetSnapPoint("NextConfig", 0);
 		//uIElement.Append(nextConfigButton);
 
 		saveConfigButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModConfigSaveConfig"), 1f, false);//"Save Config"
@@ -153,6 +171,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		saveConfigButton.HAlign = 0.33f;
 		saveConfigButton.VAlign = 1f;
 		saveConfigButton.OnLeftClick += SaveConfig;
+		saveConfigButton.SetSnapPoint("SaveConfig", 0);
 		//uIElement.Append(saveConfigButton);
 
 		backButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModConfigBack"), 1f, false);//"Back"
@@ -168,6 +187,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 				backButton.BackgroundColor = Color.Red * 0.7f;
 		};
 		backButton.OnLeftClick += BackClick;
+		backButton.SetSnapPoint("Back", 0);
 		uIElement.Append(backButton);
 
 		revertConfigButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModConfigRevertChanges"), 1f, false);//"Revert Changes"
@@ -175,6 +195,7 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		revertConfigButton.WithFadedMouseOver();
 		revertConfigButton.HAlign = 0.66f;
 		revertConfigButton.OnLeftClick += RevertConfig;
+		revertConfigButton.SetSnapPoint("RevertConfig", 0);
 		//uIElement.Append(revertConfigButton);
 
 		//float scale = Math.Min(1f, 130f/FontAssets.MouseText.Value.MeasureString("Restore Defaults").X);
@@ -183,11 +204,46 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		restoreDefaultsConfigButton.WithFadedMouseOver();
 		restoreDefaultsConfigButton.HAlign = 1f;
 		restoreDefaultsConfigButton.OnLeftClick += RestoreDefaults;
+		restoreDefaultsConfigButton.SetSnapPoint("RestoreDefaults", 0);
 		uIElement.Append(restoreDefaultsConfigButton);
 
 		uIPanel.BackgroundColor = UICommon.MainPanelBackground;
 
 		Append(uIElement);
+	}
+
+	private void LeftClickTextBox(UIMouseEvent evt, UIElement listeningElement)
+	{
+		if (!PlayerInput.UsingGamepadUI || evt.Target == clearTextFilterButton) {
+			return;
+		}
+
+		SoundEngine.PlaySound(SoundID.MenuOpen);
+		Main.clrInput();
+		UIVirtualKeyboard uIVirtualKeyboard = new UIVirtualKeyboard(Language.GetTextValue("tModLoader.ModsTypeToSearch"), filterTextField.CurrentString, OnFinishedNaming, OnCanceledNaming, 0, allowEmpty: true);
+		uIVirtualKeyboard.SetMaxInputLength(20);
+		if (Main.gameMenu)
+			Main.MenuUI.SetState(uIVirtualKeyboard);
+		else
+			Main.InGameUI.SetState(uIVirtualKeyboard);
+	}
+
+	private void OnFinishedNaming(string name)
+	{
+		filterTextField.SetText(name.Trim());
+		preserveFilterText = true;
+		if (Main.gameMenu)
+			Main.MenuUI.SetState(this);
+		else
+			Main.InGameUI.SetState(this);
+	}
+
+	private void OnCanceledNaming()
+	{
+		if (Main.gameMenu)
+			Main.MenuUI.SetState(this);
+		else
+			Main.InGameUI.SetState(this);
 	}
 
 	private void BackClick(UIMouseEvent evt, UIElement listeningElement)
@@ -402,6 +458,95 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 		}
 
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 7;
+
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		UILinkPoint linkPoint_FilterText = helper.GetLinkPoint(currentID++, filterTextField);
+		UILinkPoint linkPoint_ClearTextFilter = helper.GetLinkPoint(currentID++, clearTextFilterButton);
+		UILinkPoint linkPoint_Back = helper.GetLinkPoint(currentID++, backButton);
+		UILinkPoint linkPoint_RestoreDefaults = helper.GetLinkPoint(currentID++, restoreDefaultsConfigButton);
+		UILinkPoint linkPoint_SaveConfig = helper.GetLinkPoint(currentID++, saveConfigButton);
+		UILinkPoint linkPoint_RevertConfig = helper.GetLinkPoint(currentID++, revertConfigButton);
+		UILinkPoint linkPoint_PreviousConfig = helper.GetLinkPoint(currentID++, previousConfigButton);
+		UILinkPoint linkPoint_NextConfig = helper.GetLinkPoint(currentID++, nextConfigButton);
+
+		UILinkPoint linkPoint_LastConfigEntry = linkPoint_FilterText;
+		UILinkPoint linkPoint_BelowSearch = null;
+
+		var configListSnapPoints = mainConfigList.GetSnapPoints();
+		helper.CullPointsOutOfElementArea(spriteBatch, configListSnapPoints, mainConfigList);
+		UILinkPoint[] configListLinkPoints = helper.CreateUILinkStripVertical(ref currentID, configListSnapPoints);
+		if (configListLinkPoints.Length > 0) {
+			linkPoint_BelowSearch = configListLinkPoints[0];
+			linkPoint_LastConfigEntry = configListLinkPoints[^1];
+		}
+
+		UILinkPoint linkPoint_AboveBottomLeft = linkPoint_PreviousConfig;
+		UILinkPoint linkPoint_AboveBottomRight = linkPoint_NextConfig;
+
+		helper.PairLeftRight(linkPoint_FilterText, linkPoint_ClearTextFilter);
+
+		if (previousConfigButton.Parent != null && nextConfigButton.Parent != null)
+			helper.PairLeftRight(linkPoint_PreviousConfig, linkPoint_NextConfig);
+
+		if (previousConfigButton.Parent != null) {
+			helper.PairUpDown(linkPoint_LastConfigEntry, linkPoint_PreviousConfig);
+			if (linkPoint_BelowSearch == null && nextConfigButton.Parent == null)
+				linkPoint_BelowSearch = linkPoint_PreviousConfig;
+		}
+		else {
+			linkPoint_AboveBottomLeft = linkPoint_AboveBottomRight;
+		}
+		bool left = false;
+		if (nextConfigButton.Parent != null) {
+			helper.PairUpDown(linkPoint_LastConfigEntry, linkPoint_NextConfig);
+			if (linkPoint_BelowSearch == null)
+				linkPoint_BelowSearch = linkPoint_NextConfig;
+		}
+		else {
+			linkPoint_AboveBottomRight = linkPoint_AboveBottomLeft;
+			left = true;
+		}
+		if (nextConfigButton.Parent == null && previousConfigButton.Parent == null) {
+			linkPoint_AboveBottomLeft = linkPoint_AboveBottomRight = linkPoint_LastConfigEntry;
+		}
+
+		if (!left) {
+			helper.PairUpDown(linkPoint_AboveBottomLeft, linkPoint_SaveConfig);
+			helper.PairUpDown(linkPoint_AboveBottomLeft, linkPoint_Back);
+		}
+		helper.PairUpDown(linkPoint_AboveBottomRight, linkPoint_RevertConfig);
+		helper.PairUpDown(linkPoint_AboveBottomRight, linkPoint_RestoreDefaults);
+		if (left) {
+			helper.PairUpDown(linkPoint_AboveBottomLeft, linkPoint_SaveConfig);
+			helper.PairUpDown(linkPoint_AboveBottomLeft, linkPoint_Back);
+		}
+
+		if (linkPoint_BelowSearch == null)
+			linkPoint_BelowSearch = linkPoint_RestoreDefaults;
+		helper.PairUpDown(linkPoint_ClearTextFilter, linkPoint_BelowSearch);
+		helper.PairUpDown(linkPoint_FilterText, linkPoint_BelowSearch);
+
+		List<UILinkPoint> bottomRowButtons = [linkPoint_Back];
+		if (saveConfigButton.Parent != null)
+			bottomRowButtons.Add(linkPoint_SaveConfig);
+		if (revertConfigButton.Parent != null)
+			bottomRowButtons.Add(linkPoint_RevertConfig);
+		bottomRowButtons.Add(linkPoint_RestoreDefaults);
+		for (int i = 0; i < bottomRowButtons.Count; i++) {
+			var linkPoint = bottomRowButtons[i];
+			linkPoint.Left = ((i == 0) ? (-3) : (bottomRowButtons[i - 1].ID));
+			linkPoint.Right = ((i == bottomRowButtons.Count - 1) ? (-4) : (bottomRowButtons[i + 1].ID));
+		}
+		linkPoint_Back.Up = linkPoint_SaveConfig.Up = linkPoint_AboveBottomLeft.ID;
+		linkPoint_RevertConfig.Up = linkPoint_RestoreDefaults.Up = linkPoint_AboveBottomRight.ID;
 	}
 
 	// do we need 2 copies? We can discard changes by reloading.
@@ -438,9 +583,11 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 	public override void OnActivate()
 	{
 		Interface.modConfigList.ModToSelectOnOpen = mod;
-		filterTextField.SetText("");
-
-		updateNeeded = false;
+		if (!preserveFilterText) {
+			filterTextField.SetText("");
+			updateNeeded = false;
+		}
+		preserveFilterText = false;
 
 		if (!preserveNotificationMessage)
 			SetMessage("", Color.White);
@@ -508,6 +655,8 @@ internal class UIModConfig : UIState, IHaveBackButtonCommand
 
 			WrapIt(mainConfigList, ref top, variable, pendingConfig, order++);
 		}
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2);
 	}
 
 	public static Tuple<UIElement, UIElement> WrapIt(UIElement parent, ref int top, PropertyFieldWrapper memberInfo, object item, int order, object list = null, Type arrayType = null, int index = -1)

--- a/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Config/UI/UIModConfigList.cs
@@ -6,6 +6,7 @@ using ReLogic.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.UI;
@@ -131,6 +132,7 @@ internal class UIModConfigList : UIState
 			else
 				IngameFancyUI.Close();
 		};
+		backButton.SetSnapPoint("Back", 0);
 
 		uIElement.Append(backButton);
 	}
@@ -169,7 +171,8 @@ internal class UIModConfigList : UIState
 		var mods = ModLoader.Mods.ToList();
 		mods.Sort((x, y) => x.DisplayNameClean.CompareTo(y.DisplayNameClean));
 
-		foreach (var mod in mods) {
+		for (int i = 0; i < mods.Count; i++) {
+			Mod mod = mods[i];
 			if (ConfigManager.Configs.TryGetValue(mod, out _)) {
 				var modPanel = new UIButton<string>(mod.DisplayName) {
 					MaxWidth = { Percent = 0.95f },
@@ -188,6 +191,7 @@ internal class UIModConfigList : UIState
 					selectedMod = mod;
 					PopulateConfigs();
 				};
+				modPanel.SetSnapPoint("ModEntry", i);
 
 				modList.Add(modPanel);
 			}
@@ -208,6 +212,7 @@ internal class UIModConfigList : UIState
 				};
 				modPanel.SetPadding(6);
 				AddSmallIcon(mod, modPanel);
+				modPanel.SetSnapPoint("ModEntry", i);
 
 				modList.Add(modPanel);
 			}
@@ -247,7 +252,8 @@ internal class UIModConfigList : UIState
 		// TODO: Support sort by attribute or some other custom ordering then replicate logic in UIModConfig.SetMod too
 		var sortedConfigs = configs.OrderBy(x => Utils.CleanChatTags(x.DisplayName.Value)).ToList();
 
-		foreach (var config in sortedConfigs) {
+		for (int i = 0; i < sortedConfigs.Count; i++) {
+			ModConfig config = sortedConfigs[i];
 			var configPanel = new UIButton<LocalizedText>(config.DisplayName) {
 				MaxWidth = { Percent = 0.95f },
 				HAlign = 0.5f,
@@ -288,6 +294,7 @@ internal class UIModConfigList : UIState
 				}
 			};
 
+			configPanel.SetSnapPoint("ConfigEntry", i);
 			configPanel.Append(sideIndicator);
 			configList.Add(configPanel);
 		}
@@ -311,5 +318,31 @@ internal class UIModConfigList : UIState
 
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 100;
 		UILinkPointNavigator.Shortcuts.BackButtonGoto = Interface.modsMenuID;
+
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		var modListSnapPoints = modList.GetSnapPoints();
+		var configListSnapPoints = configList.GetSnapPoints();
+
+		var modListLinkPoints = helper.CreateUILinkStripVertical(ref currentID, modListSnapPoints);
+		var configListLinkPoints = helper.CreateUILinkStripVertical(ref currentID, configListSnapPoints);
+
+		UILinkPoint linkPoint_Back = helper.GetLinkPoint(currentID++, backButton);
+		if(configListLinkPoints.Length > 0) {
+			helper.PairUpDown(configListLinkPoints[^1], linkPoint_Back);
+		}
+		if (modListLinkPoints.Length > 0) {
+			helper.PairUpDown(modListLinkPoints[^1], linkPoint_Back);
+		}
+		if (modListLinkPoints.Length > 0 && configListLinkPoints.Length > 0) {
+			helper.LinkVerticalStrips(modListLinkPoints, configListLinkPoints, 0);
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.Elements.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.Elements.cs
@@ -2,9 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
+using Terraria.GameInput;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace Terraria.ModLoader.UI.ModBrowser;
 
@@ -26,6 +32,7 @@ internal partial class UIModBrowser
 	private UITextPanel<LocalizedText> _updateAllButton;
 	private UIPanel _filterTextBoxBackground;
 	internal UIInputTextField FilterTextBox;
+	private UIImageButton clearSearchButton;
 	private UIBrowserStatus _browserStatus;
 	private UIModTagFilterDropdown modTagFilterDropdown;
 
@@ -62,12 +69,38 @@ internal partial class UIModBrowser
 		_updateAllButton.OnLeftClick += UpdateAllMods;
 		ModList.OnStartLoading += ModListStartLoading;
 		ModList.OnFinished += ModListFinished;
+		clearSearchButton.OnLeftClick += (a, b) => FilterTextBox.Text = "";
 		_filterTextBoxBackground.OnRightClick += (a, b) => FilterTextBox.Text = "";
+		_filterTextBoxBackground.OnLeftClick += LeftClickTextBox;
 		FilterTextBox.OnRightClick += (a, b) => FilterTextBox.Text = "";
 		FilterTextBox.OnTextChange += UpdateHandler;
 		foreach (var btn in CategoryButtons) {
 			btn.OnStateChanged += UpdateHandler;
 		}
+	}
+
+	private void LeftClickTextBox(UIMouseEvent evt, UIElement listeningElement)
+	{
+		if (!PlayerInput.UsingGamepadUI || evt.Target == clearSearchButton) {
+			return;
+		}
+
+		SoundEngine.PlaySound(SoundID.MenuOpen);
+		Main.clrInput();
+		UIVirtualKeyboard uIVirtualKeyboard = new UIVirtualKeyboard(Language.GetTextValue("tModLoader.ModsTypeToSearch"), FilterTextBox.Text, OnFinishedNaming, OnCanceledNaming, 0, allowEmpty: true);
+		uIVirtualKeyboard.SetMaxInputLength(20);
+		Main.MenuUI.SetState(uIVirtualKeyboard);
+	}
+
+	private void OnFinishedNaming(string name)
+	{
+		FilterTextBox.Text = name.Trim();
+		Main.MenuUI.SetState(this);
+	}
+
+	private void OnCanceledNaming()
+	{
+		Main.MenuUI.SetState(this);
 	}
 
 	public override void OnInitialize()
@@ -118,6 +151,7 @@ internal partial class UIModBrowser
 			VAlign = 1f,
 			Top = { Pixels = -65 }
 		}.WithFadedMouseOver();
+		_reloadButton.SetSnapPoint("ReloadBrowser", 0);
 
 		_backButton = new UITextPanel<LocalizedText>(Language.GetText("UI.Back")) {
 			Width = { Pixels = -10, Percent = 0.5f },
@@ -125,6 +159,7 @@ internal partial class UIModBrowser
 			VAlign = 1f,
 			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
+		_backButton.SetSnapPoint("Back", 0);
 
 		_clearButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.MBClearSpecialFilter", "??")) {
 			Width = { Pixels = -10, Percent = 0.5f },
@@ -134,6 +169,7 @@ internal partial class UIModBrowser
 			Top = { Pixels = -65 },
 			BackgroundColor = Color.Purple * 0.7f
 		}.WithFadedMouseOver(Color.Purple, Color.Purple * 0.7f);
+		_clearButton.SetSnapPoint("ClearSpecialFilter", 0);
 
 		_updateAllButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.MBUpdateAll")) {
 			Width = { Pixels = -10, Percent = 0.5f },
@@ -143,6 +179,7 @@ internal partial class UIModBrowser
 			Top = { Pixels = -20 },
 			BackgroundColor = Color.Orange * 0.7f
 		}.WithFadedMouseOver(Color.Orange, Color.Orange * 0.7f);
+		_updateAllButton.SetSnapPoint("UpdateAll", 0);
 
 		_downloadAllButton = new UITextPanel<LocalizedText>(Language.GetText("tModLoader.MBDownloadAll")) {
 			Width = { Pixels = -10, Percent = 0.5f },
@@ -152,6 +189,7 @@ internal partial class UIModBrowser
 			Top = { Pixels = -20 },
 			BackgroundColor = Color.Azure * 0.7f
 		}.WithFadedMouseOver(Color.Azure, Color.Azure * 0.7f);
+		_downloadAllButton.SetSnapPoint("DownloadAll", 0);
 
 		NoModsFoundText = new UIText(Language.GetTextValue("tModLoader.MBNoModsFound")) {
 			HAlign = 0.5f
@@ -159,10 +197,12 @@ internal partial class UIModBrowser
 
 		FilterTextBox = new UIInputTextField(Language.GetTextValue("tModLoader.ModsTypeToSearch")) {
 			Top = { Pixels = 5 },
-			Left = { Pixels = -161, Percent = 1f },
-			Width = { Pixels = 100 },
-			Height = { Pixels = 20 }
+			Height = { Percent = 1f },
+			Width = { Percent = 1f },
+			Left = { Pixels = 5 },
+			VAlign = 0.5f,
 		};
+		FilterTextBox.SetSnapPoint("FilterTextBox", 0);
 
 		_upperMenuContainer = new UIElement {
 			Width = { Percent = 1f },
@@ -176,25 +216,40 @@ internal partial class UIModBrowser
 			Width = { Pixels = 135 },
 			Height = { Pixels = 40 }
 		};
+		_filterTextBoxBackground.SetPadding(0);
+		_filterTextBoxBackground.WithFadedMouseOver();
 
+		clearSearchButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/SearchCancel")) {
+			HAlign = 1f,
+			VAlign = 0.5f,
+			Left = new StyleDimension(-2f, 0f)
+		};
+		clearSearchButton.SetSnapPoint("ClearSearchButton", 0);
+		
 		SortModeFilterToggle = new UIBrowserFilterToggle<ModBrowserSortMode>(0, 0) {
 			Left = new StyleDimension { Pixels = 0 * 36 }
 		};
+		SortModeFilterToggle.SetSnapPoint("SortModeFilterToggle", 0);
 		TimePeriodToggle = new UIBrowserFilterToggle<ModBrowserTimePeriod>(34 * 8, 0) {
 			Left = new StyleDimension { Pixels = 1 * 36 }
 		};
+		TimePeriodToggle.SetSnapPoint("TimePeriodToggle", 0);
 		UpdateFilterToggle = new UIBrowserFilterToggle<UpdateFilter>(34, 0) {
 			Left = new StyleDimension { Pixels = 2 * 36 }
 		};
+		UpdateFilterToggle.SetSnapPoint("UpdateFilterToggle", 0);
 		SearchFilterToggle = new UIBrowserFilterToggle<SearchFilter>(34 * 2, 0) {
 			Left = new StyleDimension { Pixels = 544f }
 		};
+		SearchFilterToggle.SetSnapPoint("SearchFilterToggle", 0);
 		ModSideFilterToggle = new UIBrowserFilterToggle<ModSideFilter>(34 * 5, 0) {
 			Left = new StyleDimension { Pixels = 3 * 36 }
 		};
+		ModSideFilterToggle.SetSnapPoint("ModSideFilterToggle", 0);
 		TagFilterToggle = new UICycleImage(UICommon.ModBrowserIconsTexture, 2, 32, 32, 34 * 9, 0, 2) {
 			Left = new StyleDimension { Pixels = 4 * 36 }
 		};
+		TagFilterToggle.SetSnapPoint("TagFilterToggle", 0);
 		TagFilterToggle.OnLeftClick += OpenOrCloseTagFilterDropdown;
 		TagFilterToggle.OnLeftClick += (a, b) => RefreshTagFilterState(); // Undo the automatic state cycle rather than modify existing public UIElement class.
 		TagFilterToggle.OnRightClick += (a, b) => RefreshTagFilterState();
@@ -239,7 +294,8 @@ internal partial class UIModBrowser
 		InitializeInteractions();
 
 		_upperMenuContainer.Append(_filterTextBoxBackground);
-		_upperMenuContainer.Append(FilterTextBox);
+		_filterTextBoxBackground.Append(FilterTextBox);
+		_filterTextBoxBackground.Append(clearSearchButton);
 		_backgroundElement.Append(_upperMenuContainer);
 
 		Append(_rootElement);
@@ -249,6 +305,7 @@ internal partial class UIModBrowser
 	{
 		_backgroundElement.RemoveChild(modTagFilterDropdown);
 		// We could do UpdateNeeded = true; here instead of in modTagFilterDropdown.OnClickingTag for responsiveness. It won't update until the drop down is closed. However, the responsiveness is only an issue in debug.
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 6); // TagFilterToggle
 	}
 
 	private void OpenOrCloseTagFilterDropdown(UIMouseEvent evt, UIElement listeningElement)
@@ -265,5 +322,122 @@ internal partial class UIModBrowser
 	internal void RefreshTagFilterState()
 	{
 		TagFilterToggle.SetCurrentState(CategoryTagsFilter.Any() || LanguageTagFilter != -1 ? 1 : 0);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		int lastListButton = currentID;
+		int above = currentID;
+		var upperMenuSnapPoints = _upperMenuContainer.GetSnapPoints();
+		upperMenuSnapPoints.Sort((SnapPoint x, SnapPoint y) => x.Position.X.CompareTo(y.Position.X));
+		var upperMenuLinkPoints = helper.CreateUILinkStripHorizontal(ref currentID, upperMenuSnapPoints);
+		foreach (var item in upperMenuLinkPoints) {
+			item.Down = currentID;
+		}
+
+		if (modTagFilterDropdown.Parent != null) {
+			var modTagFilterDropdownSnapPoints = modTagFilterDropdown.GetSnapPoints();
+			List<SnapPoint> orderedPointsByCategoryName = helper.GetOrderedPointsByCategoryName(modTagFilterDropdownSnapPoints, "TagOption");
+
+			UILinkPoint[,] linkPointGrid = CreateUILinkPointGridFromVerticalListData(ref currentID, orderedPointsByCategoryName, 2, UILinkPointNavigator.Points[above + 4], null, null, UILinkPointNavigator.Points[currentID + orderedPointsByCategoryName.Count]);
+			var clearTagsSnapPoint = modTagFilterDropdownSnapPoints.Single(x => x.Name == "ClearTags");
+			var clearTagsLinkPoint = helper.MakeLinkPointFromSnapPoint(currentID++, clearTagsSnapPoint);
+
+			helper.PairUpDown(linkPointGrid[1, linkPointGrid.GetLength(1) - 1], clearTagsLinkPoint);
+			helper.PairUpDown(linkPointGrid[0, linkPointGrid.GetLength(1) - 1], clearTagsLinkPoint);
+
+			clearTagsLinkPoint.Down = currentID;
+			lastListButton = clearTagsLinkPoint.ID;
+		}
+		else {
+			List<(UIElement, List<SnapPoint>)> elementSnapPairs = ModList._items.Select(x => (x, x.GetSnapPoints())).ToList();
+			foreach (var item in elementSnapPairs) {
+				helper.CullPointsOutOfElementArea(spriteBatch, item.Item2, ModList);
+			}
+			elementSnapPairs.RemoveAll(x => x.Item2.Count == 0);
+			foreach (var item in elementSnapPairs) {
+				item.Item2.Sort((x, y) => x.Position.X.CompareTo(y.Position.X));
+				lastListButton = currentID;
+				var buttonLinkPoints = helper.CreateUILinkStripHorizontal(ref currentID, item.Item2);
+				foreach (var buttonLinkPoint in buttonLinkPoints) {
+					buttonLinkPoint.Up = above;
+					buttonLinkPoint.Down = currentID;
+				}
+				above = buttonLinkPoints[0].ID;
+			}
+		}
+
+		above = currentID;
+		UILinkPoint linkPoint_ReloadBrowser = helper.GetLinkPoint(currentID++, _reloadButton);
+		UILinkPoint linkPoint_Back = helper.GetLinkPoint(currentID++, _backButton);
+
+		helper.PairUpDown(linkPoint_ReloadBrowser, linkPoint_Back);
+		linkPoint_ReloadBrowser.Up = lastListButton;
+
+		// These conditionally appear
+		if (_clearButton.Parent != null) {
+			UILinkPoint linkPoint_ClearFilter = helper.GetLinkPoint(currentID++, _clearButton);
+			UILinkPoint linkPoint_DownloadAll = helper.GetLinkPoint(currentID++, _downloadAllButton);
+			helper.PairUpDown(linkPoint_ClearFilter, linkPoint_DownloadAll);
+			helper.PairLeftRight(linkPoint_ReloadBrowser, linkPoint_ClearFilter);
+			helper.PairLeftRight(linkPoint_Back, linkPoint_DownloadAll);
+			linkPoint_ClearFilter.Up = lastListButton;
+		}
+		if (_updateAllButton.Parent != null) {
+			UILinkPoint linkPoint_UpdateAll = helper.GetLinkPoint(currentID++, _updateAllButton);
+			helper.PairLeftRight(linkPoint_Back, linkPoint_UpdateAll);
+			linkPoint_UpdateAll.Up = lastListButton;
+		}
+	}
+
+	// Unlike UIGamepadHelper.CreateUILinkPointGrid, this takes in data arranged in columns instead of rows
+	public UILinkPoint[,] CreateUILinkPointGridFromVerticalListData(ref int currentID, List<SnapPoint> pointsForGrid, int pointsPerLine, UILinkPoint topLinkPoint, UILinkPoint leftLinkPoint, UILinkPoint rightLinkPoint, UILinkPoint bottomLinkPoint)
+	{
+		UIGamepadHelper helper;
+		int num = (int)Math.Ceiling((float)pointsForGrid.Count / (float)pointsPerLine);
+		UILinkPoint[,] array = new UILinkPoint[pointsPerLine, num];
+		for (int i = 0; i < pointsForGrid.Count; i++) {
+			int num2 = i / num; // These 2 lines are changed from CreateUILinkPointGrid
+			int num3 = i % num; 
+			array[num2, num3] = helper.MakeLinkPointFromSnapPoint(currentID++, pointsForGrid[i]);
+		}
+
+		for (int j = 0; j < array.GetLength(0); j++) {
+			for (int k = 0; k < array.GetLength(1); k++) {
+				UILinkPoint uILinkPoint = array[j, k];
+				if (uILinkPoint == null)
+					continue;
+
+				if (j < array.GetLength(0) - 1) {
+					UILinkPoint uILinkPoint2 = array[j + 1, k];
+					if (uILinkPoint2 != null)
+						helper.PairLeftRight(uILinkPoint, uILinkPoint2);
+				}
+
+				if (k < array.GetLength(1) - 1) {
+					UILinkPoint uILinkPoint3 = array[j, k + 1];
+					if (uILinkPoint3 != null)
+						helper.PairUpDown(uILinkPoint, uILinkPoint3);
+				}
+
+				if (leftLinkPoint != null && j == 0)
+					uILinkPoint.Left = leftLinkPoint.ID;
+
+				if (topLinkPoint != null && k == 0)
+					uILinkPoint.Up = topLinkPoint.ID;
+
+				if (rightLinkPoint != null && j == pointsPerLine - 1)
+					uILinkPoint.Right = rightLinkPoint.ID;
+
+				if (bottomLinkPoint != null && k == num - 1)
+					uILinkPoint.Down = bottomLinkPoint.ID;
+			}
+		}
+
+		return array;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModBrowser.cs
@@ -1,10 +1,10 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.Localization;
@@ -252,12 +252,17 @@ internal partial class UIModBrowser : UIState, IHaveBackButtonCommand
 		if (_browserStatus.IsMouseHovering && ModList.State != AsyncProviderState.Completed) {
 			UICommon.TooltipMouseText(ModList.GetEndItemText());
 		}
+
+		SetupGamepadPoints(spriteBatch);
 	}
 
 	public void HandleBackButtonUsage()
 	{
 		try {
-			CloseTagFilterDropdown();
+			if (modTagFilterDropdown.Parent != null) {
+				CloseTagFilterDropdown();
+				return;
+			}
 			if (reloadOnExit) {
 				Main.menuMode = Interface.reloadModsID;
 				return;
@@ -317,6 +322,8 @@ internal partial class UIModBrowser : UIState, IHaveBackButtonCommand
 		}
 		catch (Exception) {
 		}
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2);
 	}
 
 	private void CbLocalModsChanged(HashSet<string> modSlugs, bool isDeletion)

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModDownloadItem.cs
@@ -78,6 +78,7 @@ internal class UIModDownloadItem : UIPanel
 			Top = { Pixels = 40 }
 		};
 		_moreInfoButton.OnLeftClick += ViewModInfo;
+		_moreInfoButton.SetSnapPoint("ViewModInfo", 0);
 		Append(_moreInfoButton);
 
 		var modBuildVersion = ModDownload.ModloaderVersion;
@@ -108,7 +109,8 @@ internal class UIModDownloadItem : UIPanel
 		_updateWithDepsButton.CopyStyle(_moreInfoButton);
 		_updateWithDepsButton.Left.Pixels += 36 + PADDING;
 		_updateWithDepsButton.OnLeftClick += DownloadWithDeps;
-		
+		_updateWithDepsButton.SetSnapPoint("DownloadWithDeps", 0);
+
 		if (ModDownload.ModReferencesBySlug?.Length > 0) {
 			var icon = UICommon.ButtonDepsTexture;
 			var modReferenceIcon = new UIHoverImage(icon, Language.GetTextValue("tModLoader.MBClickToViewDependencyMods", string.Join("\n", ModDownload.ModReferencesBySlug.Split(',').Select(x => x.Trim())))) {
@@ -117,6 +119,7 @@ internal class UIModDownloadItem : UIPanel
 				Left = { Pixels = -icon.Width() - PADDING, Percent = 1f }
 			};
 			modReferenceIcon.OnLeftClick += ShowModDependencies;
+			modReferenceIcon.SetSnapPoint("ShowModDependencies", 0);
 			Append(modReferenceIcon);
 		}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModTagFilterDropdown.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/UIModTagFilterDropdown.cs
@@ -81,7 +81,7 @@ internal class UIModTagFilterDropdown : UIPanel
 				groupOptionButton.OnLeftClick += ClickLanguageTag;
 			else
 				groupOptionButton.OnLeftClick += ClickCategoryTag;
-			// groupOptionButton.SetSnapPoint("SortSteps", j);
+			groupOptionButton.SetSnapPoint("TagOption", j);
 			dropdownPanel.Append(groupOptionButton);
 			tagButtons.Add(groupOptionButton);
 		}
@@ -102,6 +102,7 @@ internal class UIModTagFilterDropdown : UIPanel
 			Interface.modBrowser.ResetTagFilters();
 			OnClickingTag?.Invoke();
 		};
+		clearTagsButton.SetSnapPoint("ClearTags", 0);
 		dropdownPanel.Append(clearTagsButton);
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIErrorMessage.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIErrorMessage.cs
@@ -1,10 +1,14 @@
-using Microsoft.Xna.Framework;
 using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace Terraria.ModLoader.UI;
 
@@ -13,6 +17,7 @@ internal class UIErrorMessage : UIState
 	private UIMessageBox messageBox;
 	private UIElement area;
 	private UITextPanel<string> continueButton; // label changes to retry/exit
+	private UITextPanel<string> openLogsButton;
 	private UITextPanel<string> exitAndDisableAllButton;
 	private UITextPanel<string> webHelpButton;
 	private UITextPanel<string> skipLoadButton;
@@ -46,6 +51,7 @@ internal class UIErrorMessage : UIState
 			Width = { Pixels = -25, Percent = 1f },
 			Height = { Percent = 1f }
 		};
+		messageBox.SetSnapPoint("Message", 0);
 		uIPanel.Append(messageBox);
 
 		var uIScrollbar = new UIScrollbar {
@@ -64,13 +70,15 @@ internal class UIErrorMessage : UIState
 		};
 		continueButton.WithFadedMouseOver();
 		continueButton.OnLeftClick += ContinueClick;
+		continueButton.SetSnapPoint("Continue", 0);
 		area.Append(continueButton);
 
-		var openLogsButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.OpenLogs"), 0.7f, true);
+		openLogsButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.OpenLogs"), 0.7f, true);
 		openLogsButton.CopyStyle(continueButton);
 		openLogsButton.HAlign = 1f;
 		openLogsButton.WithFadedMouseOver();
 		openLogsButton.OnLeftClick += OpenFile;
+		openLogsButton.SetSnapPoint("OpenLogs", 0);
 		area.Append(openLogsButton);
 
 		webHelpButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.OpenWebHelp"), 0.7f, true);
@@ -78,6 +86,7 @@ internal class UIErrorMessage : UIState
 		webHelpButton.Top.Set(-55f, 1f);
 		webHelpButton.WithFadedMouseOver();
 		webHelpButton.OnLeftClick += VisitRegisterWebpage;
+		webHelpButton.SetSnapPoint("OpenWebHelp", 0);
 		area.Append(webHelpButton);
 
 		skipLoadButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.SkipToMainMenu"), 0.7f, true);
@@ -85,6 +94,7 @@ internal class UIErrorMessage : UIState
 		skipLoadButton.Top.Set(-55f, 1f);
 		skipLoadButton.WithFadedMouseOver();
 		skipLoadButton.OnLeftClick += SkipLoad;
+		skipLoadButton.SetSnapPoint("SkipLoad", 0);
 		area.Append(skipLoadButton);
 
 		exitAndDisableAllButton = new UITextPanel<string>(Language.GetTextValue("tModLoader.ExitAndDisableAll"), 0.7f, true);
@@ -92,12 +102,14 @@ internal class UIErrorMessage : UIState
 		exitAndDisableAllButton.TextColor = Color.Red;
 		exitAndDisableAllButton.WithFadedMouseOver();
 		exitAndDisableAllButton.OnLeftClick += ExitAndDisableAll;
+		exitAndDisableAllButton.SetSnapPoint("ExitAndDisableAll", 0);
 
 		retryButton = new UITextPanel<string>("Retry", 0.7f, true);
 		retryButton.CopyStyle(continueButton);
-		retryButton.Top.Set(-50f, 1f);
+		retryButton.Top.Set(-55f, 1f);
 		retryButton.WithFadedMouseOver();
 		retryButton.OnLeftClick += (evt, elem) => retryAction();
+		retryButton.SetSnapPoint("Retry", 0);
 
 		Append(area);
 	}
@@ -175,5 +187,43 @@ internal class UIErrorMessage : UIState
 	{
 		ContinueClick(evt, listeningElement);
 		ModLoader.skipLoad = true;
+	}
+
+	public override void Draw(SpriteBatch spriteBatch)
+	{
+		base.Draw(spriteBatch);
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		// Note: GamepadPageID.FancyUI starts at 3002
+		int startID = GamepadPointID.FancyUI0 + 1;
+		int currentID = startID;
+
+		UILinkPoint linkPoint_Message = helper.GetLinkPoint(currentID++, messageBox);
+
+		// continueButton                                        openLogsButton
+		// skipLoadButton/exitAndDisableAllButton/retryButton    webHelpButton
+		var optionalBottomLeft = skipLoadButton.Parent != null ? skipLoadButton : null;
+		optionalBottomLeft ??= exitAndDisableAllButton.Parent != null ? exitAndDisableAllButton : null;
+		optionalBottomLeft ??= retryButton.Parent != null ? retryButton : null;
+		var optionalWebHelpButton = webHelpButton.Parent != null ? webHelpButton : null;
+
+		UIElement[] buttons = [
+			continueButton, openLogsButton,
+			optionalBottomLeft, optionalWebHelpButton
+		];
+
+		var buttonSnapPoints = buttons.Select(x => x?.GetSnapPoint(out SnapPoint point) == true ? point : null).ToList();
+		UILinkPoint[,] linkPointGrid = helper.CreateUILinkPointGrid(ref currentID, buttonSnapPoints, 2, linkPoint_Message, null, null, null);
+
+		linkPoint_Message.Down = linkPointGrid[0, 0].ID;
+
+		if (linkPointGrid[0, 1] == null && linkPointGrid[1, 1] != null)
+			linkPointGrid[0, 0].Down = linkPointGrid[1, 1].ID;
+		if (linkPointGrid[0, 1] != null && linkPointGrid[1, 1] == null)
+			linkPointGrid[1, 0].Down = linkPointGrid[0, 1].ID;
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIFocusInputTextField.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIFocusInputTextField.cs
@@ -41,6 +41,8 @@ internal class UIFocusInputTextField : UIElement
 
 	public override void LeftClick(UIMouseEvent evt)
 	{
+		base.LeftClick(evt);
+
 		Main.clrInput();
 		Focused = true;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIInfoMessage.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIInfoMessage.cs
@@ -1,7 +1,9 @@
-using Microsoft.Xna.Framework.Graphics;
 using System;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
+using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.UI;
@@ -63,6 +65,7 @@ internal class UIInfoMessage : UIState, IHaveBackButtonCommand
 			Top = { Pixels = -30 }
 		}.WithFadedMouseOver();
 		_button.OnLeftClick += OKClick;
+		_button.SetSnapPoint("OK", 0);
 		_area.Append(_button);
 
 		_buttonAlt = new UIAutoScaleTextTextPanel<string>("???", 0.7f, true) {
@@ -73,6 +76,7 @@ internal class UIInfoMessage : UIState, IHaveBackButtonCommand
 			Top = { Pixels = -30 }
 		}.WithFadedMouseOver();
 		_buttonAlt.OnLeftClick += AltClick;
+		_buttonAlt.SetSnapPoint("Alt", 0);
 		_area.Append(_buttonAlt);
 
 		Append(_area);
@@ -86,6 +90,8 @@ internal class UIInfoMessage : UIState, IHaveBackButtonCommand
 		bool showAlt = !string.IsNullOrEmpty(_altText);
 		_button.Left.Percent = showAlt ? 0 : .25f;
 		_area.AddOrRemoveChild(_buttonAlt, showAlt);
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2);
 	}
 
 	internal void Show(string message, int gotoMenu, UIState gotoState = null, string altButtonText = "", Action altButtonAction = null, string okButtonText = null)
@@ -129,5 +135,26 @@ internal class UIInfoMessage : UIState, IHaveBackButtonCommand
 	{
 		base.DrawSelf(spriteBatch);
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 7;
+	}
+
+	public override void Draw(SpriteBatch spriteBatch)
+	{
+		base.Draw(spriteBatch);
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		// Note: GamepadPageID.FancyUI starts at 3002
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		UILinkPoint linkPoint_Button = helper.GetLinkPoint(currentID++, _button);
+		UILinkPoint linkPoint_ButtonAlt = helper.GetLinkPoint(currentID++, _buttonAlt);
+
+		if (_buttonAlt.Parent != null) {
+			helper.PairLeftRight(linkPoint_Button, linkPoint_ButtonAlt);
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModInfo.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
@@ -26,6 +27,7 @@ internal class UIModInfo : UIState
 	private UIAutoScaleTextTextPanel<string> _extractButton;
 	private UIAutoScaleTextTextPanel<string> _deleteButton;
 	private UIAutoScaleTextTextPanel<string> _fakeDeleteButton; // easier than making new OnMouseOver code.
+	private UIAutoScaleTextTextPanel<string> backButton;
 	private readonly UILoaderAnimatedImage _loaderElement = new UILoaderAnimatedImage(0.5f, 0.5f);
 
 	private int _gotoMenu;
@@ -37,34 +39,36 @@ internal class UIModInfo : UIState
 	private ModPubId_t _publishedFileId;
 	private bool _loading;
 	private bool _ready;
+	private bool realDeleteButton;
 
 	private CancellationTokenSource _cts;
 
 	public override void OnInitialize()
 	{
 		_uIElement = new UIElement {
-			Width = {Percent = 0.8f},
+			Width = { Percent = 0.8f },
 			MaxWidth = new StyleDimension(800f, 0f), //UICommon.MaxPanelWidth,
-			Top = {Pixels = 220},
-			Height = {Pixels = -220, Percent = 1f},
+			Top = { Pixels = 220 },
+			Height = { Pixels = -220, Percent = 1f },
 			HAlign = 0.5f
 		};
 
 		var uIPanel = new UIPanel {
-			Width = {Percent = 1f},
-			Height = {Pixels = -110, Percent = 1f},
+			Width = { Percent = 1f },
+			Height = { Pixels = -110, Percent = 1f },
 			BackgroundColor = UICommon.MainPanelBackground
 		};
 		_uIElement.Append(uIPanel);
 
 		_modInfo = new UIMessageBox(string.Empty) {
-			Width = {Pixels = -25, Percent = 1f},
-			Height = {Percent = 1f}
+			Width = { Pixels = -25, Percent = 1f },
+			Height = { Percent = 1f }
 		};
+		_modInfo.SetSnapPoint("ModInfo", 0);
 		uIPanel.Append(_modInfo);
 
 		var uIScrollbar = new UIScrollbar {
-			Height = {Pixels = -12, Percent = 1f},
+			Height = { Pixels = -12, Percent = 1f },
 			VAlign = 0.5f,
 			HAlign = 1f
 		}.WithView(100f, 1000f);
@@ -73,19 +77,20 @@ internal class UIModInfo : UIState
 		_modInfo.SetScrollbar(uIScrollbar);
 		_uITextPanel = new UITextPanel<string>(Language.GetTextValue("tModLoader.ModInfoHeader"), 0.8f, true) {
 			HAlign = 0.5f,
-			Top = {Pixels = -35},
+			Top = { Pixels = -35 },
 			BackgroundColor = UICommon.DefaultUIBlue
 		}.WithPadding(15f);
 		_uIElement.Append(_uITextPanel);
 
 		_modHomepageButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoVisitHomepage")) {
 			Width = { Pixels = -10, Percent = 0.333f },
-			Height = {Pixels = 40},
+			Height = { Pixels = 40 },
 			HAlign = 0.5f,
 			VAlign = 1f,
-			Top = {Pixels = -65}
+			Top = { Pixels = -65 }
 		}.WithFadedMouseOver();
 		_modHomepageButton.OnLeftClick += VisitModHomePage;
+		_modHomepageButton.SetSnapPoint("VisitModHomePage", 0);
 
 		_modSteamButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoVisitSteampage")) {
 			Width = { Pixels = -10, Percent = 0.333f },
@@ -95,6 +100,7 @@ internal class UIModInfo : UIState
 			Top = { Pixels = -65 }
 		}.WithFadedMouseOver();
 		_modSteamButton.OnLeftClick += VisitModHostPage;
+		_modSteamButton.SetSnapPoint("VisitModHostPage", 0);
 
 		extractLocalizationButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoExtractLocalization")) {
 			Width = { Pixels = -10, Percent = 0.333f },
@@ -104,6 +110,7 @@ internal class UIModInfo : UIState
 			Top = { Pixels = -65 }
 		}.WithFadedMouseOver();
 		extractLocalizationButton.OnLeftClick += ExtractLocalization;
+		extractLocalizationButton.SetSnapPoint("ExtractLocalization", 0);
 
 		fakeExtractLocalizationButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoExtractLocalization")) {
 			Width = { Pixels = -10, Percent = 0.333f },
@@ -113,33 +120,37 @@ internal class UIModInfo : UIState
 			Top = { Pixels = -65 }
 		};
 		fakeExtractLocalizationButton.BackgroundColor = Color.Gray;
+		fakeExtractLocalizationButton.SetSnapPoint("FakeExtractLocalization", 0);
 
-		var backButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Back")) {
-			Width = {Pixels = -10, Percent = 0.333f},
-			Height = {Pixels = 40},
+		backButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Back")) {
+			Width = { Pixels = -10, Percent = 0.333f },
+			Height = { Pixels = 40 },
 			VAlign = 1f,
-			Top = {Pixels = -20}
+			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
 		backButton.OnLeftClick += BackClick;
+		backButton.SetSnapPoint("BackClick", 0);
 		_uIElement.Append(backButton);
 
 		_extractButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModInfoExtract")) {
-			Width = {Pixels = -10, Percent = 0.333f},
-			Height = {Pixels = 40},
+			Width = { Pixels = -10, Percent = 0.333f },
+			Height = { Pixels = 40 },
 			VAlign = 1f,
 			HAlign = 0.5f,
-			Top = {Pixels = -20}
+			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
 		_extractButton.OnLeftClick += ExtractMod;
+		_extractButton.SetSnapPoint("ExtractMod", 0);
 
 		_deleteButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Delete")) {
-			Width = {Pixels = -10, Percent = 0.333f},
-			Height = {Pixels = 40},
+			Width = { Pixels = -10, Percent = 0.333f },
+			Height = { Pixels = 40 },
 			VAlign = 1f,
 			HAlign = 1f,
-			Top = {Pixels = -20}
+			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
 		_deleteButton.OnLeftClick += DeleteMod;
+		_deleteButton.SetSnapPoint("DeleteMod", 0);
 
 		_fakeDeleteButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Delete")) {
 			Width = { Pixels = -10, Percent = 0.333f },
@@ -147,8 +158,9 @@ internal class UIModInfo : UIState
 			VAlign = 1f,
 			HAlign = 1f,
 			Top = { Pixels = -20 }
-		};
+		}.WithFadedMouseOver(overColor: Color.Gray, outColor: Color.Gray);
 		_fakeDeleteButton.BackgroundColor = Color.Gray;
+		_fakeDeleteButton.SetSnapPoint("FakeDeleteMod", 0);
 
 		Append(_uIElement);
 	}
@@ -158,7 +170,7 @@ internal class UIModInfo : UIState
 		SoundEngine.PlaySound(SoundID.MenuOpen);
 		// No need for a separate UIState, the process should be quick.
 		bool success = LocalizationLoader.ExtractLocalizationFiles(_modName);
-		if(success)
+		if (success)
 			extractLocalizationButton.SetText(Language.GetTextValue("tModLoader.ModInfoExtracted"));
 	}
 
@@ -254,6 +266,47 @@ internal class UIModInfo : UIState
 		if (fakeExtractLocalizationButton.IsMouseHovering) {
 			UICommon.TooltipMouseText(Language.GetTextValue("tModLoader.ModInfoEnableModToExtractLocalizationFiles"));
 		}
+
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 100;
+		int currentID = startID;
+
+		UILinkPoint linkPoint_ModInfo = helper.GetLinkPoint(currentID++, _modInfo);
+
+		var optionalSteam = _modSteamButton.Parent != null ? _modSteamButton : null;
+		var optionalHomepage = _modHomepageButton.Parent != null ? _modHomepageButton : null;
+		var optionalExtractLocalization = _localMod != null ? (realDeleteButton ? fakeExtractLocalizationButton : extractLocalizationButton) : null;
+		var optionalExtract = _localMod != null ? _extractButton : null;
+		var optionalDelete = _localMod != null ? (realDeleteButton ? _deleteButton : _fakeDeleteButton) : null;
+
+		UIElement[] buttons = [
+			optionalSteam, optionalHomepage, optionalExtractLocalization,
+			backButton, optionalExtract, optionalDelete
+		];
+		var buttonSnapPoints = buttons.Select(x => x?.GetSnapPoint(out SnapPoint point) == true ? point : null).ToList();
+		UILinkPoint[,] linkPointGrid = helper.CreateUILinkPointGrid(ref currentID, buttonSnapPoints, 3, linkPoint_ModInfo, null, null, null);
+
+		linkPoint_ModInfo.Down = linkPointGrid[0, 1].ID;
+		for (int i = 0; i < 3; i++) {
+			if (linkPointGrid[i, 0] != null) {
+				linkPoint_ModInfo.Down = linkPointGrid[i, 0].ID;
+				break;
+			}
+		}
+		for (int i = 3 - 1; i >= 0; i--) {
+			if (linkPointGrid[i, 0] == null && linkPointGrid[i, 1] != null) {
+				linkPointGrid[i, 1].Up = linkPoint_ModInfo.ID;
+			}
+		}
+
+		if (UILinkPointNavigator.CurrentPoint >= startID && UILinkPointNavigator.CurrentPoint < currentID)
+			return;
+		UILinkPointNavigator.ChangePoint(startID + 4); // Back button.
 	}
 
 	public override void OnActivate()
@@ -269,7 +322,7 @@ internal class UIModInfo : UIState
 		if (!_loading && _ready) {
 			_modInfo.SetText(_info);
 
-			if (!string.IsNullOrEmpty(_url)){
+			if (!string.IsNullOrEmpty(_url)) {
 				_uIElement.Append(_modHomepageButton);
 			}
 
@@ -278,7 +331,7 @@ internal class UIModInfo : UIState
 			}
 
 			if (_localMod != null) {
-				bool realDeleteButton = ModLoader.Mods.All(x => x.Name != _localMod.Name);
+				realDeleteButton = ModLoader.Mods.All(x => x.Name != _localMod.Name);
 				_uIElement.AddOrRemoveChild(_deleteButton, realDeleteButton);
 				_uIElement.AddOrRemoveChild(_fakeDeleteButton, !realDeleteButton);
 				_uIElement.AddOrRemoveChild(extractLocalizationButton, !realDeleteButton); // show real only if mod enabled

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -646,6 +646,7 @@ internal class UIModItem : UIPanel
 				HAlign = .15f
 			}.WithFadedMouseOver();
 			_dialogYesButton.OnLeftClick += DeleteMod;
+			_dialogYesButton.SetSnapPoint("DeleteYes", 0);
 			_deleteModDialog.Append(_dialogYesButton);
 
 			_dialogNoButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("LegacyMenu.105")) {
@@ -656,6 +657,7 @@ internal class UIModItem : UIPanel
 				HAlign = .85f
 			}.WithFadedMouseOver();
 			_dialogNoButton.OnLeftClick += Interface.modsMenu.CloseConfirmDialog;
+			_dialogNoButton.SetSnapPoint("DeleteNo", 0);
 			_deleteModDialog.Append(_dialogNoButton);
 
 			_dialogText = new UIText(Language.GetTextValue("tModLoader.DeleteModConfirm")) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModItem.cs
@@ -1,19 +1,21 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using Terraria.Audio;
+using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
-using Terraria.UI;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Config;
 using Terraria.ModLoader.Core;
 using Terraria.ModLoader.UI.ModBrowser;
-using Terraria.Audio;
-using Terraria.GameContent;
-using ReLogic.Content;
 using Terraria.Social.Base;
+using Terraria.UI;
+using Terraria.UI.Gamepad;
 
 namespace Terraria.ModLoader.UI;
 
@@ -53,7 +55,7 @@ internal class UIModItem : UIPanel
 	private string ToggleModStateText {
 		get {
 			if (_mod.Enabled) {
-				if(_modDependents.Any())
+				if (_modDependents.Any())
 					return Language.GetTextValue("tModLoader.ModsDisableAndDependents", _mod.DisplayName, _modDependents.Length);
 				return Language.GetTextValue("tModLoader.ModsDisable");
 			}
@@ -122,6 +124,7 @@ internal class UIModItem : UIPanel
 			Left = { Pixels = _modIconAdjust }
 		};
 		_uiModStateText.OnLeftClick += ToggleEnabled;
+		_uiModStateText.SetSnapPoint("ToggleEnabled", 0);
 
 		// Don't show the Enable/Disable button if there is no loadable version
 		string updateVersion = null;
@@ -167,6 +170,7 @@ internal class UIModItem : UIPanel
 			Top = { Pixels = 40 }
 		};
 		_moreInfoButton.OnLeftClick += ShowMoreInfo;
+		_moreInfoButton.SetSnapPoint("MoreInfo", 0);
 		Append(_moreInfoButton);
 
 		if (ModLoader.TryGetMod(ModName, out var loadedMod) && ConfigManager.Configs.ContainsKey(loadedMod)) {
@@ -179,6 +183,7 @@ internal class UIModItem : UIPanel
 				Top = { Pixels = 40f }
 			};
 			_configButton.OnLeftClick += OpenConfig;
+			_configButton.SetSnapPoint("OpenConfig", 0);
 			Append(_configButton);
 			if (ConfigManager.ModNeedsReload(loadedMod)) {
 				_configChangesRequireReload = true;
@@ -329,6 +334,7 @@ internal class UIModItem : UIPanel
 				Top = { Pixels = 42.5f }
 			};
 			_deleteModButton.OnLeftClick += QuickModDelete;
+			_deleteModButton.SetSnapPoint("DeleteMod", 0);
 			Append(_deleteModButton);
 		}
 
@@ -680,5 +686,25 @@ internal class UIModItem : UIPanel
 	{
 		recommendedModBrowserVersion = SocialBrowserModule.GetBrowserVersionNumber(_mod.tModLoaderVersion);
 		return recommendedModBrowserVersion == SocialBrowserModule.GetBrowserVersionNumber(BuildInfo.tMLVersion);
+	}
+
+	internal void SetupGamepadPoints(ref int current, int up, int down)
+	{
+		UIGamepadHelper helper;
+		List<UILinkPoint> linkPoints = new();
+		linkPoints.Add(helper.GetLinkPoint(current++, _uiModStateText));
+		if(_deleteModButton != null)
+			linkPoints.Add(helper.GetLinkPoint(current++, _deleteModButton));
+		if(_configButton != null)
+			linkPoints.Add(helper.GetLinkPoint(current++, _configButton));
+		if (_moreInfoButton != null)
+			linkPoints.Add(helper.GetLinkPoint(current++, _moreInfoButton));
+		for (int i = 0; i < linkPoints.Count; i++) {
+			var linkPoint = linkPoints[i];
+			linkPoint.Up = up;
+			linkPoint.Down = down;
+			linkPoint.Left = ((i == 0) ? (-3) : (linkPoints[i - 1].ID));
+			linkPoint.Right = ((i == linkPoints.Count - 1) ? (-4) : (linkPoints[i + 1].ID));
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPackItem.cs
@@ -103,12 +103,13 @@ internal class UIModPackItem : UIPanel
 		var viewListButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModPackViewList")) {
 			Width = { Pixels = 100 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 407 },
+			Left = { Pixels = 357 },
 			Top = { Pixels = 40 }
 		}.WithFadedMouseOver();
 		viewListButton.PaddingTop -= 2f;
 		viewListButton.PaddingBottom -= 2f;
 		viewListButton.OnLeftClick += ViewListInfo;
+		viewListButton.SetSnapPoint("ViewListInfo", 0);
 		Append(viewListButton);
 
 		// Enable (1-L)
@@ -116,12 +117,13 @@ internal class UIModPackItem : UIPanel
 			Language.GetTextValue("tModLoader.ModPackEnableThisList")) {
 			Width = { Pixels = 151 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 248 },
+			Left = { Pixels = 198 },
 			Top = { Pixels = 40 }
 		}.WithFadedMouseOver();
 		_enableListButton.PaddingTop -= 2f;
 		_enableListButton.PaddingBottom -= 2f;
 		_enableListButton.OnLeftClick += EnableList;
+		_enableListButton.SetSnapPoint("EnableList", 0);
 		Append(_enableListButton);
 
 		// Enable List Only (2-L)
@@ -129,12 +131,12 @@ internal class UIModPackItem : UIPanel
 			Language.GetTextValue("tModLoader.ModPackEnableOnlyThisList")) {
 			Width = { Pixels = 190 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 50 },
 			Top = { Pixels = 40 }
 		}.WithFadedMouseOver();
 		_enableListOnlyButton.PaddingTop -= 2f;
 		_enableListOnlyButton.PaddingBottom -= 2f;
 		_enableListOnlyButton.OnLeftClick += EnabledListOnly;
+		_enableListOnlyButton.SetSnapPoint("EnabledListOnly", 0);
 		Append(_enableListOnlyButton);
 
 		// View on Browser (2-R)
@@ -142,37 +144,42 @@ internal class UIModPackItem : UIPanel
 			Language.GetTextValue("tModLoader.ModPackViewModsInModBrowser")) {
 			Width = { Pixels = 246 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 50 },
 			Top = { Pixels = 80 }
 		}.WithFadedMouseOver();
 		_viewInModBrowserButton.PaddingTop -= 2f;
 		_viewInModBrowserButton.PaddingBottom -= 2f;
 		_viewInModBrowserButton.OnLeftClick += DownloadMissingMods;
+		_viewInModBrowserButton.SetSnapPoint("DownloadMissingMods", 0);
 		Append(_viewInModBrowserButton);
 
 		// Update From Local (3-L)
 		_updateListWithEnabledButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ModPackUpdateListWithEnabled")) {
 			Width = { Pixels = 225 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 304 },
+			Left = { Pixels = 254 },
 			Top = { Pixels = 80 }
 		}.WithFadedMouseOver();
 		_updateListWithEnabledButton.PaddingTop -= 2f;
 		_updateListWithEnabledButton.PaddingBottom -= 2f;
 		_updateListWithEnabledButton.OnLeftClick += UpdateModPack;
+		_updateListWithEnabledButton.SetSnapPoint("UpdateModPack", 0);
 		Append(_updateListWithEnabledButton);
 
 		// Delete button
 		_deleteButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/ButtonDelete")) {
-			Top = { Pixels = 40 }
+			Top = { Pixels = Height.Pixels - 40 },
+			Left = { Percent = 1f, Pixels = -40 }
 		};
 		_deleteButton.OnLeftClick += DeleteButtonClick;
+		_deleteButton.SetSnapPoint("DeleteButton", 0);
 		this.AddOrRemoveChild(_deleteButton, !IsLocalModPack);
 
 		_fakeDeleteButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/ButtonDelete")) {
-			Top = { Pixels = 40 }
+			Top = { Pixels = Height.Pixels - 40 },
+			Left = { Percent = 1f, Pixels = -40 }
 		};
 		_fakeDeleteButton.SetVisibility(0.4f, 0.4f);
+		_fakeDeleteButton.SetSnapPoint("FakeDeleteButton", 0);
 		this.AddOrRemoveChild(_fakeDeleteButton, IsLocalModPack);
 
 		if (_legacy)
@@ -184,36 +191,37 @@ internal class UIModPackItem : UIPanel
 		_importFromPackLocalButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.InstallPackLocal")) {
 			Width = { Pixels = 225 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 50 },
 			Top = { Pixels = 120 }
 		}.WithFadedMouseOver();
 		_importFromPackLocalButton.PaddingTop -= 2f;
 		_importFromPackLocalButton.PaddingBottom -= 2f;
 		_importFromPackLocalButton.OnLeftClick += ImportModPackLocal;
+		_importFromPackLocalButton.SetSnapPoint("ImportModPackLocal", 0);
 		Append(_importFromPackLocalButton);
 
 		// Remove Pack (Local) (3-R)
 		_removePackLocalButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.RemovePackLocal")) {
 			Width = { Pixels = 225 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 280 },
+			Left = { Pixels = 230 },
 			Top = { Pixels = 120 }
 		}.WithFadedMouseOver();
 		_removePackLocalButton.PaddingTop -= 2f;
 		_removePackLocalButton.PaddingBottom -= 2f;
 		_removePackLocalButton.OnLeftClick += RemoveModPackLocal;
+		_removePackLocalButton.SetSnapPoint("RemoveModPackLocal", 0);
 		Append(_removePackLocalButton);
 
 		// Export Pack Instance (4-L)
 		_exportPackInstanceButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.ExportPackInstance")) {
 			Width = { Pixels = 200 },
 			Height = { Pixels = 36 },
-			Left = { Pixels = 10 },
 			Top = { Pixels = 160 }
 		}.WithFadedMouseOver();
 		_exportPackInstanceButton.PaddingTop -= 2f;
 		_exportPackInstanceButton.PaddingBottom -= 2f;
 		_exportPackInstanceButton.OnLeftClick += ExportInstance;
+		_exportPackInstanceButton.SetSnapPoint("ExportInstance", 0);
 		Append(_exportPackInstanceButton);
 
 		string instancePath = Path.Combine(Directory.GetCurrentDirectory(), _filename);
@@ -222,12 +230,13 @@ internal class UIModPackItem : UIPanel
 			_removePackInstanceButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.DeletePackInstance")) {
 				Width = { Pixels = 140 },
 				Height = { Pixels = 36 },
-				Left = { Pixels = 370 },
+				Left = { Pixels = 320 },
 				Top = { Pixels = 160 }
 			}.WithFadedMouseOver();
 			_removePackInstanceButton.PaddingTop -= 2f;
 			_removePackInstanceButton.PaddingBottom -= 2f;
 			_removePackInstanceButton.OnLeftClick += DeleteInstance;
+			_removePackInstanceButton.SetSnapPoint("DeleteInstance", 0);
 			Append(_removePackInstanceButton);
 
 			//TODO: Play Instance (4-M)

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModPacks.cs
@@ -1,7 +1,3 @@
-using Ionic.Zip;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,14 +5,19 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Ionic.Zip;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Newtonsoft.Json;
+using Terraria.Audio;
 using Terraria.GameContent.UI.Elements;
 using Terraria.GameContent.UI.States;
+using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
 using Terraria.UI;
 using Terraria.UI.Gamepad;
 using Terraria.Utilities;
-using Terraria.Audio;
 
 namespace Terraria.ModLoader.UI;
 
@@ -28,6 +29,9 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 	private UIList _modPacks;
 	private UILoaderAnimatedImage _uiLoader;
 	private UIPanel _scrollPanel;
+	private UIAutoScaleTextTextPanel<LocalizedText> folderButton;
+	private UIAutoScaleTextTextPanel<LocalizedText> backButton;
+	private UIAutoScaleTextTextPanel<LocalizedText> saveNewButton;
 	private CancellationTokenSource _cts;
 	public UIState PreviousUIState { get; set; }
 
@@ -74,7 +78,7 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 		}.WithPadding(15f);
 		uIElement.Append(titleTextPanel);
 
-		var folderButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.OpenModPackFolder")) {
+		folderButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.OpenModPackFolder")) {
 			Width = new StyleDimension(-10f, 1f / 2f),
 			Height = { Pixels = 40 },
 			VAlign = 0.9f,
@@ -82,9 +86,10 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
 		folderButton.OnLeftClick += OpenFolder;
+		folderButton.SetSnapPoint("OpenFolder", 0);
 		uIElement.Append(folderButton);
 
-		var backButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("UI.Back")) {
+		backButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("UI.Back")) {
 			Width = new StyleDimension(-10f, 1f / 2f),
 			Height = { Pixels = 40 },
 			VAlign = 1f,
@@ -92,15 +97,17 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 			Top = { Pixels = -20 }
 		}.WithFadedMouseOver();
 		backButton.OnLeftClick += BackClick;
+		backButton.SetSnapPoint("Back", 0);
 		uIElement.Append(backButton);
 
-		var saveNewButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.ModPacksSaveEnabledAsNewPack"));
+		saveNewButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.ModPacksSaveEnabledAsNewPack"));
 		saveNewButton.CopyStyle(backButton);
 		saveNewButton.TextColor = Color.Green;
 		saveNewButton.VAlign = 1f;
 		saveNewButton.HAlign = 1f;
 		saveNewButton.WithFadedMouseOver();
 		saveNewButton.OnLeftClick += SaveNewModList;
+		saveNewButton.SetSnapPoint("SaveNewModList", 0);
 		uIElement.Append(saveNewButton);
 
 		Append(uIElement);
@@ -113,7 +120,7 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 
 	private static void SaveNewModList(UIMouseEvent evt, UIElement listeningElement)
 	{
-		SoundEngine.PlaySound(11);
+		SoundEngine.PlaySound(SoundID.MenuClose);
 		Main.clrInput();
 		VirtualKeyboard.Text = "";
 		Main.MenuUI.SetState(VirtualKeyboard);
@@ -153,6 +160,48 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 	{
 		base.Draw(spriteBatch);
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 7;
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0;
+		int currentID = startID;
+
+		List<(UIElement, List<SnapPoint>)> elementSnapPairs = _modPacks._items.Select(x => (x, x.GetSnapPoints())).ToList();
+		foreach (var item in elementSnapPairs) {
+			helper.CullPointsOutOfElementArea(spriteBatch, item.Item2, _modPacks);
+		}
+		elementSnapPairs.RemoveAll(x => x.Item2.Count == 0);
+		int above = -1;
+		int lastListButton = -1;
+		for (int i = 0; i < elementSnapPairs.Count; i++) {
+			var item = elementSnapPairs[i];
+			item.Item2.Sort((x, y) => {
+				var ret = x.Position.Y.CompareTo(y.Position.Y);
+				if (ret == 0)
+					ret = x.Position.X.CompareTo(y.Position.X);
+				return ret;
+			});
+			lastListButton = currentID;
+			var buttonLinkPoints = helper.CreateUILinkStripHorizontal(ref currentID, item.Item2);
+			foreach (var buttonLinkPoint in buttonLinkPoints) {
+				buttonLinkPoint.Up = above;
+				buttonLinkPoint.Down = currentID;
+			}
+			above = buttonLinkPoints[0].ID;
+		}
+
+		above = currentID;
+
+		UILinkPoint linkPoint_OpenFolder = helper.GetLinkPoint(currentID++, folderButton);
+		UILinkPoint linkPoint_Back = helper.GetLinkPoint(currentID++, backButton);
+		UILinkPoint linkPoint_SaveNew = helper.GetLinkPoint(currentID++, saveNewButton);
+		helper.PairLeftRight(linkPoint_Back, linkPoint_SaveNew);
+		helper.PairUpDown(linkPoint_OpenFolder, linkPoint_SaveNew);
+		helper.PairUpDown(linkPoint_OpenFolder, linkPoint_Back);
+		linkPoint_OpenFolder.Up = lastListButton; // Navigate to Enable only this list option
 	}
 
 	internal static string SanitizeModpackName(string name)
@@ -201,8 +250,11 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 			Main.QueueMainThreadAction(() => {
 				_modPacks.AddRange(ModPacksToAdd);
 				_scrollPanel.RemoveChild(_uiLoader);
+				UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0);
 			});
 		});
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0);
 	}
 
 	public UIModPackItem LoadModernModPack(string folderPath)
@@ -279,7 +331,7 @@ internal class UIModPacks : UIState, IHaveBackButtonCommand
 		Directory.CreateDirectory(Path.Combine(instancePath, "SaveData"));
 
 		//TODO: When implementing ModConfig as part of Mod Pack, update
-		string modsPath =  ModPackModsPath(modPackName); 
+		string modsPath = ModPackModsPath(modPackName);
 		string configPath = Config.ConfigManager.ModConfigPath; //ModPackConfigPath(modPackName);
 
 		// Deploy Mods, Configs to instance

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSourceItem.cs
@@ -87,6 +87,7 @@ internal class UIModSourceItem : UIPanel
 		buildButton.PaddingTop -= 2f;
 		buildButton.PaddingBottom -= 2f;
 		buildButton.OnLeftClick += BuildMod;
+		buildButton.SetSnapPoint("BuildMod", 0);
 		Append(buildButton);
 
 		var buildReloadButton = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MSBuildReload"));
@@ -95,6 +96,7 @@ internal class UIModSourceItem : UIPanel
 		buildReloadButton.Left.Pixels = 150;
 		buildReloadButton.WithFadedMouseOver();
 		buildReloadButton.OnLeftClick += BuildAndReload;
+		buildReloadButton.SetSnapPoint("BuildAndReload", 0);
 		Append(buildReloadButton);
 
 		_builtMod = builtMod;
@@ -112,6 +114,7 @@ internal class UIModSourceItem : UIPanel
 			publishButton.Width.Pixels = 100;
 			publishButton.Left.Pixels = 390;
 			publishButton.WithFadedMouseOver();
+			publishButton.SetSnapPoint("PublishMod", 0);
 
 			if (builtMod.properties.side == ModSide.Server) {
 				publishButton.OnLeftClick += PublishServerSideMod;
@@ -151,6 +154,7 @@ internal class UIModSourceItem : UIPanel
 					);
 				}
 			};
+			openCSProjButton.SetSnapPoint("OpenCSProj", 0);
 			Append(openCSProjButton);
 
 			contextButtonsLeft -= 26;
@@ -165,6 +169,7 @@ internal class UIModSourceItem : UIPanel
 				Top = { Pixels = 4 }
 			};
 			openFolderButton.OnLeftClick += (a, b) => Utils.OpenFolder(_mod);
+			openFolderButton.SetSnapPoint("OpenFolder", 0);
 			Append(openFolderButton);
 			contextButtonsLeft -= 26;
 		}
@@ -468,6 +473,7 @@ internal class UIModSourceItem : UIPanel
 			// When this button is pressed, the csproj no longer requires an upgrade. This means that the tModPorter button should now be added.
 			AddModPorterButton();
 		};
+		upgradeCSProjButton.SetSnapPoint("UpgradeCSProj", 0);
 
 		Append(upgradeCSProjButton);
 
@@ -506,6 +512,7 @@ internal class UIModSourceItem : UIPanel
 				Logging.tML.Error("Failed to start tModPorter", ex);
 			}
 		};
+		portModButton.SetSnapPoint("tModPorter", 0);
 
 		Append(portModButton);
 
@@ -525,6 +532,7 @@ internal class UIModSourceItem : UIPanel
 		modSaveErrorWarning.OnLeftClick += (a, b) => {
 			Interface.infoMessage.Show(fullError, 888, Interface.modSources);
 		};
+		modSaveErrorWarning.SetSnapPoint("ErrorButton", 0);
 
 		Append(modSaveErrorWarning);
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIModSources.cs
@@ -1,7 +1,3 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using ReLogic.Graphics;
-using ReLogic.OS;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,9 +8,14 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Graphics;
+using ReLogic.OS;
 using Terraria.Audio;
 using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader.Core;
@@ -35,6 +36,9 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	private UIInputTextField filterTextBox;
 	private UILoaderAnimatedImage _uiLoader;
 	private UIElement _links;
+	private UIAutoScaleTextTextPanel<string> buttonCreateMod;
+	private UIAutoScaleTextTextPanel<string> buttonB;
+	private UIAutoScaleTextTextPanel<string> buttonOS;
 	private CancellationTokenSource _cts;
 	private static bool dotnetSDKFound;
 
@@ -139,27 +143,30 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 		buttonBRA.OnLeftClick += BuildAndReload;
 		//_uIElement.Append(buttonBRA);
 
-		var buttonCreateMod = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MSCreateMod"));
+		buttonCreateMod = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MSCreateMod"));
 		buttonCreateMod.CopyStyle(buttonBA);
 		buttonCreateMod.HAlign = 1f;
 		buttonCreateMod.Top.Pixels = -20;
 		buttonCreateMod.WithFadedMouseOver();
 		buttonCreateMod.OnLeftClick += ButtonCreateMod_OnClick;
+		buttonCreateMod.SetSnapPoint("CreateMod", 0);
 		_uIElement.Append(buttonCreateMod);
 
-		var buttonB = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Back"));
+		buttonB = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("UI.Back"));
 		buttonB.CopyStyle(buttonBA);
 		//buttonB.Width.Set(-10f, 1f / 3f);
 		buttonB.Top.Pixels = -20;
 		buttonB.WithFadedMouseOver();
 		buttonB.OnLeftClick += BackClick;
+		buttonB.SetSnapPoint("Back", 0);
 		_uIElement.Append(buttonB);
 
-		var buttonOS = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MSOpenSources"));
+		buttonOS = new UIAutoScaleTextTextPanel<string>(Language.GetTextValue("tModLoader.MSOpenSources"));
 		buttonOS.CopyStyle(buttonB);
 		buttonOS.HAlign = .5f;
 		buttonOS.WithFadedMouseOver();
 		buttonOS.OnLeftClick += OpenSources;
+		buttonOS.SetSnapPoint("OpenSources", 0);
 		_uIElement.Append(buttonOS);
 
 		Append(_uIElement);
@@ -227,6 +234,42 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 	{
 		UILinkPointNavigator.Shortcuts.BackButtonCommand = 7;
 		base.Draw(spriteBatch);
+
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		List<(UIElement, List<SnapPoint>)> elementSnapPairs = _modList._items.Select(x => (x, x.GetSnapPoints())).ToList();
+		foreach (var item in elementSnapPairs) {
+			helper.CullPointsOutOfElementArea(spriteBatch, item.Item2, _modList);
+		}
+		elementSnapPairs.RemoveAll(x => x.Item2.Count == 0);
+		int above = -1;
+		int lastListButton = -1;
+		foreach (var item in elementSnapPairs) {
+			item.Item2.Sort((x, y) => x.Position.X.CompareTo(y.Position.X));
+			lastListButton = currentID;
+			var buttonLinkPoints = helper.CreateUILinkStripHorizontal(ref currentID, item.Item2);
+			foreach (var buttonLinkPoint in buttonLinkPoints) {
+				buttonLinkPoint.Up = above;
+				buttonLinkPoint.Down = currentID;
+			}
+			above = buttonLinkPoints[0].ID;
+		}
+
+		above = currentID;
+		UILinkPoint linkPoint_Back = helper.GetLinkPoint(currentID++, buttonB);
+		UILinkPoint linkPoint_OpenSources = helper.GetLinkPoint(currentID++, buttonOS);
+		UILinkPoint linkPoint_CreateMod = helper.GetLinkPoint(currentID++, buttonCreateMod);
+
+		helper.PairLeftRight(linkPoint_Back, linkPoint_OpenSources);
+		helper.PairLeftRight(linkPoint_OpenSources, linkPoint_CreateMod);
+		linkPoint_Back.Up = linkPoint_OpenSources.Up = linkPoint_CreateMod.Up = lastListButton;	
 	}
 
 	public override void OnActivate()
@@ -240,6 +283,8 @@ internal class UIModSources : UIState, IHaveBackButtonCommand
 		if (ShowInfoMessages())
 			return;
 		Populate();
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2); // Build button on 1st mod source.
 	}
 
 	public override void OnDeactivate()

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -403,6 +403,8 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		Append(_blockInput);
 
 		Append(_activeDialog = dialog);
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2); // 1st button of dialog
 	}
 
 	private void QuickEnableAll(UIMouseEvent evt, UIElement listeningElement)
@@ -460,6 +462,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		}.WithFadedMouseOver();
 		_confirmDialogYesButton.OnLeftClick += yesAction;
 		_confirmDialogYesButton.OnLeftClick += CloseConfirmDialog;
+		_confirmDialogYesButton.SetSnapPoint("Yes", 0);
 		_toggleModsDialog.Append(_confirmDialogYesButton);
 
 		_confirmDialogNoButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("LegacyMenu.105")) {
@@ -470,6 +473,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 			HAlign = .85f
 		}.WithFadedMouseOver();
 		_confirmDialogNoButton.OnLeftClick += CloseConfirmDialog;
+		_confirmDialogNoButton.SetSnapPoint("No", 0);
 		_toggleModsDialog.Append(_confirmDialogNoButton);
 
 		var yesDontAskAgainButton = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.YesDontAskAgain")) {
@@ -482,6 +486,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		yesDontAskAgainButton.OnLeftClick += (a, b) => ModLoader.showConfirmationWindowWhenEnableDisableAllMods = false;
 		yesDontAskAgainButton.OnLeftClick += yesAction;
 		yesDontAskAgainButton.OnLeftClick += CloseConfirmDialog;
+		yesDontAskAgainButton.SetSnapPoint("YesDontAskAgain", 0);
 		_toggleModsDialog.Append(yesDontAskAgainButton);
 
 		_confirmDialogText = new UIText(Language.GetTextValue(confirmDialogTextKey)) {
@@ -605,6 +610,17 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		UIGamepadHelper helper;
 		int startID = GamepadPointID.FancyUI0 + 2;
 		int currentID = startID;
+
+		if (_activeDialog?.Parent != null) {
+			var dialogSnapPoints = _activeDialog.GetSnapPoints();
+			var dialogLinkPoints = helper.CreateUILinkPointGrid(ref currentID, dialogSnapPoints, 2, null, null, null, null);
+
+			// _activeDialog could currently be delete mod (yes/no) or enable/disable all (yes/no, yes don't ask again)
+			if (dialogSnapPoints.Count == 3) {
+				dialogLinkPoints[1, 0].Down = dialogLinkPoints[0, 1].ID;
+			}
+			return;
+		}
 
 		int modsUpSide = currentID;
 		var upperMenuSnapPoints = upperMenuContainer.GetSnapPoints();

--- a/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/UIMods.cs
@@ -1,21 +1,24 @@
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria.Audio;
+using Terraria.GameContent;
 using Terraria.GameContent.UI.Elements;
+using Terraria.GameContent.UI.States;
+using Terraria.GameInput;
+using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader.Config;
+using Terraria.ModLoader.Core;
+using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.UI;
 using Terraria.UI.Gamepad;
-using Terraria.ModLoader.Config;
-using Terraria.ModLoader.UI.ModBrowser;
-using Terraria.ModLoader.Core;
-using Terraria.Audio;
-using Terraria.ID;
-using System;
-using Terraria.GameContent;
 
 namespace Terraria.ModLoader.UI;
 
@@ -37,11 +40,13 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 	private bool showRamUsage;
 	public bool loading;
 	private UIInputTextField filterTextBox;
+	private UIImageButton clearSearchButton;
 	public UICycleImage SearchFilterToggle;
 	public ModsMenuSortMode sortMode = ModsMenuSortMode.RecentlyUpdated;
 	public EnabledFilter enabledFilterMode = EnabledFilter.All;
 	public ModSideFilter modSideFilterMode = ModSideFilter.All;
 	public SearchFilter searchFilterMode = SearchFilter.Name;
+	private UIElement upperMenuContainer;
 	internal readonly List<UICycleImage> _categoryButtons = new List<UICycleImage>();
 	internal string filter;
 	private UIAutoScaleTextTextPanel<LocalizedText> buttonEA;
@@ -116,6 +121,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 			Top = { Pixels = -65 }
 		}.WithFadedMouseOver();
 		buttonEA.OnLeftClick += QuickEnableAll;
+		buttonEA.SetSnapPoint("EnableAll", 0);
 		uIElement.Append(buttonEA);
 
 		// TODO CopyStyle doesn't capture all the duplication here, consider an inner method
@@ -125,6 +131,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		buttonDA.HAlign = 0.5f;
 		buttonDA.WithFadedMouseOver();
 		buttonDA.OnLeftClick += QuickDisableAll;
+		buttonDA.SetSnapPoint("DisableAll", 0);
 		uIElement.Append(buttonDA);
 
 		buttonRM = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.ModsForceReload"));
@@ -133,6 +140,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		buttonRM.HAlign = 1f;
 		buttonRM.WithFadedMouseOver();
 		buttonRM.OnLeftClick += ReloadMods;
+		buttonRM.SetSnapPoint("ReloadMods", 0);
 		uIElement.Append(buttonRM);
 
 		UpdateTopRowButtons();
@@ -145,6 +153,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		}.WithFadedMouseOver();
 
 		buttonB.OnLeftClick += (_, _) => HandleBackButtonUsage();
+		buttonB.SetSnapPoint("Back", 0);
 
 		uIElement.Append(buttonB);
 		buttonOMF = new UIAutoScaleTextTextPanel<LocalizedText>(Language.GetText("tModLoader.ModsOpenModsFolders"));
@@ -152,10 +161,11 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		buttonOMF.HAlign = 0.5f;
 		buttonOMF.WithFadedMouseOver();
 		buttonOMF.OnLeftClick += OpenModsFolder;
+		buttonOMF.SetSnapPoint("OpenModsFolder", 0);
 		uIElement.Append(buttonOMF);
 
 		var texture = UICommon.ModBrowserIconsTexture;
-		var upperMenuContainer = new UIElement {
+		upperMenuContainer = new UIElement {
 			Width = { Percent = 1f },
 			Height = { Pixels = 32 },
 			Top = { Pixels = 10 }
@@ -222,6 +232,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 				}
 			}
 			toggleImage.Left.Pixels = j * 36;
+			toggleImage.SetSnapPoint("ToggleImage" + j, 0);
 			_categoryButtons.Add(toggleImage);
 			upperMenuContainer.Append(toggleImage);
 		}
@@ -233,7 +244,9 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 			Height = { Pixels = 40 }
 		};
 		filterTextBoxBackground.SetPadding(0);
+		filterTextBoxBackground.OnLeftClick += LeftClickTextBox;
 		filterTextBoxBackground.OnRightClick += ClearSearchField;
+		filterTextBoxBackground.WithFadedMouseOver();
 		upperMenuContainer.Append(filterTextBoxBackground);
 
 		filterTextBox = new UIInputTextField(Language.GetTextValue("tModLoader.ModsTypeToSearch")) {
@@ -244,9 +257,10 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 			VAlign = 0.5f,
 		};
 		filterTextBox.OnTextChange += (a, b) => updateNeeded = true;
+		filterTextBox.SetSnapPoint("FilterTextBox", 0);
 		filterTextBoxBackground.Append(filterTextBox);
 
-		UIImageButton clearSearchButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/SearchCancel")) {
+		clearSearchButton = new UIImageButton(Main.Assets.Request<Texture2D>("Images/UI/SearchCancel")) {
 			HAlign = 1f,
 			VAlign = 0.5f,
 			Left = new StyleDimension(-2f, 0f)
@@ -254,6 +268,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 
 		//clearSearchButton.OnMouseOver += searchCancelButton_OnMouseOver;
 		clearSearchButton.OnLeftClick += ClearSearchField;
+		clearSearchButton.SetSnapPoint("ClearSearchButton", 0); // TODO: Does this click the filterTextBoxBackground as well?
 		filterTextBoxBackground.Append(clearSearchButton);
 
 		SearchFilterToggle = new UICycleImage(texture, 2, 32, 32, 34 * 2, 0) {
@@ -268,6 +283,7 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 			searchFilterMode = searchFilterMode.PreviousEnum();
 			updateNeeded = true;
 		};
+		SearchFilterToggle.SetSnapPoint("SearchFilterToggle", 0);
 		_categoryButtons.Add(SearchFilterToggle);
 		upperMenuContainer.Append(SearchFilterToggle);
 
@@ -276,10 +292,35 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		buttonCL.HAlign = 1f;
 		buttonCL.WithFadedMouseOver();
 		buttonCL.OnLeftClick += GotoModConfigList;
+		buttonCL.SetSnapPoint("GotoModConfigList", 0);
 		uIElement.Append(buttonCL);
 
 		uIPanel.Append(upperMenuContainer);
 		Append(uIElement);
+	}
+
+	private void LeftClickTextBox(UIMouseEvent evt, UIElement listeningElement)
+	{
+		if (!PlayerInput.UsingGamepadUI || evt.Target == clearSearchButton) {
+			return;
+		}
+
+		SoundEngine.PlaySound(SoundID.MenuOpen);
+		Main.clrInput();
+		UIVirtualKeyboard uIVirtualKeyboard = new UIVirtualKeyboard(Language.GetTextValue("tModLoader.ModsTypeToSearch"), filterTextBox.Text, OnFinishedNaming, OnCanceledNaming, 0, allowEmpty: true);
+		uIVirtualKeyboard.SetMaxInputLength(20);
+		Main.MenuUI.SetState(uIVirtualKeyboard);
+	}
+
+	private void OnFinishedNaming(string name)
+	{
+		filterTextBox.Text = name.Trim();
+		Main.MenuUI.SetState(this);
+	}
+
+	private void OnCanceledNaming()
+	{
+		Main.MenuUI.SetState(this);
 	}
 
 	private void ClearSearchField(UIMouseEvent evt, UIElement listeningElement) => filterTextBox.Text = "";
@@ -551,11 +592,65 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 						break;
 				}
 				UICommon.TooltipMouseText(text);
-				return;
 			}
 		}
 		if (buttonOMF.IsMouseHovering)
 			UICommon.TooltipMouseText(Language.GetTextValue("tModLoader.ModsOpenModsFoldersTooltip"));
+
+		SetupGamepadPoints(spriteBatch);
+	}
+
+	private void SetupGamepadPoints(SpriteBatch spriteBatch)
+	{
+		UIGamepadHelper helper;
+		int startID = GamepadPointID.FancyUI0 + 2;
+		int currentID = startID;
+
+		int modsUpSide = currentID;
+		var upperMenuSnapPoints = upperMenuContainer.GetSnapPoints();
+		upperMenuSnapPoints.Sort((SnapPoint x, SnapPoint y) => x.Position.X.CompareTo(y.Position.X));
+		var categoryLinkPoints = helper.CreateUILinkStripHorizontal(ref currentID, upperMenuSnapPoints);
+		foreach (var item in categoryLinkPoints) {
+			item.Down = currentID;
+		}
+
+		if (showRamUsage) {
+			UILinkPointNavigator.SetPosition(currentID, ramUsage.GetInnerDimensions().ToRectangle().Center.ToVector2());
+			UILinkPoint ramUsageLinkPoint = UILinkPointNavigator.Points[currentID];
+			ramUsageLinkPoint.Unlink();
+			ramUsageLinkPoint.Up = modsUpSide;
+			ramUsageLinkPoint.Down = currentID + 1;
+			modsUpSide = currentID;
+			currentID++;
+		}
+
+		int modsLast = modsUpSide;
+		List<(UIModItem, List<SnapPoint>)> elementSnapPairs = modList._items.OfType<UIModItem>().Select(x => (x, x.GetSnapPoints())).ToList();
+		float num = 1f / Main.UIScale;
+		Rectangle clippingRectangle = modList.GetClippingRectangle(spriteBatch);
+		Vector2 minimum = clippingRectangle.TopLeft() * num;
+		Vector2 maximum = clippingRectangle.BottomRight() * num;
+		for (int i = 0; i < elementSnapPairs.Count; i++) {
+			if (!elementSnapPairs[i].Item2[0].Position.Between(minimum, maximum)) {
+				elementSnapPairs.Remove(elementSnapPairs[i]);
+				i--;
+			}
+			else {
+				int down = currentID + 10;
+				modsLast = currentID;
+				elementSnapPairs[i].Item1.SetupGamepadPoints(ref currentID, modsUpSide, down);
+				modsUpSide = modsLast;
+				currentID = down;
+			}
+		}
+
+		UIElement[] buttons = [buttonEA, buttonDA, buttonRM, buttonB, buttonOMF, buttonCL];
+		var buttonSnapPoints = buttons.Select(x => x.GetSnapPoint(out SnapPoint point) ? point : null).ToList();
+		UILinkPoint[,] linkPointGrid = helper.CreateUILinkPointGrid(ref currentID, buttonSnapPoints, 3, null, null, null, null);
+
+		linkPointGrid[0, 0].Up = modsLast;
+		linkPointGrid[1, 0].Up = modsLast;
+		linkPointGrid[2, 0].Up = modsLast;
 	}
 
 	public override void OnActivate()
@@ -569,6 +664,8 @@ internal class UIMods : UIState, IHaveBackButtonCommand
 		ConfigManager.LoadAll(); // Makes sure MP configs are cleared.
 		Populate();
 		UpdateTopRowButtons();
+
+		UILinkPointNavigator.ChangePoint(GamepadPointID.FancyUI0 + 2); // Sort button.
 	}
 
 	public override void OnDeactivate()

--- a/patches/tModLoader/Terraria/UI/Gamepad/GamepadPointID.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/GamepadPointID.cs.patch
@@ -1,5 +1,14 @@
 --- src/TerrariaNetCore/Terraria/UI/Gamepad/GamepadPointID.cs
 +++ src/tModLoader/Terraria/UI/Gamepad/GamepadPointID.cs
+@@ -1,5 +_,8 @@
+ namespace Terraria.UI.Gamepad;
+ 
++/// <summary>
++/// Contains known UILinkPoint ID values (<see cref="UILinkPoint.ID"/>). Some entries indicate the start of a range of values rather than list out each possible value.
++/// </summary>
+ public static class GamepadPointID
+ {
+ 	public const int EndUp = -1;
 @@ -166,7 +_,7 @@
  	public const int ChestActRenameChest = 504;
  	public const int ChestSort = 505;

--- a/patches/tModLoader/Terraria/UI/Gamepad/UILinkPage.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/UILinkPage.cs.patch
@@ -1,0 +1,24 @@
+--- src/TerrariaNetCore/Terraria/UI/Gamepad/UILinkPage.cs
++++ src/tModLoader/Terraria/UI/Gamepad/UILinkPage.cs
+@@ -3,6 +_,10 @@
+ 
+ namespace Terraria.UI.Gamepad;
+ 
++/// <summary>
++/// Represents a collection of <see cref="UILinkPoint"/> all belonging to the same "page/menu/section" of the game UI. Users can use the gamepad trigger buttons to navigate to the next or previous "page", <see cref="PageOnLeft"/> or <see cref="PageOnRight"/>, rather than travel through each <see cref="UILinkPoint"/> individually. When they do this they will arrive at <see cref="DefaultPoint"/>.
++/// <br/><br/> Each UILinkPage has a unique <see cref="ID"/> (see <see cref="GamepadPageID"/>) assigned during registration. 
++/// </summary>
+ public class UILinkPage
+ {
+ 	public int ID;
+@@ -10,6 +_,10 @@
+ 	public int PageOnRight = -1;
+ 	public int DefaultPoint;
+ 	public int CurrentPoint;
++	/// <summary>
++	/// Contains all <see cref="UILinkPoint"/> belonging to this page indexed by their <see cref="UILinkPoint.ID"/> (<see cref="GamepadPointID"/>).
++	/// <br/><br/> Mirrored to <see cref="UILinkPointNavigator.Points"/> during registration.
++	/// </summary>
+ 	public Dictionary<int, UILinkPoint> LinkMap = new Dictionary<int, UILinkPoint>();
+ 
+ 	public event Action<int, int> ReachEndEvent;

--- a/patches/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/UI/Gamepad/UILinkPoint.cs
 +++ src/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs
-@@ -3,6 +_,11 @@
+@@ -3,10 +_,21 @@
  
  namespace Terraria.UI.Gamepad;
  
@@ -11,4 +11,14 @@
 +/// </summary>
  public class UILinkPoint
  {
++	/// <summary>
++	/// A unique identifier for this UILinkPoint. Known IDs and ID ranges are found in <see cref="GamepadPointID"/>.
++	/// </summary>
  	public int ID;
+ 	public bool Enabled;
++	/// <summary>
++	/// The screen coordinates of this UILinkPoint. Use <see cref="UILinkPointNavigator.SetPosition(int, Vector2)"/> to assign this to properly account for <see cref="Main.UIScale"/>.
++	/// </summary>
+ 	public Vector2 Position;
+ 	public int Left;
+ 	public int Right;

--- a/patches/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs.patch
@@ -1,0 +1,14 @@
+--- src/TerrariaNetCore/Terraria/UI/Gamepad/UILinkPoint.cs
++++ src/tModLoader/Terraria/UI/Gamepad/UILinkPoint.cs
+@@ -3,6 +_,11 @@
+ 
+ namespace Terraria.UI.Gamepad;
+ 
++/// <summary>
++/// Represents a gamepad interaction point. Each UILinkPoint has a unique <see cref="ID"/> (see <see cref="GamepadPointID"/>). Each UILinkPoint belongs to a <see cref="Page"/> (see <see cref="UILinkPage"/>). <see cref="UILinkPointNavigator.Points"/> can be used to retrieve a specific UILinkPoint.
++/// <br/><br/> <see cref="Position"/> is the screen coordinates of this interaction point. It is typically set manually through <see cref="UILinkPointNavigator.SetPosition(int, Vector2)"/> or derived from the <see cref="SnapPoint"/> of a <see cref="UIElement"/> using <see cref="GameContent.UI.States.UIGamepadHelper.MakeLinkPointFromSnapPoint(int, SnapPoint)"/>.
++/// <br/><br/> The <see cref="Left"/>, <c>Right</c>, <c>Up</c>, and <c>Down</c> fields indicate the ID of the UILinkPoint that will be navigated to if the user moves the gamepad in those directions. <see cref="Enabled"/> is unused.
++/// </summary>
+ public class UILinkPoint
+ {
+ 	public int ID;

--- a/patches/tModLoader/Terraria/UI/Gamepad/UILinkPointNavigator.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/UILinkPointNavigator.cs.patch
@@ -22,6 +22,28 @@
  	public static Dictionary<int, UILinkPoint> Points = new Dictionary<int, UILinkPoint>();
  	public static int CurrentPage = 1000;
  	public static int OldPage = 1000;
+@@ -56,6 +_,9 @@
+ 	private static int? _suggestedPointID;
+ 	private static int? _preSuggestionPoint;
+ 
++	/// <summary>
++	/// The ID of the current <see cref="UILinkPoint"/> selected by the gamepad.
++	/// </summary>
+ 	public static int CurrentPoint => Pages[CurrentPage].CurrentPoint;
+ 
+ 	public static bool Available {
+@@ -343,6 +_,11 @@
+ 		YCooldown = time;
+ 	}
+ 
++	/// <summary>
++	/// Sets the <see cref="UILinkPoint.Position"/> of the UILinkPoint with the provided <paramref name="ID"/> to the provided <paramref name="Position"/>, scaled appropriately.
++	/// <br/><br/> Can be used to directly set a UILinkPoint position in rare cases where creating a UILinkPoint from a <see cref="SnapPoint"/> is not suitable (such as <see cref="GameContent.UI.States.UIGamepadHelper.GetLinkPoint"/> or <see cref="GameContent.UI.States.UIGamepadHelper.MakeLinkPointFromSnapPoint"/>).
++	/// <br/><br/> Use this instead of directly setting <see cref="UILinkPoint.Position"/> because this method scales <paramref name="Position"/> by <see cref="Main.UIScale"/> to properly convert the provided UI coordinate to screen coordinates.
++	/// </summary>
+ 	public static void SetPosition(int ID, Vector2 Position)
+ 	{
+ 		Points[ID].Position = Position * Main.UIScale;
 @@ -371,6 +_,9 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/UI/Gamepad/UILinkPointNavigator.cs.patch
+++ b/patches/tModLoader/Terraria/UI/Gamepad/UILinkPointNavigator.cs.patch
@@ -8,3 +8,27 @@
  		public static int FANCYUI_HIGHEST_INDEX = 1;
  		public static int FANCYUI_SPECIAL_INSTRUCTIONS = 0;
  		public static int INFOACCCOUNT = 0;
+@@ -42,7 +_,13 @@
+ 		public static int INV_MOVE_OPTION_CD = 0;
+ 	}
+ 
++	/// <summary>
++	/// Contains all <see cref="UILinkPage"/> indexed by their <see cref="UILinkPage.ID"/> (<see cref="GamepadPageID"/>).
++	/// </summary>
+ 	public static Dictionary<int, UILinkPage> Pages = new Dictionary<int, UILinkPage>();
++	/// <summary>
++	/// Contains all <see cref="UILinkPoint"/> indexed by their <see cref="UILinkPoint.ID"/> (<see cref="GamepadPointID"/>).
++	/// </summary>
+ 	public static Dictionary<int, UILinkPoint> Points = new Dictionary<int, UILinkPoint>();
+ 	public static int CurrentPage = 1000;
+ 	public static int OldPage = 1000;
+@@ -371,6 +_,9 @@
+ 		}
+ 	}
+ 
++	/// <summary>
++	/// Navigates to a specific <see cref="UILinkPoint"/> using its ID (<see cref="GamepadPointID"/>).
++	/// </summary>
+ 	public static void ChangePoint(int PointID)
+ 	{
+ 		if (Points.ContainsKey(PointID)) {

--- a/patches/tModLoader/Terraria/UI/SnapPoint.cs.patch
+++ b/patches/tModLoader/Terraria/UI/SnapPoint.cs.patch
@@ -1,0 +1,16 @@
+--- src/TerrariaNetCore/Terraria/UI/SnapPoint.cs
++++ src/tModLoader/Terraria/UI/SnapPoint.cs
+@@ -3,6 +_,13 @@
+ 
+ namespace Terraria.UI;
+ 
++/// <summary>
++/// Represents an interaction target for a specific UIElement.
++/// <br/><br/> <see cref="Name"/> serves as a tag, allowing logic to locate or filter the SnapPoints of specific UIElements. <see cref="ID"/> indicates an order within that tag when multiple elements share the same <see cref="Name"/>.
++/// <br/><br/> <see cref="_anchor"/> and <see cref="_offset"/> are used to calculate <see cref="Position"/> from the dimensions of this UIElement. Position is the mouse location to use when snapping to a SnapPoint. Adjusting the anchor and offset can adjust where tooltips are displayed.
++/// <br/><br/> SnapPoints are typically created through <see cref="UIElement.SetSnapPoint(string, int, Vector2?, Vector2?)"/>, which defaults to centering the anchor on the element.
++/// <br/><br/> SnapPoints are used to populate <see cref="Gamepad.UILinkPoint"/> positions by using <see cref="GameContent.UI.States.UIGamepadHelper.MakeLinkPointFromSnapPoint(int, SnapPoint)"/> or other helper methods in <see cref="GameContent.UI.States.UIGamepadHelper"/>.
++/// </summary>
+ [DebuggerDisplay("Snap Point - {Name} {Id}")]
+ public class SnapPoint
+ {

--- a/patches/tModLoader/Terraria/UI/SnapPoint.cs.patch
+++ b/patches/tModLoader/Terraria/UI/SnapPoint.cs.patch
@@ -8,7 +8,7 @@
 +/// Represents an interaction target for a specific UIElement.
 +/// <br/><br/> <see cref="Name"/> serves as a tag, allowing logic to locate or filter the SnapPoints of specific UIElements. <see cref="ID"/> indicates an order within that tag when multiple elements share the same <see cref="Name"/>.
 +/// <br/><br/> <see cref="_anchor"/> and <see cref="_offset"/> are used to calculate <see cref="Position"/> from the dimensions of this UIElement. Position is the mouse location to use when snapping to a SnapPoint. Adjusting the anchor and offset can adjust where tooltips are displayed.
-+/// <br/><br/> SnapPoints are typically created through <see cref="UIElement.SetSnapPoint(string, int, Vector2?, Vector2?)"/>, which defaults to centering the anchor on the element.
++/// <br/><br/> SnapPoints are typically created through <see cref="UIElement.SetSnapPoint(string, int, Vector2?, Vector2?)"/>, which defaults to centering the anchor on the element. Manually creating additional SnapPoints for a specific UIElement is also possible and would usually be done in <see cref="UIElement.GetSnapPoints"/>.
 +/// <br/><br/> SnapPoints are used to populate <see cref="Gamepad.UILinkPoint"/> positions by using <see cref="GameContent.UI.States.UIGamepadHelper.MakeLinkPointFromSnapPoint(int, SnapPoint)"/> or other helper methods in <see cref="GameContent.UI.States.UIGamepadHelper"/>.
 +/// </summary>
  [DebuggerDisplay("Snap Point - {Name} {Id}")]

--- a/patches/tModLoader/Terraria/UI/UIElement.cs.patch
+++ b/patches/tModLoader/Terraria/UI/UIElement.cs.patch
@@ -90,7 +90,7 @@
  	public bool IsMouseHovering { get; private set; }
  
  	public event MouseEvent OnLeftMouseDown;
-@@ -68,10 +_,15 @@
+@@ -68,16 +_,26 @@
  	public event MouseEvent OnRightMouseUp;
  	public event MouseEvent OnRightClick;
  	public event MouseEvent OnRightDoubleClick;
@@ -106,6 +106,27 @@
  
  	public UIElement()
  	{
+ 		UniqueId = _idCounter++;
+ 	}
+ 
++	/// <summary>
++	/// Sets the <see cref="SnapPoint"/> for this UIElement. <paramref name="name"/> and <paramref name="id"/> are used as "tags" and <paramref name="anchor"/> and <paramref name="offset"/> are used when calculating where the mouse should snap to within the element dimensions.
++	/// <br/><br/> Can be retrieved using <see cref="GetSnapPoints"/> or <see cref="GetSnapPoint(out SnapPoint)"/>.
++	/// <br/><br/> Setting a SnapPoint helps facilitate populating <see cref="UI.Gamepad.UILinkPoint"/>s with appropriate data, especially for dynamic UI such as those using UIList or UIGrid. 
++	/// </summary>
+ 	public void SetSnapPoint(string name, int id, Vector2? anchor = null, Vector2? offset = null)
+ 	{
+ 		if (!anchor.HasValue)
+@@ -89,6 +_,9 @@
+ 		_snapPoint = new SnapPoint(name, id, anchor.Value, offset.Value);
+ 	}
+ 
++	/// <summary>
++	/// Retrieves the <see cref="SnapPoint"/> of this element. Returns false if the SnapPoint has not been assigned (<see cref="SetSnapPoint"/>).
++	/// </summary>
+ 	public bool GetSnapPoint(out SnapPoint point)
+ 	{
+ 		point = _snapPoint;
 @@ -106,10 +_,14 @@
  		}
  	}
@@ -177,6 +198,16 @@
  	public virtual void Update(GameTime gameTime)
  	{
  		if (this.OnUpdate != null)
+@@ -212,6 +_,9 @@
+ 		return new Rectangle(num3, num4, num5 - num3, num6 - num4);
+ 	}
+ 
++	/// <summary>
++	/// Returns a list of the <see cref="SnapPoint"/>s of this element and all the children elements recursively.
++	/// </summary>
+ 	public virtual List<SnapPoint> GetSnapPoints()
+ 	{
+ 		List<SnapPoint> list = new List<SnapPoint>();
 @@ -296,6 +_,9 @@
  
  	public virtual Rectangle GetViewCullingArea() => _dimensions.ToRectangle();

--- a/patches/tModLoader/Terraria/UI/UIElement.cs.patch
+++ b/patches/tModLoader/Terraria/UI/UIElement.cs.patch
@@ -90,7 +90,7 @@
  	public bool IsMouseHovering { get; private set; }
  
  	public event MouseEvent OnLeftMouseDown;
-@@ -68,16 +_,26 @@
+@@ -68,16 +_,27 @@
  	public event MouseEvent OnRightMouseUp;
  	public event MouseEvent OnRightClick;
  	public event MouseEvent OnRightDoubleClick;
@@ -112,7 +112,8 @@
 +	/// <summary>
 +	/// Sets the <see cref="SnapPoint"/> for this UIElement. <paramref name="name"/> and <paramref name="id"/> are used as "tags" and <paramref name="anchor"/> and <paramref name="offset"/> are used when calculating where the mouse should snap to within the element dimensions.
 +	/// <br/><br/> Can be retrieved using <see cref="GetSnapPoints"/> or <see cref="GetSnapPoint(out SnapPoint)"/>.
-+	/// <br/><br/> Setting a SnapPoint helps facilitate populating <see cref="UI.Gamepad.UILinkPoint"/>s with appropriate data, especially for dynamic UI such as those using UIList or UIGrid. 
++	/// <br/><br/> Setting a SnapPoint helps facilitate populating <see cref="UI.Gamepad.UILinkPoint"/>s with appropriate data, especially for dynamic UI such as those using UIList or UIGrid.
++	/// <br/><br/> If a specific UIElement needs multiple SnapPoints, <see cref="GetSnapPoints"/> can be used to supply them.
 +	/// </summary>
  	public void SetSnapPoint(string name, int id, Vector2? anchor = null, Vector2? offset = null)
  	{
@@ -198,12 +199,24 @@
  	public virtual void Update(GameTime gameTime)
  	{
  		if (this.OnUpdate != null)
-@@ -212,6 +_,9 @@
+@@ -212,6 +_,21 @@
  		return new Rectangle(num3, num4, num5 - num3, num6 - num4);
  	}
  
 +	/// <summary>
 +	/// Returns a list of the <see cref="SnapPoint"/>s of this element and all the children elements recursively.
++	/// <br/><br/> This method can be overridden to add additional SnapPoints for UIElement that should have multiple interaction points. One such example might be a Up/Down button. Here is an example:
++	/// <code>
++	/// // Gets the default "Up" SnapPoint defined normally and all the children SnapPoints
++	/// List&lt;SnapPoint&gt; snapPoints = base.GetSnapPoints();
++	///
++	/// // Creates a new "Down" SnapPoint centered on the element and offset 4 pixels down. 
++	/// var downSnap = new SnapPoint("Down", 0, new Vector2(0.5f, 0.5f), new Vector2(0, 4));
++	/// downSnap.Calculate(upDownButton);
++	/// snapPoints.Add(downSnap);
++	/// 
++	/// return snapPoints;
++	/// </code>
 +	/// </summary>
  	public virtual List<SnapPoint> GetSnapPoints()
  	{


### PR DESCRIPTION
**WIP**

This PR adds gamepad support to the tModLoader added menus. These menus have never had proper gamepad support, which limits the functionality of tModLoader for gamepad only users. The fixes in this PR should bring gamepad support up to good enough to say we support gamepads. Hopefully we can get the "controllers not supported" warning and Steam Deck compatibility shortcomings resolved as well once this is in Stable.

<details><summary>Steam gamepad and Steam Deck compatibility warnings</summary><blockquote>

<img width="853" height="415" alt="image" src="https://github.com/user-attachments/assets/5a388d62-baa2-4513-9767-bae90bf63c23" />
<img width="525" height="141" alt="image" src="https://github.com/user-attachments/assets/5e738b0d-0dda-40cf-a93e-8d5970dfac76" />

</blockquote></details>

In terms of mods, there have been some mods that have supported gamepads, but the API is not friendly. This PR adds plenty of documentation to help guide interested modders. There have been ongoing conversations about designing an API for supporting gamepads for modded UI elements more easily, but this PR will not include any of that.

ExampleFullscreenUI has also been updated with gamepad support, but it is easier to make a fullscreen UI compatible because it doesn't need to accommodate for compatibility with other mods. In-game UI such as inventory screen additions or new menus would require more support for properly allocating UILinkPages and UILinkPoints.

# TODO
* Video demonstrating new support
* Way to toggle ExampleFullscreenUI with gamepad itself. Currently you still need to type the command.
* ModConfig support. 
* Maybe change the up/down behavior for UIModItem/UIModDownloadItem/UIModSourceItem. Right now up and down go to the enable/download/build buttons instead of the button of the same type currently on. These are a bit complicated since many of the buttons may or may not exist, so setting up the links is a bit complicated.