### PR TITLE
Fix CloneDefaults applying difficulty scaling that will already be applied afterwards

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -863,7 +863,7 @@
  		return result;
  	}
  
-@@ -2105,9 +_,27 @@
+@@ -2105,19 +_,41 @@
  		defDamage = damage;
  		defDefense = defense;
  		if (flag) {
@@ -883,7 +883,7 @@
 +		var originalModNPC = ModNPC;
 +		var originalGlobals = _globals;
 +
-+		SetDefaultsKeepPlayerInteraction(Type);
++		SetDefaultsKeepPlayerInteraction(Type, new NPCSpawnParams() { gameModeData = GameModeData.NormalMode, strengthMultiplierOverride = 1f });
 +
 +		type = originalType;
 +		netID = originalNetID;
@@ -892,6 +892,21 @@
  	}
  
  	public void SetDefaultsKeepPlayerInteraction(int Type)
+ 	{
++		SetDefaultsKeepPlayerInteraction(Type, default(NPCSpawnParams));
++	}
++	public void SetDefaultsKeepPlayerInteraction(int Type, NPCSpawnParams spawnparams)
++	{
+ 		bool[] array = new bool[playerInteraction.Length];
+ 		for (int i = 0; i < playerInteraction.Length; i++) {
+ 			array[i] = playerInteraction[i];
+ 		}
+ 
+-		SetDefaults(Type);
++		SetDefaults(Type, spawnparams);
+ 		for (int j = 0; j < playerInteraction.Length; j++) {
+ 			playerInteraction[j] = array[j];
+ 		}
 @@ -2156,6 +_,15 @@
  			return;
  		}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -863,7 +863,7 @@
  		return result;
  	}
  
-@@ -2105,19 +_,41 @@
+@@ -2105,19 +_,48 @@
  		defDamage = damage;
  		defDefense = defense;
  		if (flag) {
@@ -876,6 +876,12 @@
 +	}
 +
 +	// Added by TML.
++	/// <summary>
++	/// Clones all the default stats (damage, health, defense, etc) of another NPC type. This should be used in <see cref="ModNPC.SetDefaults"/> prior to changing any other stats.
++	/// <para/> This is useful for creating a ModNPC that should be a copy of another NPC. Using CloneDefaults instead of manually setting stats will ensure that modifications done to the NPC being cloned by other mods will automatically apply to this clone as well.
++	/// <para/> Note that for cloning negative <see cref="NPCID"/>, the final values might be very slightly off for higher difficulty modes due to the way difficulty scaling is applied.
++	/// </summary>
++	/// <param name="Type"></param>
 +	public void CloneDefaults(int Type)
 +	{
 +		int originalType = type;
@@ -895,6 +901,7 @@
  	{
 +		SetDefaultsKeepPlayerInteraction(Type, default(NPCSpawnParams));
 +	}
++
 +	public void SetDefaultsKeepPlayerInteraction(int Type, NPCSpawnParams spawnparams)
 +	{
  		bool[] array = new bool[playerInteraction.Length];


### PR DESCRIPTION
### What is the bug?
Using `CloneDefaults` causes difficulty modifiers to NPC value, max life, damage, and knockback resistance to be applied twice, or even more if cloning from an NPC which uses `CloneDefaults`.

### How did you fix the bug?
`CloneDefaults` now specifies `NPCSpawnParams` which prevent any scaling.