### PR TITLE
Add Debian Steam Installation path to Linux auto-detection

### DIFF
--- a/setup/Core/Utilities/SteamUtils.cs
+++ b/setup/Core/Utilities/SteamUtils.cs
@@ -90,6 +90,8 @@ namespace Terraria.ModLoader.Setup.Core.Utilities
 				path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/Steam");
 				if (!Directory.Exists(path))
 					path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam/steam");
+                if (!Directory.Exists(path))
+					path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam/debian-installation");
 			}
 
 			return path != null && Directory.Exists(path);

--- a/setup/Core/Utilities/SteamUtils.cs
+++ b/setup/Core/Utilities/SteamUtils.cs
@@ -90,6 +90,7 @@ namespace Terraria.ModLoader.Setup.Core.Utilities
 				path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/share/Steam");
 				if (!Directory.Exists(path))
 					path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam/steam");
+
                 if (!Directory.Exists(path))
 					path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam/debian-installation");
 			}


### PR DESCRIPTION
### What is the new feature?
Resolves #5076 

Currently, when Steam is installed via `apt` on Debian-based distributions, the Terraria game files are located in `.steam/debian-installation`. Because this path was missing from the auto-detection logic, modders were forced to manually specify the directory using `./setup-cli.sh update-workspace-info <path>`. 

This PR adds a fallback check for the `.steam/debian-installation` directory if the default `.local/share/Steam` and `.steam/steam` paths do not exist.

### Why should this be part of tModLoader?
It significantly reduces friction for modders setting up a development environment on Debian/Ubuntu by removing the need for a manual workaround.

### Are there alternative designs?
No. Appending the specific path to the existing fallback chain is the most direct and reliable solution.

### Sample usage for the new feature
Simply running `./setup-cli.sh setup` will now automatically find the game files on Debian/Ubuntu distributions without requiring any manual path configuration.