### PR TITLE
Add NPC.StrikeOtherNPC helper method

### DIFF
--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2402,7 +2402,7 @@
  	public int checkArmorPenetration(int armorPenetration, float armorPenetrationPercent)
  	{
  		if (ichor)
-@@ -64591,26 +_,165 @@
+@@ -64591,26 +_,169 @@
  
  		return armorPenetration / 2;
  	}
@@ -2499,6 +2499,10 @@
 +	/// <param name="damageVariation">Whether to apply damage variation. Defaults to false.</param>
 +	/// <param name="luck">Luck modifier to produce weight damageVariation towards higher (positive) or lower (negative) values. Defaults to 0</param>
 +	/// <returns>A <see cref="HitInfo"/> for use with <see cref="StrikeNPC(HitInfo, bool, bool)"/> and <see cref="NetMessage.SendStrikeNPC"/></returns>
++    ///<remarks>
++    /// Note: This method doesn't include entity-related hit modifying hooks and shouldn't be used in normal contexts.
++    /// Consider using <see cref="StrikeOtherNPC"/> instead.
++    //</remarks>
 +	public HitInfo CalculateHitInfo(int damage, int hitDirection, bool crit = false, float knockBack = 0f, DamageClass damageType = null, bool damageVariation = false, float luck = 0) {
 +		return GetIncomingStrikeModifiers(damageType, hitDirection).ToHitInfo(damage, crit, knockBack, damageVariation, luck);
 +	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2630,7 +2630,7 @@
 +
 +    ///<summary>
 +    /// A helper method for an NPC striking another NPC
-+    /// Handels modifiers, hit info, network, syncing, and hooks automatically.
++    /// Handels modifiers, hit info, network, and hooks automatically.
 +    ///</summary>
 +    public void StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit = false, bool randomizeDamage = true)
 +    {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2630,7 +2630,7 @@
 +
 +    ///<summary>
 +    /// A helper method for an NPC striking another NPC
-+    /// Handels modifiers, hit info, network, and hooks automatically.
++    /// Handles modifiers, hit info, network, and hooks automatically.
 +    ///</summary>
 +    public void StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit = false, bool randomizeDamage = true)
 +    {

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2499,10 +2499,10 @@
 +	/// <param name="damageVariation">Whether to apply damage variation. Defaults to false.</param>
 +	/// <param name="luck">Luck modifier to produce weight damageVariation towards higher (positive) or lower (negative) values. Defaults to 0</param>
 +	/// <returns>A <see cref="HitInfo"/> for use with <see cref="StrikeNPC(HitInfo, bool, bool)"/> and <see cref="NetMessage.SendStrikeNPC"/></returns>
-+    ///<remarks>
-+    /// Note: This method doesn't include entity-related hit modifying hooks and shouldn't be used in normal contexts.
-+    /// Consider using <see cref="StrikeOtherNPC"/> instead.
-+    //</remarks>
++	/// <remarks>
++	/// Note: This method doesn't include entity-related hit modifying hooks and shouldn't be used in normal contexts.
++	/// <br/><br/> Consider using <see cref="StrikeOtherNPC"/> instead.
++	/// </remarks>
 +	public HitInfo CalculateHitInfo(int damage, int hitDirection, bool crit = false, float knockBack = 0f, DamageClass damageType = null, bool damageVariation = false, float luck = 0) {
 +		return GetIncomingStrikeModifiers(damageType, hitDirection).ToHitInfo(damage, crit, knockBack, damageVariation, luck);
 +	}
@@ -2616,7 +2616,7 @@
  			}
  
  			if (HitSound != null)
-@@ -64818,11 +_,34 @@
+@@ -64818,10 +_,31 @@
  			else
  				checkDead();
  
@@ -2626,33 +2626,30 @@
  
 -		return 0.0;
 +		return 0;
++	}
++
++	/// <summary>
++	/// A helper method for an NPC striking another NPC.
++	/// <br/><br/> Handles modifiers, hit info, network, and hooks automatically.
++	/// </summary>
++	public void StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit = false, bool randomizeDamage = true)
++	{
++		NPC.HitModifiers modifiers = target.GetIncomingStrikeModifiers(DamageClass.Default, hitDirection, default);
++
++		NPCLoader.ModifyHitNPC(this, target, ref modifiers);
++
++		NPC.HitInfo hitInfo = modifiers.ToHitInfo(damage, crit, knockback, randomizeDamage);
++
++		target.StrikeNPC(hitInfo, false, true);
++
++		if (Main.netMode != 0) {
++			NetMessage.SendStrikeNPC(target, hitInfo);
++		}
++
++		NPCLoader.OnHitNPC(this, target, hitInfo);
  	}
-+
-+    ///<summary>
-+    /// A helper method for an NPC striking another NPC
-+    /// Handles modifiers, hit info, network, and hooks automatically.
-+    ///</summary>
-+    public void StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit = false, bool randomizeDamage = true)
-+    {
-+        NPC.HitModifiers modifiers = target.GetIncomingStrikeModifiers(DamageClass.Default, hitDirection, default);
-+        
-+        NPCLoader.ModifyHitNPC(NPC, target, ref modifiers);
-+
-+        NPC.HitInfo hitInfo = modifiers.ToHitInfo(damage, crit, knockback, randomizeDamage);
-+
-+        target.StrikeNPC(hitInfo, false, true);
-+
-+        if(Main.netMode != 0)
-+        {
-+            NetMessage.SendStrikeNPC(target, hitInfo);
-+        }
-+
-+        NPCLoader.OnHitNPC(this, target, hitInfo);
-+        
-+    }
  
  	public static void LadyBugKilled(Vector2 Position, bool GoldLadyBug = false)
- 	{
 @@ -64897,7 +_,29 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2612,7 +2612,7 @@
  			}
  
  			if (HitSound != null)
-@@ -64818,10 +_,10 @@
+@@ -64818,11 +_,34 @@
  			else
  				checkDead();
  
@@ -2623,8 +2623,32 @@
 -		return 0.0;
 +		return 0;
  	}
++
++    ///<summary>
++    /// A helper method for an NPC striking another NPC
++    /// Handels modifiers, hit info, network, syncing, and hooks automatically.
++    ///</summary>
++    public void StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit = false, bool randomizeDamage = true)
++    {
++        NPC.HitModifiers modifiers = target.GetIncomingStrikeModifiers(DamageClass.Default, hitDirection, default);
++        
++        NPCLoader.ModifyHitNPC(NPC, target, ref modifiers);
++
++        NPC.HitInfo hitInfo = modifiers.ToHitInfo(damage, crit, knockback, randomizeDamage);
++
++        target.StrikeNPC(hitInfo, false, true);
++
++        if(Main.netMode != 0)
++        {
++            NetMessage.SendStrikeNPC(target, hitInfo);
++        }
++
++        NPCLoader.OnHitNPC(this, target, hitInfo);
++        
++    }
  
  	public static void LadyBugKilled(Vector2 Position, bool GoldLadyBug = false)
+ 	{
 @@ -64897,7 +_,29 @@
  		}
  	}


### PR DESCRIPTION
### What is the new feature?
Implements part 1 and 3 of #5086.

1. Adds new `NPC.StrikeOtherNPC` helper method to simplify writing code
2. Adds a XML remark to `NPC.CalculateHitInfo` warning that it doesn't include entity-related hit modifying hooks.

### Why should this be part of tModLoader?
Reduces boilerplate code when making NPCs hit each other.

### Are there alternative designs?
N/A - Implemented exactly as requested in the issue.e

### Sample usage for the new feature
```csharp
// Simplify 6 lines of boilerplate into a single call
NPC.StrikeOtherNPC(NPC target, int damage, float knockback, int hitDirection, bool crit, bool randomizeDamage);
```