### PR TITLE
Fix: Incorrect Annotation in ExemplarMod. ExemplarAdvancedFailProjectile.cs

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleAdvancedFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleAdvancedFlailProjectile.cs
@@ -156,7 +156,7 @@ namespace ExampleMod.Content.Projectiles
 							// This is where Drippler Crippler spawns its projectile
 							/*
 							if (Main.myPlayer == Projectile.owner)
-								Projectile.NewProjectile(Projectile.GetProjectileSource_FromThis(), Projectile.Center, Projectile.velocity, 928, Projectile.damage, Projectile.knockBack, Main.myPlayer);
+								Projectile.NewProjectile(Projectile.GetSource_FromThis(), Projectile.Center, Projectile.velocity, ProjectileID.DripplerFlailExtraBall, Projectile.damage, Projectile.knockBack, Main.myPlayer);
 							*/
 							break;
 						}


### PR DESCRIPTION
### What are the changes to ExampleMod?
There is actually a problem with a line of annotation in InstanceAdvancedFailProjectile.cs, which used an internal method and resulted in an error state when the annotation was canceled. I changed it to use the corresponding public method and also modified the magic number

### Do these changes need additional documentation?
No