### PR TITLE
ModItem/GlobalItem.ApplyPrefix

### DIFF
--- a/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
@@ -1,4 +1,5 @@
 using ExampleMod.Content.Projectiles;
+using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -27,6 +28,20 @@ namespace ExampleMod.Content.Items.Weapons
 			Item.shoot = ModContent.ProjectileType<ExampleShortswordProjectile>(); // The projectile is what makes a shortsword work
 			Item.shootSpeed = 2.1f; // This value bleeds into the behavior of the projectile as velocity, keep that in mind when tweaking values
 		}
+
+		// Since this weapon is a projectile (uses noUseGraphic), it isn't naturally considered a melee weapon for the purposes of prefixes. This allows the expected prefixes to be applied.
+		public override bool MeleePrefix() {
+			var old = base.MeleePrefix();
+			return true;
+		}
+
+		/* Here is an example of using ApplyPrefix to apply item-specific tweaks to a specific prefix.
+		public override void ApplyPrefix(int pre) {
+			if(pre == PrefixID.Agile) {
+				Item.crit += 10;
+			}
+		}
+		*/
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
 		public override void AddRecipes() {

--- a/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
@@ -1,5 +1,4 @@
 using ExampleMod.Content.Projectiles;
-using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
+++ b/ExampleMod/Content/Items/Weapons/ExampleShortsword.cs
@@ -29,10 +29,7 @@ namespace ExampleMod.Content.Items.Weapons
 		}
 
 		// Since this weapon is a projectile (uses noUseGraphic), it isn't naturally considered a melee weapon for the purposes of prefixes. This allows the expected prefixes to be applied.
-		public override bool MeleePrefix() {
-			var old = base.MeleePrefix();
-			return true;
-		}
+		public override bool MeleePrefix() => true;
 
 		/* Here is an example of using ApplyPrefix to apply item-specific tweaks to a specific prefix.
 		public override void ApplyPrefix(int pre) {

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -1001,13 +1001,14 @@
  		damage = (int)Math.Round((float)damage * dmg);
  		useAnimation = (int)Math.Round((float)useAnimation * spd);
  		useTime = (int)Math.Round((float)useTime * spd);
-@@ -356,6 +_,12 @@
+@@ -356,6 +_,13 @@
  		scale *= size;
  		shootSpeed *= shtspd;
  		crit += crt;
 +
 +		if (rolledPrefix >= PrefixID.Count)
 +			PrefixLoader.GetPrefix(rolledPrefix)?.Apply(this);
++		ItemLoader.ApplyPrefix(this, rolledPrefix);
 +
 +		ApplyItemAnimationCompensationsToVanillaItems();
 +

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -81,7 +81,7 @@ public abstract class GlobalItem : GlobalType<Item, GlobalItem>
 	public virtual bool AllowPrefix(Item item, int pre) => true;
 
 	/// <summary>
-	/// Called immediately after <see cref="ModPrefix.Apply(Item)"/>
+	/// Called immediately after prefix stat changes are applied (as well as <see cref="ModPrefix.Apply(Item)"/>), facilitating item-specific tweaks to prefix effects.
 	/// </summary>
 	public virtual void ApplyPrefix(Item item, int pre) { }
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalItem.cs
@@ -81,6 +81,11 @@ public abstract class GlobalItem : GlobalType<Item, GlobalItem>
 	public virtual bool AllowPrefix(Item item, int pre) => true;
 
 	/// <summary>
+	/// Called immediately after <see cref="ModPrefix.Apply(Item)"/>
+	/// </summary>
+	public virtual void ApplyPrefix(Item item, int pre) { }
+
+	/// <summary>
 	/// Returns whether or not any item can be used. Returns true by default. The inability to use a specific item overrides this, so use this to stop an item from being used.
 	/// <para/> Called on local, server, and remote clients.
 	/// <br/><br/> The item may or not be used after this method is called, so logic in this method should have no side effects such as consuming items or resources.

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -281,7 +281,7 @@ public static class ItemLoader
 	{
 		item.ModItem?.ApplyPrefix(pre);
 		foreach (var g in HookApplyPrefix.Enumerate(item)) {
-			g.AllowPrefix(item, pre);
+			g.ApplyPrefix(item, pre);
 		}
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -275,6 +275,16 @@ public static class ItemLoader
 		return result;
 	}
 
+	private static HookList HookApplyPrefix = AddHook<Action<Item, int>>(g => g.ApplyPrefix);
+
+	public static void ApplyPrefix(Item item, int pre)
+	{
+		item.ModItem?.ApplyPrefix(pre);
+		foreach (var g in HookApplyPrefix.Enumerate(item)) {
+			g.AllowPrefix(item, pre);
+		}
+	}
+
 	private static HookList HookCanUseItem = AddHook<Func<Item, Player, bool>>(g => g.CanUseItem);
 
 	public static bool CanUseItem(Item item, Player player)

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -188,6 +188,11 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 	public virtual bool AllowPrefix(int pre) => true;
 
 	/// <summary>
+	/// Called immediately after <see cref="ModPrefix.Apply(Item)"/>
+	/// </summary>
+	public virtual void ApplyPrefix(int pre) { }
+
+	/// <summary>
 	/// Returns whether or not this item can be used. By default returns true.
 	/// <para/> Called on local, server, and remote clients.
 	/// <br/><br/> The item may or not be used after this method is called, so logic in this method should have no side effects such as consuming items or resources.

--- a/patches/tModLoader/Terraria/ModLoader/ModItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModItem.cs
@@ -188,7 +188,7 @@ public abstract class ModItem : ModType<Item, ModItem>, ILocalizedModType
 	public virtual bool AllowPrefix(int pre) => true;
 
 	/// <summary>
-	/// Called immediately after <see cref="ModPrefix.Apply(Item)"/>
+	/// Called immediately after prefix stat changes are applied (as well as <see cref="ModPrefix.Apply(Item)"/>), facilitating item-specific tweaks to prefix effects.
 	/// </summary>
 	public virtual void ApplyPrefix(int pre) { }
 


### PR DESCRIPTION
### What is the new feature?
Adds an ApplyPrefix hook to ModItem and GlobalItem

### Why should this be part of tModLoader?
Some modders may want to edit or replace the bonuses applied by prefixes to an item, such as for items with unique stats.

### Are there alternative designs?
The hook could be called slightly earlier or later

### Sample usage for the new feature
```
public static int DefaultAmmoMax => 50;
public int ammoMax = DefaultAmmoMax;
...
public override void ApplyPrefix(int pre) {
	ammoMax = DefaultAmmoMax - (Item.useTime - DefaultAmmoMax);
}
```