### PR TITLE
[1.4.5] Fix mannequins

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
@@ -10,6 +10,7 @@ public partial class TEDisplayDoll
 	{
 		tag["items"] = PlayerIO.SaveInventory(_equip);
 		tag["dyes"] = PlayerIO.SaveInventory(_dyes);
+		tag["misc"] = PlayerIO.SaveInventory(_misc);
 	}
 
 	public override void LoadData(TagCompound tag)
@@ -17,34 +18,44 @@ public partial class TEDisplayDoll
 		// TML 1.4.4 saved as "items", 1.4.5 changed field from _items to _equip.
 		PlayerIO.LoadInventory(_equip, tag.GetList<TagCompound>("items"));
 		PlayerIO.LoadInventory(_dyes, tag.GetList<TagCompound>("dyes"));
+		PlayerIO.LoadInventory(_misc, tag.GetList<TagCompound>("misc"));
 	}
 
 	public override void NetSend(BinaryWriter writer)
 	{
 		BitsByte itemsBits = default;
 		BitsByte dyesBits = default;
+		BitsByte extraBits = default;
 
 		for (int i = 0; i < 8; i++) {
 			itemsBits[i] = !_equip[i].IsAir;
 			dyesBits[i] = !_dyes[i].IsAir;
 		}
 
+		extraBits[0] = !_misc[0].IsAir;
+		extraBits[1] = !_equip[8].IsAir;
+		extraBits[2] = !_dyes[8].IsAir;
+
 		writer.Write(itemsBits);
 		writer.Write(dyesBits);
+		writer.Write(_pose);
+		writer.Write(extraBits);
 
-		for (int i = 0; i < 8; i++) {
-			var item = _equip[i];
-
+		foreach (var item in _equip) {
 			if (!item.IsAir) {
 				ItemIO.Send(item, writer, true);
 			}
 		}
 
-		for (int i = 0; i < 8; i++) {
-			var dye = _dyes[i];
+		foreach (var item in _dyes) {
+			if (!item.IsAir) {
+				ItemIO.Send(item, writer, true);
+			}
+		}
 
-			if (!dye.IsAir) {
-				ItemIO.Send(dye, writer, true);
+		foreach (var item in _misc) {
+			if (!item.IsAir) {
+				ItemIO.Send(item, writer, true);
 			}
 		}
 	}
@@ -53,13 +64,19 @@ public partial class TEDisplayDoll
 	{
 		BitsByte presentItems = reader.ReadByte();
 		BitsByte presentDyes = reader.ReadByte();
+		_pose =  reader.ReadByte();
+		BitsByte extraBits = reader.ReadByte();
 
 		for (int i = 0; i < 8; i++) {
 			_equip[i] = presentItems[i] ? ItemIO.Receive(reader, true) : new Item();
 		}
+		_equip[8] = extraBits[1] ? ItemIO.Receive(reader, true) : new Item();
 
 		for (int i = 0; i < 8; i++) {
 			_dyes[i] = presentDyes[i] ? ItemIO.Receive(reader, true) : new Item();
 		}
+		_dyes[8] = extraBits[2] ? ItemIO.Receive(reader, true) : new Item();
+
+		_misc[0] = extraBits[0] ? ItemIO.Receive(reader, true) : new Item();
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.TML.cs
@@ -23,23 +23,21 @@ public partial class TEDisplayDoll
 
 	public override void NetSend(BinaryWriter writer)
 	{
-		BitsByte itemsBits = default;
-		BitsByte dyesBits = default;
-		BitsByte extraBits = default;
+		var bitWriter = new BitWriter();
 
-		for (int i = 0; i < 8; i++) {
-			itemsBits[i] = !_equip[i].IsAir;
-			dyesBits[i] = !_dyes[i].IsAir;
+		foreach (var item in _equip) {
+			bitWriter.WriteBit(!item.IsAir);
 		}
 
-		extraBits[0] = !_misc[0].IsAir;
-		extraBits[1] = !_equip[8].IsAir;
-		extraBits[2] = !_dyes[8].IsAir;
+		foreach (var item in _dyes) {
+			bitWriter.WriteBit(!item.IsAir);
+		}
 
-		writer.Write(itemsBits);
-		writer.Write(dyesBits);
-		writer.Write(_pose);
-		writer.Write(extraBits);
+		foreach (var item in _misc) {
+			bitWriter.WriteBit(!item.IsAir);
+		}
+
+		bitWriter.Flush(writer);
 
 		foreach (var item in _equip) {
 			if (!item.IsAir) {
@@ -58,25 +56,26 @@ public partial class TEDisplayDoll
 				ItemIO.Send(item, writer, true);
 			}
 		}
+
+		writer.Write(_pose);
 	}
 
 	public override void NetReceive(BinaryReader reader)
 	{
-		BitsByte presentItems = reader.ReadByte();
-		BitsByte presentDyes = reader.ReadByte();
-		_pose =  reader.ReadByte();
-		BitsByte extraBits = reader.ReadByte();
+		var bitReader = new BitReader(reader);
 
-		for (int i = 0; i < 8; i++) {
-			_equip[i] = presentItems[i] ? ItemIO.Receive(reader, true) : new Item();
+		for (int i = 0; i < _equip.Length; ++i) {
+			_equip[i] = bitReader.ReadBit() ? ItemIO.Receive(reader, true) : new Item();
 		}
-		_equip[8] = extraBits[1] ? ItemIO.Receive(reader, true) : new Item();
 
-		for (int i = 0; i < 8; i++) {
-			_dyes[i] = presentDyes[i] ? ItemIO.Receive(reader, true) : new Item();
+		for (int i = 0; i < _dyes.Length; ++i) {
+			_dyes[i] = bitReader.ReadBit() ? ItemIO.Receive(reader, true) : new Item();
 		}
-		_dyes[8] = extraBits[2] ? ItemIO.Receive(reader, true) : new Item();
 
-		_misc[0] = extraBits[0] ? ItemIO.Receive(reader, true) : new Item();
+		for (int i = 0; i < _misc.Length; ++i) {
+			_misc[i] = bitReader.ReadBit() ? ItemIO.Receive(reader, true) : new Item();
+		}
+
+		_pose = reader.ReadByte();
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Tile_Entities/TEDisplayDoll.cs.patch
@@ -37,6 +37,17 @@
  				writer.Write((short)item2.stack);
  			}
  		}
+@@ -186,8 +_,8 @@
+ 		equip = _misc;
+ 		foreach (Item item3 in equip) {
+ 			if (!item3.IsAir) {
+-				writer.Write((short)item3.type);
+-				writer.Write(item3.prefix);
++				ItemIO.WriteShortVanillaID(item3, writer);
++				ItemIO.WriteByteVanillaPrefix(item3, writer);
+ 				writer.Write((short)item3.stack);
+ 			}
+ 		}
 @@ -278,11 +_,14 @@
  			return;
  


### PR DESCRIPTION
### What is the bug?
Mannequins in 1.4.5 have an extra mount and misc slot that was not present in 1.4.4. When using a mannequin the misc slot would not save properly when leaving the world and rejoining.
### How did you fix the bug?
Add the necessary patches and networking to make the misc slot work properly.
### Are there alternatives to your fix?
No
