### PR TITLE
[1.4.5] Some ID Updates

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -74,7 +74,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
   - Seems to control MessageID.PlayerControls being sent but I don't know why. 1 is unused.
 - Adjacent tiles are now contained in Recipe.TileCountsAs rather than hard-coded. Need to adjust TileLoader.AdjTiles hooks/docs/exampels to prioritize using Recipe.TileCountsAs
   - Restore `TileLoader.AdjTiles(this, Main.tile[j, k].type);` patch to new Player.SetAdjTile method
-- Add 697 to TileID.Sets.CanPlaceNextToNonSolidTile
 - ItemID.Sets.ExtractinatorMode entries seem to have changed a lot. There is also a new CanBeExtractinated set. Need to investigate and adjust things if necessary.
 - Terraria added a CanConsumeConsumableItem stub method. Should it check item.consumable or only ItemLoader.ConsumeItem.
 - We'll need to check all bag drops and update the drop database.
@@ -108,7 +107,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - "// Sound is played on animation start #ItemTimeOnAllClients" comments around "SoundEngine.PlaySound(item6.UseSound" in MessageBuffer's `ShotAnimationAndSound` code. ShotAnimationAndSound was renamed, we might need to verify that this is still fixed in tmod.
 - ApplyDifficultyAndPlayerScaling needs to be revisited.
 - Need to restore rejected PopupText.rare patch logic in Item.GetPopupRarityColor
-- Add 26 to TileID.Sets.AvoidedByMeteorLanding
 - Check for ` = new Tile();` not gated by null checks. These will all throw exception. Change to `Tile.Clear(TileDataType.All);`
 - WorldGen.StopWaterfallAmbienceAudio might be a better place for some existing patches. Need to verify save and quit stopping waterfall sounds properly.
 - TileLoader.DropCritterChance could be updated with LuckyClover chance. Also Lavafly/HellButterfly chance
@@ -122,7 +120,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - It seems like bomb damage logic has been reworked. Maybe many of our patches are no longer necessary or our explosive projectile examples need fixing. 
 - CombinedHooks.CanHitNPCWithProj patches might need to be reworked, it seems like they should be able to be simplified
 - Whip tag damage changed. Player.TagEffectState. Need to reapply "float num13 = ProjectileID.Sets.SummonTagDamageMultiplier[type];" patch somewhere.
-- Update ProjectileID.Sets.IsInteractable: 1093, 1094, 1098
 - Looks like we might want to split out the collision hitbox modification from TileCollideStyle. There is a new Projectile.GetCollisionParams method.
 - Biome conversion patches will need to be fixed, or maybe the vanilla changes will make it much easier to implement. Projectile, WorldGen
 - Double check new DoScrollingInInventory logic against PlayerInput.MouseInModdedUI

--- a/patches/tModLoader/Terraria/ID/ItemID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ItemID.TML.cs
@@ -145,7 +145,8 @@ partial class ItemID
 			MonkStaffT2,
 			MonkStaffT3,
 			ChlorophytePartisan,
-			NorthPole
+			NorthPole,
+			SlimeSpear
 		);
 
 		/// <summary>

--- a/patches/tModLoader/Terraria/ID/ProjAIStyleID.cs
+++ b/patches/tModLoader/Terraria/ID/ProjAIStyleID.cs
@@ -825,4 +825,44 @@ public class ProjAIStyleID
 	/// Used by: <see cref="ProjectileID.JimsDrone"/>
 	/// </summary>
 	public const short JimsDrone = 195;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.FlowerWhipPetal"/>
+	/// </summary>
+	public const short Petal = 196;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.DeadCellsBarnacle"/>
+	/// </summary>
+	public const short CeilingAndHoverTurret = 197;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.DeadCellsFlint"/>
+	/// </summary>
+	public const short Flint = 198;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.MeteorOre"/>
+	/// </summary>
+	public const short MeteorOre = 199;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.BirdDroppings"/>
+	/// </summary>
+	public const short BirdDroppings = 200;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.AntlionClaw"/> and <see cref="ProjectileID.StylistKilLaKillScissorsIWish"/>
+	/// </summary>
+	public const short ThrownMelee = 201;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.TorchGodHelper"/>
+	/// </summary>
+	public const short TorchGodHelper = 202;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.StormLightning"/>
+	/// </summary>
+	public const short StormLightning = 203;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.PalworldDigtoise"/>
+	/// </summary>
+	public const short Digtoise = 204;
+	/// <summary>
+	/// Used by: <see cref="ProjectileID.RemoteControlCar"/>
+	/// </summary>
+	public const short RemoteControlCar = 205;
 }

--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -73,13 +73,14 @@ partial class ProjectileID
 			ClusterRocketII, ClusterMineII, ClusterFragmentsII, WetRocket, WetGrenade, WetMine, LavaRocket, LavaGrenade, LavaMine, HoneyRocket, HoneyGrenade, HoneyMine,
 			MiniNukeRocketI, MiniNukeGrenadeI, MiniNukeMineI, MiniNukeRocketII, MiniNukeGrenadeII, MiniNukeMineII, DryRocket, DryGrenade, DryMine, ClusterSnowmanRocketI,
 			ClusterSnowmanRocketII, WetSnowmanRocket, LavaSnowmanRocket, HoneySnowmanRocket, MiniNukeSnowmanRocketI, MiniNukeSnowmanRocketII, DrySnowmanRocket,
-			ClusterSnowmanFragmentsI, ClusterSnowmanFragmentsII, WetBomb, LavaBomb, HoneyBomb, DryBomb, DirtBomb, DirtStickyBomb, SantankMountRocket, TNTBarrel);
+			ClusterSnowmanFragmentsI, ClusterSnowmanFragmentsII, WetBomb, LavaBomb, HoneyBomb, DryBomb, DirtBomb, DirtStickyBomb, SantankMountRocket, TNTBarrel,
+			FreezeBomb, SuperBomb, SuperStickyBomb, AcornSlingshotAcorn);
 
 		/// <summary>
 		/// This projectile is a candidate for player interaction. The projectile will be able to be targeted with smart cursor. Projectile that can be right clicked should set this to true.
 		/// <br/><br/> The <see href="https://github.com/tModLoader/tModLoader/tree/1.4.4/ExampleMod/Content/Projectiles/ExampleInteractableProjectile.cs">ExampleInteractableProjectile.cs</see> example demonstrates properly implementing an interactable projectile.
-		/// <br/><br/> Defaults to false. Vanilla entries include <see cref="FlyingPiggyBank"/>, <see cref="VoidLens"/>, and <see cref="ChesterPet"/>.
+		/// <br/><br/> Defaults to false. Vanilla entries include <see cref="FlyingPiggyBank"/>, <see cref="VoidLens"/>, <see cref="ChesterPet"/>, <see cref="PalworldMinionCattiva"/>, <see cref="PalworldMinionFoxsparks"/>, and <see cref="PalworldDigtoise"/>.
 		/// </summary>
-		public static bool[] IsInteractable = Factory.CreateBoolSet(false, 525, 734, 960);
+		public static bool[] IsInteractable = Factory.CreateBoolSet(false, 525, 734, 960, 1093, 1094, 1098);
 	}
 }

--- a/patches/tModLoader/Terraria/ID/TileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/TileID.TML.cs
@@ -82,10 +82,10 @@ partial class TileID
 		public static bool[] IgnoredByGrowingSaplings = Factory.CreateBoolSet(3, 24, 32, 61, 62, 69, 71, 73, 74, 82, 83, 84, 110, 113, 184, 201, 233, 352, 485, 529, 530, 637, 655);
 
 		/// <summary> Whether or not this tile prevents a meteor from landing near it.
-		/// <para/> Contains LihzahrdBrick, DisplayDoll, HatRack, FallenLog, and TeleportationPylon.
+		/// <para/> Contains DemonAltar, LihzahrdBrick, DisplayDoll, HatRack, FallenLog, and TeleportationPylon.
 		/// </summary>
 		/// <remarks> Note: Chests and Dungeon tiles are not in this set, but also prevent landing (handled through <see cref="BasicChest"/> and <see cref="Main.tileDungeon"/>)</remarks>
-		public static bool[] AvoidedByMeteorLanding = Factory.CreateBoolSet(226, 470, 475, 488, 597);
+		public static bool[] AvoidedByMeteorLanding = Factory.CreateBoolSet(26, 226, 470, 475, 488, 597);
 
 		/// <summary>
 		/// Whether or not this tile will prevent sand/slush from falling beneath it.
@@ -119,7 +119,7 @@ partial class TileID
 		/// Allows tiles to be placed next to any tile or wall. (Tiles normally need a <see cref="Main.tileSolid"/> tile, <see cref="Rope"/> tile, <see cref="IsBeam"/> tile, or a wall adjacent to the target position to be placeable.)
 		/// <br>Used by: Cobweb, Coin Piles, Living Fire Blocks, Smoke Blocks, Bubble Blocks</br>
 		/// </summary>
-		public static bool[] CanPlaceNextToNonSolidTile = Factory.CreateBoolSet(false, Cobweb, CopperCoinPile, SilverCoinPile, GoldCoinPile, PlatinumCoinPile, LivingFire, LivingCursedFire, LivingDemonFire, LivingFrostFire, LivingIchor, LivingUltrabrightFire, ChimneySmoke, Bubble);
+		public static bool[] CanPlaceNextToNonSolidTile = Factory.CreateBoolSet(false, Cobweb, CopperCoinPile, SilverCoinPile, GoldCoinPile, PlatinumCoinPile, LivingFire, LivingCursedFire, LivingDemonFire, LivingFrostFire, LivingIchor, LivingUltrabrightFire, ChimneySmoke, Bubble, CobwebReplica);
 
 		/// New created sets to facilitate vanilla biome block counting including modded blocks. To replace the current hardcoded counts in SceneMetrics.cs
 		public static int[] CorruptBiome = Factory.CreateIntSet(0, 23, 1, 661, 1, 24, 1, 25, 1, 32, 1, 112, 1, 163, 1, 400, 1, 398, 1, 27, -10);


### PR DESCRIPTION
### What was changed?
Updated some of the ID files with 1.4.5 content.
* `ItemID.TML.cs`: Added the Slime Spear to the `Spears` set.
* `ProjAIStyleID.cs`: Added the new projectile aiStyles.
* `ProjectileID.TML.cs`:
  * Added FreezeBomb, SuperBomb, SuperStickyBomb, and AcornSlingshotAcorn to the `Explosives` set. (Yeah AcornSlingshotAcorn uses aiStyle 16)
    * There's a porting note about explosives being changed, I can investigate that later.
  * Added Cativa, Foxparks, and Digtoise to the `IsInteractable` set.
* `TileID.TML.cs`:
  * Added Demon Altars to the `AvoidedByMeteorLanding` set.
  * Added CobwebReplica to the `CanPlaceNextToNonSolidTile` set.