### PR TITLE
Use new C# static abstract interface methods to provide more customizable and lower boilerplate autoloading

### DIFF
--- a/ExampleMod/Common/ManualMusicRegistrationExample.cs
+++ b/ExampleMod/Common/ManualMusicRegistrationExample.cs
@@ -4,19 +4,17 @@ namespace ExampleMod.Common
 {
 	// An example ILoadable showing off manual music loading.
 	// Manual loading is rarely needed, as, by default, TML will autoload every .wav, .ogg and .mp3 sound file in a 'Music' folder (including sub-directories) as a music track.
-	public sealed class ManualMusicRegistrationExample : ILoadable
+	public sealed class ManualMusicRegistrationExample : ICustomAutoload
 	{
-		public void Load(Mod mod) {
+		public static void Autoload(Mod mod) {
 			// When registering music manually, you will have to provide an instance to your mod.
 			// Since you're providing an instance of your mod, you should not start the path with your mod's name.
 			// Accepted music formats are: .mp3, .ogg, and .wav files.
 			// Do NOT add the file extension in your code when adding music!
 
-			// MusicLoader.AddMusic(Mod, "Assets/Music/MysteriousMystery");
+			// MusicLoader.AddMusic(mod, "Assets/Music/MysteriousMystery");
 
 			// An example of registration of Music Boxes can be found in 'Content/Items/Placeable/ExampleMusicBox.cs'.
 		}
-
-		public void Unload() { }
 	}
 }

--- a/ExampleMod/Content/Clouds/DefaultCloudsLoader.cs
+++ b/ExampleMod/Content/Clouds/DefaultCloudsLoader.cs
@@ -3,14 +3,11 @@
 namespace ExampleMod.Content.Clouds
 {
 	// By default, image files in a "Clouds" folder will autoload as clouds. We use this class to manually load ExampleCloud.png before autoloading happens to register the cloud with custom parameters instead.
-	public class DefaultCloudsLoader : ILoadable
+	public class DefaultCloudsLoader : ICustomAutoload
 	{
-		public void Load(Mod mod) {
+		public static void Autoload(Mod mod) {
 			// Registers a new simple cloud. See Content/Clouds/AdvancedExampleCloud.cs for a cloud with custom logic.
 			CloudLoader.AddCloudFromTexture(mod, "ExampleMod/Content/Clouds/ExampleCloud", spawnChance: 0.1f, rareCloud: false);
-		}
-
-		public void Unload() {
 		}
 	}
 }

--- a/ExampleMod/Content/CustomModType/NonAutoloadVictoryPose.cs
+++ b/ExampleMod/Content/CustomModType/NonAutoloadVictoryPose.cs
@@ -7,18 +7,12 @@ using Terraria.ModLoader;
 namespace ExampleMod.Content.CustomModType
 {
 	// This class doesn't autoload because it has a non-default constructor, it is loaded manually 2 times in NonAutoloadVictoryPoseLoader.Load
-	public class NonAutoloadVictoryPose : ModVictoryPose
+	public class NonAutoloadVictoryPose : ModVictoryPose, ICustomAutoload
 	{
-		public class NonAutoloadVictoryPoseLoader : ILoadable
-		{
-			public void Load(Mod mod) {
-				// Manually load additional ModVictoryPose from this mod.
-				mod.AddContent(new NonAutoloadVictoryPose("ShortPose", 120));
-				mod.AddContent(new NonAutoloadVictoryPose("LongPose", 180));
-			}
-
-			public void Unload() {
-			}
+		public static void Autoload(Mod mod) {
+			// Manually load additional ModVictoryPose from this mod.
+			mod.AddContent(new NonAutoloadVictoryPose("ShortPose", 120));
+			mod.AddContent(new NonAutoloadVictoryPose("LongPose", 180));
 		}
 
 		private readonly string nameOverride;

--- a/ExampleMod/Content/CustomModType/VictoryPoseLoader.cs
+++ b/ExampleMod/Content/CustomModType/VictoryPoseLoader.cs
@@ -12,7 +12,7 @@ namespace ExampleMod.Content.CustomModType
 	/// <para/> This is the also the main API exposed and intended to be used by other mods. For example, other mods could use the API to trigger a specific ModVictoryPose manually, such as when they craft a specific item.
 	/// <para/> The internal methods are not part of the API.
 	/// </summary>
-	public class VictoryPoseLoader : ILoadable
+	public class VictoryPoseLoader
 	{
 		internal static readonly List<ModVictoryPose> victoryPoses = [];
 
@@ -23,12 +23,6 @@ namespace ExampleMod.Content.CustomModType
 			int type = victoryPoses.Count;
 			victoryPoses.Add(victoryPose);
 			return type;
-		}
-
-		public void Load(Mod mod) {
-		}
-
-		public void Unload() {
 		}
 
 		/// <summary>

--- a/ExampleMod/Content/Items/Placeable/ExampleTrap.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleTrap.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Terraria;
 using Terraria.ID;
-using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items.Placeable
@@ -9,19 +8,11 @@ namespace ExampleMod.Content.Items.Placeable
 	// This item shows off using 1 class to load multiple items. This is an alternate to typical inheritance.
 	// Read the comments in this example carefully, as there are many parts necessary to make this approach work.
 	// The real strength of this approach is when you have many items that vary by small changes, like how these 2 trap items vary only by placeStyle.
-	public class ExampleTrap : ModItem
+	public class ExampleTrap : ModItem, ICustomAutoload
 	{
-		// This inner class is an ILoadable, the game will automatically call the Load method when loading this mod.
-		// Using this class, we manually call AddContent with 2 instances of the ExampleTrap class. This adds them to the game.
-		public class ExampleTrapLoader : ILoadable
-		{
-			public void Load(Mod mod) {
-				mod.AddContent(new ExampleTrap(0));
-				mod.AddContent(new ExampleTrap(1));
-			}
-
-			public void Unload() {
-			}
+		public static void Autoload(Mod mod) {
+			mod.AddContent(new ExampleTrap(0));
+			mod.AddContent(new ExampleTrap(1));
 		}
 
 		// CloneNewInstances is needed so that fields in this class are Cloned onto new instances, such as when this item is crafted or hovered over.

--- a/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Terraria.ModLoader;
 
@@ -7,6 +8,10 @@ namespace Terraria.ModLoader;
 /// The corresponding <typeparamref name="TImpl"/>.<see cref="IAutoloader.Autoload(Mod, Type)"/> method will be called on all non-abstract subtypes which implement this interface
 /// </summary>
 /// <typeparam name="TImpl">Concrete type containing a static <see cref="IAutoloader.Autoload(Mod, Type)"/> implementation method</typeparam>
+[UsedImplicitly(
+	ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,
+	ImplicitUseTargetFlags.WithMembers | ImplicitUseTargetFlags.WithInheritors
+)]
 public interface IAutoload<TImpl> where TImpl : IAutoloader
 {
 }

--- a/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
@@ -2,10 +2,18 @@
 
 namespace Terraria.ModLoader;
 
+/// <summary>
+/// Generalized marker interface for autoloading.
+/// The corresponding <typeparamref name="TImpl"/>.<see cref="IAutoloader.Autoload(Mod, Type)"/> method will be called on all non-abstract subtypes which implement this interface
+/// </summary>
+/// <typeparam name="TImpl">Concrete type containing a static <see cref="IAutoloader.Autoload(Mod, Type)"/> implementation method</typeparam>
 public interface IAutoload<TImpl> where TImpl : IAutoloader
 {
 }
 
+/// <summary>
+/// <see cref="IAutoload{TImpl}"/>. Used by <see cref="ILoadable"/> in tML
+/// </summary>
 public interface IAutoloader
 {
 	public static abstract void Autoload(Mod mod, Type type);

--- a/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/IAutoload.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Terraria.ModLoader;
+
+public interface IAutoload<TImpl> where TImpl : IAutoloader
+{
+}
+
+public interface IAutoloader
+{
+	public static abstract void Autoload(Mod mod, Type type);
+}

--- a/patches/tModLoader/Terraria/ModLoader/ICustomAutoload.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ICustomAutoload.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Reflection;
+
+namespace Terraria.ModLoader;
+
+/// <summary>
+/// Provides a static abstract <see cref="Autoload(Mod)"/> method for mods to implement their own autoloading for types where <see cref="ILoadable"/> does not suffice.<br/>
+/// Sample use cases:<br/>
+/// <list type="bullet">
+/// <item>When the type has multiple instances of the same class</item>
+/// <item>To manually call some content registration methods during autoloading (eg <seealso cref="MusicLoader.AddMusic"/>)</item>
+/// </list>
+/// To implement completely custom loading behavior in a library, consider making an interface that extends from <see cref="IAutoload{TImpl}"/>
+/// </summary>
+public interface ICustomAutoload : IAutoload<ICustomAutoload.AutoloadImpl>
+{
+	public static abstract void Autoload(Mod mod);
+
+	public class AutoloadImpl : IAutoloader
+	{
+		private static void Invoker<T>(Mod mod) where T : ICustomAutoload => T.Autoload(mod);
+		private static readonly MethodInfo _invoker = typeof(AutoloadImpl).GetMethod(nameof(Invoker), BindingFlags.Static | BindingFlags.NonPublic);
+
+		public static void Autoload(Mod mod, Type type) => _invoker.MakeGenericMethod(type).Invoke(null, [mod]);
+	}
+}

--- a/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
@@ -5,12 +5,10 @@ using JetBrains.Annotations;
 namespace Terraria.ModLoader;
 
 /// <summary>
-/// Allows for implementing types to be loaded and unloaded.
+/// Works with <see cref="Mod.AddContent"/> to provide Load and Unload callbacks.<br/>
+/// All non-abstract types extending this class which have a default constructor will be autoloaded and passed to <see cref="Mod.AddContent"/><br/>
+/// For autoloading types which do not have a default constructor, see <see cref="ICustomAutoload"/>
 /// </summary>
-[UsedImplicitly(
-	ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,
-	ImplicitUseTargetFlags.WithMembers | ImplicitUseTargetFlags.WithInheritors
-)]
 public interface ILoadable : IAutoload<ILoadable.AutoloadImpl>
 {
 	/// <summary>

--- a/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Terraria.ModLoader;
@@ -9,7 +11,7 @@ namespace Terraria.ModLoader;
 	ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature,
 	ImplicitUseTargetFlags.WithMembers | ImplicitUseTargetFlags.WithInheritors
 )]
-public interface ILoadable
+public interface ILoadable : IAutoload<ILoadable.AutoloadImpl>
 {
 	/// <summary>
 	/// Called when loading the type.
@@ -27,4 +29,15 @@ public interface ILoadable
 	/// Called during unloading when needed.
 	/// </summary>
 	public abstract void Unload();
+
+	public class AutoloadImpl : IAutoloader
+	{
+		public static void Autoload(Mod mod, Type type)
+		{
+			if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes) == null)
+				return;
+
+			mod.AddContent((ILoadable)Activator.CreateInstance(type, true));
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ILoadable.cs
@@ -34,10 +34,8 @@ public interface ILoadable : IAutoload<ILoadable.AutoloadImpl>
 	{
 		public static void Autoload(Mod mod, Type type)
 		{
-			if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes) == null)
-				return;
-
-			mod.AddContent((ILoadable)Activator.CreateInstance(type, true));
+			if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes) is { } ctor)
+				mod.AddContent((ILoadable)ctor.Invoke(null));
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -54,12 +54,10 @@ partial class Mod
 		if (ContentAutoloadingEnabled) {
 			var loadableTypes = AssemblyManager.GetLoadableTypes(Code)
 				.Where(t => !t.IsAbstract && !t.ContainsGenericParameters)
-				.Where(t => t.IsAssignableTo(typeof(ILoadable)))
-				.Where(t => t.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes) != null) // has default constructor
 				.Where(t => AutoloadAttribute.GetValue(t).NeedsAutoloading)
 				.OrderBy(type => type.FullName, StringComparer.InvariantCulture);
 
-			LoaderUtils.ForEachAndAggregateExceptions(loadableTypes, t => AddContent((ILoadable)Activator.CreateInstance(t, true)));
+			LoaderUtils.ForEachAndAggregateExceptions(loadableTypes, TryAutoload);
 		}
 
 		// Skip loading client assets if this is a dedicated server;
@@ -77,6 +75,15 @@ partial class Mod
 
 		if (BackgroundAutoloadingEnabled)
 			BackgroundTextureLoader.AutoloadBackgrounds(this);
+	}
+	private static void AutoloadInvoker<T, Impl>(Mod mod) where T : IAutoload<Impl> where Impl : IAutoloader => Impl.Autoload(mod, typeof(T));
+
+	private static readonly MethodInfo _autoloadInvoker = typeof(Mod).GetMethod(nameof(AutoloadInvoker), BindingFlags.Static | BindingFlags.NonPublic);
+	public void TryAutoload(Type type)
+	{
+		var iAutoload = type.GetInterfaces().SingleOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAutoload<>));
+		if (iAutoload != null)
+			_autoloadInvoker.MakeGenericMethod(type, iAutoload.GetGenericArguments()[0]).Invoke(null, [this]);
 	}
 
 	internal void PrepareAssets()

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -76,14 +76,14 @@ partial class Mod
 		if (BackgroundAutoloadingEnabled)
 			BackgroundTextureLoader.AutoloadBackgrounds(this);
 	}
-	private static void AutoloadInvoker<T, Impl>(Mod mod) where T : IAutoload<Impl> where Impl : IAutoloader => Impl.Autoload(mod, typeof(T));
+	private static void AutoloadInvoker<TImpl>(Mod mod, Type type) where TImpl : IAutoloader => TImpl.Autoload(mod, type);
 
 	private static readonly MethodInfo _autoloadInvoker = typeof(Mod).GetMethod(nameof(AutoloadInvoker), BindingFlags.Static | BindingFlags.NonPublic);
 	public void TryAutoload(Type type)
 	{
 		// IAutoload<> can be implemented multiple times with different generic args. Call all of them
 		foreach (var iAutoload in type.GetInterfaces().Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAutoload<>)))
-			_autoloadInvoker.MakeGenericMethod(type, iAutoload.GetGenericArguments()[0]).Invoke(null, [this]);
+			_autoloadInvoker.MakeGenericMethod(iAutoload.GetGenericArguments()).Invoke(null, [this, type]);
 	}
 
 	internal void PrepareAssets()

--- a/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.Internals.cs
@@ -81,8 +81,8 @@ partial class Mod
 	private static readonly MethodInfo _autoloadInvoker = typeof(Mod).GetMethod(nameof(AutoloadInvoker), BindingFlags.Static | BindingFlags.NonPublic);
 	public void TryAutoload(Type type)
 	{
-		var iAutoload = type.GetInterfaces().SingleOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAutoload<>));
-		if (iAutoload != null)
+		// IAutoload<> can be implemented multiple times with different generic args. Call all of them
+		foreach (var iAutoload in type.GetInterfaces().Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IAutoload<>)))
 			_autoloadInvoker.MakeGenericMethod(type, iAutoload.GetGenericArguments()[0]).Invoke(null, [this]);
 	}
 


### PR DESCRIPTION
### What is the new feature?

New interfaces allow implementation of custom autoloading that isn't just `mod.AddContent(Activator.CreateInstance(type))`

```cs
public interface IAutoload<TImpl> where TImpl : IAutoloader
{
}

public interface IAutoloader 
{ 
	public static abstract void Autoload(Mod mod, Type type); 
}

public interface ICustomAutoload : IAutoload<ICustomAutoload.AutoloadImpl>
{
	public static abstract void Autoload(Mod mod);
	
	...
}
```

`ILoadable` has been changed to:
```cs
public interface ILoadable : IAutoload<ILoadable.AutoloadImpl>
{
	...
	
	public class AutoloadImpl : IAutoloader 
	{ 
		public static void Autoload(Mod mod, Type type) 
		{ 
			if (type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes) is { } ctor) 
				mod.AddContent((ILoadable)ctor.Invoke(null)); 
		} 
	}
}
```

### Why should this be part of tModLoader?

Autoloading via `ILoadable` requires that types have a default constructor which can be called to create a 'template instance' of the content which is passed to `Mod.AddContent`. Sometimes, having to provide default constructors is just needless boilerplate. 

Sometimes, especially for systems and types provided by library mods and consumed by other dependent mods, there may be no notion of a 'template instance', but the library may still want to do `Type` level reflection based registration, on behalf of all consuming mod types. For example, a mod providing a serialization library, where packets are structs and types are auto-registered. Eg:

```cs
public interface IPacket<TSelf> : IAutoload<PacketAutoloader> {}
{
    void Write(BinaryWriter w);
    static abstract TSelf Read(BinaryReader r);
    static abstract void Handle(TSelf packet, int fromClient);
}

public readonly record struct CustomSoundPacket(ushort TileX, ushort TileY) : IPacket<CustomSoundPacket>
{
    public void Write(BinaryWriter w) {
        w.Write(TileX);
        w.Write(TileY);
    }

    public static CustomSoundPacketRead(...) => new(r.ReadUShort(), r.ReadUShort());

    public static void Handle(CustomSoundPacket packet, int fromClient)
    {
        if (Main.netMode == NetmodeID.MultiplayerServer)
            packet.Broadcast(ignoreClient: fromClient);
        else
            SoundEngine.PlaySound(MySound, new Vector2(TileX * 16, TileY * 16);
    }
}
```

### Are there alternative designs?

1. The existing workaround of making an inner `MyThingLoader : ILoadable` class and overriding `Load`
- Continues to work, but the reduced boilerplate of `ICustomAutoload` seems worthwhile.
2. Removing the `<IAutoloader>` parameter from `IAutoload` and putting the static abstract method in `IAutoload`
  - Since interfaces cannot 'override' static abstract methods, there is nowhere to put the default implementation of `ILoadable` (except separately hardcoded in `Mod.cs`)
  - Implementation would always need to exist in an abstract base `class`, which would be incompatible with `struct` use cases.
  - `ILoadable` would still be privileged and able to do things that mods cannot.
3. Similar to 2, but we make the method `static virtual` instead of `static abstract` and use reflection to look through the hierarchy of classes to find the 'override'
- Not compiler supported. Relies on special names/signatures
- Subclass overriding may make sense for `ILoadable` where the default implementation is insufficient, but not for other modded autoload scenarios.
4. Attribute based loading. Library mods use `ModSystem` or their own `ILoadable` class and scan other mods for attributes or interfaces using `GetLoadableTypes`
- Lower performance
- More difficult for library mods to implement correctly
- Loss of load order guarantees from tML
- Exceptions on loading cannot be easily attributed to the correct mod

### Sample usage for the new feature

If you're a library mod author, see the `ILoadable` code snippet above.
If you're a typical modder, see the `ExampleMod` updates below.

### ExampleMod updates
`NonAutoloadVictoryPose`, `DefaultCloudsLoader`, `ManualMusicRegistrationExample`, and `ExampleTrap` now use `ICustomAutoload`

Example:
```cs
	public class ExampleTrap : ModItem, ICustomAutoload
	{ 
		public static void Autoload(Mod mod) { 
			mod.AddContent(new ExampleTrap(0)); 
			mod.AddContent(new ExampleTrap(1)); 
		}
		
		...
```

### Porting Notes
100% backwards compatible
