### PR TITLE
Updated the documentation of StartRain() and StopRain() within Main.cs.

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -128,7 +128,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - MapRenderer class now contains what was Main.mapSectionTexture and mapTarget. Most static fields there should probably be public.
 - New vanilla TooltipLine options. Need to add to docs and decide on name (is there a wiki page as well?): CommonItemTooltip.ItemUnlockedByTeammate, armorPenetration, bonusTagDamage, check for others. Seems like "Social" and "SocialDesc" logic changed, compare tooltips to 1.4.4 and adjust.
 - DrawBlockReplacementIcon return changed from void to bool. Does that affect how the builders toggle works? Did vanilla behavior change? New state bool in logic, and DoStatefulTickSound
-- StartRain method now seems to be more controllable. Update docs accordingly. (StopRain as well)
 - See updated `toolTipNames[numLines] = "UseMana";` patch. Look into IsSpaceGun and GetManaCost, might need updates. 
 - Double check PlayerLoader.ModifyZoom logic. Seems like there is only 1 callsite now, code was cleaned up?
 - What is Main.boulderLogo? Seems like MenuLoader needs to be updated with a new vanilla menu option?

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6759,24 +6759,32 @@
  	public static void NewText(string newText, byte R = byte.MaxValue, byte G = byte.MaxValue, byte B = byte.MaxValue)
  	{
  		chatMonitor.NewText(newText, R, G, B);
-@@ -55915,6 +_,10 @@
+@@ -55915,6 +_,13 @@
  		SoundEngine.PlaySound(12);
  	}
  
 +	/// <summary>
-+	/// Stops rain. Should be called on the server (netMode != client) - vanilla syncs it using <see cref="SyncRain"/>.
-+	/// <br>You can also call this on the client to update visuals immediately, assuming it was called serverside as well (Journey Mode rain slider does this).</br>
++	/// Stops rain. Should be called on the server (netMode != client).<br/>
++	/// Vanilla syncs the result to clients through <see cref="SyncRain"/>.<br/>
++	/// You can also call this on the client to update visuals immediately, assuming it was called serverside as well (Journey Mode rain slider does this).<br/>
++	/// Has no effect if <see cref="IsRainingForever"/> is <see langword="true"/>.<br/>
++	/// If <paramref name="instant"/> is <see langword="true"/>, <see cref="cloudAlpha"/> is snapped to 0f instead of fading out gradually.<br/>
 +	/// </summary>
  	public static void StopRain(bool instant = false)
  	{
  		if (!IsRainingForever) {
-@@ -55927,6 +_,10 @@
+@@ -55927,6 +_,15 @@
  		}
  	}
  
 +	/// <summary>
-+	/// Starts rain for a random amount of time. Should be called on the server (netMode != client) - vanilla syncs it using <see cref="SyncRain"/>.
-+	/// <br>You can also call this on the client to update visuals immediately, assuming it was/will be called serverside as well (Journey Mode rain slider does this).</br>
++	/// Starts rain for a random amount of time, optionally triggering a coin rain. Should be called on the server (netMode != client).<br/>
++	/// Vanilla syncs the result to clients through <see cref="SyncRain"/>.<br/>
++	/// You can also call this on the client to update visuals immediately, assuming it was/will be called server-side as well (Journey Mode rain slider does this).<br/>
++	/// Has no effect on <see cref="rainTime"/> if <see cref="IsRainingForever"/> is <see langword="true"/>.<br/>
++	/// If <paramref name="instant"/> is <see langword="true"/>, <see cref="cloudAlpha"/> jumps to the target rain strength immediately instead of fading in gradually.<br/>
++	/// <paramref name="strengthOverride"/> overrides the rain intensity written to <see cref="maxRaining"/>. When <see langword="null"/>, a random strength is chosen by <see cref="ChangeRain(bool, float?)"/>.<br/>
++	/// If <paramref name="garenteeCoinRain"/> is <see langword="true"/>, forces a coin rain event to start, bypassing the luck-based roll.<br/>
 +	/// </summary>
  	public static void StartRain(bool instant = false, float? strengthOverride = null, bool garenteeCoinRain = false)
  	{


### PR DESCRIPTION
### Why should this be a part of TModLoader?

As per [https://github.com/tModLoader/tModLoader/blob/1.4.5/PortingNotes_1.4.5.md](url), the `StartRain()` and `StopRain()` functions in `Main.cs` needed updated documentation.

> StartRain method now seems to be more controllable. Update docs accordingly. (StopRain as well)

+ Added missing parameter descriptions for `instant`, `strengthOverride` and `garenteeCoinRain`.
+ Documented `IsRainingForever` guard behavior in both methods.
+ Noted coin rain trigger conditions and luck-based roll for `garenteeCoinRain`.
+ Clarified `cloudAlpha` snap/fade behavior for `instant`.