### PR TITLE
[1.4.5] Make SceneState.ManageSpecialBiomeVisuals public

### DIFF
--- a/patches/tModLoader/Terraria/SceneState.cs.patch
+++ b/patches/tModLoader/Terraria/SceneState.cs.patch
@@ -1,0 +1,12 @@
+--- src/TerrariaNetCore/Terraria/SceneState.cs
++++ src/tModLoader/Terraria/SceneState.cs
+@@ -292,7 +_,8 @@
+ 			MoveTowards(ref Main.shimmerAlpha, 0f, 0.05f);
+ 	}
+ 
++	// TML: Made public
+-	private void ManageSpecialBiomeVisuals(string biomeName, bool inZone, Vector2 activationSource = default(Vector2), bool alwaysInstant = false)
++	public void ManageSpecialBiomeVisuals(string biomeName, bool inZone, Vector2 activationSource = default(Vector2), bool alwaysInstant = false)
+ 	{
+ 		if (SkyManager.Instance[biomeName] != null && inZone != SkyManager.Instance[biomeName].IsActive()) {
+ 			if (inZone)


### PR DESCRIPTION
This PR simply publicizes ``SceneState.ManageSpecialBiomeVisuals``, as it was a public method in the ``Player`` class in 1.4.4 used by modders.

If another approach would be preferable, this PR can be closed