### PR TITLE
[1.4.5] Use SDL3 to Set Window Icon

### DIFF
--- a/patches/tModLoader/ReLogic/OS/IWindowService.cs.patch
+++ b/patches/tModLoader/ReLogic/OS/IWindowService.cs.patch
@@ -25,8 +25,8 @@
 +	// Added by TML.
 +	void SetIcon(GameWindow window)
 +	{
-+		IntPtr surface = SDL2.SDL.SDL_LoadBMP("Libraries/Native/tModLoader.bmp");
-+		SDL2.SDL.SDL_SetWindowIcon(window.Handle, surface);
++		IntPtr surface = SDL3.SDL.SDL_LoadBMP("Libraries/Native/tModLoader.bmp");
++		SDL3.SDL.SDL_SetWindowIcon(window.Handle, surface);
 +	}
  
  	void Activate(GameWindow window);


### PR DESCRIPTION
We ported to SDL3 in #4952, so update this code accordingly.

The `Terraria` project has way more tML-specific code using SDL2 we'll have to address later.