### PR TITLE
Fix: The problem of drawing the upper limit of life in special circumstances

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerStatsSnapshot.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/ResourceSets/PlayerStatsSnapshot.cs.patch
@@ -25,7 +25,7 @@
 +	/// How many life hearts should be drawn
 +	/// </summary>
 +	public int AmountOfLifeHearts {
-+		get => numLifeHearts;
++		get => numLifeHearts = Utils.Clamp(numLifeHearts, int.MinValue, 20);
 +		set => numLifeHearts = Utils.Clamp(value, int.MinValue, 20);
 +	}
 +


### PR DESCRIPTION
### What is the bug?
When Player.statLifeMax and Player.statLifeMax2 are both greater than a certain value, there will be an error in drawing the upper limit of health when setting Health and Mana Style: Classic and Health and Mana Style: Bars

### How did you fix the bug?
I modified the PlayerStatsSnapshot.AmountOfLifeHearts property to force it to return a maximum of 20 when getting

### Are there alternatives to your fix?
Perhaps we can modify the drawing code in HorizontalBarsPlayerResourcesDisplaySet. cs and ClassicPlayerResourcesDisplaySet. cs separately