### PR TITLE
Backport PatchReviewer/Setup updates for 1.4.4

### DIFF
--- a/setup/CLI/Commands/PatchSubCommands.cs
+++ b/setup/CLI/Commands/PatchSubCommands.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using Spectre.Console.Cli;
 using Terraria.ModLoader.Setup.Core;
 

--- a/setup/Core/Abstractions/IPatchReviewer.cs
+++ b/setup/Core/Abstractions/IPatchReviewer.cs
@@ -1,4 +1,4 @@
-using DiffPatch;
+using CodeChicken.DiffPatch;
 
 namespace Terraria.ModLoader.Setup.Core.Abstractions;
 

--- a/setup/Core/DiffTask.cs
+++ b/setup/Core/DiffTask.cs
@@ -1,4 +1,4 @@
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 using Terraria.ModLoader.Setup.Core.Utilities;
 

--- a/setup/Core/PatchTask.cs
+++ b/setup/Core/PatchTask.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using Microsoft.Extensions.DependencyInjection;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 using Terraria.ModLoader.Setup.Core.Utilities;

--- a/setup/Core/ProgramSettings.cs
+++ b/setup/Core/ProgramSettings.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 
 namespace Terraria.ModLoader.Setup.Core;
 

--- a/setup/Core/RegenSourceTask.cs
+++ b/setup/Core/RegenSourceTask.cs
@@ -1,4 +1,4 @@
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using Microsoft.Extensions.DependencyInjection;
 using Terraria.ModLoader.Setup.Core.Abstractions;
 

--- a/setup/Core/SettingsMigrator.cs
+++ b/setup/Core/SettingsMigrator.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 
 namespace Terraria.ModLoader.Setup.Core;
 

--- a/setup/Core/Setup.Core.csproj
+++ b/setup/Core/Setup.Core.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\PatchReviewer\DiffPatch\DiffPatch.csproj" />
+		<ProjectReference Include="..\PatchReviewer\DiffPatch\src\DiffPatch.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/setup/GUI/MainForm.cs
+++ b/setup/GUI/MainForm.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using System.Windows.Forms.Integration;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using PatchReviewer;
 using Terraria.ModLoader.Setup.Core;
 using Terraria.ModLoader.Setup.Core.Abstractions;

--- a/setup/GUI/Program.cs
+++ b/setup/GUI/Program.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using DiffPatch;
+using CodeChicken.DiffPatch;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Terraria.ModLoader.Setup.Core;

--- a/setup/GUI/Setup.GUI.csproj
+++ b/setup/GUI/Setup.GUI.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\PatchReviewer\DiffPatch\DiffPatch.csproj" />
+		<ProjectReference Include="..\PatchReviewer\DiffPatch\src\DiffPatch.csproj" />
 		<ProjectReference Include="..\PatchReviewer\PatchReviewer\PatchReviewer.csproj" />
 		<ProjectReference Include="..\Core\Setup.Core.csproj" />
 	</ItemGroup>

--- a/setup/GUI/Setup.GUI.csproj
+++ b/setup/GUI/Setup.GUI.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\PatchReviewer\DiffPatch\DiffPatch.csproj" />
-		<ProjectReference Include="..\PatchReviewer\PatchReviewer.csproj" />
+		<ProjectReference Include="..\PatchReviewer\PatchReviewer\PatchReviewer.csproj" />
 		<ProjectReference Include="..\Core\Setup.Core.csproj" />
 	</ItemGroup>
 

--- a/setup/setup.sln
+++ b/setup/setup.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PatchReviewer", "PatchReviewer\PatchReviewer.csproj", "{699D3F3F-F974-4384-AAE2-AEF7B14F920E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PatchReviewer", "PatchReviewer\PatchReviewer\PatchReviewer.csproj", "{699D3F3F-F974-4384-AAE2-AEF7B14F920E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiffPatch", "PatchReviewer\DiffPatch\DiffPatch.csproj", "{6A990A34-DA3B-4AB0-BA1D-11551B3B4D87}"
 EndProject

--- a/setup/setup.sln
+++ b/setup/setup.sln
@@ -1,11 +1,11 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PatchReviewer", "PatchReviewer\PatchReviewer\PatchReviewer.csproj", "{699D3F3F-F974-4384-AAE2-AEF7B14F920E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiffPatch", "PatchReviewer\DiffPatch\DiffPatch.csproj", "{6A990A34-DA3B-4AB0-BA1D-11551B3B4D87}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiffPatch", "PatchReviewer\DiffPatch\src\DiffPatch.csproj", "{6A990A34-DA3B-4AB0-BA1D-11551B3B4D87}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Setup.CLI", "CLI\Setup.CLI.csproj", "{B257A874-0758-4096-983B-41483CEB7EE5}"
 EndProject


### PR DESCRIPTION
Since PatchReviewer and DiffPatch had a reorganization that moved their projects and code into inner `PatchReviewer` in first case and into an inner `src/` folder in the latter case, switching from 1.4.5 to 1.4.4 branches is now likely to cause the following error, caused by newer `obj` folders becoming part of build processes:
<img width="1884" height="281" alt="image" src="https://github.com/user-attachments/assets/a0a96858-d8a9-4db2-b45c-129838ba7dee" />
This PR simply cherrypicks all changes to the submodule and imports in the setup project in order to avoid that. Excluding hash/gameversion bits.

### Alternatives
An alternative would be to go and make a diffpatch branch that excludes `src\` and `PatchReviewer\` from `Compile`/`None`/`Content`/`EmbeddedResource` groups, but I see no reason to choose that at the moment.