### PR TITLE
Fix tModCodeAssist code inconsistency

### DIFF
--- a/tModCodeAssist/tModCodeAssist.CodeFixes/CodeFixes/AbstractCodeFixProvider.cs
+++ b/tModCodeAssist/tModCodeAssist.CodeFixes/CodeFixes/AbstractCodeFixProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 
-namespace tModCodeAssist;
+namespace tModCodeAssist.CodeFixes;
 
 public abstract class AbstractCodeFixProvider(string diagnosticId) : CodeFixProvider
 {


### PR DESCRIPTION
closes: #4970

---

Moved `AbstractCodeFixProvider.cs` into `CodeFixes` folder.