### PR TITLE
Make ExampleStatue glow with spelunker potion

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleStatue.cs
+++ b/ExampleMod/Content/Tiles/ExampleStatue.cs
@@ -16,6 +16,7 @@ namespace ExampleMod.Content.Tiles
 		public override void SetStaticDefaults() {
 			Main.tileFrameImportant[Type] = true;
 			Main.tileObsidianKill[Type] = true;
+			Main.tileSpelunker[Type] = true;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			TileID.Sets.IsAMechanism[Type] = true; // Ensures that this tile and connected pressure plate won't be removed during the "Remove Broken Traps" worldgen step
 


### PR DESCRIPTION
Vanilla statues glow under the spelunker buff, but example statue does not. This updates Example Mod to match vanilla behaviour.