### PR TITLE
Fix Linux multi-client logging

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Logging.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.cs
@@ -212,7 +212,7 @@ public static partial class Logging
 	private static bool CanOpen(string fileName)
 	{
 		try {
-			using (new FileStream(fileName, FileMode.Append)) { };
+			using (new FileStream(fileName, FileMode.Append, FileAccess.Write, FileShare.None)) { };
 
 			return true;
 		}


### PR DESCRIPTION
### What is the bug?
Fixes #5055 

This PR fixes an issue on Linux where multiple tModLoader clients write to the same `client.log` file instead of creating `client2.log`. This happens because Linux file locking is advisory by default, allowing multiple instances to append to the same file.

### How did you fix the bug?
I explicitly added `FileAccess.Write` and `FileShare.None` to the `FileStream` constructor in `Logging.cs` to enforce an exclusive lock, matching the default Windows behavior.

### Are there alternatives to your fix?
No.