### PR TITLE
[1.4.5] extra array resizes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ConditionalDialogue.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ConditionalDialogue.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/GameContent/ConditionalDialogue.cs
++++ src/tModLoader/Terraria/GameContent/ConditionalDialogue.cs
+@@ -48,7 +_,7 @@
+ 		}
+ 	}
+ 
+-	private static List<ConditionalDialogue>[] _registry = new List<ConditionalDialogue>[NPCID.Count];
++	internal static List<ConditionalDialogue>[] _registry = new List<ConditionalDialogue>[NPCID.Count]; // TML: Made internal.
+ 	public readonly Predicate<NPC> ConditionsMet;
+ 
+ 	public bool ShowIndicator { get; private set; }

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -87,12 +87,16 @@ public static class NPCLoader
 		Array.Resize(ref Main.npcCatchable, NPCCount);
 		Array.Resize(ref Main.npcFrameCount, NPCCount);
 		Array.Resize(ref Main.SceneMetrics.NPCBannerBuff, NPCCount);
+		Array.Resize(ref Main.SceneMetrics.ClosestNPCPosition, NPCCount);
 		Array.Resize(ref BannerSystem.killCount, NPCCount);
 		Array.Resize(ref NPC.ShimmeredTownNPCs, NPCCount);
 		Array.Resize(ref NPC.npcsFoundForCheckActive, NPCCount);
 		Array.Resize(ref Lang._npcNameCache, NPCCount);
 		Array.Resize(ref EmoteBubble.CountNPCs, NPCCount);
 		Array.Resize(ref WorldGen.TownManager._hasRoom, NPCCount);
+		Array.Resize(ref NPCDamageTracker.CustomBossDefinitions, NPCCount);
+		Array.Resize(ref NPCDamageTracker.BossTypeForMob, NPCCount);
+		Array.Resize(ref ConditionalDialogue._registry, NPCCount);
 
 		foreach (var player in Main.player) {
 			Array.Resize(ref player.npcTypeNoAggro, NPCCount);

--- a/patches/tModLoader/Terraria/SceneMetrics.cs.patch
+++ b/patches/tModLoader/Terraria/SceneMetrics.cs.patch
@@ -212,13 +212,16 @@
  	public void Reset()
  	{
  		LastScanTime = uint.MaxValue;
-@@ -717,6 +_,9 @@
+@@ -717,6 +_,12 @@
  		_bestOreDistSq = int.MaxValue;
  		TownNPCCount = 0;
  		PerspectivePlayer = _dummyPlayer;
 +
 +		if (NPCBannerBuff.Length < ModLoader.NPCLoader.NPCCount)
 +			Array.Resize(ref NPCBannerBuff, ModLoader.NPCLoader.NPCCount);
++
++		if (ClosestNPCPosition.Length < ModLoader.NPCLoader.NPCCount)
++			Array.Resize(ref ClosestNPCPosition, ModLoader.NPCLoader.NPCCount);
  	}
  
  	private void UpdateOreFinder(Point pos, Tile tile)


### PR DESCRIPTION
### What is the bug?
Modded NPCs (friendly and hostile) despawn immediately when spawned, or outright crash the game when spawned.
### How did you fix the bug?
Extra arrays required for modded NPC support have been resized, including support for modded bosses. #5057 originally did two of these but has since removed them, so they are included here.
### Are there alternatives to your fix?
N/A - Unsure.

Please let me know if any comments should be updated.