### PR TITLE
Fix Lots of Liquid Edge Rendering Bugs

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -443,19 +443,8 @@
  		return num;
  	}
  
-@@ -2825,6 +_,7 @@
- 
- 				int num6 = (int)num5 * 2;
- 				if (tileCache.slope() != 0) {
-+
- 					vector = new Vector2(tileX * 16, tileY * 16 + num6);
- 					liquidSize = new Rectangle(0, num6, 16, 16 - num6);
- 				}
-@@ -2875,9 +_,11 @@
- 		vertices.BottomRightColor *= num7;
- 		vertices.TopLeftColor *= num7;
+@@ -2877,7 +_,8 @@
  		vertices.TopRightColor *= num7;
-+
  		bool flag7 = false;
  		if (flag6) {
 +			int totalCount = LoaderManager.Get<WaterStylesLoader>().TotalCount;

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
@@ -31,7 +31,7 @@ public static class LiquidEdgeRenderer
 	/// <summary>
 	/// Whether the new rendering is actually active for this frame.
 	/// </summary>
-	public static bool Active => Lighting.NotRetro/* && !Main.keyState.PressingShift()*/;
+	public static bool Active => Enabled && Lighting.NotRetro/* && !Main.keyState.PressingShift()*/;
 
 	/// <summary>
 	/// Turns all pixels with alpha above zero white, and all others transparent.

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -292,17 +292,19 @@
  		}
  
  		if (this.WaveFilters != null)
-@@ -524,7 +_,8 @@
+@@ -524,7 +_,11 @@
  			LiquidDrawCache* ptr2 = ptr;
  			for (int i = drawArea.X; i < drawArea.X + drawArea.Width; i++) {
  				for (int j = drawArea.Y; j < drawArea.Y + drawArea.Height; j++) {
--					if (ptr2->IsVisible) {
 +					// TML: Liquid draw caches merged, add shimmer type check
++					/*
+ 					if (ptr2->IsVisible) {
++					*/
 +					if (ptr2->IsVisible && ptr2->Type != LiquidID.Shimmer) {
  						Rectangle sourceRectangle = ptr2->SourceRectangle;
  						if (ptr2->IsSurfaceLiquid)
  							sourceRectangle.Y = 1280;
-@@ -566,12 +_,28 @@
+@@ -566,12 +_,27 @@
  	{
  		Rectangle drawArea = _drawArea;
  		Main.tileBatch.Begin();
@@ -311,10 +313,9 @@
  			SpecialLiquidDrawCache* ptr2 = ptr;
  			int num = _drawCacheForShimmer.Length;
 +		*/
-+		fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
++					fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
 +			LiquidDrawCache* ptr2 = ptr;
 +			/*
-+			int num = _drawCache.Length;
  			for (int i = 0; i < num; i++) {
 +			*/
 +			for (int num3 = drawArea.X; num3 < drawArea.X + drawArea.Width; num3++)

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -261,8 +261,8 @@
  								if (ptr2->IsHalfBrick && ptr2->IsSolid && num23 > 0.5f)
  									num23 = 0.5f;
  
-+								ptr4->X = num18;
-+								ptr4->Y = num19;
++								ptr4->X = rectangle.X + num18;
++								ptr4->Y = rectangle.Y + num19;
 -								ptr4->IsVisible = ptr2->HasWall || !ptr2->IsHalfBrick || !ptr2->HasLiquid || !(ptr2->LiquidLevel < 1f);
 +								ptr4->IsVisible = ptr2->HasWall || !ptr2->IsHalfBrick || !ptr2->HasLiquid || !(ptr2->LiquidLevel < 1f) || ptr2->EdgeData.HasValue;
  								ptr4->SourceRectangle = new Rectangle((int)(16f - num21 * 16f) + ptr2->FrameOffset.X, (int)(16f - num23 * 16f) + ptr2->FrameOffset.Y, (int)Math.Ceiling((num21 - num20) * 16f), (int)Math.Ceiling((num23 - num22) * 16f));
@@ -320,8 +320,8 @@
  						}
  
 +						// TML: use cached X and Y instead of loop positions
-+						int i = ptr2->X + drawArea.X - 2;
-+						int j = ptr2->Y + drawArea.Y - 2;
++						int i = ptr2->X;
++						int j = ptr2->Y;
  						num = Math.Min(1f, num);
  						Lighting.GetCornerColors(i, j, out var vertices);
  						vertices.BottomLeftColor *= num;
@@ -350,3 +350,14 @@
  
  				Rectangle sourceRectangle = ptr2->SourceRectangle;
  				if (ptr2->IsSurfaceLiquid)
+@@ -583,8 +_,8 @@
+ 				float val = ptr2->Opacity * (isBackgroundDraw ? 1f : 0.75f);
+ 				int num2 = 14;
+ 				val = Math.Min(1f, val);
+-				int num3 = ptr2->X + drawArea.X - 2;
+-				int num4 = ptr2->Y + drawArea.Y - 2;
++				int num3 = ptr2->X;
++				int num4 = ptr2->Y;
+ 				Lighting.GetCornerColors(num3, num4, out var vertices);
+ 				SetShimmerVertexColors(ref vertices, val, num3, num4);
+ 				Main.DrawTileInWater(drawOffset, num3, num4);

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -15,7 +15,7 @@
  	{
  		public float LiquidLevel;
  		public float VisibleLiquidLevel;
-@@ -35,10 +_,13 @@
+@@ -35,9 +_,10 @@
  		public float VisibleTopWall;
  		public byte Type;
  		public byte VisibleType;
@@ -25,11 +25,8 @@
 -	private struct LiquidDrawCache
 +	public struct LiquidDrawCache
  	{
-+		public int X;
-+		public int Y;
  		public Rectangle SourceRectangle;
  		public Vector2 LiquidOffset;
- 		public bool IsVisible;
 @@ -48,6 +_,7 @@
  		public bool HasWall;
  	}
@@ -257,12 +254,10 @@
  							if (ptr2->HasTopEdge)
  								ptr2->VisibleTopWall = (ptr2->TopWall * 2f + liquidCache3.TopWall + liquidCache4.TopWall) * 0.25f;
  
-@@ -424,7 +_,9 @@
+@@ -424,7 +_,7 @@
  								if (ptr2->IsHalfBrick && ptr2->IsSolid && num23 > 0.5f)
  									num23 = 0.5f;
  
-+								ptr4->X = rectangle.X + num18;
-+								ptr4->Y = rectangle.Y + num19;
 -								ptr4->IsVisible = ptr2->HasWall || !ptr2->IsHalfBrick || !ptr2->HasLiquid || !(ptr2->LiquidLevel < 1f);
 +								ptr4->IsVisible = ptr2->HasWall || !ptr2->IsHalfBrick || !ptr2->HasLiquid || !(ptr2->LiquidLevel < 1f) || ptr2->EdgeData.HasValue;
  								ptr4->SourceRectangle = new Rectangle((int)(16f - num21 * 16f) + ptr2->FrameOffset.X, (int)(16f - num23 * 16f) + ptr2->FrameOffset.Y, (int)Math.Ceiling((num21 - num20) * 16f), (int)Math.Ceiling((num23 - num22) * 16f));
@@ -297,35 +292,17 @@
  		}
  
  		if (this.WaveFilters != null)
-@@ -522,9 +_,17 @@
- 		Main.tileBatch.Begin();
- 		fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
+@@ -524,7 +_,8 @@
  			LiquidDrawCache* ptr2 = ptr;
-+			// TML: Liquid draw caches merged, screen loop redundant
-+			/*
  			for (int i = drawArea.X; i < drawArea.X + drawArea.Width; i++) {
  				for (int j = drawArea.Y; j < drawArea.Y + drawArea.Height; j++) {
- 					if (ptr2->IsVisible) {
-+			*/
-+			{
-+				int cacheLength = drawArea.Width * drawArea.Height /*_drawCache.Length*/;
-+				for (int k = 0; k < cacheLength; k++) {
+-					if (ptr2->IsVisible) {
 +					// TML: Liquid draw caches merged, add shimmer type check
 +					if (ptr2->IsVisible && ptr2->Type != LiquidID.Shimmer) {
  						Rectangle sourceRectangle = ptr2->SourceRectangle;
  						if (ptr2->IsSurfaceLiquid)
  							sourceRectangle.Y = 1280;
-@@ -544,6 +_,9 @@
- 								break;
- 						}
- 
-+						// TML: use cached X and Y instead of loop positions
-+						int i = ptr2->X;
-+						int j = ptr2->Y;
- 						num = Math.Min(1f, num);
- 						Lighting.GetCornerColors(i, j, out var vertices);
- 						vertices.BottomLeftColor *= num;
-@@ -566,12 +_,24 @@
+@@ -566,12 +_,28 @@
  	{
  		Rectangle drawArea = _drawArea;
  		Main.tileBatch.Begin();
@@ -336,8 +313,12 @@
 +		*/
 +		fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
 +			LiquidDrawCache* ptr2 = ptr;
-+			int num = drawArea.Width * drawArea.Height /*_drawCache.Length*/;
++			/*
++			int num = _drawCache.Length;
  			for (int i = 0; i < num; i++) {
++			*/
++			for (int num3 = drawArea.X; num3 < drawArea.X + drawArea.Width; num3++)
++			for (int num4 = drawArea.Y; num4 < drawArea.Y + drawArea.Height; num4++) {
 +				// TML: Liquid draw caches merged, add shimmer type check
 +				/*
  				if (!ptr2->IsVisible)
@@ -356,8 +337,8 @@
  				val = Math.Min(1f, val);
 -				int num3 = ptr2->X + drawArea.X - 2;
 -				int num4 = ptr2->Y + drawArea.Y - 2;
-+				int num3 = ptr2->X;
-+				int num4 = ptr2->Y;
++				// int num3 = ptr2->X;
++				// int num4 = ptr2->Y;
  				Lighting.GetCornerColors(num3, num4, out var vertices);
  				SetShimmerVertexColors(ref vertices, val, num3, num4);
  				Main.DrawTileInWater(drawOffset, num3, num4);

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -313,7 +313,7 @@
  			SpecialLiquidDrawCache* ptr2 = ptr;
  			int num = _drawCacheForShimmer.Length;
 +		*/
-+					fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
++		fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
 +			LiquidDrawCache* ptr2 = ptr;
 +			/*
  			for (int i = 0; i < num; i++) {
@@ -332,14 +332,14 @@
  
  				Rectangle sourceRectangle = ptr2->SourceRectangle;
  				if (ptr2->IsSurfaceLiquid)
-@@ -583,8 +_,8 @@
+@@ -583,8 +_,10 @@
  				float val = ptr2->Opacity * (isBackgroundDraw ? 1f : 0.75f);
  				int num2 = 14;
  				val = Math.Min(1f, val);
--				int num3 = ptr2->X + drawArea.X - 2;
--				int num4 = ptr2->Y + drawArea.Y - 2;
-+				// int num3 = ptr2->X;
-+				// int num4 = ptr2->Y;
++				/*
+ 				int num3 = ptr2->X + drawArea.X - 2;
+ 				int num4 = ptr2->Y + drawArea.Y - 2;
++				*/
  				Lighting.GetCornerColors(num3, num4, out var vertices);
  				SetShimmerVertexColors(ref vertices, val, num3, num4);
  				Main.DrawTileInWater(drawOffset, num3, num4);

--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidRenderer.cs.patch
@@ -308,7 +308,7 @@
  					if (ptr2->IsVisible) {
 +			*/
 +			{
-+				int cacheLength = _drawCache.Length;
++				int cacheLength = drawArea.Width * drawArea.Height /*_drawCache.Length*/;
 +				for (int k = 0; k < cacheLength; k++) {
 +					// TML: Liquid draw caches merged, add shimmer type check
 +					if (ptr2->IsVisible && ptr2->Type != LiquidID.Shimmer) {
@@ -336,7 +336,7 @@
 +		*/
 +		fixed (LiquidDrawCache* ptr = &_drawCache[0]) {
 +			LiquidDrawCache* ptr2 = ptr;
-+			int num = _drawCache.Length;
++			int num = drawArea.Width * drawArea.Height /*_drawCache.Length*/;
  			for (int i = 0; i < num; i++) {
 +				// TML: Liquid draw caches merged, add shimmer type check
 +				/*

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6470,6 +6470,25 @@
  		Asset<Texture2D> asset = TextureAssets.MapBGs[0];
  		int num = -1;
  		Microsoft.Xna.Framework.Color color = Microsoft.Xna.Framework.Color.White;
+@@ -46783,6 +_,9 @@
+ 
+ 	public void DrawCapture(Microsoft.Xna.Framework.Rectangle area, CaptureSettings settings)
+ 	{
++		// Remove in 1.4.5
++		bool lidquidEdgeRendererEnabled = LiquidEdgeRenderer.Enabled;
++		LiquidEdgeRenderer.Enabled = false;
+ 		float[] array = bgAlphaFrontLayer;
+ 		bgAlphaFrontLayer = new float[array.Length];
+ 		float[] array2 = bgAlphaFarBackLayer;
+@@ -47132,6 +_,8 @@
+ 		SceneMetrics.HolyTileCount = holyTileCount;
+ 		Lighting.Initialize();
+ 		GameViewMatrix = gameViewMatrix;
++		// Remove in 1.4.5
++		LiquidEdgeRenderer.Enabled = lidquidEdgeRendererEnabled;
+ 	}
+ 
+ 	protected void RenderTiles()
 @@ -47244,6 +_,12 @@
  			case 4:
  				return 13;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6543,15 +6543,14 @@
  			TilesRenderer.DrawLiquidBehindTiles(waterStyle);
  
  		LiquidRenderer.Instance.DrawNormalLiquids(spriteBatch, drawOffset, waterStyle, Alpha, bg);
-@@ -47337,6 +_,14 @@
+@@ -47337,6 +_,13 @@
  
  	public static void DrawTileInWater(Vector2 drawOffset, int x, int y)
  	{
-+		// TML(liquid-slopes): There seems to be an IOOB being thrown here,
-+		// presumably due to tile coordinates being stored as relative XY
-+		// positions as a result of the merger with the shimmer draw cache.
-+		// For now, just add a safety check here.  We can keep this even if
-+		// it's properly addressed.
++		// TML(liquid-slopes): There was an IOOB being thrown here when liquid
++		// draw cache sitll used relative XY coordinates.  We now use absolute
++		// XY coordinates, which should fix the issue, but it doesn't hurt to
++		// be safe.
 +		if (!WorldGen.InWorld(x, y))
 +			return;
 +

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6562,20 +6562,6 @@
  			TilesRenderer.DrawLiquidBehindTiles(waterStyle);
  
  		LiquidRenderer.Instance.DrawNormalLiquids(spriteBatch, drawOffset, waterStyle, Alpha, bg);
-@@ -47337,6 +_,13 @@
- 
- 	public static void DrawTileInWater(Vector2 drawOffset, int x, int y)
- 	{
-+		// TML(liquid-slopes): There was an IOOB being thrown here when liquid
-+		// draw cache sitll used relative XY coordinates.  We now use absolute
-+		// XY coordinates, which should fix the issue, but it doesn't hurt to
-+		// be safe.
-+		if (!WorldGen.InWorld(x, y))
-+			return;
-+
- 		if (Main.tile[x, y] != null && Main.tile[x, y].active() && Main.tile[x, y].type == 518) {
- 			instance.LoadTiles(Main.tile[x, y].type);
- 			Tile tile = Main.tile[x, y];
 @@ -47776,6 +_,7 @@
  			}
  		}


### PR DESCRIPTION
Fixes basically every known issue with the new liquid rendering aside from #4838.

- Removed XY coordinates from draw cache, regular draw loop now uses old approach and shimmer loop now uses the same loop as the regular liquids,
  - fixes issues with using outdated cache values,
- camera mode is temporarily patched to not use the fixes (1.4.5 should remove these limitations),
- fixed the `Active` property not checking for `Enabled`.

This should fix the issue with liquid sticking to the screen (though it'd be great to get someone who can reliably reproduce the issue to confirm this independently), and I believe provides a better fix to #4850 (though I've kept the patch just to be safe).