### PR TITLE
Add BossBarDrawParams.BossBarColor and add its example

### DIFF
--- a/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
+++ b/ExampleMod/Common/GlobalBossBars/ExampleGlobalBossBar.cs
@@ -6,6 +6,7 @@ using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;
+using System;
 
 namespace ExampleMod.Common.GlobalBossBars
 {
@@ -15,6 +16,7 @@ namespace ExampleMod.Common.GlobalBossBars
 		public override bool PreDraw(SpriteBatch spriteBatch, NPC npc, ref BossBarDrawParams drawParams) {
 			if (npc.type == NPCID.EyeofCthulhu) {
 				drawParams.IconColor = Main.DiscoColor;
+				drawParams.BarColor = Color.Lerp(Color.White, Color.Transparent, (float)Math.Sin(Main.GameUpdateCount / 50f));
 			}
 
 			return true;

--- a/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
+++ b/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
@@ -91,7 +91,7 @@ public struct BossBarDrawParams
 		TextOffset = textOffset;
 	}
 
-	[Obsolete("BossBarDrawParams has added BarColor to modify the color of the bar")]
+	[Obsolete("Use the updated method signature")]
 	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield = 0f, float shieldMax = 0f, float iconScale = 1f, bool showText = true, Vector2 textOffset = default)
 	{
 		BarTexture = barTexture;
@@ -126,7 +126,7 @@ public struct BossBarDrawParams
 		textOffset = TextOffset;
 	}
 
-	[Obsolete("BossBarDrawParams has added BarColor to modify the color of the bar")]
+	[Obsolete("Use the updated method signature")]
 	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
 	{
 		barTexture = BarTexture;

--- a/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
+++ b/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -90,11 +91,46 @@ public struct BossBarDrawParams
 		TextOffset = textOffset;
 	}
 
+	[Obsolete("BossBarDrawParams has added BarColor to modify the color of the bar")]
+	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield = 0f, float shieldMax = 0f, float iconScale = 1f, bool showText = true, Vector2 textOffset = default)
+	{
+		BarTexture = barTexture;
+		BarCenter = barCenter;
+		BarColor = Color.White;
+		IconTexture = iconTexture;
+		IconFrame = iconFrame;
+		IconColor = iconColor;
+		Life = life;
+		LifeMax = lifeMax;
+		Shield = shield;
+		ShieldMax = shieldMax;
+		IconScale = iconScale;
+		ShowText = showText;
+		TextOffset = textOffset;
+	}
+
 	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Color barColor, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
 	{
 		barTexture = BarTexture;
 		barCenter = BarCenter;
 		barColor = BarColor;
+		iconTexture = IconTexture;
+		iconFrame = IconFrame;
+		iconColor = IconColor;
+		life = Life;
+		lifeMax = LifeMax;
+		shield = Shield;
+		shieldMax = ShieldMax;
+		iconScale = IconScale;
+		showText = ShowText;
+		textOffset = TextOffset;
+	}
+
+	[Obsolete("BossBarDrawParams has added BarColor to modify the color of the bar")]
+	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
+	{
+		barTexture = BarTexture;
+		barCenter = BarCenter;
 		iconTexture = IconTexture;
 		iconFrame = IconFrame;
 		iconColor = IconColor;

--- a/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
+++ b/patches/tModLoader/Terraria/DataStructures/BossBarDrawParams.cs
@@ -17,7 +17,11 @@ public struct BossBarDrawParams
 	/// The screen position of the center of the bar.
 	/// </summary>
 	public Vector2 BarCenter;
-	//No barColor because it consists of 6 separate frames with different things on each frame. Easier to supply a custom texture.
+
+	/// <summary>
+	/// The tint of the Bar.
+	/// </summary>
+	public Color BarColor;
 
 	/// <summary>
 	/// The displayed icon texture.
@@ -69,10 +73,11 @@ public struct BossBarDrawParams
 	/// </summary>
 	public Vector2 TextOffset;
 
-	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield = 0f, float shieldMax = 0f, float iconScale = 1f, bool showText = true, Vector2 textOffset = default)
+	public BossBarDrawParams(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, Color? barColor = null, float shield = 0f, float shieldMax = 0f, float iconScale = 1f, bool showText = true, Vector2 textOffset = default)
 	{
 		BarTexture = barTexture;
 		BarCenter = barCenter;
+		BarColor = barColor is null ? Color.White : barColor.Value;
 		IconTexture = iconTexture;
 		IconFrame = iconFrame;
 		IconColor = iconColor;
@@ -85,10 +90,11 @@ public struct BossBarDrawParams
 		TextOffset = textOffset;
 	}
 
-	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
+	public void Deconstruct(out Texture2D barTexture, out Vector2 barCenter, out Color barColor, out Texture2D iconTexture, out Rectangle iconFrame, out Color iconColor, out float life, out float lifeMax, out float shield, out float shieldMax, out float iconScale, out bool showText, out Vector2 textOffset)
 	{
 		barTexture = BarTexture;
 		barCenter = BarCenter;
+		barColor = BarColor;
 		iconTexture = IconTexture;
 		iconFrame = IconFrame;
 		iconColor = IconColor;

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
@@ -38,10 +38,10 @@
 +			BossBarLoader.drawingInfo = null;
 +
 +			Vector2 barCenter = Main.ScreenSize.ToVector2() * new Vector2(0.5f, 1f) + new Vector2(0f, -50f);
-+			Color iconColor = Color.White;
++			Color iconColor = Color.White, BossBarColor = Color.White;
 +			float iconScale = 1f;
 +
-+			BossBarDrawParams drawParams = new BossBarDrawParams(value, barCenter, barIconTexture, barIconFrame, iconColor, lifeAmount, lifeMax, shieldCurrent, shieldMax, iconScale, info.showText, Vector2.Zero);
++			BossBarDrawParams drawParams = new BossBarDrawParams(value, barCenter, barIconTexture, barIconFrame, iconColor, lifeAmount, lifeMax, BossBarColor, shieldCurrent, shieldMax, iconScale, info.showText, Vector2.Zero);
 +
 +			bool skipped = !BossBarLoader.PreDraw(spriteBatch, info, ref drawParams);
 +			if (!skipped)

--- a/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/BigProgressBar/BigProgressBarHelper.cs.patch
@@ -27,7 +27,7 @@
  		Texture2D value = Main.Assets.Request<Texture2D>("Images/UI/UI_BossBar").Value;
  		Point p = new Point(456, 22);
  		Point p2 = new Point(32, 24);
-@@ -75,6 +_,27 @@
+@@ -75,6 +_,28 @@
  	public static void DrawFancyBar(SpriteBatch spriteBatch, float lifeAmount, float lifeMax, Texture2D barIconTexture, Rectangle barIconFrame, float shieldCurrent, float shieldMax)
  	{
  		Texture2D value = Main.Assets.Request<Texture2D>("Images/UI/UI_BossBar").Value;
@@ -38,7 +38,8 @@
 +			BossBarLoader.drawingInfo = null;
 +
 +			Vector2 barCenter = Main.ScreenSize.ToVector2() * new Vector2(0.5f, 1f) + new Vector2(0f, -50f);
-+			Color iconColor = Color.White, BossBarColor = Color.White;
++			Color iconColor = Color.White;
++			Color BossBarColor = Color.White;
 +			float iconScale = 1f;
 +
 +			BossBarDrawParams drawParams = new BossBarDrawParams(value, barCenter, barIconTexture, barIconFrame, iconColor, lifeAmount, lifeMax, BossBarColor, shieldCurrent, shieldMax, iconScale, info.showText, Vector2.Zero);

--- a/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/BossBarLoader.cs
@@ -242,14 +242,14 @@ public static class BossBarLoader
 		// DrawFancyBar without shieldCurrent gets redirected to DrawFancyBar with shieldCurrent as 0f
 		// DrawFancyBar with shieldCurrent gets redirected to this
 
-		(Texture2D barTexture, Vector2 barCenter, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield, float shieldMax, float iconScale, bool showText, Vector2 textOffset) = drawParams;
+		(Texture2D barTexture, Vector2 barCenter, Color barColor, Texture2D iconTexture, Rectangle iconFrame, Color iconColor, float life, float lifeMax, float shield, float shieldMax, float iconScale, bool showText, Vector2 textOffset) = drawParams;
 
 		Point barSize = new Point(456, 22); //Size of the bar
 		Point topLeftOffset = new Point(32, 24); //Where the top left of the bar starts
 		int frameCount = 6;
 
 		Rectangle bgFrame = barTexture.Frame(verticalFrames: frameCount, frameY: 3);
-		Color bgColor = Color.White * 0.2f;
+		Color bgColor = barColor * 0.2f;
 
 		int scale = (int)(barSize.X * life / lifeMax);
 		scale -= scale % 2;
@@ -289,7 +289,6 @@ public static class BossBarLoader
 
 		// Bar itself
 		Vector2 stretchScale = new Vector2(scale / barFrame.Width, 1f);
-		Color barColor = Color.White;
 		spriteBatch.Draw(barTexture, barTopLeft, barFrame, barColor, 0f, Vector2.Zero, stretchScale, SpriteEffects.None, 0f);
 
 		// Tip
@@ -306,7 +305,7 @@ public static class BossBarLoader
 
 		// Frame
 		Rectangle frameFrame = barTexture.Frame(verticalFrames: frameCount, frameY: 0);
-		spriteBatch.Draw(barTexture, topLeft, frameFrame, Color.White, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+		spriteBatch.Draw(barTexture, topLeft, frameFrame, barColor, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
 
 		// Icon
 		Vector2 iconOffset = new Vector2(4f, 20f);


### PR DESCRIPTION
### What is the new feature?

fixes #4914

Added the `BarColor` field to `BossBarDrawParams` and modified several `Color.White` values inside `BossBarLoader. DrawFancyBar_TML(),` so that the Color of the Bar can be adjusted using the newly added `BarColor`

### Why should this be part of tModLoader?

This can quickly modify the color of the Bar or achieve effects such as fading without rewriting the drawing

### Are there alternative designs?

The existing design can actually achieve a similar effect, but if you want to quickly modify the color, there should be no alternative design

### Sample usage for the new feature

For `BossBarDrawParams.BarColor`, refer to `ExampleGlobalBossBar.cs`

### ExampleMod updates

Modified `ExampleGlobalBossBar.cs`