### PR TITLE
fix: Resolve CurrentPlayerOverride implementation breaking mod accessory slots.

### DIFF
--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -72,6 +72,7 @@ public partial class Main
 	// Tracks whether the Stylist has had her hairstyle list updated for the current interaction.
 	private static bool hairstylesUpdatedForThisInteraction; // TML: Track whether hairstyle cache needs refreshing for Stylist UI.
 
+	[ThreadStatic]
 	private static Player _currentPlayerOverride;
 
 	/// <summary>


### PR DESCRIPTION
Resolves what seems to be the root issue behind Path-of-Terraria/PathOfTerraria#1655 by making `Main_currentPlayerOverride` `[ThreadStatic]`. See https://github.com/Path-of-Terraria/PathOfTerraria/pull/1655/commits/bce51bfa43f881ac6aa5bdb9437985732fbc12b4 in particular.

> Modded accessory slots (3 & 4) can begin pointing to the wrong player instance's inventory, thus becoming "locked out" from swapping, and eventually causing item duplication.

If a mod or some vanilla behavior causes players to be loaded from disk during gameplay, a `CurrentPlayerOverride` value placed in `LoadPlayerFromStream` (or in another callsite ran outside the main thread), can result in the override permanently or temporarily breaking behavior of custom accessory slots.