### PR TITLE
fix: Prevent unobtainable items from breaking characters in TML.

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IO/ItemIO.cs
@@ -106,6 +106,12 @@ public static class ItemIO
 			}
 		}
 
+		// The item may have turned to air if it is deprecated in one way or another.
+		// Short-circuit in order to avoid throwing errors down the line.
+		if (item.IsAir) {
+			return;
+		}
+
 		LoadModdedPrefix(item, tag);
 
 		item.stack = tag.Get<int?>("stack") ?? 1;


### PR DESCRIPTION
### What is the bug?
Acquiring an unobtainable item such as one of [these hammers](https://terraria.wiki.gg/wiki/Luminite_Hammers) causes player characters to fail to load in TML, at `GetGlobalItem<UnloadedGlobalItem>()` being called with an empty state, if not earlier.

### How did you fix the bug?
Short-circuit if item IsAir after netDefaults.

### Are there alternatives to your fix?
Explicitly check for Sets.Deprecated, duplicating vanilla code.