### PR TITLE
tModLoader patches for 1.4.5

### DIFF
--- a/patches/tModLoader/Terraria/Cloud.cs.patch
+++ b/patches/tModLoader/Terraria/Cloud.cs.patch
@@ -15,7 +15,7 @@
  {
  	public Vector2 position;
  	public float scale;
-@@ -87,6 +_,11 @@
+@@ -88,6 +_,11 @@
  		if (rand.Next(3) == 0)
  			Main.cloud[num].position.Y -= rand.Next((int)((float)Main.screenHeight * 0.1f));
  
@@ -27,7 +27,7 @@
  		Main.cloud[num].type = rand.Next(4);
  		if ((Main.cloudAlpha > 0f && rand.Next(4) != 0) || (Main.cloudBGActive >= 1f && rand.Next(2) == 0)) {
  			Main.cloud[num].type = rand.Next(18, 22);
-@@ -105,12 +_,15 @@
+@@ -106,12 +_,15 @@
  		else if (Main.cloud[num].position.Y > (float)(-Main.screenHeight) * 0.15f && rand.Next(2) == 0 && (double)Main.numClouds > 20.0) {
  			Main.cloud[num].type = rand.Next(14, 18);
  		}
@@ -43,7 +43,7 @@
  		if ((double)Main.cloud[num].scale > 1.2)
  			Main.cloud[num].position.Y += 100f;
  
-@@ -128,6 +_,8 @@
+@@ -129,6 +_,8 @@
  		if (Main.cloud[num].position.X + (float)TextureAssets.Cloud[Main.cloud[num].type].Width() * Main.cloud[num].scale < -400f)
  			Main.cloud[num].Alpha = 1f;
  
@@ -52,7 +52,7 @@
  		Rectangle rectangle = new Rectangle((int)Main.cloud[num].position.X, (int)Main.cloud[num].position.Y, Main.cloud[num].width, Main.cloud[num].height);
  		for (int j = 0; j < 200; j++) {
  			if (num != j && Main.cloud[j].active) {
-@@ -143,6 +_,13 @@
+@@ -144,6 +_,13 @@
  		int num = -1;
  		bool flag = false;
  		while (!flag) {

--- a/patches/tModLoader/Terraria/Dust.cs.patch
+++ b/patches/tModLoader/Terraria/Dust.cs.patch
@@ -161,7 +161,7 @@
 +	/// <inheritdoc cref="Dust.QuickDust(Vector2, Color)"/>
  	public static Dust QuickDust(Point tileCoords, Color color) => QuickDust(tileCoords.ToWorldCoordinates(), color);
  
-@@ -290,6 +_,12 @@
+@@ -298,6 +_,12 @@
  		}
  	}
  
@@ -174,7 +174,7 @@
  	public static Dust QuickDust(Vector2 pos, Color color)
  	{
  		Dust obj = Main.dust[NewDust(pos, 0, 0, 267)];
-@@ -325,6 +_,9 @@
+@@ -333,6 +_,9 @@
  
  	public static int dustWater()
  	{
@@ -184,7 +184,7 @@
  		switch (Main.waterStyle) {
  			case 2:
  				return 98;
-@@ -368,6 +_,16 @@
+@@ -376,6 +_,16 @@
  					continue;
  
  				dCount += 1f;
@@ -201,7 +201,7 @@
  				if (dust.scale > 10f)
  					dust.active = false;
  
-@@ -1735,7 +_,7 @@
+@@ -1743,7 +_,7 @@
  
  					Lighting.AddLight((int)(dust.position.X / 16f), (int)(dust.position.Y / 16f), num108 * 0.7f, num108, num108 * 0.8f);
  				}
@@ -210,7 +210,7 @@
  					dust.velocity.X *= 0.99f;
  				}
  
-@@ -1966,6 +_,8 @@
+@@ -1974,6 +_,8 @@
  
  				if (dust.scale < num117)
  					dust.active = false;
@@ -219,7 +219,7 @@
  			}
  			else {
  				dust.active = false;
-@@ -1989,9 +_,17 @@
+@@ -1997,9 +_,17 @@
  
  	public Color GetAlpha(Color newColor)
  	{

--- a/patches/tModLoader/Terraria/Lighting.cs.patch
+++ b/patches/tModLoader/Terraria/Lighting.cs.patch
@@ -22,7 +22,7 @@
  	private static ILightingEngine _activeEngine;
  
  	public static float GlobalBrightness { get; set; }
-@@ -94,12 +_,19 @@
+@@ -96,12 +_,19 @@
  			GlobalBrightness = 1f;
  	}
  
@@ -42,7 +42,7 @@
  	public static Vector3 GetSubLight(Vector2 position)
  	{
  		Vector2 vector = position / 16f - new Vector2(0.5f, 0.5f);
-@@ -115,11 +_,27 @@
+@@ -117,11 +_,27 @@
  		return Vector3.Lerp(value, value2, vector2.Y);
  	}
  
@@ -70,7 +70,7 @@
  	public static void AddLight(Vector2 position, float r, float g, float b)
  	{
  		AddLight((int)(position.X / 16f), (int)(position.Y / 16f), r, g, b);
-@@ -137,6 +_,15 @@
+@@ -139,6 +_,15 @@
  		AddLight((int)position.X / 16, (int)position.Y / 16, R, G, B);
  	}
  
@@ -86,7 +86,7 @@
  	public static void AddLight(int i, int j, float r, float g, float b)
  	{
  		if (!Main.gamePaused && Main.netMode != 2)
-@@ -157,6 +_,7 @@
+@@ -159,6 +_,7 @@
  		_activeEngine.Clear();
  	}
  
@@ -94,7 +94,7 @@
  	public static Color GetColor(Point tileCoords)
  	{
  		if (Main.gameMenu)
-@@ -165,6 +_,10 @@
+@@ -167,6 +_,10 @@
  		return new Color(_activeEngine.GetColor(tileCoords.X, tileCoords.Y) * GlobalBrightness);
  	}
  
@@ -105,7 +105,7 @@
  	public static Color GetColor(Point tileCoords, Color originalColor)
  	{
  		if (Main.gameMenu)
-@@ -173,6 +_,7 @@
+@@ -175,6 +_,7 @@
  		return new Color(_activeEngine.GetColor(tileCoords.X, tileCoords.Y) * originalColor.ToVector3());
  	}
  
@@ -113,7 +113,7 @@
  	public static Color GetColor(int x, int y, Color oldColor)
  	{
  		if (Main.gameMenu)
-@@ -191,6 +_,10 @@
+@@ -193,6 +_,10 @@
  		return new Color(color * oldColor.ToVector3());
  	}
  


### PR DESCRIPTION
### What is the bug?

The existing Cloud, Dust, and Lighting patches in tModLoader fail to apply on 1.4.5 because method and field changes

### How did you fix the bug?

- Updated the Cloud patch to match the new Cloud class in 1.4.5
- Updated the Dust patch to match the new Dust class in 1.4.5
- Updated the Lightning patch to match the new Lightning class in 1.4.5
- Verified in the patch.log file that all patches now apply successfully

### Are there alternatives?

No alternative

### Additional info

--