### PR TITLE
[1.4.5] Fix slime body ore drop stack size

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -18,16 +18,29 @@
  		ItemDropAttemptResult result = default(ItemDropAttemptResult);
  		result.State = ItemDropAttemptResultState.Success;
  		return result;
-@@ -50,4 +_,0 @@
--			case 11:
--			case 12:
--			case 13:
--			case 14:
-@@ -58,4 +_,0 @@
--			case 699:
--			case 700:
--			case 701:
--			case 702:
+@@ -47,18 +_,22 @@
+ 				amountDroppedMinimum = 20;
+ 				amountDroppedMaximum = 45;
+ 				break;
++			/*
+ 			case 11:
+ 			case 12:
+ 			case 13:
+ 			case 14:
++			*/
+ 			case 174:
+ 			case 364:
+ 			case 365:
+ 			case 366:
++			/*
+ 			case 699:
+ 			case 700:
+ 			case 701:
+ 			case 702:
++			*/
+ 			case 1104:
+ 			case 1105:
+ 			case 1106:
 @@ -109,6 +_,10 @@
  				amountDroppedMinimum = 2;
  				amountDroppedMaximum = 5;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/SlimeBodyItemDropRule.cs.patch
@@ -18,22 +18,16 @@
  		ItemDropAttemptResult result = default(ItemDropAttemptResult);
  		result.State = ItemDropAttemptResultState.Success;
  		return result;
-@@ -47,6 +_,7 @@
- 				amountDroppedMinimum = 20;
- 				amountDroppedMaximum = 45;
- 				break;
-+			/*
- 			case 11:
- 			case 12:
- 			case 13:
-@@ -66,6 +_,7 @@
- 				amountDroppedMinimum = 3;
- 				amountDroppedMaximum = 13;
- 				break;
-+			*/
- 			case 71:
- 				amountDroppedMinimum = 50;
- 				amountDroppedMaximum = 99;
+@@ -50,4 +_,0 @@
+-			case 11:
+-			case 12:
+-			case 13:
+-			case 14:
+@@ -58,4 +_,0 @@
+-			case 699:
+-			case 700:
+-			case 701:
+-			case 702:
 @@ -109,6 +_,10 @@
  				amountDroppedMinimum = 2;
  				amountDroppedMaximum = 5;


### PR DESCRIPTION
### What is the bug?
Some vanilla slime body drops that should use the `3..13` stack range were falling back to the default stack size of `1`. The existing tModLoader patch moved normal ore stack sizes to `ItemID.Sets.OreDropsFromSlime`, but it commented out the entire vanilla `3..13` case group. That group also contained other vanilla items, such as hardmode ores, Hellstone, and Desert Fossil, which are not currently registered in `OreDropsFromSlime`.

### How did you fix the bug?
The patch now removes only the normal ore item IDs that are handled by `ItemID.Sets.OreDropsFromSlime`, while preserving the remaining vanilla `3..13` slime body drop cases.
This keeps the existing `OreDropsFromSlime` behavior intact and restores the correct vanilla stack range for the affected special slime body drops. The default `1..1` behavior remains unchanged for items without a special stack range.
Tested in-game with a custom mod that spawned the affected special slimes and verified the drop stack sizes.

### Are there alternatives to your fix?
The affected vanilla items could be added to `ItemID.Sets.OreDropsFromSlime`, but that set is also used to choose which ore items can appear inside slimes. Preserving the existing vanilla switch cases is more targeted and avoids changing the slime body item selection pool.