### PR TITLE
[1.4.5] Fix Modded Town NPCs Not Showing Up in the Housing UI

### DIFF
--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -134,7 +134,6 @@ Mods: {
 
 			ExampleTownPet: {
 				DisplayName: Example Town Pet
-				TownNPCMood.NoHome: *Example Town Pet noises*?
 				Census.SpawnCondition: Use an [i:ExampleMod/ExampleTownPetLicense] Example Town Pet License. Purchased from the Zoologist at 50% Bestiary completetion.
 
 				Names: {

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -134,6 +134,7 @@ Mods: {
 
 			ExampleTownPet: {
 				DisplayName: Example Town Pet
+				TownNPCMood.NoHome: *Example Town Pet noises*?
 				Census.SpawnCondition: Use an [i:ExampleMod/ExampleTownPetLicense] Example Town Pet License. Purchased from the Zoologist at 50% Bestiary completetion.
 
 				Names: {

--- a/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCHeadLoader.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Terraria.GameContent;
 using Terraria.Graphics.Renderers;
 using Terraria.ID;
@@ -89,6 +90,13 @@ public static class NPCHeadLoader
 
 		//Etc
 		Array.Resize(ref Main.instance._npcIndexWhoHoldsHeadIndex, nextHead);
+
+		// Add each head to the end of the HeadListOrder so they can be shown in the housing UI.
+		foreach (int head in heads.Values) {
+			if (NPCHeadID.Sets.HeadListOrder.Contains(head))
+				continue;
+			NPCHeadID.Sets.HeadListOrder = NPCHeadID.Sets.HeadListOrder.Append(head).ToArray();
+		}
 	}
 
 	internal static void Unload()


### PR DESCRIPTION
### What is the bug?

1.4.5 introduced a `NPCHeadID.Sets.HeadListOrder` so that vanilla Town NPCs always appeared in the same order in the housing UI. The issue was since modded Town NPCs weren't in that list, their heads wouldn't be drawn in the housing UI (their heads still worked on the map and housing banners, but not in the menu that lets you relocate them).

### How did you fix the bug?

Appended all Town NPC heads to the end of `NPCHeadID.Sets.HeadListOrder` in `NPCHeadLoader.ResizeAndFillArrays`.

This does works for Town NPCs that have multiple head variants like the Town Pets.

### Are there alternatives to your fix?

* I don't know if the check if the set already contains the head is necessary. I added it to prevent possible duplicate entries, but that might not be an issue. Let me know if I should remove it.
* Making `NPCHeadID.Sets.HeadListOrder` a `List<int>` instead of int array would make appending it easier, but this would require a couple of extra patches in `NPCHeadID.Sets` and `Main`. The current approach doesn't require any patches.
* I tried appending the head in `Mod.AddNPCHeadTexture` instead of `NPCHeadLoader.ResizeAndFillArrays`, but for some reason the set would reset after the mods were done loading.
* The order that they appear is based on mod load order and then alphabetically based on the class name. This is how it's always been, but maybe modders might want their own NPCs listed in a specific way. This fix doesn't facilitate that.
