### PR TITLE
Add ModPlayer.BadlLifeRegenHurt hook and add its example

### DIFF
--- a/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
+++ b/ExampleMod/Content/Buffs/ExampleLifeRegenDebuff.cs
@@ -1,4 +1,5 @@
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -44,6 +45,15 @@ namespace ExampleMod.Content.Buffs
 				// lifeRegen is measured in 1/2 life per second. Therefore, this effect causes 8 life lost per second
 				Player.lifeRegen -= 16;
 			}
+		}
+
+		// Allows you to modify the player's health loss caused by a negative Player.lifeRegenCount, the damage and damage number displayed for each condition,
+		// and also modify the cause of death caused by a certain debuff.
+		// The damage parameter is the number that appears above the Player's head if it takes damage over time.
+		public override void BadlLifeRegenHurt(ref int damage, ref PlayerDeathReason damageSource) {
+			// Modify both damage
+			if (lifeRegenDebuff)
+				damage = 8;
 		}
 	}
 }

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 741/741, 100%, missing 0
-ru-RU, 6/741, 1%, missing 735
-zh-Hans, 2/741, 0%, missing 739
+en-US, 742/742, 100%, missing 0
+ru-RU, 6/742, 1%, missing 736
+zh-Hans, 2/742, 0%, missing 740

--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -215,6 +215,17 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	}
 
 	/// <summary>
+	/// Allows you to modify the player's health loss caused by a negative <see cref="Player.lifeRegenCount"/>, the damage and damage number displayed for each condition, and also modify the cause of death caused by a certain debuff.
+	/// <para/> The damage parameter is the number that appears above the Player's head if it takes damage over time.
+	/// <para/> Called on local, server, and remote clients.
+	/// </summary>
+	/// <param name="damage"></param>
+	/// <param name="damageSource">The source of the damage (debuff)</param>
+	public virtual void BadlLifeRegenHurt(ref int damage, ref PlayerDeathReason damageSource)
+	{
+	}
+
+	/// <summary>
 	/// Allows you to modify the player's stats while the game is paused due to the autopause setting being on.
 	/// This is called in single player only, some time before the player's tick update would happen when the game isn't paused.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/PlayerLoader.cs
@@ -242,6 +242,17 @@ public static class PlayerLoader
 		}
 	}
 
+	private delegate void DelegateBadlLifeRegenHurt(ref int damage, ref PlayerDeathReason damageSource);
+	private static HookList HookBadlLifeRegenHurt = AddHook<DelegateBadlLifeRegenHurt>(p => p.BadlLifeRegenHurt);
+
+	public static void BadlLifeRegenHurt(Player player, ref int damage, ref PlayerDeathReason damageSource)
+	{
+		foreach (var modPlayer in HookBadlLifeRegenHurt.Enumerate(player)) {
+			try { modPlayer.BadlLifeRegenHurt(ref damage, ref damageSource); }
+			catch { }
+		}
+	}
+
 	private static HookList HookUpdateAutopause = AddHook<Action>(p => p.UpdateAutopause);
 
 	public static void UpdateAutopause(Player player)

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -3785,6 +3785,110 @@
  		float num7 = (float)statLifeMax2 / 400f * 0.85f + 0.15f;
  		num5 *= num7;
  		lifeRegen += (int)Math.Round(num5);
+@@ -15021,17 +_,26 @@
+ 		}
+ 
+ 		if (burned || suffocating || (tongued && Main.expertMode)) {
++			int damage = 5;
++			PlayerDeathReason damageSource = (suffocating, tongued) switch {
++				(true, _) => PlayerDeathReason.ByOther(7),
++				(false, true) => PlayerDeathReason.ByOther(12),
++				_ => PlayerDeathReason.ByOther(8)
++			};
++
++			PlayerLoader.BadlLifeRegenHurt(this, ref damage, ref damageSource);
++
++			if (lifeRegen <= -240 && damage < 2)
++				damage = 2;
++
++			int damage2 = 120 * damage;
++
+-			while (lifeRegenCount <= -600) {
++			while (lifeRegenCount <= -damage2) {
+-				lifeRegenCount += 600;
++				lifeRegenCount += damage2;
+-				statLife -= 5;
++				statLife -= damage;
+-				CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), CombatText.LifeRegen, 5, dramatic: false, dot: true);
++				CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), CombatText.LifeRegen, damage, dramatic: false, dot: true);
+ 				if (statLife <= 0 && whoAmI == Main.myPlayer) {
+-					if (suffocating)
+-						KillMe(PlayerDeathReason.ByOther(7), 10.0, 0);
+-					else if (tongued)
+-						KillMe(PlayerDeathReason.ByOther(12), 10.0, 0);
+-					else
+-						KillMe(PlayerDeathReason.ByOther(8), 10.0, 0);
++					KillMe(damageSource, 10.0, 0);
+ 				}
+ 			}
+ 
+@@ -15039,18 +_,51 @@
+ 		}
+ 
+ 		if (starving) {
++			PlayerDeathReason damageSource = PlayerDeathReason.ByOther(18);
+ 			int num12 = statLifeMax2 / 50;
+ 			if (num12 < 2)
+ 				num12 = 2;
+ 
+ 			int num13 = ((ZoneDesert || ZoneSnow) ? (num12 * 2) : num12);
++
++			PlayerLoader.BadlLifeRegenHurt(this, ref num13, ref damageSource);
++
++			if (lifeRegen <= -240 && num13 < 2)
++				num13 = 2;
++
+ 			int num14 = 120 * num12;
+ 			while (lifeRegenCount <= -num14) {
+ 				lifeRegenCount += num14;
+ 				statLife -= num13;
+ 				CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), CombatText.LifeRegen, num13, dramatic: false, dot: true);
+ 				if (statLife <= 0 && whoAmI == Main.myPlayer)
+-					KillMe(PlayerDeathReason.ByOther(18), 10.0, 0);
++					KillMe(damageSource, 10.0, 0);
++			}
++
++			return;
++		}
++
++		int damage3 = 1;
++		PlayerDeathReason damageSource2 = (poisoned || venom, electrified) switch {
++			(true, _) => PlayerDeathReason.ByOther(9),
++			(false, true) => PlayerDeathReason.ByOther(10),
++			_ => PlayerDeathReason.ByOther(8)
++		};
++
++		PlayerLoader.BadlLifeRegenHurt(this, ref damage3, ref damageSource2);
++
++		if (lifeRegen <= -240 && damage3 < 2)
++			damage3 = 2;
++
++		if (damage3 > 1) {
++			while (lifeRegenCount <= -120 * damage3) {
++				lifeRegenCount += 120 * damage3;
++				statLife -= damage3;
++				CombatText.NewText(new Rectangle((int)position.X, (int)position.Y, width, height), CombatText.LifeRegen, damage3, dramatic: false, dot: true);
++
++				if (statLife <= 0 && whoAmI == Main.myPlayer) {
++					KillMe(damageSource2, 10.0, 0);
++				}
+ 			}
+ 
+ 			return;
+@@ -15079,12 +_,7 @@
+ 			}
+ 
+ 			if (statLife <= 0 && whoAmI == Main.myPlayer) {
+-				if (poisoned || venom)
+-					KillMe(PlayerDeathReason.ByOther(9), 10.0, 0);
+-				else if (electrified)
+-					KillMe(PlayerDeathReason.ByOther(10), 10.0, 0);
+-				else
+-					KillMe(PlayerDeathReason.ByOther(8), 10.0, 0);
++				KillMe(damageSource2, 10.0, 0);
+ 			}
+ 		}
+ 	}
 @@ -15166,8 +_,8 @@
  	public void UpdateJumpHeight()
  	{


### PR DESCRIPTION
### What is the new feature?
Added a new rewrite function `BadlLifeRegenHurt` to `ModPlayer`, which is used to modify the damage, damage display, and cause of death caused by a negative `lifeRegenCount` in the `Player.UpdateLifeRegen` method

### Why should this be part of tModLoader?
Requires an IL edit otherwise. It allows modders to write damage and damage display modified effects similar to [Suffocation](https://terraria.wiki.gg/wiki/Suffocation).

### Are there alternative designs?
None

### Sample usage for the new feature
For `ModPlayer.BadlLifeRegenHurt`, refer to `ExampleLifeRegenDebuffr.cs`

### ExampleMod updates
Modified `ExampleLifeRegenDebuff.cs`