### PR TITLE
[1.4.5] Implemented tModPorter Journeymode-check changes

### DIFF
--- a/tModPorter/tModPorter.Tests/TestData/IsJourneyModeTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/IsJourneyModeTest.Expected.cs
@@ -1,0 +1,11 @@
+using Terraria;
+
+public class IsJourneyModeTest
+{
+	void Method()
+	{
+		bool isJourney = Main.IsJourneyMode;
+		bool isJourneyQualified = Terraria.Main.IsJourneyMode;
+		bool isJourneyGlobalQualified = global::Terraria.Main.IsJourneyMode;
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/IsJourneyModeTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/IsJourneyModeTest.cs
@@ -1,0 +1,11 @@
+using Terraria;
+
+public class IsJourneyModeTest
+{
+	void Method()
+	{
+		bool isJourney = Main.GameModeInfo.IsJourneyMode;
+		bool isJourneyQualified = Terraria.Main.GameModeInfo.IsJourneyMode;
+		bool isJourneyGlobalQualified = global::Terraria.Main.GameModeInfo.IsJourneyMode;
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/RenameRewriterTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RenameRewriterTest.Expected.cs
@@ -68,4 +68,11 @@ public class SimpleIdentifiersTest : Mod
 		Dummy item = new();
 		item.FieldA = 0;
 	}
+
+	public void QualifiedMemberAccess()
+	{
+		_ = Main.PipsUseGrid;
+		_ = Terraria.Main.PipsUseGrid;
+		_ = global::Terraria.Main.PipsUseGrid;
+	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/RenameRewriterTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RenameRewriterTest.cs
@@ -66,4 +66,11 @@ public class SimpleIdentifiersTest : Mod
 		Dummy item = new();
 		item.FieldA = 0;
 	}
+
+	public void QualifiedMemberAccess()
+	{
+		_ = Main.recBigList;
+		_ = Terraria.Main.recBigList;
+		_ = global::Terraria.Main.recBigList;
+	}
 }

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -341,7 +341,6 @@ public static partial class Config
 		RefactorStaticMember("Terraria.ID.ProjectileID.Sets", "DontAttachHideToAlpha", Removed("Removed. Now true by default. See Projectile.usesOwnerLight and Projectile.drawLayer for more details."));
 		RefactorStaticMember("Terraria.Item", "whoAmI", Removed("Moved to WorldItem"));
 		RefactorStaticMember("Terraria.Item", "beingGrabbed", Removed("Moved to WorldItem"));
-		RefactorStaticMember("Terraria.Main", "GameModeInfo", RewriteIsJourneyMode);
 		RefactorStaticMember("Terraria.NPC", "netSkip", Removed("No longer necessary when setting life <= 0 and was never necessary when setting active = false"));
 
 		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", RemoveParameter(1, "noMatCheck", "bool"));
@@ -552,4 +551,3 @@ public static partial class Config
 		RenameGenVar("StatuesWithTraps");
 	}
 }
-

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -341,6 +341,7 @@ public static partial class Config
 		RefactorStaticMember("Terraria.ID.ProjectileID.Sets", "DontAttachHideToAlpha", Removed("Removed. Now true by default. See Projectile.usesOwnerLight and Projectile.drawLayer for more details."));
 		RefactorStaticMember("Terraria.Item", "whoAmI", Removed("Moved to WorldItem"));
 		RefactorStaticMember("Terraria.Item", "beingGrabbed", Removed("Moved to WorldItem"));
+		RefactorStaticMember("Terraria.Main", "GameModeInfo", RewriteIsJourneyMode);
 		RefactorStaticMember("Terraria.NPC", "netSkip", Removed("No longer necessary when setting life <= 0 and was never necessary when setting active = false"));
 
 		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", RemoveParameter(1, "noMatCheck", "bool"));

--- a/tModPorter/tModPorter/Rewriters/BaseRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/BaseRewriter.cs
@@ -107,6 +107,12 @@ public abstract class BaseRewriter : CSharpSyntaxRewriter
 		switch (node.Parent) {
 			case MemberAccessExpressionSyntax memberAccess when node == memberAccess.Name && MemberReferenceInvalid(memberAccess, out op, out isInvoke):
 				targetType = model.GetTypeInfo(memberAccess.Expression).Type;
+
+				// With qualified member access expressions (such as Terraria.Main.field instead of Main.field), for some reason I can't get the correct Type unless we fallback to this.
+				var expressionSymbolInfo = model.GetSymbolInfo(memberAccess.Expression);
+				var expressionSymbol = expressionSymbolInfo.Symbol ?? (expressionSymbolInfo.CandidateSymbols.Length == 1 ? expressionSymbolInfo.CandidateSymbols[0] : null);
+				if (expressionSymbol is INamedTypeSymbol namedTypeSymbol)
+					targetType = namedTypeSymbol;
 				return true;
 
 			case MemberBindingExpressionSyntax memberBinding when MemberReferenceInvalid(memberBinding, out op, out isInvoke) && op.ChildOperations.First() is IConditionalAccessInstanceOperation target:

--- a/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
@@ -21,40 +21,6 @@ public class MemberUseRewriter : BaseRewriter {
 	public static void RefactorStaticMember(string type, string name, RewriteMemberUse handler) => handlers.Add((type, name, handler));
 	public static void RefactorStaticMember(string type, string name, AddComment comment) => RefactorStaticMember(type, name, (_, _, n) => comment.Apply(n));
 
-	public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node) {
-		bool rewriteIsJourneyMode =
-			node.Name.Identifier.Text == "IsJourneyMode" &&
-			node.Expression is MemberAccessExpressionSyntax innerOriginal &&
-			innerOriginal.Name.Identifier.Text == "GameModeInfo" &&
-			IsTerrariaMainQualifier(innerOriginal.Expression);
-
-		node = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node);
-
-		if (!rewriteIsJourneyMode || node.Expression is not MemberAccessExpressionSyntax innerAccess)
-			return node;
-
-		return MemberAccessExpression(innerAccess.Expression.WithoutTrivia(), "IsJourneyMode").WithTriviaFrom(node);
-	}
-
-	private bool IsTerrariaMainQualifier(ExpressionSyntax expression) {
-		if (model.GetTypeInfo(expression).Type is INamedTypeSymbol { Name: "Main", ContainingNamespace: { } ns } && ns.ToString() == "Terraria")
-			return true;
-
-		if (expression is IdentifierNameSyntax { Identifier.Text: "Main" })
-			return IsUsingNamespace("Terraria");
-
-		if (expression is MemberAccessExpressionSyntax {
-			Expression: IdentifierNameSyntax { Identifier.Text: "Terraria" },
-			Name.Identifier.Text: "Main"
-		})
-			return true;
-
-		if (expression.ToString() == "global::Terraria.Main")
-			return true;
-
-		return false;
-	}
-
 	public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node) {
 		if (!IdentifierNameInvalid(node, out var op, out var targetType, out bool isInvoke) || op == null || isInvoke)
 			return node;
@@ -139,4 +105,18 @@ public class MemberUseRewriter : BaseRewriter {
 
 		return memberName;
 	};
+
+	public static SyntaxNode RewriteIsJourneyMode(MemberUseRewriter rw, IOperation op, IdentifierNameSyntax memberName)
+	{
+		// memberName corresponds to the identifier "GameModeInfo" in an expression like Main.GameModeInfo.IsJourneyMode
+		if (memberName.Parent is MemberAccessExpressionSyntax innerAccess && innerAccess.Parent is MemberAccessExpressionSyntax outerAccess) {
+			if (outerAccess.Name.Identifier.Text == "IsJourneyMode") {
+				// Replace the outer access (Main.GameModeInfo.IsJourneyMode) with Main.IsJourneyMode
+				rw.RegisterAction<MemberAccessExpressionSyntax>(outerAccess, n =>
+					MemberAccessExpression(innerAccess.Expression.WithoutTrivia(), "IsJourneyMode").WithTriviaFrom(n)
+				);
+			}
+		}
+		return memberName;
+	}
 }

--- a/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
+++ b/tModPorter/tModPorter/Rewriters/MemberUseRewriter.cs
@@ -21,6 +21,39 @@ public class MemberUseRewriter : BaseRewriter {
 	public static void RefactorStaticMember(string type, string name, RewriteMemberUse handler) => handlers.Add((type, name, handler));
 	public static void RefactorStaticMember(string type, string name, AddComment comment) => RefactorStaticMember(type, name, (_, _, n) => comment.Apply(n));
 
+	public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node) {
+		bool rewriteIsJourneyMode =
+			node.Name.Identifier.Text == "IsJourneyMode" &&
+			node.Expression is MemberAccessExpressionSyntax innerOriginal &&
+			innerOriginal.Name.Identifier.Text == "GameModeInfo" &&
+			IsTerrariaMainQualifier(innerOriginal.Expression);
+
+		node = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node);
+
+		if (!rewriteIsJourneyMode || node.Expression is not MemberAccessExpressionSyntax innerAccess)
+			return node;
+
+		return MemberAccessExpression(innerAccess.Expression.WithoutTrivia(), "IsJourneyMode").WithTriviaFrom(node);
+	}
+
+	private bool IsTerrariaMainQualifier(ExpressionSyntax expression) {
+		if (model.GetTypeInfo(expression).Type is INamedTypeSymbol { Name: "Main", ContainingNamespace: { } ns } && ns.ToString() == "Terraria")
+			return true;
+
+		if (expression is IdentifierNameSyntax { Identifier.Text: "Main" })
+			return IsUsingNamespace("Terraria");
+
+		if (expression is MemberAccessExpressionSyntax {
+			Expression: IdentifierNameSyntax { Identifier.Text: "Terraria" },
+			Name.Identifier.Text: "Main"
+		})
+			return true;
+
+		if (expression.ToString() == "global::Terraria.Main")
+			return true;
+
+		return false;
+	}
 
 	public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node) {
 		if (!IdentifierNameInvalid(node, out var op, out var targetType, out bool isInvoke) || op == null || isInvoke)
@@ -106,18 +139,4 @@ public class MemberUseRewriter : BaseRewriter {
 
 		return memberName;
 	};
-
-	public static SyntaxNode RewriteIsJourneyMode(MemberUseRewriter rw, IOperation op, IdentifierNameSyntax memberName)
-	{
-		// memberName corresponds to the identifier "GameModeInfo" in an expression like Main.GameModeInfo.IsJourneyMode
-		if (memberName.Parent is MemberAccessExpressionSyntax innerAccess && innerAccess.Parent is MemberAccessExpressionSyntax outerAccess) {
-			if (outerAccess.Name.Identifier.Text == "IsJourneyMode") {
-				// Replace the outer access (Main.GameModeInfo.IsJourneyMode) with Main.IsJourneyMode
-				rw.RegisterAction<MemberAccessExpressionSyntax>(outerAccess, n =>
-					MemberAccessExpression(innerAccess.Expression.WithoutTrivia(), "IsJourneyMode").WithTriviaFrom(n)
-				);
-			}
-		}
-		return memberName;
-	}
 }


### PR DESCRIPTION
This is my first merge-request to this project, therefore i am uncertain if followed the code and usage guidelines correctly. Or even if my code is adequate. If someone could give some feedback on these changes, it would be greatly appreciated. Afterwards, i would mark it as ready for review.

### What is the bug?
For the 1.4.5 API changes, `tModPorter` should rewrite `Main.GameModeInfo.IsJourneyMode` to `Main.IsJourneyMode`.
The migration entry for this existed, but the config-based `GameModeInfo` refactor did not actually apply to the full access chain, so the old 1.4.4-style was left unchanged.

### How did you fix the bug?
I replaced the unused `GameModeInfo` member refactor with a localized rewrite in `MemberUseRewriter.VisitMemberAccessExpression` that matches the full `...GameModeInfo.IsJourneyMode` access and rewrites it to the 1.4.5 property:
  - `Main.GameModeInfo.IsJourneyMode` to `Main.IsJourneyMode`
  - `Terraria.Main.GameModeInfo.IsJourneyMode` to `Terraria.Main.IsJourneyMode`
  - `global::Terraria.Main.GameModeInfo.IsJourneyMode` to `global::Terraria.Main.IsJourneyMode`

I also removed the unused `RefactorStaticMember("Terraria.Main", "GameModeInfo", ...)` registration from `Config.Terraria` and added a regression test covering unqualified, qualified, and `global::`-qualified forms.

### Are there alternatives to your fix?
The alternative could be trying to keep this in the config-driven `RefactorStaticMember` path, but this migration needs visibility of the full member-access chain, not just the `GameModeInfo` identifier. Handling it in `VisitMemberAccessExpression` is the smaller and more direct fix probably.