### PR TITLE
Preemptively load SDL2 before FNA3D, resolving NixOS & Linux dl-lookup edge-cases.

### DIFF
--- a/patches/TerrariaNetCore/Terraria/MonoLaunch.cs.patch
+++ b/patches/TerrariaNetCore/Terraria/MonoLaunch.cs.patch
@@ -16,12 +16,12 @@
  	private static void Main(string[] args)
  	{
 +#if NETCORE
-+		AssemblyLoadContext.Default.ResolvingUnmanagedDll += ResolveNativeLibrary;
++		AssemblyLoadContext.Default.ResolvingUnmanagedDll += static (a, n) => ResolveNativeLibrary(a, n);
 +#else
  		AppDomain.CurrentDomain.AssemblyResolve += delegate (object sender, ResolveEventArgs sargs) {
  			string resourceName = new AssemblyName(sargs.Name).Name + ".dll";
  			string text = Array.Find(typeof(Program).Assembly.GetManifestResourceNames(), (string element) => element.EndsWith(resourceName));
-@@ -25,9 +_,73 @@
+@@ -25,9 +_,79 @@
  				return Assembly.Load(array);
  			}
  		};
@@ -44,7 +44,7 @@
 +
 +	// Note: AssemblyLoadContext.Default.ResolvingUnmanagedDll is only called if the dll is not found on PATH
 +	// In a production environment, you need to prepend to PATH prioritise your shipped libraries, making this logging mostly useless.
-+	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name)
++	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name, string indent = null)
 +	{
 +		const string tab = "  ";
 +		static void LogLine(string message) => Console.WriteLine(message);
@@ -54,8 +54,8 @@
 +			if (assemblies.TryGetValue(name, out var handle))
 +				return handle;
 +
-+			LogLine($"Native Resolve: '{name}' requested by '{assembly.FullName}'");
-+			string indent = tab;
++			LogLine($"{indent}Native Resolve: '{name}' requested by '{assembly.FullName}'");
++			indent = $"{tab}{indent}";
 +
 +			if (name.StartsWith("/tmp/"))
 +				return IntPtr.Zero;
@@ -79,6 +79,12 @@
 +			}
 +
 +			LogLine($"{indent}attempting load {path}");
++
++			// Preemptively load dependencies using our logic rather than the system's.
++			if (name is "FNA3D" or "FAudio" or "nfd") {
++				ResolveNativeLibrary(assembly, "SDL2", indent: indent);
++			}
++
 +			try {
 +				handle = NativeLibrary.Load(path);
 +			}

--- a/patches/TerrariaNetCore/Terraria/MonoLaunch.cs.patch
+++ b/patches/TerrariaNetCore/Terraria/MonoLaunch.cs.patch
@@ -21,7 +21,7 @@
  		AppDomain.CurrentDomain.AssemblyResolve += delegate (object sender, ResolveEventArgs sargs) {
  			string resourceName = new AssemblyName(sargs.Name).Name + ".dll";
  			string text = Array.Find(typeof(Program).Assembly.GetManifestResourceNames(), (string element) => element.EndsWith(resourceName));
-@@ -25,9 +_,59 @@
+@@ -25,9 +_,73 @@
  				return Assembly.Load(array);
  			}
  		};
@@ -46,34 +46,48 @@
 +	// In a production environment, you need to prepend to PATH prioritise your shipped libraries, making this logging mostly useless.
 +	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name)
 +	{
-+		// This method shouldn't be throwing exceptions, in case we're in a TryLoad scenario.
++		const string tab = "  ";
++		static void LogLine(string message) => Console.WriteLine(message);
++
++		// This method shouldn't be throwing exceptions, in case we're in a TryLoad scenario, but we still want exception info.
 +		lock (resolverLock) {
 +			if (assemblies.TryGetValue(name, out var handle))
 +				return handle;
 +
-+			Console.WriteLine($"Native Resolve: {assembly.FullName} -> {name}");
++			LogLine($"Native Resolve: '{name}' requested by '{assembly.FullName}'");
++			string indent = tab;
++
++			if (name.StartsWith("/tmp/"))
++				return IntPtr.Zero;
++
 +			if (name.StartsWith("steam_api")) {
-+				Console.WriteLine("\tdelegating to Steamworks.NET.AnyCPU resolver");
++				LogLine($"{indent}delegating to Steamworks.NET.AnyCPU resolver");
 +				return assemblies[name] = IntPtr.Zero;
 +			}
 +
-+			var files = Directory.GetFiles(NativesDir, $"*{name}*", SearchOption.AllDirectories);
++			string[] files;
++			try {
++				files = Directory.GetFiles(NativesDir, $"*{name}*", SearchOption.AllDirectories);
++			}
++			catch {
++				files = [];
++			}
++
 +			if (files.FirstOrDefault() is not string path) {
-+				Console.WriteLine("\tnot found");
++				LogLine($"{indent}not found");
 +				return IntPtr.Zero;
 +			}
 +
-+			// This method shouldn't be throwing exceptions, in case we're in a TryLoad scenario, but we still want exception info
-+			Console.WriteLine($"\tattempting load {path}");
++			LogLine($"{indent}attempting load {path}");
 +			try {
 +				handle = NativeLibrary.Load(path);
 +			}
 +			catch (Exception e) {
-+				Console.WriteLine($"\t\tFailed to load {name}.\n{e}");
++				LogLine($"{indent}{tab}Failed to load {name}.\n{e}");
 +				return IntPtr.Zero;
 +			}
 +
-+			Console.WriteLine("\tsuccess");
++			LogLine($"{indent}success");
 +			return assemblies[name] = handle;
 +		}
 +	}

--- a/patches/tModLoader/Terraria/MonoLaunch.cs.patch
+++ b/patches/tModLoader/Terraria/MonoLaunch.cs.patch
@@ -65,50 +65,12 @@
  		Program.LaunchGame(args, monoArgs: true);
  	}
  
-@@ -57,29 +_,39 @@
- 			if (assemblies.TryGetValue(name, out var handle))
- 				return handle;
+@@ -53,7 +_,7 @@
+ 	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name)
+ 	{
+ 		const string tab = "  ";
+-		static void LogLine(string message) => Console.WriteLine(message);
++		static void LogLine(string message) => Logging.tML.Debug(message);
  
--			Console.WriteLine($"Native Resolve: {assembly.FullName} -> {name}");
-+			Logging.tML.Debug($"Native Resolve: {assembly.FullName} -> {name}");
-+			if (name.StartsWith("/tmp/"))
-+				return IntPtr.Zero;
-+
- 			if (name.StartsWith("steam_api")) {
--				Console.WriteLine("\tdelegating to Steamworks.NET.AnyCPU resolver");
-+				Logging.tML.Debug("\tdelegating to Steamworks.NET.AnyCPU resolver");
- 				return assemblies[name] = IntPtr.Zero;
- 			}
- 
-+			string[] files;
-+			try {
--			var files = Directory.GetFiles(NativesDir, $"*{name}*", SearchOption.AllDirectories);
-+				files = Directory.GetFiles(NativesDir, $"*{name}*", SearchOption.AllDirectories);
-+			}
-+			catch {
-+				files = [];
-+			}
-+
- 			if (files.FirstOrDefault() is not string path) {
--				Console.WriteLine("\tnot found");
-+				Logging.tML.Debug("\tnot found");
- 				return IntPtr.Zero;
- 			}
- 
- 			// This method shouldn't be throwing exceptions, in case we're in a TryLoad scenario, but we still want exception info
--			Console.WriteLine($"\tattempting load {path}");
-+			Logging.tML.Debug($"\tattempting load {path}");
- 			try {
- 				handle = NativeLibrary.Load(path);
- 			}
- 			catch (Exception e) {
--				Console.WriteLine($"\t\tFailed to load {name}.\n{e}");
-+				Logging.tML.Debug($"\t\tFailed to load {name}.\n{e}");
- 				return IntPtr.Zero;
- 			}
- 
--			Console.WriteLine("\tsuccess");
-+			Logging.tML.Debug("\tsuccess");
- 			return assemblies[name] = handle;
- 		}
- 	}
+ 		// This method shouldn't be throwing exceptions, in case we're in a TryLoad scenario, but we still want exception info.
+ 		lock (resolverLock) {

--- a/patches/tModLoader/Terraria/MonoLaunch.cs.patch
+++ b/patches/tModLoader/Terraria/MonoLaunch.cs.patch
@@ -26,7 +26,7 @@
 +
  #if NETCORE
 +		NativeLibraries.SetNativeLibraryPath(NativesDir);
- 		AssemblyLoadContext.Default.ResolvingUnmanagedDll += ResolveNativeLibrary;
+ 		AssemblyLoadContext.Default.ResolvingUnmanagedDll += static (a, n) => ResolveNativeLibrary(a, n);
  #else
  		AppDomain.CurrentDomain.AssemblyResolve += delegate (object sender, ResolveEventArgs sargs) {
 @@ -34,6 +_,35 @@
@@ -66,7 +66,7 @@
  	}
  
 @@ -53,7 +_,7 @@
- 	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name)
+ 	private static IntPtr ResolveNativeLibrary(Assembly assembly, string name, string indent = null)
  	{
  		const string tab = "  ";
 -		static void LogLine(string message) => Console.WriteLine(message);


### PR DESCRIPTION
### What is the bug?
On Linux (& Mac???) systems, if the `LD_LIBRARY_PATH` was not configured for the game's process, be it manually or by starting the game with our launch scripts, or even by having a system-wide configuration, then resolution of SDL may often fail, as it is a library that happens to be looked up by the OS as a dependency of FNA3D, rather than something requested and processed directly by the managed assembly.  This is a significant usability problem for mod developers, due the fact that their tooling often uses `dotnet ./tModLoader.dll` to start the game when debugging their mods. An even bigger problem is mod building - even if the developer explicitly runs `dotnet build` after manually setting up and exporting the environment variable, MSBuild will not inherit it when running the `<Exec/>` block we use for packaging `.tmod` files, leading to the following crash on systems that cannot find SDL on their own:
<img width="1754" height="764" alt="image" src="https://github.com/user-attachments/assets/41653de0-a38f-43c6-ba83-e521795f39fe" />

This issue of course does not occur on all Linux systems, as some will even have SDL installed at a FHS path, or simply have varying LD implementations. It is however nearly always present on NixOS, a developer-oriented system which by default does not even have an FHS-like environment.

### How did you fix the bug?
I have made the `ResolveNativeLibrary` callback load `SDL` before loading `FNA3D`/`FAudio`/`nfd`, thus giving the system a full path to load, instead of having it look for it itself as a dependency. Perhaps there are better ways, but out of the 2 solutions I know with this one seems most reliable, and reliable enough.

New logging will look like this:
<img width="907" height="112" alt="image" src="https://github.com/user-attachments/assets/a24094a7-41cd-46d9-8975-28ebd0f0baf4" />
<img width="1450" height="351" alt="image" src="https://github.com/user-attachments/assets/7aa5ac52-2a3c-442d-a0c4-d64ef1b8b813" />


### Are there alternatives to your fix?
We could modify tMLMod.targets to explicitly pass the environment variable to the Exec block, but while that would help `dotnet build`, it wouldn't assist with other uses like running the game via Rider.
```diff
 <Target Name="BuildMod" AfterTargets="Build" Condition="'$(BuildMod)' == 'true'">
 	<Exec
+		EnvironmentVariables="LD_LIBRARY_PATH=/path/to/tModLoader/Libraries/Native/Linux/"
 		Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)"
 		WorkingDirectory="$(tMLSteamPath)"
 	/>
 </Target>
```