### PR TITLE
Fix: Incorrect comments on the GetAdvancedShadow method in Player.cs

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -1405,7 +1405,7 @@
 +	/// <summary>
 +	/// Returns positioning data for this player <paramref name="shadowIndex"/> frames ago, up to <see cref="availableAdvancedShadowsCount"/>.
 +	/// <br/><br/> This can be used to draw trails that follow the movement of the player. You'll usually want to iterate from <see cref="availableAdvancedShadowsCount"/> down to 1 for proper draw layering and to skip index 0 which would be the current frame when using this to draw a trail.
-+	/// <br/><br/> See <see href="https://github.com/tModLoader/tModLoader/blob/stable/ExampleMod/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs">ExampleArmorSetBonusPlayer.DrawPlayer</see> for an example of correctly using this.
++	/// <br/><br/> See <see href="https://github.com/tModLoader/tModLoader/blob/stable/ExampleMod/Common/Players/ExampleArmorSetBonusPlayer.cs">ExampleArmorSetBonusPlayer.DrawPlayer</see> for an example of correctly using this.
 +	/// </summary>
  	public EntityShadowInfo GetAdvancedShadow(int shadowIndex)
  	{


### PR DESCRIPTION
### What is the bug?
The example file URL provided in the comments of the GetAdvancedShadow method in Player.cs is incorrect

### How did you fix the bug?
Change to the correct URL

### Are there alternatives to your fix?
No