### PR TITLE
Fix ClassUsedAsKey in ExampleMod

### DIFF
--- a/ExampleMod/Common/Configs/CustomDataTypes/ClassUsedAsKey.cs
+++ b/ExampleMod/Common/Configs/CustomDataTypes/ClassUsedAsKey.cs
@@ -1,11 +1,27 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Terraria.ModLoader.Config;
 
 // This file defines a custom data type that can be used as a key in dictionary.
 namespace ExampleMod.Common.Configs.CustomDataTypes
 {
-	[TypeConverter(typeof(ToFromStringConverter<ClassUsedAsKey>))]
+	public class ClassUsedAsKeyConverter : TypeConverter
+	{
+		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) {
+			return sourceType == typeof(string);
+		}
+		public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType) {
+			return destinationType != typeof(string);
+		}
+		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
+			if (value is string v)
+				return ClassUsedAsKey.FromString(v);
+			return base.ConvertFrom(context, culture, value);
+		}
+	}
+	[TypeConverter("ExampleMod.Common.Configs.CustomDataTypes.ClassUsedAsKeyConverter")]
 	public class ClassUsedAsKey
 	{
 		// When you save data from a dictionary into a file (json), you need to represent the key as a string

--- a/ExampleMod/Common/Configs/CustomDataTypes/ClassUsedAsKey.cs
+++ b/ExampleMod/Common/Configs/CustomDataTypes/ClassUsedAsKey.cs
@@ -7,27 +7,18 @@ using Terraria.ModLoader.Config;
 // This file defines a custom data type that can be used as a key in dictionary.
 namespace ExampleMod.Common.Configs.CustomDataTypes
 {
-	public class ClassUsedAsKeyConverter : TypeConverter
-	{
-		public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) {
-			return sourceType == typeof(string);
-		}
-		public override bool CanConvertTo(ITypeDescriptorContext? context, [NotNullWhen(true)] Type? destinationType) {
-			return destinationType != typeof(string);
-		}
-		public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
-			if (value is string v)
-				return ClassUsedAsKey.FromString(v);
-			return base.ConvertFrom(context, culture, value);
-		}
+	public class ClassUsedAsKeyConverter : ToFromStringConverter<ClassUsedAsKey> {
 	}
+
 	[TypeConverter("ExampleMod.Common.Configs.CustomDataTypes.ClassUsedAsKeyConverter")]
+	// Note: do not use typeof(ClassUsedAsKeyConverter)... that overload does not work.
 	public class ClassUsedAsKey
 	{
 		// When you save data from a dictionary into a file (json), you need to represent the key as a string
 		// But to get the object back, you need a TypeConverter, and this example shows how to implement one
 
-		// You start with the [TypeConverter(typeof(ToFromStringConverter<NameOfClassHere>))] attribute above the class
+		// You start with implementing ToFromStringConverter<T> as a specific converter for this class.
+		// Then you add the TypeConverter as the means by which this class will be converted as an attribute
 		// For this to work, you need the usual Equals and GetHashCode overrides as explained in the other examples,
 		// plus ToString and FromString, which are used to transform your object into a string and back
 
@@ -55,6 +46,10 @@ namespace ExampleMod.Common.Configs.CustomDataTypes
 		public static ClassUsedAsKey FromString(string s) {
 			// This following code depends on your implementation of ToString, here we just have two values separated by a ','
 			string[] vars = s.Split(new char[] { ',' }, 2, StringSplitOptions.RemoveEmptyEntries);
+
+			if (vars.Length != 2)
+				throw new Exception($"Invalid input string {s}");
+
 			// The System.Convert class provides methods to transform data types between each other, here using the string overload
 			return new ClassUsedAsKey {
 				SomeBool = Convert.ToBoolean(vars[0]),

--- a/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseDataTypes.cs
+++ b/ExampleMod/Common/Configs/ModConfigShowcases/ModConfigShowcaseDataTypes.cs
@@ -58,7 +58,6 @@ namespace ExampleMod.Common.Configs.ModConfigShowcases
 			[new PrefixDefinition(PrefixID.Awkward)] = 0.8f,
 		};
 
-		// TODO: Not working at the moment.
 		// Using a custom class as a key in a Dictionary. When used as a Dictionary Key, special code must be used.
 		public Dictionary<ClassUsedAsKey, Color> CustomKey = new Dictionary<ClassUsedAsKey, Color>();
 


### PR DESCRIPTION
Fixes #4543

### What are the changes to ExampleMod?
I noticed there's a comment in ModConfigShowcaseDataTypes.cs
```csharp
// TODO: Not working at the moment.
// Using a custom class as a key in a Dictionary. When used as a Dictionary Key, special code must be used.
public Dictionary<ClassUsedAsKey, Color> CustomKey = new Dictionary<ClassUsedAsKey, Color>();
```
Then I found that TypeDescriptor.GetConverter cant find the TypeConverter of this class,
although with the attribute [TypeConverter(typeof(ToFromStringConverter<ClassUsedAsKey>))]

Then I Just copy the Code of ToFromStringConverter\<T\>, and simplified the ConvertFrom method
Uses [TypeConverter("ExampleMod.Common.Configs.CustomDataTypes.ClassUsedAsKeyConverter")] make it worked

I don't know the mechanism of the TypeDescriptor,
I've tried the two other versions below
```csharp
[TypeConverter("Terraria.ModLoader.Config.ToFromStringConverter`1[ExampleMod.Common.Configs.CustomDataTypes.ClassUsedAsKey]")]
//↑ use strings instead of type

[TypeConverter(typeof(ClassUsedAsKeyConverter))] //use type directly instead of the strings
```
but both of them just not worked


For other modders willing to use multiple classes as key, like these
```csharp
public Dictionary<ClassA,int> dictionaryA = [];
public Dictionary<ClassB,int> dictionaryB = [];
public Dictionary<ClassC,int> dictionaryC = [];
```
They can just copy the code of ToFromStringConverter\<T\> to their project
and uses the attributes like these:
```csharp
[TypeConverter("MyMod.SomeNameSpace.ToFromStringConverter`1[MyMod.TheOtherNameSpace.ClassA]")]
public class ClassA

[TypeConverter("MyMod.SomeNameSpace.ToFromStringConverter`1[MyMod.TheOtherNameSpace.ClassB]")]
public class ClassB

[TypeConverter("MyMod.SomeNameSpace.ToFromStringConverter`1[MyMod.TheOtherNameSpace.ClassC]")]
public class ClassC
```

I'd know this seems ugly, but I can't find alternative ways.

### Do these changes need additional documentation?
No