### PR TITLE
Add Jetbrains.Annotations as a Dependency and Annotate Important Types

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
@@ -1,8 +1,14 @@
+using JetBrains.Annotations;
+
 namespace Terraria.ModLoader;
 
 /// <summary>
 /// Allows for implementing types to be loaded and unloaded.
 /// </summary>
+[UsedImplicitly(
+	ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,
+	ImplicitUseTargetFlags.WithMembers | ImplicitUseTargetFlags.WithInheritors
+)]
 public interface ILoadable
 {
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -1,23 +1,28 @@
-using log4net;
-using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
-using Terraria.ID;
-using Terraria.Localization;
-using Terraria.ModLoader.Core;
-using Terraria.ModLoader.Exceptions;
 using System.Linq;
-using Terraria.ModLoader.Config;
+using System.Reflection;
+using JetBrains.Annotations;
+using log4net;
+using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using ReLogic.Content.Sources;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader.Config;
+using Terraria.ModLoader.Core;
+using Terraria.ModLoader.Exceptions;
 
 namespace Terraria.ModLoader;
 
 /// <summary>
 /// Mod is an abstract class that you will override. It serves as a central place from which the mod's contents are stored. It provides methods for you to use or override.
 /// </summary>
+[UsedImplicitly(
+	ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,
+	ImplicitUseTargetFlags.WithMembers | ImplicitUseTargetFlags.WithInheritors
+)]
 public partial class Mod
 {
 	/// <summary>

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -8,7 +8,7 @@
  
  	<!-- General -->
  	<PropertyGroup>
-@@ -11,59 +_,98 @@
+@@ -11,59 +_,99 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -79,7 +79,6 @@
 +		<Reference Include="TerrariaHooks" />
  
 +		<PackageReference Include="DotNetZip" Version="1.16.0" />
-+
 +		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
  		<PackageReference Include="Steamworks.NET.AnyCPU" Version="2025.162.4" />
 +		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.5.0" />

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -8,7 +8,7 @@
  
  	<!-- General -->
  	<PropertyGroup>
-@@ -11,59 +_,95 @@
+@@ -11,59 +_,98 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -37,6 +37,9 @@
 +		<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
 +		<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
 +		<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
++
++		<!-- Include annotations in compiled binary for mods to see. -->
++		<DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
 +	</PropertyGroup>
 +
 +	<!-- Versioning -->
@@ -76,6 +79,8 @@
 +		<Reference Include="TerrariaHooks" />
  
 +		<PackageReference Include="DotNetZip" Version="1.16.0" />
++
++		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
  		<PackageReference Include="Steamworks.NET.AnyCPU" Version="2025.162.4" />
 +		<PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.5.0" />
 +		<PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.2" />

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- Set the default value for BuildMod -->
+	<!-- Set default values for our build config properties -->
 	<PropertyGroup>
 		<BuildMod Condition="'$(BuildMod)' == ''">true</BuildMod>
 		<OutputTmlReferences Condition="'$(OutputTmlReferences)' == ''">false</OutputTmlReferences>
@@ -11,6 +11,9 @@
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>12.0</LangVersion>
+
+		<!-- Include annotations in compiled binary for mods to see. -->
+		<DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
### What is the new feature?

Implements what's suggested in #4892 for important tModLoader types (`ILoadable`, `Mod`).

### Why should this be part of tModLoader?

Letting tModLoader directly provide the `Jetbrains.Annotations` dependency allows mods to keep their annotations in their binaries without worrying about how assemblies will be loaded. This also allows tModLoader to mark its commonly-used types that are loaded through reflection as implicitly used, relieving many annoying code quality/maintenance warnings given by R#/Rider.

### Are there alternative designs?

It's also feasible to maintain an [external XML file](https://github.com/terraria-catalyst/catalyst/blob/1a8b052863aa5c3e55ebf38a894d4cbe9920dd18/src/TeamCatalyst.Catalyst.Annotations/tModLoader/Attributes.xml) providing these annotations.
Read more here: https://www.jetbrains.com/help/resharper/Code_Analysis__External_Annotations.html
