### PR TITLE
[1.4.5] Fix Modded Town NPCs' NoHome Dialogue

### DIFF
--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -134,6 +134,7 @@ Mods: {
 
 			ExampleTownPet: {
 				DisplayName: Example Town Pet
+				TownNPCMood.NoHome: *Example Town Pet noises*?
 				Census.SpawnCondition: Use an [i:ExampleMod/ExampleTownPetLicense] Example Town Pet License. Purchased from the Zoologist at 50% Bestiary completetion.
 
 				Names: {

--- a/patches/tModLoader/Terraria/GameContent/NPCInteractions.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/NPCInteractions.cs.patch
@@ -1,5 +1,13 @@
 --- src/TerrariaNetCore/Terraria/GameContent/NPCInteractions.cs
 +++ src/tModLoader/Terraria/GameContent/NPCInteractions.cs
+@@ -4,6 +_,7 @@
+ using Terraria.GameContent.Achievements;
+ using Terraria.ID;
+ using Terraria.Localization;
++using Terraria.ModLoader;
+ using Terraria.UI;
+ 
+ namespace Terraria.GameContent;
 @@ -191,12 +_,25 @@
  
  			public override void Interact()
@@ -28,3 +36,15 @@
  				Main.GetCoinValueText_Nurse(ref chatColor, ref coinValue);
  				return coinValue > 0;
  			}
+@@ -265,7 +_,10 @@
+ 					text = "Slime" + slimeType + "Chatter";
+ 				}
+ 
++				if (talkNPC.ModNPC is ModNPC modNPC)
++					Main.npcChatText = Language.GetTextValue(modNPC.GetLocalizationKey("TownNPCMood") + ".NoHome");
++				else
+-				Main.npcChatText = Language.GetTextValue(text + ".NoHome");
++					Main.npcChatText = Language.GetTextValue(text + ".NoHome");
+ 				Main.npcChatText += "\n\n";
+ 				if (talkNPC.type == 160) {
+ 					Main.npcChatText += Language.GetTextValueWith("HousingText.HousingRequirements_Truffle", new {


### PR DESCRIPTION
### What is the bug?
If a Town NPC is homeless, the Housing button when speaking to them has the Town NPC's NoHome quote as well as a message about valid housing. If the Town NPC is a modded one, it was trying to use the wrong localization key resulting in something like "TownNPCMood_ModName/NPCName.NoHome".

### How did you fix the bug?
If the Town NPC is a ModNPC, it uses a different localization key. This is similar to how `ShopHelper.AddHappinessReportText` changes the localization key if it is a ModNPC.

### Are there alternatives to your fix?
Unlikely

### TODO For the Future
Add some way to change the housing requirement text. Maybe tie it into `ModNPC.CheckConditions` which is where any housing requirement changes would be made.