### PR TITLE
New-Feature: Allow /enablehighdpi:0 command-line to turn off highdpi (A solution for issue 4257)

### DIFF
--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -392,6 +392,12 @@ public static partial class Program
 			return;
 
 		// Move DPI detection before early return.
+		if (Platform.IsWindows) {
+			[System.Runtime.InteropServices.DllImport("user32.dll")]
+			static extern bool SetProcessDPIAware();
+
+			SetProcessDPIAware();
+		}
 		SDL2.SDL.SDL_VideoInit(null);
 		SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
 		Logging.tML.Info($"Display DPI: Diagonal DPI is {ddpi}. Vertical DPI is {vdpi}. Horizontal DPI is {hdpi}");
@@ -404,13 +410,6 @@ public static partial class Program
 			}
 		}
 		
-		if (Platform.IsWindows) {
-			[System.Runtime.InteropServices.DllImport("user32.dll")]
-			static extern bool SetProcessDPIAware();
-
-			SetProcessDPIAware();
-		}
-
 		if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold) {
 			Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 			Logging.tML.Info($"High DPI Display detected: setting FNA to highdpi mode");

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -402,39 +402,14 @@ public static partial class Program
 		SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
 		Logging.tML.Info($"Display DPI: Diagonal DPI is {ddpi}. Vertical DPI is {vdpi}. Horizontal DPI is {hdpi}");
 
-		// Only affect OSX path
+		// Only affect OSX path, see dicussion on https://github.com/tModLoader/tModLoader/pull/4951 for the reason.
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-			if (!GetEnableHighDpiOverride()) {
-				Logging.tML.Info($"Will not set FNA highdpi mode due to /enablehighdpi:0");
-				return;
-			}
+			return; // Let FNA decide by /enablehighdpi command-line argument, default: 0
 		}
 		
 		if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold) {
 			Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 			Logging.tML.Info($"High DPI Display detected: setting FNA to highdpi mode");
 		}
-	}
-
-	//Check FNA enablehighdpi command-line argument (/enablehighdpi:0)
-	private static bool GetEnableHighDpiOverride()
-	{
-		string[] args = Environment.GetCommandLineArgs();
-		for (int i = 1; i < args.Length; i++) {
-			string arg = args[i];
-			if (arg.StartsWith("/enablehighdpi", StringComparison.OrdinalIgnoreCase)) {
-				string? parsed = null;
-				int colonIndex = arg.IndexOf(':');
-				if (colonIndex >= 0 && colonIndex + 1 < arg.Length) {
-					parsed = arg.Substring(colonIndex + 1);
-				}
-			
-				if (string.IsNullOrWhiteSpace(parsed))
-					return true;
-
-				return parsed != "0";
-			}
-		}
-		return false;
 	}
 }

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -391,6 +391,14 @@ public static partial class Program
 		if (isServer)
 			return;
 
+		// Only affect OSX path
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+			if (!GetEnableHighDpiOverride()) {
+				Logging.tML.Info($"Will not set FNA highdpi mode due to /enablehighdpi:0");
+				return;
+			}
+		}
+		
 		if (Platform.IsWindows) {
 			[System.Runtime.InteropServices.DllImport("user32.dll")]
 			static extern bool SetProcessDPIAware();
@@ -405,5 +413,27 @@ public static partial class Program
 			Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 			Logging.tML.Info($"High DPI Display detected: setting FNA to highdpi mode");
 		}
+	}
+
+	//Check FNA enablehighdpi command-line argument (/enablehighdpi:0)
+	private static bool GetEnableHighDpiOverride()
+	{
+		string[] args = Environment.GetCommandLineArgs();
+		for (int i = 1; i < args.Length; i++) {
+			string arg = args[i];
+			if (arg.StartsWith("/enablehighdpi", StringComparison.OrdinalIgnoreCase)) {
+				string? parsed = null;
+				int colonIndex = arg.IndexOf(':');
+				if (colonIndex >= 0 && colonIndex + 1 < arg.Length) {
+					parsed = arg.Substring(colonIndex + 1);
+				}
+			
+				if (string.IsNullOrWhiteSpace(parsed))
+					return true;
+
+				return parsed != "0";
+			}
+		}
+		return false;
 	}
 }

--- a/patches/tModLoader/Terraria/Program.TML.cs
+++ b/patches/tModLoader/Terraria/Program.TML.cs
@@ -391,6 +391,11 @@ public static partial class Program
 		if (isServer)
 			return;
 
+		// Move DPI detection before early return.
+		SDL2.SDL.SDL_VideoInit(null);
+		SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
+		Logging.tML.Info($"Display DPI: Diagonal DPI is {ddpi}. Vertical DPI is {vdpi}. Horizontal DPI is {hdpi}");
+
 		// Only affect OSX path
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 			if (!GetEnableHighDpiOverride()) {
@@ -406,9 +411,6 @@ public static partial class Program
 			SetProcessDPIAware();
 		}
 
-		SDL2.SDL.SDL_VideoInit(null);
-		SDL2.SDL.SDL_GetDisplayDPI(0, out var ddpi, out float hdpi, out float vdpi);
-		Logging.tML.Info($"Display DPI: Diagonal DPI is {ddpi}. Vertical DPI is {vdpi}. Horizontal DPI is {hdpi}");
 		if (ddpi >= HighDpiThreshold || hdpi >= HighDpiThreshold || vdpi >= HighDpiThreshold) {
 			Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");
 			Logging.tML.Info($"High DPI Display detected: setting FNA to highdpi mode");


### PR DESCRIPTION
### Background

[Issue 4257](https://github.com/tModLoader/tModLoader/issues/4257) reported that on macOS, 4K high resolution is forcibly enabled, resulting in poor game graphics performance, meanwhile this issue does not exist in the original version of Terraria. 

While reading the source code, I noticed that tModLoader enables HighDPI mode whenever the detected screen DPI is greater than a fixed threshold (96). This behavior makes sense on many platforms and is generally a good idea, as it improves visual clarity on high-DPI displays.

However, on macOS this logic causes an unintended side effect, Because the MacOS already provides a global scaling mechanism (HiDPI / Retina scaling).
Applications are expected to render at a logical resolution, while macOS transparently maps that to the physical pixel resolution of the display. **Adjusting DPI scaling by the program is always not expected on MacOS**.

By forcing HighDPI mode solely based on the raw DPI value, tModLoader ends up:
- Ignoring the user’s macOS global scaling settings
- Rendering directly at the display’s native physical resolution (e.g. 5K or 6K). Note: most macOS users are using high-resolution displays.
- Significantly increasing the internal render resolution and **severely degrade rendering performance**, 

### What is the new feature?

To preserve compatibility with the existing tModLoader behavior, this change does not disable HighDPI support by default on macOS.

Instead, the logic is adjusted to respect the existing command-line flag -enablehighdpi, which is also used by the underlying FNA framework:
- When running on macOS, tModLoader now checks the value of -enablehighdpi
- If /enablehighdpi:0 is specified, HighDPI mode will no longer be forcibly enabled, even if the detected DPI exceeds the threshold
- If the flag is not provided, or is set to 1, the previous behavior is preserved

Importantly:
- This change only applies at runtime when the platform is macOS
- All other platforms continue to use the original DPI-based logic without modification

### Why should this be part of tModLoader?

This issue is triggered by tModLoader’s own HighDPI enabling logic (DPI > 96 ⇒ force HighDPI), and it has a real performance impact on macOS because it can cause the game to render at the display’s native physical resolution rather than respecting macOS’ effective scaling.

Adding this to tModLoader makes sense because:
- It fixes a platform-specific regression/footgun: macOS DPI semantics differ from Windows, so a fixed DPI threshold does not reliably represent the intended render scale.
- It keeps the default behavior unchanged for existing users, while providing a supported way to opt out when needed.
- It aligns with FNA’s existing configuration surface by honoring -enablehighdpi, rather than introducing a new flag or UI setting.
- It is minimal and low-risk: the change is gated to macOS at runtime and does not affect other platforms.

In short, this makes HighDPI behavior on macOS more predictable and prevents accidental “native-resolution rendering” that can severely hurt FPS on high-resolution displays.

### Are there alternative designs?

Yes. From my view, tModLoader should disable self-adjustment of HighDPI by default on macOS, this is the expected behavior for MacOS applications. After applying my patch, using /enablehighdpi:0 on macOS to forcibly disable HiDPI adaptation does not cause issues like blurry graphics, while improving game graphics performance.

### Sample usage for the new feature

Just add command-line arugment /enablehighdpi:0 to the tModLoader

### ExampleMod updates

There's no update for the ExampleMod
