### PR TITLE
Removed DrawYOffset in ExampleChandelier to avoid double offset

### DIFF
--- a/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
@@ -59,7 +59,6 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.newTile.RandomStyleRange = 6;
 			TileObjectData.newTile.StyleHorizontal = true;
 			TileObjectData.newTile.StyleLineSkip = 2;
-			TileObjectData.newTile.DrawYOffset = +2;
 			TileObjectData.addTile(Type);
 
 			AddMapEntry(new Color(235, 166, 135), Language.GetText("MapObject.Chandelier"));

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
@@ -59,7 +59,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.newTile.RandomStyleRange = 6;
 			TileObjectData.newTile.StyleHorizontal = true;
 			TileObjectData.newTile.StyleLineSkip = 2;
-			TileObjectData.newTile.DrawYOffset = -2;
+			TileObjectData.newTile.DrawYOffset = +2;
 			TileObjectData.addTile(Type);
 
 			AddMapEntry(new Color(235, 166, 135), Language.GetText("MapObject.Chandelier"));

--- a/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleChandelier.cs
@@ -59,6 +59,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.newTile.RandomStyleRange = 6;
 			TileObjectData.newTile.StyleHorizontal = true;
 			TileObjectData.newTile.StyleLineSkip = 2;
+			TileObjectData.newTile.DrawYOffset = -2; // Draw this tile 2 pixels up to align visually with the bottom of the tile it is anchored to.
 			TileObjectData.addTile(Type);
 
 			AddMapEntry(new Color(235, 166, 135), Language.GetText("MapObject.Chandelier"));
@@ -68,6 +69,12 @@ namespace ExampleMod.Content.Tiles.Furniture
 
 			// Frozen style uses the temporary animation system to cycle between frames to give this style a flickering light effect when turning on.
 			turningOnAnimationType = Animation.RegisterTemporaryAnimation(frameRate: 12, frames: [0, 2, 2, 3, 2, 2, 1, 3]);
+		}
+
+		public override void SetDrawPositions(int i, int j, ref int width, ref int offsetY, ref int height, ref short tileFrameX, ref short tileFrameY) {
+			// Due to MultiTileVine rendering the tile 2 pixels higher than expected for modded tiles using TileObjectData.DrawYOffset, we need to add 2 to fix the math for correct drawing
+			offsetY += 2;
+			return;
 		}
 
 		public override void HitWire(int i, int j) {

--- a/ExampleMod/Content/Tiles/Furniture/ExampleWideBannerTile.cs
+++ b/ExampleMod/Content/Tiles/Furniture/ExampleWideBannerTile.cs
@@ -27,7 +27,7 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.newTile.Origin = Point16.Zero;
 			TileObjectData.newTile.AnchorBottom = AnchorData.Empty;
 			TileObjectData.newTile.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.SolidBottom | AnchorType.PlanterBox, TileObjectData.newTile.Width, 0);
-			TileObjectData.newTile.DrawYOffset = -2;
+			TileObjectData.newTile.DrawYOffset = -2; // Draw this tile 2 pixels up to align visually with the bottom of the tile it is anchored to.
 
 			// This alternate allows for placing the banner on platforms, just like in vanilla.
 			TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
@@ -36,6 +36,12 @@ namespace ExampleMod.Content.Tiles.Furniture
 			TileObjectData.addAlternate(0);
 
 			TileObjectData.addTile(Type);
+		}
+
+		public override void SetDrawPositions(int i, int j, ref int width, ref int offsetY, ref int height, ref short tileFrameX, ref short tileFrameY) {
+			// Due to MultiTileVine rendering the tile 2 pixels higher than expected for modded tiles using TileObjectData.DrawYOffset, we need to add 2 to fix the math for correct drawing
+			offsetY += 2;
+			return;
 		}
 
 		public override bool PreDraw(int i, int j, SpriteBatch spriteBatch) {


### PR DESCRIPTION
Closes #4988.
### What is the bug?
ExampleChandelier was being drawn higher than expected, and higher than the vanilla chandeliers it matched due to being affected by both DrawYAsset and TileID.Sets.MultiTileSway, doubling its offset.

### How did you fix the bug?
I removed the DrawYAsset line affecting ExampleChandelier.

### Are there alternatives to your fix?
Finding a way to avoid double-offsetting it might be helpful, or finding a more root cause.