### PR TITLE
Fix HoldItem persistence Issue

### DIFF
--- a/ExampleMod/Content/Items/Accessories/ExampleShield.cs
+++ b/ExampleMod/Content/Items/Accessories/ExampleShield.cs
@@ -23,7 +23,7 @@ namespace ExampleMod.Content.Items.Accessories
 		public override void UpdateAccessory(Player player, bool hideVisual) {
 			player.GetDamage(DamageClass.Generic) += 1f; // Increase ALL player damage by 100%
 			player.endurance = 1f - (0.1f * (1f - player.endurance));  // The percentage of damage reduction
-			player.GetModPlayer<ExampleDashPlayer>().DashAccessoryEquipped = true;
+			player.GetModPlayer<ExampleDashPlayer>().dashAccessoryEquipped = true;
 		}
 
 		// Please see Content/ExampleRecipes.cs for a detailed explanation of recipe creation.
@@ -37,108 +37,49 @@ namespace ExampleMod.Content.Items.Accessories
 
 	public class ExampleDashPlayer : ModPlayer
 	{
-		// These indicate what direction is what in the timer arrays used
-		public const int DashDown = 0;
-		public const int DashUp = 1;
-		public const int DashRight = 2;
-		public const int DashLeft = 3;
+		public bool dashAccessoryEquipped;
 
-		public const int DashCooldown = 50; // Time (frames) between starting dashes. If this is shorter than DashDuration you can start a new dash before an old one has finished
-		public const int DashDuration = 35; // Duration of the dash afterimage effect in frames
+		private const int dashCooldown = 45; // Time before the player can dash again after a dash
+		private int dashCooldownTimer = 0; // Time remaining until the player can dash again
+		private const float dashVelocity = 10f; // The initial velocity of the dash
 
-		// The initial velocity.  10 velocity is about 37.5 tiles/second or 50 mph
-		public const float DashVelocity = 10f;
-
-		// The direction the player has double tapped.  Defaults to -1 for no dash double tap
-		public int DashDir = -1;
-
-		// The fields related to the dash accessory
-		public bool DashAccessoryEquipped;
-		public int DashDelay = 0; // frames remaining till we can dash again
-		public int DashTimer = 0; // frames remaining in the dash
+		private int dashTime = 0; // The time the player has to input the second press of left/right. Necessary for Player.DoCommonDashHandle.
 
 		public override void ResetEffects() {
-			// Reset our equipped flag. If the accessory is equipped somewhere, ExampleShield.UpdateAccessory will be called and set the flag before PreUpdateMovement
-			DashAccessoryEquipped = false;
+			// Reset our equipped flag
+			dashAccessoryEquipped = false;
+		}
 
-			// ResetEffects is called not long after player.doubleTapCardinalTimer's values have been set
-			// When a directional key is pressed and released, vanilla starts a 15 tick (1/4 second) timer during which a second press activates a dash
-			// If the timers are set to 15, then this is the first press just processed by the vanilla logic.  Otherwise, it's a double-tap
-			if (Player.controlDown && Player.releaseDown && Player.doubleTapCardinalTimer[DashDown] < 15) {
-				DashDir = DashDown;
-			}
-			else if (Player.controlUp && Player.releaseUp && Player.doubleTapCardinalTimer[DashUp] < 15) {
-				DashDir = DashUp;
-			}
-			else if (Player.controlRight && Player.releaseRight && Player.doubleTapCardinalTimer[DashRight] < 15 && Player.doubleTapCardinalTimer[DashLeft] == 0) {
-				DashDir = DashRight;
-			}
-			else if (Player.controlLeft && Player.releaseLeft && Player.doubleTapCardinalTimer[DashLeft] < 15 && Player.doubleTapCardinalTimer[DashRight] == 0) {
-				DashDir = DashLeft;
-			}
-			else {
-				DashDir = -1;
+		// PostDash is called right after vanilla dash movement, so we should handle our modded dash functionality here.
+		public override void PostDash() {
+			if (dashAccessoryEquipped) {
+				// If we are on cooldown, decrement the cooldown timer
+				if (dashCooldownTimer > 0) dashCooldownTimer--;
+
+				// If we can dash, handle player dash input
+				if (CanDash())
+					Player.DoCommonDashHandle(out int dir, out bool dashing, ref dashTime, DoExampleDash);
 			}
 		}
 
-		// This is the perfect place to apply dash movement, it's after the vanilla movement code, and before the player's position is modified based on velocity.
-		// If they double tapped this frame, they'll move fast this frame
-		public override void PreUpdateMovement() {
-			// if the player can use our dash, has double tapped in a direction, and our dash isn't currently on cooldown
-			if (CanUseDash() && DashDir != -1 && DashDelay == 0) {
-				Vector2 newVelocity = Player.velocity;
+		// Called by Player.DoCommonDashHandle when a dash is started, since we passed it as an argument
+		private void DoExampleDash(int direction) {
+			dashCooldownTimer = dashCooldown; // Set the cooldown timer
 
-				switch (DashDir) {
-					// Only apply the dash velocity if our current speed in the wanted direction is less than DashVelocity
-					case DashUp when Player.velocity.Y > -DashVelocity:
-					case DashDown when Player.velocity.Y < DashVelocity: {
-							// Y-velocity is set here
-							// If the direction requested was DashUp, then we adjust the velocity to make the dash appear "faster" due to gravity being immediately in effect
-							// This adjustment is roughly 1.3x the intended dash velocity
-							float dashDirection = DashDir == DashDown ? 1 : -1.3f;
-							newVelocity.Y = dashDirection * DashVelocity;
-							break;
-						}
-					case DashLeft when Player.velocity.X > -DashVelocity:
-					case DashRight when Player.velocity.X < DashVelocity: {
-							// X-velocity is set here
-							float dashDirection = DashDir == DashRight ? 1 : -1;
-							newVelocity.X = dashDirection * DashVelocity;
-							break;
-						}
-					default:
-						return; // not moving fast enough, so don't start our dash
-				}
+			// Give player horizontal velocity in the appropriate direction
+			Vector2 newVelocity = Player.velocity;
+			newVelocity.X = direction * dashVelocity;
+			Player.velocity = newVelocity;
 
-				// start our dash
-				DashDelay = DashCooldown;
-				DashTimer = DashDuration;
-				Player.velocity = newVelocity;
-
-				// Here you'd be able to set an effect that happens when the dash first activates
-				// Some examples include:  the larger smoke effect from the Master Ninja Gear and Tabi
-			}
-
-			if (DashDelay > 0)
-				DashDelay--;
-
-			if (DashTimer > 0) { // dash is active
-				// This is where we set the afterimage effect.  You can replace these two lines with whatever you want to happen during the dash
-				// Some examples include:  spawning dust where the player is, adding buffs, making the player immune, etc.
-				// Here we take advantage of "player.eocDash" and "player.armorEffectDrawShadowEOCShield" to get the Shield of Cthulhu's afterimage effect
-				Player.eocDash = DashTimer;
-				Player.armorEffectDrawShadowEOCShield = true;
-
-				// count down frames remaining
-				DashTimer--;
-			}
+			// Here you'd be able to set an effect that happens when the dash first activates
+			// Some examples include:  the larger smoke effect from the Master Ninja Gear and Tabi
 		}
 
-		private bool CanUseDash() {
-			return DashAccessoryEquipped
-				&& Player.dashType == DashID.None // player doesn't have Tabi or EoCShield equipped (give priority to those dashes)
-				&& !Player.setSolar // player isn't wearing solar armor
+		private bool CanDash() {
+			return dashAccessoryEquipped
+				&& Player.dashType == DashID.None // player doesn't have a vanilla dash equipped (give priority to those dashes)
+				&& dashCooldownTimer <= 0 // dash is not on cooldown
 				&& !Player.mount.Active; // player isn't mounted, since dashes on a mount look weird
-		}
+		} 
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1437,4 +1437,20 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	public virtual void DrawPlayer(Camera camera)
 	{
 	}
+
+	/// <summary>
+	/// Called whenever the player starts a dash.
+	/// <br/><br/> Called in <see cref="Terraria.Player.DoCommonDashHandle(out int, out bool, ref int, Player.DashStartAction)"/>.
+	/// </summary>
+	/// <param name="dir">The direction in which the dash is. -1 for left, 1 for right.</param>
+	public virtual void OnDash(int dir)
+	{
+	}
+
+	/// <summary>
+	/// Called right after vanilla handles its dash logic in <see cref="Player.Update(int)"/>. Useful for implementing modded dashes.
+	/// </summary>
+	public virtual void PostDash()
+	{
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -1532,4 +1532,22 @@ public static class PlayerLoader
 			modPlayer.DrawPlayer(camera);
 		}
 	}
+
+	private static HookList HookOnDash = AddHook<Action<int>>(p => p.OnDash);
+
+	public static void OnDash(Player player, int dir)
+	{
+		foreach (var modPlayer in HookOnDash.Enumerate(player)) {
+			modPlayer.OnDash(dir);
+		}
+	}
+
+	private static HookList HookPostDash = AddHook<Action>(p => p.PostDash);
+
+	public static void PostDash(Player player)
+	{
+		foreach (var modPlayer in HookPostDash.Enumerate(player)) {
+			modPlayer.PostDash();
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7187,6 +7187,17 @@
  						if (item.stack > 0)
  							item.stack--;
  
+@@ -33753,7 +_,9 @@
+ 				if (item.stack <= 0 && itemAnimation == 0)
+ 					inventory[selectedItem] = new Item();
+ 
++				// Fix ModItem fields not persisting sometimes when selected with the mouse
+-				if (selectedItem == 58 && itemAnimation != 0)
++				// if (selectedItem == 58 && itemAnimation != 0)
++				if (selectedItem == 58) 
+ 					Main.mouseItem = item.Clone();
+ 			}
+ 		}
 @@ -33770,6 +_,8 @@
  		if (Main.myPlayer == whoAmI && itemAnimation == 0) {
  			Tile targetTile = Main.tile[tileTargetX, tileTargetY];

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -4149,21 +4149,75 @@
  						int num7 = Projectile.NewProjectile(GetProjectileSource_OnHit(nPC2, 2), base.Center.X, base.Center.Y, 0f, 0f, 608, (int)num4, 15f, Main.myPlayer);
  						Main.projectile[num7].Kill();
  					}
-@@ -16631,6 +_,14 @@
+@@ -16523,7 +_,7 @@
+ 				return;
+ 
+ 			if (dash == 1) {
+-				DoCommonDashHandle(out var dir, out var dashing);
++				DoCommonDashHandle(out var dir, out var dashing, ref dashTime);
+ 				if (dashing) {
+ 					velocity.X = 16.9f * (float)dir;
+ 					Point point = (base.Center + new Vector2(dir * width / 2 + 2, gravDir * (float)(-height) / 2f + gravDir * 2f)).ToTileCoordinates();
+@@ -16551,7 +_,7 @@
+ 				}
+ 			}
+ 			else if (dash == 2) {
+-				DoCommonDashHandle(out var dir2, out var dashing2);
++				DoCommonDashHandle(out var dir2, out var dashing2, ref dashTime);
+ 				if (dashing2) {
+ 					velocity.X = 14.5f * (float)dir2;
+ 					Point point3 = (base.Center + new Vector2(dir2 * width / 2 + 2, gravDir * (float)(-height) / 2f + gravDir * 2f)).ToTileCoordinates();
+@@ -16571,7 +_,7 @@
+ 				}
+ 			}
+ 			else if (dash == 3) {
+-				DoCommonDashHandle(out var dir3, out var dashing3, SolarDashStart);
++				DoCommonDashHandle(out var dir3, out var dashing3, ref dashTime, SolarDashStart);
+ 				if (dashing3) {
+ 					velocity.X = 21.9f * (float)dir3;
+ 					Point point5 = (base.Center + new Vector2(dir3 * width / 2 + 2, gravDir * (float)(-height) / 2f + gravDir * 2f)).ToTileCoordinates();
+@@ -16596,7 +_,7 @@
+ 			if (dash != 5)
+ 				return;
+ 
+-			DoCommonDashHandle(out var dir4, out var dashing4);
++			DoCommonDashHandle(out var dir4, out var dashing4, ref dashTime);
+ 			if (dashing4) {
+ 				velocity.X = 16.9f * (float)dir4;
+ 				Point point7 = (base.Center + new Vector2(dir4 * width / 2 + 2, gravDir * (float)(-height) / 2f + gravDir * 2f)).ToTileCoordinates();
+@@ -16631,7 +_,15 @@
  		solarDashConsumedFlare = false;
  	}
  
 +
-+	// TODO:
-+	// - Make public, as it has little reason to be private and could be of great help to those making modded dashes
-+	// - Properly explain how to use this in the context of programming a modded dash (use ExampleShield for this; see below)
-+	// - Make ExampleShield use this, and simplify it accordingly (it currently has way too many moving parts that require extra upkeep, for way too little payoff)
-+	//
-+	// I'll do all this in an upcoming PR if nobody else does.
-+	// - Thomas
- 	private void DoCommonDashHandle(out int dir, out bool dashing, DashStartAction dashStartAction = null)
++	/// <summary>
++	/// Handles "normal" dash functionality, tracking if the player has double tapped in a direction and setting <paramref name="dir"/>, <paramref name="dashing"/>, and <paramref name="dashTime"/> accordingly.
++	/// </summary>
++	/// <param name="dir">Set based on the direction the player is dashing: -1 for left, 1 for right, 0 for none.</param>
++	/// <param name="dashing">Set to true if the player has started a dash, false otherwise.</param>
++	/// <param name="dashTime">The time the player has left to input another left/right press. A negative value indicates waiting for a left press, and a postive one indicates a right press.</param>
++	/// <param name="dashStartAction">The <see cref="DashStartAction"/> to invoke when a dash is started.</param>
+-	private void DoCommonDashHandle(out int dir, out bool dashing, DashStartAction dashStartAction = null)
++	public void DoCommonDashHandle(out int dir, out bool dashing, ref int dashTime, DashStartAction dashStartAction = null)
  	{
  		dir = 0;
+ 		dashing = false;
+@@ -16647,6 +_,7 @@
+ 				dashing = true;
+ 				dashTime = 0;
+ 				timeSinceLastDashStarted = 0;
++				PlayerLoader.OnDash(this, dir);
+ 				dashStartAction?.Invoke(dir);
+ 			}
+ 			else {
+@@ -16659,6 +_,7 @@
+ 				dashing = true;
+ 				dashTime = 0;
+ 				timeSinceLastDashStarted = 0;
++				PlayerLoader.OnDash(this, dir);
+ 				dashStartAction?.Invoke(dir);
+ 			}
+ 			else {
 @@ -16745,7 +_,7 @@
  	public void CarpetMovement()
  	{
@@ -4772,6 +4826,14 @@
  		}
  
  		if (!carpet) {
+@@ -20444,6 +_,7 @@
+ 			canRocket = false;
+ 			rocketRelease = false;
+ 			DashMovement();
++			PlayerLoader.PostDash(this);
+ 			UpdateControlHolds();
+ 		}
+ 		else if (grappling[0] == -1 && !tongued) {
 @@ -20511,6 +_,7 @@
  				}
  			}
@@ -4799,6 +4861,14 @@
  			HorizontalMovement();
  			bool flag20 = !mount.Active;
  			if (forcedGravity > 0) {
+@@ -20651,6 +_,7 @@
+ 				CancelAllJumpVisualEffects();
+ 
+ 			DashMovement();
++			PlayerLoader.PostDash(this);
+ 			WallslideMovement();
+ 			CarpetMovement();
+ 			DoubleJumpVisuals();
 @@ -20684,12 +_,13 @@
  				CancelAllJumpVisualEffects();
  			}


### PR DESCRIPTION
### What is the bug?
As mentioned in #4896, ModItem fields do not persist when the player selects the item with the mouse, due to Main.mouseItem not being properly updated, which causes a desync between inventory[58] and Main.mouseItem.

### How did you fix the bug?
I removed the part of the conditional that checks if `itemAnimation != 0`, which, when not removed, causes the clone to not be created for some items

### Are there alternatives to your fix?
There might be a way to keep the `itemAnimation != 0` conditional if another conditional is added to compensate for the desync that this conditional creates, but I did not look into it too much.