### PR TITLE
[1.4.5] Add missing MapLayers

### DIFF
--- a/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
+++ b/patches/tModLoader/Terraria/Map/IMapLayer.TML.cs
@@ -2,7 +2,9 @@
 
 public partial interface IMapLayer
 {
+	public static IMapLayer BossBag { get; private set; } = new BossBagMapLayer();
 	public static IMapLayer Spawn { get; private set; } = new SpawnMapLayer();
+	public static IMapLayer TeamBasedSpawn { get; private set; } = new TeamBasedSpawnMapLayer();
 	public static IMapLayer Pylons { get; private set; } = new TeleportPylonsMapLayer();
 	public static IMapLayer Pings { get; private set; } = new PingMapLayer();
 

--- a/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MapLayerLoader.cs
@@ -10,7 +10,9 @@ public static class MapLayerLoader
 	public static int MapLayerCount => MapLayers.Count;
 
 	internal static readonly List<IMapLayer> MapLayers = [
+		IMapLayer.BossBag,
 		IMapLayer.Spawn,
+		IMapLayer.TeamBasedSpawn,
 		IMapLayer.Pylons,
 		IMapLayer.Pings
 	];


### PR DESCRIPTION
### What is the bug?
The new 1.4.5 Map Layers `BossBagMapLayer` and `TeamBasedSpawnMapLayer` were not being displayed in game.
### How did you fix the bug?
Added those layers to `MapLayerLoader`.
### Are there alternatives to your fix?
No.
