### PR TITLE
Fix stack overflow when a type has ReinitializeDuringResizeArrays and nested types

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/SystemLoader.cs
@@ -57,7 +57,7 @@ public static partial class SystemLoader
 		{
 			RuntimeHelpers.RunClassConstructor(type.TypeHandle);
 			foreach (var nestedType in type.GetNestedTypes())
-				RunStaticCtorIfNotAlreadyRun(type);
+				RunStaticCtorIfNotAlreadyRun(nestedType);
 		}
 
 		foreach (var typesToReinitialize in TypesWithResizeArraysAttribute(mod.Code))


### PR DESCRIPTION
It is clear that for whatever reason, the intended behavior here is to initialize the nested types once and not again during resize arrays, given nested types are not initialized during ``ResizeArrays``, while I don't understand why that was the intended behavior, it would be useful behavior if it worked, instead it currently calls the function intended to initialize the type recursively on the same type instead of its nested types.