### PR TITLE
[CodeAnalysis] Iterate Over Argument Operations Directly

### DIFF
--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -343,11 +343,11 @@ public sealed class ChangeMagicNumberToIDUnitTest
 			var item = new Item();
 			item.createTile =
 							[|42|];
-			
+
 			//Binary
 			_ = new Item().type == /* Note */ [|1|] /* Note2 */;
 			_ = new Item().type ==[|1|];
-			
+
 			// CaseSwitchLabel
 			switch (new NPC().type) {
 				case [|420|] /* Note */:
@@ -391,5 +391,33 @@ public sealed class ChangeMagicNumberToIDUnitTest
 					break;
 			}
 			"""");
+	}
+
+	[TestMethod]
+	public async Task Test_4889()
+	{
+		// https://github.com/tModLoader/tModLoader/issues/4889
+
+		await VerifyCS.Run(
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, [|0|], 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? 0 : 1), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? 0 : ProjectileID.WoodenArrowFriendly), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? ProjectileID.None : 1), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? ProjectileID.None : ProjectileID.WoodenArrowFriendly), 0, 0f, 0, 0f, 0f);
+			""",
+			"""
+			using Terraria;
+			using Terraria.ID;
+
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, ProjectileID.None, 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? 0 : 1), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? 0 : ProjectileID.WoodenArrowFriendly), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? ProjectileID.None : 1), 0, 0f, 0, 0f, 0f);
+			Projectile.NewProjectile(null, 0f, 0f, 0f, 0f, (true ? ProjectileID.None : ProjectileID.WoodenArrowFriendly), 0, 0f, 0, 0f, 0f);
+			""");
 	}
 }

--- a/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
+++ b/tModCodeAssist/tModCodeAssist.Tests/CodeFixes/ChangeMagicNumberToIDUnitTest.cs
@@ -398,6 +398,9 @@ public sealed class ChangeMagicNumberToIDUnitTest
 	{
 		// https://github.com/tModLoader/tModLoader/issues/4889
 
+		// TODO: In the future, we may want to teach the analyzer how to process
+		//       these complex expressions.
+
 		await VerifyCS.Run(
 			"""
 			using Terraria;


### PR DESCRIPTION
*Fixes #4889.*

Rewrites `ChangeMagicNumberToIDAnalyzer`s `SyntaxKind.InvocationExpression` handler to iterate over argument operations directly, instead of trying to operate on syntax before operations.

A simpler fix would have been to just check if `GetOperation` returns `null`, but this fix allows us to teach the analyzer to better handle these complex expressions in the future (`argument.Syntax is not ArgumentSyntax argumentSyntax` still filters to only simple argument syntax, but we can do much more with it if someone has the time).

The fundamental issue is that `GetOperation` may return `null` for complex argument syntaxes, but if we derive the invocation operation from its syntax, we can interpret the arguments directly (this should also give us better compatibility with named argument syntax (`a(b: c)`) and `params` collection arguments.