### PR TITLE
1.4.4 Alert User to Changes in Visibility of Mods they are subbed to and include reupload scenario

### DIFF
--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nAktualisierte Mods:",
 		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		"DependenciesNeededForOtherMods": "\nEinige Abhängigkeiten fehlen:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Installiere Abhängigkeiten",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nUpdated Mods:",
 		"ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		"DependenciesNeededForOtherMods": "\nSome dependencies are missing:",
+		"RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		"ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Install Dependencies",
 		"RedownloadMods": "Redownload Mods",
 		"InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nMods actualizados:",
 		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		"DependenciesNeededForOtherMods": "\nFaltan algunas dependencias:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Instalar dependencias",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nMods mis à jour:",
 		"ShowRemovedModsInfoMessageUpdatedMods": "\nMods supprimés depuis la dernière session. Si certains de ces mods ont été retirés par erreur, cliquez sur 'Télécharcher les dépendances' pour pouvoir les retélecharger",
 		"DependenciesNeededForOtherMods": "\nDes dépendances sont manquantes:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Installer les dépendances",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -27,6 +27,8 @@
 		// "ShowNewUpdatedModsInfoMessageUpdatedMods": "\nUpdated Mods:",
 		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		// "DependenciesNeededForOtherMods": "\nSome dependencies are missing:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		// "InstallDependencies": "Install Dependencies",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nZaktualizowane mody:",
 		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		"DependenciesNeededForOtherMods": "\nBrakuje niektórych zależności:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Zainstaluj zależności",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nMods atualizados:",
 		// "ShowRemovedModsInfoMessageUpdatedMods": "\nRemoved Mods since last session. If any of these were removed in error, please click 'Redownload Mods' to have the option to redownload",
 		"DependenciesNeededForOtherMods": "\nAlgumas dependências estão ausentes:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Instalar Dependências",
 		// "RedownloadMods": "Redownload Mods",
 		// "InstallDependenciesAndRedownloadMods": "Install Dependencies and Redownload Mods",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -25,6 +25,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\nБыли обновлены следующие моды:",
 		"ShowRemovedModsInfoMessageUpdatedMods": "\nС последнего запуска были удалены моды. Если какие-то из них удалены по ошибке, нажмите «Повторно скачать моды», чтобы появилась возможность повторно их скачать.",
 		"DependenciesNeededForOtherMods": "\nОтсутствуют некоторые зависимости:",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "Установить зависимости",
 		"RedownloadMods": "Повторно скачать моды",
 		"InstallDependenciesAndRedownloadMods": "Установить зависимости и повторно скачать моды",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -27,6 +27,8 @@
 		"ShowNewUpdatedModsInfoMessageUpdatedMods": "\n更新模组：",
 		"ShowRemovedModsInfoMessageUpdatedMods": "\n自上次启动以来，以下模组已被删除。 如果有模组被误删，请点击“重新下载模组”以重新下载。",
 		"DependenciesNeededForOtherMods": "\n以下依赖缺失：",
+		// "RemovedWorkshopMods": "These mods were found installed by Steam but aren't visible on Workshop today.\nThis could be anything from malware to DMCA to it simply being made private. Delete?",
+		// "ReuploadedWorkshopMods": "These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?",
 		"InstallDependencies": "安装依赖",
 		"RedownloadMods": "重新下载模组",
 		"InstallDependenciesAndRedownloadMods": "安装依赖并重新下载模组",

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -247,14 +247,14 @@ internal static class ModOrganizer
 		var messages = new StringBuilder();
 
 		if (abnormalWorkshopDownloads.Any()) {
-			messages.AppendLine("These mods were found installed by Steam but aren't visible on Workshop today. Delete?");
+			messages.AppendLine(Language.GetTextValue("tModLoader.RemovedWorkshopMods"));
 			foreach (var mod in abnormalWorkshopDownloads) {
 				messages.AppendLine($"  {mod.DisplayNameClean}");
 			}
 		}
 		
 		if (reuploadMDItems.Any()) {
-			messages.AppendLine("These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?");
+			messages.AppendLine(Language.GetTextValue("tModLoader.ReuploadedWorkshopMods"));
 			foreach (var mod in reuploadMDItems) {
 				messages.AppendLine($"  {mod.DisplayNameClean}");
 			}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -204,6 +204,19 @@ internal static class ModOrganizer
 		return modPath.Contains(Path.Combine("workshop"), StringComparison.InvariantCultureIgnoreCase);
 	}
 
+	internal static HashSet<string> DetectAbnormalSteamWorkshopDownloads(out Action resolveAbnormalDownloads)
+	{
+		// During initialize it forces update of CachedInstalledModDownloadItems
+		WorkshopBrowserModule.Instance.Initialize();
+		var foundMDItems = WorkshopBrowserModule.Instance.CachedInstalledModDownloadItems;
+
+		var workshopDownloads = FindWorkshopMods();
+
+		// if workshopDownloads has a mod not in foundMDItems, then what
+
+		// if foundMDItems has a mod that is newer then those in workshopDownloads, then what
+	}
+
 	internal static HashSet<string> IdentifyMissingWorkshopDependencies()
 	{
 		var mods = FindWorkshopMods();

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,12 +5,16 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.CodeAnalysis;
+using Newtonsoft.Json;
 using Terraria.Localization;
 using Terraria.ModLoader.Exceptions;
 using Terraria.ModLoader.UI;
 using Terraria.ModLoader.UI.DownloadManager;
+using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.Social.Base;
 using Terraria.Social.Steam;
+using static Terraria.Social.Steam.WorkshopHelper.UGCBased;
 
 namespace Terraria.ModLoader.Core;
 
@@ -204,17 +206,61 @@ internal static class ModOrganizer
 		return modPath.Contains(Path.Combine("workshop"), StringComparison.InvariantCultureIgnoreCase);
 	}
 
-	internal static HashSet<string> DetectAbnormalSteamWorkshopDownloads(out Action resolveAbnormalDownloads)
+	internal static string DetectAbnormalSteamWorkshopDownloads(out Action resolveAbnormalDownloads)
 	{
 		// During initialize it forces update of CachedInstalledModDownloadItems
 		WorkshopBrowserModule.Instance.Initialize();
+
 		var foundMDItems = WorkshopBrowserModule.Instance.CachedInstalledModDownloadItems;
 
-		var workshopDownloads = FindWorkshopMods();
+		// if found installed mod download item that is newer then those in workshopDownloads and under a different publish ID
+		var reuploadMDItems = foundMDItems.Where(a => a.Installed is null);
 
-		// if workshopDownloads has a mod not in foundMDItems, then what
+		// if a local mod is installed and it doesn't have a corresponding workshop publish item AND isn't the reupload case
+		var abnormalWorkshopDownloads = FindWorkshopMods().Except(foundMDItems.Select(a => a.Installed));
 
-		// if foundMDItems has a mod that is newer then those in workshopDownloads, then what
+		if (!reuploadMDItems.Any() && !abnormalWorkshopDownloads.Any()) {
+			resolveAbnormalDownloads = null;
+			return string.Empty;
+		}
+
+		var toDeleteOldMods = abnormalWorkshopDownloads.Where(a => reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
+		abnormalWorkshopDownloads = abnormalWorkshopDownloads.Where(a => !reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
+
+		resolveAbnormalDownloads = async () => {
+			// Group 1: If the mod is Reuploaded, delete the old and sub to the new.
+			foreach (var mod in toDeleteOldMods)
+				DeleteMod(mod);
+
+			if (reuploadMDItems.Any()) {
+				await UIModBrowser.DownloadMods(
+					reuploadMDItems,
+					Interface.loadModsID);
+			}
+
+			// Group 2: Delete mods that originated from workshop but workshop doesn't have a replacement
+			foreach (var mod in abnormalWorkshopDownloads)
+				DeleteMod(mod);
+		};
+
+		// Messages for Users
+		var messages = new StringBuilder();
+
+		if (abnormalWorkshopDownloads.Any()) {
+			messages.AppendLine("These mods were found installed by Steam but aren't visible on Workshop today. Delete?");
+			foreach (var mod in abnormalWorkshopDownloads) {
+				messages.AppendLine($"  {mod.DisplayNameClean}");
+			}
+		}
+		
+		if (reuploadMDItems.Any()) {
+			messages.AppendLine("These mods were reuploaded to Steam under a new Publish ID. Transfer your subscription?");
+			foreach (var mod in reuploadMDItems) {
+				messages.AppendLine($"  {mod.DisplayNameClean}");
+			}
+		}
+
+		return messages.Length > 0 ? messages.ToString() : null;
 	}
 
 	internal static HashSet<string> IdentifyMissingWorkshopDependencies()

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -213,7 +213,7 @@ internal static class ModOrganizer
 		var foundMDItems = WorkshopBrowserModule.Instance.CachedInstalledModDownloadItems;
 
 		// if found installed mod download item that is newer then those in workshopDownloads and under a different publish ID
-		var reuploadMDItems = foundMDItems.Where(a => a.Installed is null);
+		var reuploadMDItems = foundMDItems.Where(a => a.IsReupload());
 
 		// if a local mod is installed and it doesn't have a corresponding workshop publish item AND isn't the reupload case
 		var abnormalWorkshopDownloads = FindWorkshopMods().Except(foundMDItems.Select(a => a.Installed));

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -216,15 +216,15 @@ internal static class ModOrganizer
 		var reuploadMDItems = foundMDItems.Where(a => a.IsReupload());
 
 		// if a local mod is installed and it doesn't have a corresponding workshop publish item AND isn't the reupload case
-		var abnormalWorkshopDownloads = FindWorkshopMods().Except(foundMDItems.Select(a => a.Installed));
+		var installedWorkshopModsNotFoundOnWorkshop = FindWorkshopMods().Except(foundMDItems.Select(a => a.Installed));
 
-		if (!reuploadMDItems.Any() && !abnormalWorkshopDownloads.Any()) {
+		if (!reuploadMDItems.Any() && !installedWorkshopModsNotFoundOnWorkshop.Any()) {
 			resolveAbnormalDownloads = null;
 			return string.Empty;
 		}
 
-		var toDeleteOldMods = abnormalWorkshopDownloads.Where(a => reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
-		abnormalWorkshopDownloads = abnormalWorkshopDownloads.Where(a => !reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
+		var toDeleteOldMods = installedWorkshopModsNotFoundOnWorkshop.Where(a => reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
+		installedWorkshopModsNotFoundOnWorkshop = installedWorkshopModsNotFoundOnWorkshop.Where(a => !reuploadMDItems.Select(b => b.ModName).Contains(a.Name));
 
 		resolveAbnormalDownloads = async () => {
 			// Group 1: If the mod is Reuploaded, delete the old and sub to the new.
@@ -238,16 +238,16 @@ internal static class ModOrganizer
 			}
 
 			// Group 2: Delete mods that originated from workshop but workshop doesn't have a replacement
-			foreach (var mod in abnormalWorkshopDownloads)
+			foreach (var mod in installedWorkshopModsNotFoundOnWorkshop)
 				DeleteMod(mod);
 		};
 
 		// Messages for Users
 		var messages = new StringBuilder();
 
-		if (abnormalWorkshopDownloads.Any()) {
+		if (installedWorkshopModsNotFoundOnWorkshop.Any()) {
 			messages.AppendLine(Language.GetTextValue("tModLoader.RemovedWorkshopMods"));
-			foreach (var mod in abnormalWorkshopDownloads) {
+			foreach (var mod in installedWorkshopModsNotFoundOnWorkshop) {
 				messages.AppendLine($"  {mod.DisplayNameClean}");
 			}
 		}

--- a/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/ModOrganizer.cs
@@ -14,7 +14,6 @@ using Terraria.ModLoader.UI.DownloadManager;
 using Terraria.ModLoader.UI.ModBrowser;
 using Terraria.Social.Base;
 using Terraria.Social.Steam;
-using static Terraria.Social.Steam.WorkshopHelper.UGCBased;
 
 namespace Terraria.ModLoader.Core;
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -193,6 +193,9 @@ internal static class Interface
 				var missingDeps = ModOrganizer.IdentifyMissingWorkshopDependencies().ToList();
 
 				string message = $"{ModOrganizer.DetectModChangesForInfoMessage(out IEnumerable<string> removedMods)}";
+				if (message.Length > 0)
+					message += "\n";
+
 				message += ModOrganizer.DetectAbnormalSteamWorkshopDownloads(out Action resolveAbnormalDownloads);
 
 				if (missingDeps.Any()) {

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -189,6 +189,10 @@ internal static class Interface
 			else if (!ModLoader.DownloadedDependenciesOnStartup) { // Keep this at the end of the if/else chain since it doesn't necessarily change Main.menuMode
 				ModLoader.DownloadedDependenciesOnStartup = true;
 
+				// https://github.com/tModLoader/tModLoader/pull/5071#discussion_r3031162540
+				// The UI here needs some sort of refactor. There is 4 or 5 different systems now running through this UI.
+				// Fix before 1.4.5 release.
+
 				// Find dependencies that need to be downloaded.
 				var missingDeps = ModOrganizer.IdentifyMissingWorkshopDependencies().ToList();
 

--- a/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/Interface.cs
@@ -193,16 +193,19 @@ internal static class Interface
 				var missingDeps = ModOrganizer.IdentifyMissingWorkshopDependencies().ToList();
 
 				string message = $"{ModOrganizer.DetectModChangesForInfoMessage(out IEnumerable<string> removedMods)}";
+				message += ModOrganizer.DetectAbnormalSteamWorkshopDownloads(out Action resolveAbnormalDownloads);
+
 				if (missingDeps.Any()) {
 					message += $"{Language.GetTextValue("tModLoader.DependenciesNeededForOtherMods")}\n  {string.Join("\n  ", missingDeps)}";
 				}
 				message = message.Trim('\n');
 
 				bool anyMissingDependency = missingDeps.Any();
-				bool anyRemovedMod = removedMods.Any();
+				bool anyRemovedMod = removedMods.Any() || resolveAbnormalDownloads is not null;
 				bool promptDepDownloads = anyMissingDependency || anyRemovedMod;
 
 				string cancelButton = promptDepDownloads ? Language.GetTextValue("tModLoader.ContinueAnyway") : null;
+
 				string continueButton = "";
 				if (anyMissingDependency && anyRemovedMod)
 					continueButton = Language.GetTextValue("tModLoader.InstallDependenciesAndRedownloadMods");
@@ -236,6 +239,10 @@ internal static class Interface
 							downloads,
 							loadModsID);
 					}
+
+					//TODO: This code was added hastily in response to a reasonably popular mod being hit by a DMCA and reuploading it.
+					// Revisit this code at a later date. Its not apparent how well the interaction of both dependencies and removed mods will play out in terms of UX
+					resolveAbnormalDownloads?.Invoke();
 
 					//TODO: This code was added hastily in response to a popular mod being transferred ownership by reuploading it.
 					// Revisit this code at a later date. Its not apparent how well the interaction of both dependencies and removed mods will play out in terms of UX

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Terraria.ModLoader.Core;
 using Terraria.Social.Base;
+using Terraria.Social.Steam;
 
 namespace Terraria.ModLoader.UI.ModBrowser;
 
@@ -30,10 +31,16 @@ public class ModDownloadItem
 	public readonly string Homepage;
 	public readonly Version ModloaderVersion;
 
-	internal LocalMod Installed;
+	/// <summary>
+	/// WARNING: If UpdateInstallState() hasn't been called, then this will be null.
+	/// </summary>
+	internal LocalMod Installed { get; set; }
 	public bool NeedUpdate { get; private set; }
 	public bool AppNeedRestartToReinstall { get; private set; }
 
+	/// <summary>
+	/// WARNING: If UpdateInstallState() hasn't been called, then this will be false
+	/// </summary>
 	public bool IsInstalled => Installed != null;
 
 	public ModDownloadItem(string displayName, string name, Version version, string author, string modReferences, ModSide modSide, string modIconUrl, string publishId, int downloads, int hot, DateTime timeStamp, Version modloaderversion, string homepage, string ownerId, string[] referencesById, bool banned, DeveloperMetadata devMetadata)
@@ -71,6 +78,14 @@ public class ModDownloadItem
 		// The below line is to identify the transient state where it isn't installed, but Steam considers it as such - Solxan
 		// Steam keeps a cache once a download starts, and doesn't clean up cache until game close, which gets very confusing.
 		AppNeedRestartToReinstall = Installed == null && Interface.modBrowser.SocialBackend.DoesAppNeedRestartToReinstallItem(PublishId);
+	}
+
+	internal bool IsReupload()
+	{
+		if (!WorkshopHelper.GetPublishIdLocal(Installed.modFile, out var localPublishId))
+			return false;
+
+		return localPublishId.ToString() != PublishId.m_ModPubId;
 	}
 
 	public override bool Equals(object obj) => Equals(obj as ModDownloadItem);

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -31,16 +31,9 @@ public class ModDownloadItem
 	public readonly string Homepage;
 	public readonly Version ModloaderVersion;
 
-	/// <summary>
-	/// WARNING: If UpdateInstallState() hasn't been called, then this will be null.
-	/// </summary>
 	internal LocalMod Installed { get; set; }
 	public bool NeedUpdate { get; private set; }
 	public bool AppNeedRestartToReinstall { get; private set; }
-
-	/// <summary>
-	/// WARNING: If UpdateInstallState() hasn't been called, then this will be false
-	/// </summary>
 	public bool IsInstalled => Installed != null;
 
 	public ModDownloadItem(string displayName, string name, Version version, string author, string modReferences, ModSide modSide, string modIconUrl, string publishId, int downloads, int hot, DateTime timeStamp, Version modloaderversion, string homepage, string ownerId, string[] referencesById, bool banned, DeveloperMetadata devMetadata)
@@ -76,7 +69,7 @@ public class ModDownloadItem
 		//TODO: This should assess the source of the ModDownloadItem and ensure matches with the active SocialBrowserModule instance for safety, but eh.
 		Installed = Interface.modBrowser.SocialBackend.IsItemInstalled(ModName);
 
-		NeedUpdate = Installed != null && Interface.modBrowser.SocialBackend.DoesItemNeedUpdate(PublishId, Installed, Version);
+		NeedUpdate = IsInstalled && Interface.modBrowser.SocialBackend.DoesItemNeedUpdate(PublishId, Installed, Version);
 		
 		// The below line is to identify the transient state where it isn't installed, but Steam considers it as such - Solxan
 		// Steam keeps a cache once a download starts, and doesn't clean up cache until game close, which gets very confusing.

--- a/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/UI/ModBrowser/ModDownloadItem.cs
@@ -64,6 +64,8 @@ public class ModDownloadItem
 		ModloaderVersion = modloaderversion;
 		Banned = banned;
 		DevMetadata = devMetadata;
+
+		UpdateInstallState();
 	}
 
 	internal void UpdateInstallState()
@@ -75,6 +77,7 @@ public class ModDownloadItem
 		Installed = Interface.modBrowser.SocialBackend.IsItemInstalled(ModName);
 
 		NeedUpdate = Installed != null && Interface.modBrowser.SocialBackend.DoesItemNeedUpdate(PublishId, Installed, Version);
+		
 		// The below line is to identify the transient state where it isn't installed, but Steam considers it as such - Solxan
 		// Steam keeps a cache once a download starts, and doesn't clean up cache until game close, which gets very confusing.
 		AppNeedRestartToReinstall = Installed == null && Interface.modBrowser.SocialBackend.DoesAppNeedRestartToReinstallItem(PublishId);
@@ -82,6 +85,9 @@ public class ModDownloadItem
 
 	internal bool IsReupload()
 	{
+		if (Installed is null)
+			return false;
+
 		if (!WorkshopHelper.GetPublishIdLocal(Installed.modFile, out var localPublishId))
 			return false;
 
@@ -116,7 +122,6 @@ public class ModDownloadItem
 			if (item == null)
 				return false;
 
-			item.UpdateInstallState();
 			return !item.IsInstalled || item.NeedUpdate;
 		});
 	}

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -66,6 +66,9 @@ public interface SocialBrowserModule
 		var listIds = new List<ModPubId_t>();
 		var modSlugs = new List<string>();
 
+		// We provide both the Mod Internal Name (Slug) and Publish ID
+		// This allows us to find a local mod on workshop that is no longer available under the original Publish ID (Author transfer / DMCA reupload)
+		// This recovery method works because Steam does not delete files from users during the 30 days of DMCA claim processing or when items are 'hidden' via incompatible flag
 		foreach (var mod in mods) {
 			if (GetModIdFromLocalFiles(mod.modFile, out var id)) {
 				listIds.Add(id);

--- a/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Base/SocialBrowserModule.cs
@@ -64,13 +64,17 @@ public interface SocialBrowserModule
 	public List<ModDownloadItem> DirectQueryInstalledMDItems(QueryParameters qParams = new QueryParameters()) {
 		var mods = GetInstalledMods();
 		var listIds = new List<ModPubId_t>();
+		var modSlugs = new List<string>();
 
 		foreach (var mod in mods) {
-			if (GetModIdFromLocalFiles(mod.modFile, out var id))
+			if (GetModIdFromLocalFiles(mod.modFile, out var id)) {
 				listIds.Add(id);
+				modSlugs.Add(mod.Name);
+			}
 		}
 
 		qParams.searchModIds = listIds.ToArray();
+		qParams.searchModSlugs = modSlugs.ToArray();
 
 		return DirectQueryItems(qParams, out _);
 	}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopBrowserModule.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopBrowserModule.cs
@@ -91,7 +91,6 @@ internal class WorkshopBrowserModule : SocialBrowserModule
 	// assumes SteamAvailable
 	public void DownloadItem(ModDownloadItem item, IDownloadProgress uiProgress)
 	{
-		item.UpdateInstallState();
 		if (item.Banned)
 			throw new BannedModException($"Attempted to Download a Banned Mod {item.DisplayName} with ID {item.PublishId}. Aborting...", item.DisplayName, item.PublishId.ToString());
 

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -456,8 +456,6 @@ public partial class WorkshopHelper
 			/// <summary>
 			/// Only Use if we don't have a PublishID source.
 			/// This method does NOT guard against banned items. Plan usage accordingly.
-			/// This method does not call item.UpdateInstallState so item.Installed will be null until called;
-			/// Installed status can take some time, so it is left to downsteam callers
 			/// </summary>
 			internal static WorkshopSearchReturnState TryGetModDownloadItem(string modSlug, out ModDownloadItem item)
 			{
@@ -478,7 +476,6 @@ public partial class WorkshopHelper
 			/// <summary>
 			/// Only Use if we don't have a PublishID source.
 			/// This method does NOT guard against banned items. Plan usage accordingly.
-			/// This method does not call item.UpdateInstallState so item.Installed will be null until called. 
 			/// </summary>
 			private WorkshopSearchReturnState TrySearchByInternalName(string slug, out ModDownloadItem item)
 			{

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -341,16 +341,14 @@ public partial class WorkshopHelper
 					}
 
 					// Check if any of the mods flagged for reupload review are actually reuploaded or if the user has a now hidden mod
-					try {
-						foreach (var item in checkReupload) {
-							var match2 = TryGetModDownloadItem(item, out var reupload);
-							if (match2 == WorkshopSearchReturnState.Success) {
-								items.Add(reupload);
-							}
+					foreach (var item in checkReupload) {
+						var match2 = TryGetModDownloadItem(item, out var reupload);
+						if (match2 == WorkshopSearchReturnState.Success) {
+							// We intentionally don't call UpdateInstallStatus here; this is to ensure we know that it has been reuploaded
+							// Specifically, although from a ModName/Slug standpoint it is installed, it is not installed from a PublishID standpoint.
+							reupload.UpdateInstallState();
+							items.Add(reupload);
 						}
-					}
-					finally {
-						ReleaseWorkshopQuery();
 					}
 				}
 
@@ -448,6 +446,12 @@ public partial class WorkshopHelper
 				return true;
 			}
 
+			/// <summary>
+			/// Only Use if we don't have a PublishID source.
+			/// This method does NOT guard against banned items. Plan usage accordingly.
+			/// This method does not call item.UpdateInstallState so item.Installed will be null until called;
+			/// Installed status can take some time, so it is left to downsteam callers
+			/// </summary>
 			internal static WorkshopSearchReturnState TryGetModDownloadItem(string modSlug, out ModDownloadItem item)
 			{
 				var query = new AQueryInstance(new QueryParameters() { queryType = QueryType.SearchDirect, returnDevMetadata = true });
@@ -466,7 +470,8 @@ public partial class WorkshopHelper
 
 			/// <summary>
 			/// Only Use if we don't have a PublishID source.
-			/// This method does NOT guard against banned items. Plan usage accordingly
+			/// This method does NOT guard against banned items. Plan usage accordingly.
+			/// This method does not call item.UpdateInstallState so item.Installed will be null until called. 
 			/// </summary>
 			private WorkshopSearchReturnState TrySearchByInternalName(string slug, out ModDownloadItem item)
 			{

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -304,6 +304,7 @@ public partial class WorkshopHelper
 				for (int i = 0; i < numPages; i++) {
 					var pageIds = queryParameters.searchModIds.Take(new Range(i * Constants.kNumUGCResultsPerPage, Constants.kNumUGCResultsPerPage * (i + 1)));
 					var idArray = pageIds.Select(x => x.m_ModPubId).ToArray();
+					var checkReupload = new List<string>();
 
 					try {
 						WaitForQueryResult(SteamedWraps.GenerateDirectItemsQuery(idArray, queryParameters));
@@ -311,8 +312,20 @@ public partial class WorkshopHelper
 						for (int j = 0; j < _queryReturnCount; j++) {
 							var itemsIndex = j + i * Constants.kNumUGCResultsPerPage;
 							var match = TryGenerateModDownloadItem((uint)j, out var item);
-							if (match != WorkshopSearchReturnState.Success) {
 
+							// Check for reupload when searchModSlugs is provided
+							if ((item.Banned || match == WorkshopSearchReturnState.NotFound)
+								&& queryParameters.searchModSlugs?.Length == queryParameters.searchModIds.Length) {
+
+								// Currently, only known case is if a mod the user is subbed to is set to hidden & not deleted by the user
+								// Includes DMCA'd mods and banned mods
+								Logging.tML.Warn($"Unable to find Mod with ID {idArray[j]} on the Steam Workshop");
+								missingMods.Add(idArray[j]);
+								checkReupload.Add(queryParameters.searchModSlugs[itemsIndex]);
+								continue;
+							}
+
+							if (match != WorkshopSearchReturnState.Success) {		
 								// Currently, only known case is if a mod the user is subbed to is set to hidden & not deleted by the user
 								Logging.tML.Warn($"Unable to find Mod with ID {idArray[j]} on the Steam Workshop");
 								missingMods.Add(idArray[j]);
@@ -321,6 +334,19 @@ public partial class WorkshopHelper
 
 							item.UpdateInstallState();
 							items.Add(item);
+						}
+					}
+					finally {
+						ReleaseWorkshopQuery();
+					}
+
+					// Check if any of the mods flagged for reupload review are actually reuploaded or if the user has a now hidden mod
+					try {
+						foreach (var item in checkReupload) {
+							var match2 = TryGetModDownloadItem(item, out var reupload);
+							if (match2 == WorkshopSearchReturnState.Success) {
+								items.Add(reupload);
+							}
 						}
 					}
 					finally {

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -332,7 +332,6 @@ public partial class WorkshopHelper
 								continue;
 							}
 
-							item.UpdateInstallState();
 							items.Add(item);
 						}
 					}
@@ -344,9 +343,6 @@ public partial class WorkshopHelper
 					foreach (var item in checkReupload) {
 						var match2 = TryGetModDownloadItem(item, out var reupload);
 						if (match2 == WorkshopSearchReturnState.Success) {
-							// We intentionally don't call UpdateInstallStatus here; this is to ensure we know that it has been reuploaded
-							// Specifically, although from a ModName/Slug standpoint it is installed, it is not installed from a PublishID standpoint.
-							reupload.UpdateInstallState();
 							items.Add(reupload);
 						}
 					}

--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -313,21 +313,30 @@ public partial class WorkshopHelper
 							var itemsIndex = j + i * Constants.kNumUGCResultsPerPage;
 							var match = TryGenerateModDownloadItem((uint)j, out var item);
 
-							// Check for reupload when searchModSlugs is provided
-							if ((item.Banned || match == WorkshopSearchReturnState.NotFound)
-								&& queryParameters.searchModSlugs?.Length == queryParameters.searchModIds.Length) {
-
+							// Because we are directly querying the state of the mod via its publish ID, developers are able to see that it is banned.
+							// For regular users, they will see WorkshopState NotFound. The banned state includes DMCA and Malware, so its a mix bag
+							if (match == WorkshopSearchReturnState.Success && item.Banned) {
 								// Currently, only known case is if a mod the user is subbed to is set to hidden & not deleted by the user
-								// Includes DMCA'd mods and banned mods
-								Logging.tML.Warn($"Unable to find Mod with ID {idArray[j]} on the Steam Workshop");
+								// Includes 'Hide As Incompatible', Changes in Visibility (Friends-Only, Private), and as of April 2026 banned states (DMCA, Malware)
+								Logging.tML.Warn($"Mod ID {idArray[j]} is banned on Steam Workshop. Consult a developer for more details");
+								missingMods.Add(idArray[j]);
+								//checkReupload.Add(queryParameters.searchModSlugs[itemsIndex]); // Enable this line if doing dev testing for NotFound state in DMCA
+								continue;
+							}
+
+							// Check for reupload when searchModSlugs is provided
+							if (match == WorkshopSearchReturnState.NotFound	&& queryParameters.searchModSlugs?.Length == queryParameters.searchModIds.Length) {
+								// Currently, only known case is if a mod the user is subbed to is set to hidden & not deleted by the user
+								// Includes 'Hide As Incompatible', Changes in Visibility (Friends-Only, Private), and as of April 2026 banned states (DMCA, Malware)
+								Logging.tML.Warn($"Mod ID {idArray[j]} Not Found on the Steam Workshop. Queuing for Search by Slug {queryParameters.searchModSlugs[itemsIndex]}");
 								missingMods.Add(idArray[j]);
 								checkReupload.Add(queryParameters.searchModSlugs[itemsIndex]);
 								continue;
 							}
 
 							if (match != WorkshopSearchReturnState.Success) {		
-								// Currently, only known case is if a mod the user is subbed to is set to hidden & not deleted by the user
-								Logging.tML.Warn($"Unable to find Mod with ID {idArray[j]} on the Steam Workshop");
+								// This would be the case if Steam workshop failed to respond or the mod item is corrupt
+								Logging.tML.Warn($"{match}: Search Attempt Failed for Mod with ID {idArray[j]}");
 								missingMods.Add(idArray[j]);
 								continue;
 							}
@@ -340,6 +349,8 @@ public partial class WorkshopHelper
 					}
 
 					// Check if any of the mods flagged for reupload review are actually reuploaded or if the user has a now hidden mod
+					// As per the method description, we've intentionally ensured that all upstream functions do not need to care about order.
+					// The mod is either found or in the missingMods summary; this gives a second chance for DMCA / hidden mods to transfer users
 					foreach (var item in checkReupload) {
 						var match2 = TryGetModDownloadItem(item, out var reupload);
 						if (match2 == WorkshopSearchReturnState.Success) {

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,7 +1,8 @@
-ru-RU 1
-pt-BR 42
-pl-PL 39
-it-IT 990
-fr-FR 455
-es-ES 414
-de-DE 415
+zh-Hans 2
+ru-RU 3
+pt-BR 44
+pl-PL 41
+it-IT 992
+fr-FR 457
+es-ES 416
+de-DE 417

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,7 @@
-zh-Hans 2
-ru-RU 3
-pt-BR 44
-pl-PL 41
-it-IT 992
-fr-FR 457
-es-ES 416
-de-DE 417
+ru-RU 1
+pt-BR 42
+pl-PL 39
+it-IT 990
+fr-FR 455
+es-ES 414
+de-DE 415


### PR DESCRIPTION
This adds hardening to alert users that a mod that still exists on their system has been hidden or removed from Steam Workshop for an unknown reason. 

This adds a capability to detect if a mod has been unlisted or banned and reuploaded to allow transfer over to the new item via querying workshop.

This increases startup times by about 200ms per 50 mods installed; the security feature is valuable.

Tested using Remnants

<img width="1333" height="1106" alt="image" src="https://github.com/user-attachments/assets/f543a847-1a6f-4e3d-ad96-fa1c90a73f84" />