### PR TITLE
Setup-CLI: Auto detect Terraria.app/Contents/Resources on MacOS

### DIFF
--- a/setup/Core/TerrariaExecutableSetter.cs
+++ b/setup/Core/TerrariaExecutableSetter.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 using Terraria.ModLoader.Setup.Core.Utilities;
 

--- a/setup/Core/TerrariaExecutableSetter.cs
+++ b/setup/Core/TerrariaExecutableSetter.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 using Terraria.ModLoader.Setup.Core.Utilities;
 
@@ -95,11 +96,23 @@ public class TerrariaExecutableSetter
 			terrariaFolderPath = await PromptForTerrariaDirectory(cancellationToken);
 		}
 
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			terrariaFolderPath = AppendMacOsTerrariaResourcesPath(terrariaFolderPath);
+
 		SetTerrariaDirectory(terrariaFolderPath, tmlDevSteamDirectoryOverride);
 	}
 
 	private void SetTerrariaDirectory(string terrariaSteamDirectory, string? tmlDevSteamDirectoryOverride)
 	{
 		workspaceInfo.UpdatePaths(terrariaSteamDirectory, tmlDevSteamDirectoryOverride);
+	}
+
+	private static string AppendMacOsTerrariaResourcesPath(string terrariaDirectory)
+	{
+		if (terrariaDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal))
+			return terrariaDirectory;
+
+		string resourcesPath = Path.Combine(terrariaDirectory, "Terraria.app", "Contents", "Resources");
+		return Directory.Exists(resourcesPath) ? resourcesPath : terrariaDirectory;
 	}
 }

--- a/setup/Core/TerrariaExecutableSetter.cs
+++ b/setup/Core/TerrariaExecutableSetter.cs
@@ -96,8 +96,9 @@ public class TerrariaExecutableSetter
 			terrariaFolderPath = await PromptForTerrariaDirectory(cancellationToken);
 		}
 
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 			terrariaFolderPath = AppendMacOsTerrariaResourcesPath(terrariaFolderPath);
+		}
 
 		SetTerrariaDirectory(terrariaFolderPath, tmlDevSteamDirectoryOverride);
 	}
@@ -109,8 +110,9 @@ public class TerrariaExecutableSetter
 
 	private static string AppendMacOsTerrariaResourcesPath(string terrariaDirectory)
 	{
-		if (terrariaDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal))
+		if (terrariaDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal)) {
 			return terrariaDirectory;
+		}
 
 		string resourcesPath = Path.Combine(terrariaDirectory, "Terraria.app", "Contents", "Resources");
 		return Directory.Exists(resourcesPath) ? resourcesPath : terrariaDirectory;

--- a/setup/Core/TerrariaExecutableSetter.cs
+++ b/setup/Core/TerrariaExecutableSetter.cs
@@ -96,25 +96,11 @@ public class TerrariaExecutableSetter
 			terrariaFolderPath = await PromptForTerrariaDirectory(cancellationToken);
 		}
 
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-			terrariaFolderPath = AppendMacOsTerrariaResourcesPath(terrariaFolderPath);
-		}
-
 		SetTerrariaDirectory(terrariaFolderPath, tmlDevSteamDirectoryOverride);
 	}
 
 	private void SetTerrariaDirectory(string terrariaSteamDirectory, string? tmlDevSteamDirectoryOverride)
 	{
 		workspaceInfo.UpdatePaths(terrariaSteamDirectory, tmlDevSteamDirectoryOverride);
-	}
-
-	private static string AppendMacOsTerrariaResourcesPath(string terrariaDirectory)
-	{
-		if (terrariaDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal)) {
-			return terrariaDirectory;
-		}
-
-		string resourcesPath = Path.Combine(terrariaDirectory, "Terraria.app", "Contents", "Resources");
-		return Directory.Exists(resourcesPath) ? resourcesPath : terrariaDirectory;
 	}
 }

--- a/setup/Core/Utilities/SteamUtils.cs
+++ b/setup/Core/Utilities/SteamUtils.cs
@@ -59,6 +59,14 @@ namespace Terraria.ModLoader.Setup.Core.Utilities
 					if (match.Success) {
 						path = Path.Combine(directory, "common", match.Groups[1].Value);
 
+						if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+							string resourcesPath = Path.Combine(path, "Terraria.app", "Contents", "Resources");
+							if (Directory.Exists(resourcesPath)) {
+								path = resourcesPath;
+								return true;
+							}
+						}
+
 						if (Directory.Exists(path)) {
 							return true;
 						}

--- a/setup/Core/WorkspaceInfo.cs
+++ b/setup/Core/WorkspaceInfo.cs
@@ -114,17 +114,17 @@ public sealed class WorkspaceInfo
 
 		TerrariaSteamDirectory = PathUtils.GetCrossPlatformFullPath(terrariaSteamDirectory);
 
-		string tmlDevDirectory = tMLDevSteamDirectory ?? "";
-		if (string.IsNullOrWhiteSpace(tmlDevDirectory)) {
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && IsMacOsTerrariaResourcesPath(TerrariaSteamDirectory)) {
-				tmlDevDirectory = Path.Combine(GetMacOsSteamAppsCommonDirectory(TerrariaSteamDirectory), "tModLoaderDev");
+		if (string.IsNullOrWhiteSpace(tMLDevSteamDirectory)) {
+			var steamappsCommonDirectory = TerrariaSteamDirectory;
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+					steamappsCommonDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal)) {
+				steamappsCommonDirectory = Path.Combine(steamappsCommonDirectory, "..", "..", "..");
 			}
-			else {
-				tmlDevDirectory = Path.Combine(terrariaSteamDirectory, "..", "tModLoaderDev");
-			}
+			
+			tMLDevSteamDirectory = Path.Combine(steamappsCommonDirectory, "..", "tModLoaderDev");
 		}
 
-		TMLDevSteamDirectory = PathUtils.GetCrossPlatformFullPath(tmlDevDirectory);
+		TMLDevSteamDirectory = PathUtils.GetCrossPlatformFullPath(tMLDevSteamDirectory);
 
 		Directory.CreateDirectory(TMLDevSteamDirectory);
 
@@ -139,21 +139,5 @@ public sealed class WorkspaceInfo
 	private void WriteToFile()
 	{
 		document.Save(FilePath);
-	}
-
-	private static bool IsMacOsTerrariaResourcesPath(string terrariaSteamDirectory)
-	{
-		return terrariaSteamDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal);
-	}
-
-	private static string GetMacOsSteamAppsCommonDirectory(string terrariaSteamDirectory)
-	{
-		var resourcesDir = new DirectoryInfo(terrariaSteamDirectory);
-		var contentsDir = resourcesDir.Parent;
-		var appDir = contentsDir?.Parent;
-		var terrariaDir = appDir?.Parent;
-		var commonDir = terrariaDir?.Parent;
-
-		return commonDir?.FullName ?? Path.Combine(terrariaSteamDirectory, "..", "..", "..", "..");
 	}
 }

--- a/setup/Core/WorkspaceInfo.cs
+++ b/setup/Core/WorkspaceInfo.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Terraria.ModLoader.Setup.Core.Utilities;
 
@@ -112,10 +113,18 @@ public sealed class WorkspaceInfo
 		ArgumentException.ThrowIfNullOrWhiteSpace(terrariaSteamDirectory);
 
 		TerrariaSteamDirectory = PathUtils.GetCrossPlatformFullPath(terrariaSteamDirectory);
-		TMLDevSteamDirectory = PathUtils.GetCrossPlatformFullPath(
-			string.IsNullOrWhiteSpace(tMLDevSteamDirectory)
-				? Path.Combine(terrariaSteamDirectory, "..", "tModLoaderDev")
-				: tMLDevSteamDirectory);
+
+		string tmlDevDirectory = tMLDevSteamDirectory ?? "";
+		if (string.IsNullOrWhiteSpace(tmlDevDirectory)) {
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && IsMacOsTerrariaResourcesPath(TerrariaSteamDirectory)) {
+				tmlDevDirectory = Path.Combine(GetMacOsSteamAppsCommonDirectory(TerrariaSteamDirectory), "tModLoaderDev");
+			}
+			else {
+				tmlDevDirectory = Path.Combine(terrariaSteamDirectory, "..", "tModLoaderDev");
+			}
+		}
+
+		TMLDevSteamDirectory = PathUtils.GetCrossPlatformFullPath(tmlDevDirectory);
 
 		Directory.CreateDirectory(TMLDevSteamDirectory);
 
@@ -130,5 +139,21 @@ public sealed class WorkspaceInfo
 	private void WriteToFile()
 	{
 		document.Save(FilePath);
+	}
+
+	private static bool IsMacOsTerrariaResourcesPath(string terrariaSteamDirectory)
+	{
+		return terrariaSteamDirectory.EndsWith(Path.Combine("Terraria.app", "Contents", "Resources"), StringComparison.Ordinal);
+	}
+
+	private static string GetMacOsSteamAppsCommonDirectory(string terrariaSteamDirectory)
+	{
+		var resourcesDir = new DirectoryInfo(terrariaSteamDirectory);
+		var contentsDir = resourcesDir.Parent;
+		var appDir = contentsDir?.Parent;
+		var terrariaDir = appDir?.Parent;
+		var commonDir = terrariaDir?.Parent;
+
+		return commonDir?.FullName ?? Path.Combine(terrariaSteamDirectory, "..", "..", "..", "..");
 	}
 }


### PR DESCRIPTION
### What is the new feature?

On macOS, the automatic Terraria path detection now appends Terraria.app/Contents/Resources, ensuring Terraria.exe and related dependencies (e.g. mscorlib/FNA) are found. The default tModLoaderDev path remains directly under steamapps/common. 

### Why should this be part of tModLoader?

It fixes macOS setup so users no longer have to manually locate the executable(e.g. using ./setup-cli.sh update-workspace-info /path/to/Terraria.app/Contents/Resources/). This improves the development experience on macOS.

### Are there alternative designs?

I think this patch is the smallest consistent change.

### Sample usage for the new feature

Just run ./setup-cli.sh setup On MacOS, do not require ./setup-cli.sh update-workspace-info

### ExampleMod updates

No update for the ExampleMod

### Additional Note

- The changes are wrapped in 'if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))' clause and do not affect non-macos paths.
- Build test passed on my Apple Silicon Macbook via:
```
/usr/local/share/dotnet/x64/dotnet build src/tModLoader/Terraria/Terraria.csproj
```

The compiled tModLoader will be released to ~/Library/Application Support/Steam/steamapps/common/tModLoaderDev, and it runs fine.