### PR TITLE
Fixed main engine crash when approaching unloaded mod plants

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/TilePaintSystemV2.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/TilePaintSystemV2.cs.patch
@@ -92,21 +92,22 @@
  			PrepareTextureIfNecessary(asset.Value);
  		}
  
-@@ -112,7 +_,22 @@
+@@ -112,7 +_,23 @@
  
  		public override void Prepare()
  		{
 +			/*
  			Asset<Texture2D> asset = Main.Assets.Request<Texture2D>(TextureAssets.Tile[Key.TileType].Name);
 +			*/
-+			Asset<Texture2D> asset;
++			Asset<Texture2D> asset = null;
 +
 +			if (PlantLoader.plantIdToStyleLimit.TryGetValue(Key.TileType, out int val)
 +				&& val <= Math.Abs(Key.TileStyle)) {
 +
 +				int lookup = Math.Abs(Key.TileStyle) - val;
 +				asset = PlantLoader.GetTexture(Key.TileType, lookup);
-+			} else {
++			}
++			if (asset is null) {
 +				Main.instance.LoadTiles(Key.TileType);
 +				asset = TextureAssets.Tile[Key.TileType];
 +			}


### PR DESCRIPTION
I can't fathom how this didn't get caught when ``PlantLoader`` was introduced, ``PlantLoader.GetTexture`` can return null, and therefore ``asset`` should be treated as potentially null until it's guaranteed not to be (or at least until it can't be null without modders actively trying to make it null), as treating it as not null can lead to exceptions and it's exclusively used somewhere that any exception is guaranteed to crash the game.