### PR TITLE
Bug Fix: [Setup-CLI, MacOS] Fix decompiling error on Apple silicon MacOS

### DIFF
--- a/setup/Core/DecompileTask.cs
+++ b/setup/Core/DecompileTask.cs
@@ -26,11 +26,13 @@ namespace Terraria.ModLoader.Setup.Core
 
 			private readonly PEFile baseModule;
 			private readonly UniversalAssemblyResolver _resolver;
+			private readonly IReadOnlyList<string> extraSearchDirs;
 			private readonly Dictionary<string, PEFile> cache = new();
 
 			public TerrariaAssemblyResolver(PEFile baseModule, string targetFramework, IEnumerable<string> extraSearchDirs)
 			{
 				this.baseModule = baseModule;
+				this.extraSearchDirs = extraSearchDirs.ToList();
 				// pass mainAssemblyFileName: null so we can control the order of the search paths. We need to search the framework directory before the Terraria.exe folder on Mono platforms 
 				_resolver = new UniversalAssemblyResolver(mainAssemblyFileName: null, throwOnError: true, targetFramework, streamOptions: PEStreamOptions.PrefetchMetadata);
 
@@ -46,6 +48,17 @@ namespace Terraria.ModLoader.Setup.Core
 				{
 					if (cache.TryGetValue(name.FullName, out var module))
 						return module;
+
+					if (name.Name == "mscorlib") {
+						foreach (string dir in extraSearchDirs) {
+							string path = Path.Combine(dir, "mscorlib.dll");
+							if (File.Exists(path)) {
+								module = new PEFile(path);
+								cache[name.FullName] = module;
+								return module;
+							}
+						}
+					}
 
 					//look in the base module's embedded resources
 					var resName = name.Name + ".dll";

--- a/setup/Core/TerrariaDecompileExecutableProvider.cs
+++ b/setup/Core/TerrariaDecompileExecutableProvider.cs
@@ -34,11 +34,27 @@ internal sealed class TerrariaDecompileExecutableProvider
 		async Task DecryptTerrariaExe(string destinationPath)
 		{
 			if (key == null) {
-				CheckVersion(workspaceInfo.TerrariaPath, ClientVersion);
+				var proofPaths = GetProofOfOwnershipPaths();
+				string? proofPathUsed = null;
+				foreach (string proofPath in proofPaths) {
+					if (!File.Exists(proofPath)) {
+						continue;
+					}
 
-				if (!Secrets.TryDeriveKey(workspaceInfo.TerrariaPath, out key)) {
+					if (Path.GetExtension(proofPath).Equals(".exe", StringComparison.OrdinalIgnoreCase)) {
+						CheckVersion(proofPath, ClientVersion);
+					}
+
+					if (Secrets.TryDeriveKey(proofPath, out key)) {
+						proofPathUsed = proofPath;
+						break;
+					}
+				}
+
+				if (key == null) {
+					string attemptedPaths = string.Join(", ", proofPaths.Select(p => $"'{p}'"));
 					throw new InvalidOperationException(
-						$"Failed to derive key from '{workspaceInfo.TerrariaPath}'. Cannot decrypt Terraria Windows executable.");
+						$"Failed to derive key from {attemptedPaths}. Cannot decrypt Terraria Windows executable.");
 				}
 			}
 
@@ -102,13 +118,33 @@ internal sealed class TerrariaDecompileExecutableProvider
 		}
 	}
 
+	private IReadOnlyList<string> GetProofOfOwnershipPaths()
+	{
+		var paths = new List<string>();
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+			paths.Add(Path.Combine(workspaceInfo.TerrariaSteamDirectory, "Terraria.app", "Contents", "Resources", "Terraria.exe"));
+		}
+
+		paths.Add(workspaceInfo.TerrariaPath);
+
+		return paths;
+	}
+
 	public async Task<IReadOnlyCollection<string>> RetrieveExtraReferences(ITaskProgress taskProgress, CancellationToken cancellationToken = default)
 	{
 		var paths = new List<string>();
-		if (File.Exists(Path.Combine(workspaceInfo.TerrariaSteamDirectory, "mscorlib.dll")))
+		string? resourcesDirectory = GetTerrariaResourcesDirectory();
+		bool hasMscorlib = File.Exists(Path.Combine(workspaceInfo.TerrariaSteamDirectory, "mscorlib.dll"))
+			|| (resourcesDirectory != null && File.Exists(Path.Combine(resourcesDirectory, "mscorlib.dll")));
+		if (hasMscorlib)
 			paths.Add(await RetrieveFrameworkRefs(taskProgress, cancellationToken));
 
+		if (resourcesDirectory != null)
+			paths.Add(resourcesDirectory);
+
 		if (File.Exists(Path.Combine(workspaceInfo.TerrariaSteamDirectory, "FNA.dll"))
+			|| (resourcesDirectory != null && File.Exists(Path.Combine(resourcesDirectory, "FNA.dll")))
 			|| UniversalAssemblyResolver.GetAssemblyInGac(AssemblyNameReference.Parse("Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553")) is null)
 			paths.Add(Path.Combine("setup", "xna_redist"));
 
@@ -137,5 +173,16 @@ internal sealed class TerrariaDecompileExecutableProvider
 		}
 
 		return path;
+	}
+
+	private string? GetTerrariaResourcesDirectory()
+	{
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+			string resourcesPath = Path.Combine(workspaceInfo.TerrariaSteamDirectory, "Terraria.app", "Contents", "Resources");
+			if (Directory.Exists(resourcesPath))
+				return resourcesPath;
+		}
+
+		return null;
 	}
 }

--- a/setup/Core/TerrariaExecutableSetter.cs
+++ b/setup/Core/TerrariaExecutableSetter.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 using Terraria.ModLoader.Setup.Core.Utilities;
 
@@ -35,7 +36,7 @@ public class TerrariaExecutableSetter
 			return;
 		}
 
-		string terrariaExecutablePath = Path.Combine(terrariaDirectory, "Terraria.exe");
+		string terrariaExecutablePath = GetTerrariaExecutablePath(terrariaDirectory);
 
 		if (File.Exists(terrariaExecutablePath)) {
 			SetTerrariaDirectory(terrariaDirectory, tmlDevSteamDirectoryOverride);
@@ -43,7 +44,10 @@ public class TerrariaExecutableSetter
 		}
 
 		if (!string.IsNullOrWhiteSpace(terrariaSteamDirectoryOverride)) {
-			throw new InvalidOperationException($"Directory '{terrariaSteamDirectoryOverride}' does not contain 'Terraria.exe'.");
+			string expectedName = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+				? "Terraria.app/Contents/MacOS/Terraria.bin.osx"
+				: "Terraria.exe";
+			throw new InvalidOperationException($"Directory '{terrariaSteamDirectoryOverride}' does not contain '{expectedName}'.");
 		}
 
 		await FindTerrariaDirectory(tmlDevSteamDirectoryOverride, cancellationToken);
@@ -66,14 +70,33 @@ public class TerrariaExecutableSetter
 			string executablePath = await terrariaExecutableSelectionPrompt.Prompt(cancellationToken);
 
 			string errorText;
-			if (Path.GetFileName(executablePath) != "Terraria.exe") {
-				errorText = "File must be named Terraria.exe";
-			}
-			else if (!File.Exists(Path.Combine(Path.GetDirectoryName(executablePath)!, "TerrariaServer.exe"))) {
-				errorText = "TerrariaServer.exe does not exist in the same directory";
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+				if (Path.GetFileName(executablePath) != "Terraria.bin.osx") {
+					errorText = "File must be named Terraria.bin.osx";
+				}
+				else {
+					string? macOsDir = Path.GetDirectoryName(executablePath);
+					string? contentsDir = macOsDir != null ? Directory.GetParent(macOsDir)?.FullName : null;
+					string? appDir = contentsDir != null ? Directory.GetParent(contentsDir)?.FullName : null;
+					string? rootDir = appDir != null ? Directory.GetParent(appDir)?.FullName : null;
+
+					if (rootDir != null) {
+						return rootDir;
+					}
+
+					errorText = "Unable to resolve Terraria install directory from selected file";
+				}
 			}
 			else {
-				return Path.GetDirectoryName(executablePath)!;
+				if (Path.GetFileName(executablePath) != "Terraria.exe") {
+					errorText = "File must be named Terraria.exe";
+				}
+				else if (!File.Exists(Path.Combine(Path.GetDirectoryName(executablePath)!, "TerrariaServer.exe"))) {
+					errorText = "TerrariaServer.exe does not exist in the same directory";
+				}
+				else {
+					return Path.GetDirectoryName(executablePath)!;
+				}
 			}
 
 			if (!userPrompt.Prompt(
@@ -105,5 +128,12 @@ public class TerrariaExecutableSetter
 	private void SetTerrariaDirectory(string terrariaSteamDirectory, string? tmlDevSteamDirectoryOverride)
 	{
 		workspaceInfo.UpdatePaths(terrariaSteamDirectory, tmlDevSteamDirectoryOverride);
+	}
+
+	private static string GetTerrariaExecutablePath(string terrariaDirectory)
+	{
+		return RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+			? Path.Combine(terrariaDirectory, "Terraria.app", "Contents", "MacOS", "Terraria.bin.osx")
+			: Path.Combine(terrariaDirectory, "Terraria.exe");
 	}
 }

--- a/setup/Core/WorkspaceInfo.cs
+++ b/setup/Core/WorkspaceInfo.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using System.Runtime.InteropServices;
 using Terraria.ModLoader.Setup.Core.Utilities;
 
 namespace Terraria.ModLoader.Setup.Core;
@@ -67,7 +68,10 @@ public sealed class WorkspaceInfo
 		}
 	}
 
-	public string TerrariaPath => Path.Combine(TerrariaSteamDirectory, "Terraria.exe");
+	public string TerrariaPath =>
+		RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+			? Path.Combine(TerrariaSteamDirectory, "Terraria.app", "Contents", "MacOS", "Terraria.bin.osx")
+			: Path.Combine(TerrariaSteamDirectory, "Terraria.exe");
 
 	public string TerrariaServerPath => Path.Combine(TerrariaSteamDirectory, "TerrariaServer.exe");
 


### PR DESCRIPTION
### What is the bug?

In the current 1.4.4 version, decompiling Terraria on an Apple Silicon MacBook fails.

The specific reasons are:
- 1.	When locating the Terraria executable on macOS, the attempted path is ~/Library/Application\ Support/Steam/steamapps/common/Terraria/Terraria.exe, but the correct path should be ~/Library/Application\ Support/Steam/steamapps/common/Terraria/Terraria.app/Contents/MacOS/Terraria.bin.osx.
- 2.	When decrypting the executable, the key for the Windows version binary is still being used, rather than the OSX version key from keys.json.
- 3.	On OSX, the required libraries for the decompilation process, such as mscorlib and FNA, should be found in ~/Library/Application Support/Steam/steamapps/common/Terraria/Terraria.app/Contents/Resources.

### How did you fix the bug?

I modified the source code of the setup project to adapt the file paths for cases where the operating system platform is OSX.

### Are there alternatives to your fix?

I think this is the only solution.

### Verification on MacOS

- Make './setup-cli.sh setup' works:

<img width="1446" height="368" alt="a2ee26ca69a213b6964cba5982bde830" src="https://github.com/user-attachments/assets/4d7c47ad-4530-4f7d-9784-7f423a6e5af9" />

- Build tModLoader on Apple Silicon MacOS:

Use command(Requires installing x64 version dotnet SDK):

```
/usr/local/share/dotnet/x64/dotnet build src/tModLoader/Terraria/Terraria.csproj
```

<img width="825" height="375" alt="image" src="https://github.com/user-attachments/assets/47f6f494-7eb7-4ef8-8bde-1537fcc9a010" />

<img width="1728" height="1024" alt="image" src="https://github.com/user-attachments/assets/159e518b-2b2e-4ef2-a65a-79e2b5bacf5b" />

### Addtional 

The modifications to the code should not affect setup on non-OSX platforms, but I don’t have the conditions to test it on a non-OSX system (mainly Windows). It may need to be tested on Windows before being merged into the 1.4.4 branch.