### PR TITLE
[1.4.5] Re-Enable Liquid Edge Rendering

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
+++ b/patches/tModLoader/Terraria/GameContent/Liquid/LiquidEdgeRenderer.cs
@@ -74,7 +74,7 @@ public static class LiquidEdgeRenderer
 		edgeSpans.Clear();
 	}
 
-	public static void DrawTileMask(SpriteBatch spriteBatch, RenderTarget2D tileTarget, Vector2 tileTargetOffset)
+	public static void DrawTileMask(SpriteBatch spriteBatch, Texture2D tileTarget, Vector2 tileTargetOffset)
 	{
 		spriteBatch.End();
 		spriteBatch.Begin(SpriteSortMode.Deferred, MaskingBlendState, Main.DefaultSamplerState, DepthStencilState.None, RasterizerState.CullNone, MaskShader);
@@ -138,12 +138,10 @@ public static class LiquidEdgeRenderer
 
 	private static void DrawScreenTargetSlices(SpriteBatch spriteBatch, EdgeSpan span)
 	{
-		/* TODO: Restore edits.
 		Vector2 position = new Vector2(span.X * 16, span.YStart * 16) + new Vector2(Main.drawToScreen ? 0 : Main.offScreenRange) - Main.screenPosition;
 
-		var offset = Main.sceneTilePos;
-		spriteBatch.Draw(Main.tileTarget, position, new Rectangle(span.X * 16 - (int)offset.X, span.YStart * 16 - (int)offset.Y, 16, 16 * span.Height), Color.White, 0f, Vector2.Zero, 1f, 0, 0f);
-		*/
+		var offset = Main.tileTarget.Position;
+		spriteBatch.Draw(Main.tileTarget.Texture, position, new Rectangle(span.X * 16 - (int)offset.X, span.YStart * 16 - (int)offset.Y, 16, 16 * span.Height), Color.White, 0f, Vector2.Zero, 1f, 0, 0f);
 	}
 
 	public static unsafe void CollectEdgeData(LiquidRenderer.LiquidCache* pCache, Tile tileCache, int tileX, int tileY)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6224,15 +6224,13 @@
  			if (IsLiquidStyleWater(j) && liquidAlpha[j] > 0f && j != waterStyle) {
  				DrawLiquid(isBackground, j, isBackground ? 1f : liquidAlpha[j], waterOnly: true);
  				flag = true;
-@@ -49753,9 +_,14 @@
+@@ -49753,9 +_,12 @@
  			TimeLogger.DrawBackgroundWaterTiles.AddTime(fromTimestamp);
  		else
  			TimeLogger.DrawWaterTiles.AddTime(fromTimestamp);
 +
-+		/* TODO: What is sceneTilePos now?
 +		if (LiquidEdgeRenderer.Active && !drawToScreen)
-+			LiquidEdgeRenderer.DrawTileMask(spriteBatch, tileTarget, sceneTilePos - screenPosition + new Vector2(drawToScreen ? 0 : offScreenRange));
-+		*/
++			LiquidEdgeRenderer.DrawTileMask(spriteBatch, tileTarget.Texture, tileTarget.Position - screenPosition + new Vector2(drawToScreen ? 0 : offScreenRange));
  	}
  
 -	protected void DrawLiquid(bool bg, int waterStyle, float Alpha = 1f, bool waterOnly = false)


### PR DESCRIPTION
simple fix

1.4.5.6 also made the DrawBlack patch redundant, but I didn't touch it here because it doesn't matter (the code isn't run).