### PR TITLE
Fix HoldItem persistence Issue

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7187,6 +7187,17 @@
  						if (item.stack > 0)
  							item.stack--;
  
+@@ -33753,7 +_,9 @@
+ 				if (item.stack <= 0 && itemAnimation == 0)
+ 					inventory[selectedItem] = new Item();
+ 
++				// Fix ModItem fields not persisting sometimes when selected with the mouse
+-				if (selectedItem == 58 && itemAnimation != 0)
++				// if (selectedItem == 58 && itemAnimation != 0)
++				if (selectedItem == 58) 
+ 					Main.mouseItem = item.Clone();
+ 			}
+ 		}
 @@ -33770,6 +_,8 @@
  		if (Main.myPlayer == whoAmI && itemAnimation == 0) {
  			Tile targetTile = Main.tile[tileTargetX, tileTargetY];


### PR DESCRIPTION
### What is the bug?
As mentioned in #4896, ModItem fields do not persist when the player selects the item with the mouse, due to Main.mouseItem not being properly updated, which causes a desync between inventory[58] and Main.mouseItem.

### How did you fix the bug?
I removed the part of the conditional that checks if itemAnimation != 0, which, when not removed, causes the clone to not be created for some items

### Are there alternatives to your fix?
There might be a way to keep the itemAnimation != 0 conditional if another conditional is added to compensate for the desync that this conditional creates, but I did not look into it too much.