### PR TITLE
[1.4.5] Implement `FileWatcherPath`/`Refresh` for `ContentSource`s

### DIFF
--- a/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
+++ b/patches/tModLoader/ReLogic/Content/Sources/ContentSource.cs
@@ -14,6 +14,8 @@ public abstract class ContentSource : IContentSource
 	protected string[] assetPaths;
 	protected Dictionary<string, string> assetExtensions = new();
 
+	public abstract string FileWatcherPath { get; }
+
 	protected void SetAssetNames(IEnumerable<string> paths) {
 		assetPaths = paths.ToArray();
 		assetExtensions.Clear();
@@ -37,4 +39,6 @@ public abstract class ContentSource : IContentSource
 	public string GetExtension(string assetName) => assetExtensions.TryGetValue(AssetPathHelper.CleanPath(assetName), out var ext) ? ext : null;
 
 	public abstract Stream OpenStream(string fullAssetName);
+
+	public abstract void Refresh();
 }

--- a/patches/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/ReLogic/Content/Sources/FileSystemContentSource.cs
 +++ src/tModLoader/ReLogic/Content/Sources/FileSystemContentSource.cs
-@@ -1,16 +_,21 @@
+@@ -1,20 +_,25 @@
  using System;
  using System.Collections.Generic;
  using System.IO;
@@ -23,13 +23,15 @@
  
  	public int FileCount => _nameToAbsolutePath.Count;
  
-@@ -23,8 +_,17 @@
+-	public string FileWatcherPath => _basePath;
++	public override string FileWatcherPath => _basePath;
+ 
+ 	public FileSystemContentSource(string basePath)
+ 	{
+@@ -23,8 +_,14 @@
  			_basePath += Path.DirectorySeparatorChar;
  
  		Refresh();
-+
-+		// Added by TML.
-+		SetAssetNames(_nameToAbsolutePath.Keys);
 +
 +		// #2617 - Allow using paths with extensions in GetExtension calls, because we happen to return such paths in EnumerateAssets().
 +		foreach (var pair in assetExtensions.ToArray()) {
@@ -52,7 +54,15 @@
  	{
  		if (!_nameToAbsolutePath.TryGetValue(assetName, out var value))
  			throw AssetLoadException.FromMissingAsset(assetName);
-@@ -75,14 +_,19 @@
+@@ -68,21 +_,29 @@
+ 		}
+ 	}
+ 
+-	public void Refresh()
++	public override void Refresh()
+ 	{
+ 		_nameToAbsolutePath.Clear();
+ 		if (Directory.Exists(_basePath)) {
  			string[] files = Directory.GetFiles(_basePath, "*", SearchOption.AllDirectories);
  			for (int i = 0; i < files.Length; i++) {
  				string fullPath = Path.GetFullPath(files[i]);
@@ -66,6 +76,9 @@
  				_nameToAbsolutePath[path] = fullPath;
  			}
  		}
++
++		// Added by TML.
++		SetAssetNames(_nameToAbsolutePath.Keys);
  	}
  
 +	/*

--- a/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/IContentSource.cs.patch
@@ -45,6 +45,8 @@
  
  	bool TryGetRejections(List<string> rejectionReasons);
 +	*/
+ 
+ 	void Refresh();
 +
 +	// Added by TML.
 +	/// <summary>
@@ -67,6 +69,4 @@
 +
 +		return EnumerateAssets().Where(s => s.StartsWith(assetNameStart, comparison));
 +	}
- 
- 	void Refresh();
  }

--- a/patches/tModLoader/ReLogic/Content/Sources/XnaDirectContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/XnaDirectContentSource.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/ReLogic/Content/Sources/XnaDirectContentSource.cs
 +++ src/tModLoader/ReLogic/Content/Sources/XnaDirectContentSource.cs
-@@ -1,9 +_,36 @@
+@@ -1,9 +_,43 @@
  using System;
  using System.Collections.Generic;
  using System.IO;
@@ -13,13 +13,12 @@
 +{
 +	private readonly string[] _rootDirectories;
 +
++	public override string FileWatcherPath => null;
++
 +	public XnaDirectContentSource(IEnumerable<string> rootDirectories)
 +	{
 +		_rootDirectories = rootDirectories.Select(AssetPathHelper.CleanPath).ToArray();
-+		SetAssetNames(
-+			_rootDirectories
-+				.SelectMany(rootDir => Directory.GetFiles(rootDir, "*.xnb", SearchOption.AllDirectories).Select(path => path.Substring(rootDir.Length + 1)))
-+				.ToHashSet());
++		Refresh();
 +	}
 +
 +	public override Stream OpenStream(string assetName)
@@ -30,6 +29,14 @@
 +		catch (Exception innerException) {
 +			throw AssetLoadException.FromMissingAsset(assetName, innerException);
 +		}
++	}
++
++	public override void Refresh()
++	{
++		SetAssetNames(
++			_rootDirectories
++				.SelectMany(rootDir => Directory.GetFiles(rootDir, "*.xnb", SearchOption.AllDirectories).Select(path => path.Substring(rootDir.Length + 1)))
++				.ToHashSet());
 +	}
 +}
 +

--- a/patches/tModLoader/ReLogic/Content/Sources/ZipContentSource.cs.patch
+++ b/patches/tModLoader/ReLogic/Content/Sources/ZipContentSource.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/ReLogic/Content/Sources/ZipContentSource.cs
 +++ src/tModLoader/ReLogic/Content/Sources/ZipContentSource.cs
-@@ -7,18 +_,16 @@
+@@ -7,19 +_,17 @@
  
  namespace ReLogic.Content.Sources;
  
@@ -18,23 +18,24 @@
  
 -	public IContentValidator ContentValidator { get; set; }
 -
- 	public string FileWatcherPath => null;
+-	public string FileWatcherPath => null;
++	public override string FileWatcherPath => null;
  
  	public ZipContentSource(string path)
+ 		: this(path, "")
 @@ -38,9 +_,11 @@
  			throw new ArgumentException("Content directory cannot contain \"..\"", "contentDir");
  
  		_basePath = CleanZipPath(contentDir);
--		Refresh();
 +
-+		BuildEntryList(); //BuildExtensionFreeEntryList();
+ 		Refresh();
  	}
  
 +	/*
  	public bool HasAsset(string assetName)
  	{
  		if (!_entries.TryGetValue(assetName, out var _))
-@@ -70,28 +_,42 @@
+@@ -70,28 +_,41 @@
  
  		return Path.GetExtension(value.FileName) ?? "";
  	}
@@ -59,8 +60,7 @@
  	}
  
 -	public void Refresh()
-+	//TML: Renamed from BuildExtensionFreeEntryList()
-+	private void BuildEntryList()
++	public override void Refresh()
  	{
  		_entries.Clear();
  		foreach (ZipEntry item in _zipFile.Entries.Where((ZipEntry entry) => !entry.IsDirectory && entry.FileName.StartsWith(_basePath))) {

--- a/patches/tModLoader/Terraria/ModLoader/Assets/AssemblyResourcesContentSource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Assets/AssemblyResourcesContentSource.cs
@@ -13,6 +13,9 @@ public sealed class AssemblyResourcesContentSource : ContentSource
 {
 	private readonly string rootPath;
 	private readonly Assembly assembly;
+	private readonly string[] excludedStartingPaths;
+
+	public override string FileWatcherPath => null;
 
 	[Obsolete]
 	private AssemblyResourcesContentSource(Assembly assembly, string rootPath)
@@ -20,24 +23,27 @@ public sealed class AssemblyResourcesContentSource : ContentSource
 
 	public AssemblyResourcesContentSource(Assembly assembly, string rootPath = null, IEnumerable<string> excludedStartingPaths = null)
 	{
+		this.rootPath = rootPath ?? "";
 		this.assembly = assembly;
-		excludedStartingPaths ??= Enumerable.Empty<string>();
+		this.excludedStartingPaths = excludedStartingPaths?.ToArray() ?? [];
+	}
 
+	public override Stream OpenStream(string assetName) => assembly.GetManifestResourceStream(rootPath + assetName);
+
+	public override void Refresh()
+	{
 		IEnumerable<string> resourceNames = assembly.GetManifestResourceNames();
 
 		foreach (string startingPath in excludedStartingPaths ?? Enumerable.Empty<string>()) {
 			resourceNames = resourceNames.Where(p => !p.StartsWith(startingPath));
 		}
 
-		if (rootPath != null) {
+		if (!string.IsNullOrEmpty(rootPath)) {
 			resourceNames = resourceNames
 				.Where(p => p.StartsWith(rootPath))
 				.Select(p => p.Substring(rootPath.Length));
 		}
 
-		this.rootPath = rootPath ?? "";
 		SetAssetNames(resourceNames);
 	}
-
-	public override Stream OpenStream(string assetName) => assembly.GetManifestResourceStream(rootPath + assetName);
 }

--- a/patches/tModLoader/Terraria/ModLoader/Assets/TModContentSource.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Assets/TModContentSource.cs
@@ -11,10 +11,21 @@ public class TModContentSource : ContentSource
 {
 	private readonly TmodFile file;
 
+	// TODO: tModLoader will eventually want to support hot reloading for mod
+	// assets.
+	public override string FileWatcherPath => null;
+
 	public TModContentSource(TmodFile file)
 	{
 		this.file = file ?? throw new ArgumentNullException(nameof(file));
 
+		Refresh();
+	}
+
+	public override Stream OpenStream(string assetName) => file.GetStream(assetName, newFileStream: true); //todo, might be sloww
+
+	public override void Refresh()
+	{
 		// Skip loading assets if this is a dedicated server
 		if (Main.dedServ)
 			return;
@@ -26,6 +37,4 @@ public class TModContentSource : ContentSource
 			.Select(fileEntry => fileEntry.Name)
 			.Where(name => AssetInitializer.assetReaderCollection.TryGetReader(Path.GetExtension(name), out _)));
 	}
-
-	public override Stream OpenStream(string assetName) => file.GetStream(assetName, newFileStream: true); //todo, might be sloww
 }


### PR DESCRIPTION
Rearranges some code to always run in `Refresh` and makes `ContentSource` expect a `FileWatcherPatch`.

We will need to come back to `TModContentSource` once we want to add asset hot reloading to mods.

Bonus: if #5034 is also merged, this PR should make `ReLogic` compile.