### PR TITLE
Fix Glowing Mushroom interactions

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -788,7 +788,6 @@ public static class TileLoader
 
 		RegisterConversionFallback(TileID.CorruptJungleGrass, TileID.JungleGrass, BiomeConversionID.Corruption, BiomeConversionID.GlowingMushroom);
 		RegisterConversionFallback(TileID.CrimsonJungleGrass, TileID.JungleGrass, BiomeConversionID.Crimson, BiomeConversionID.GlowingMushroom);
-		RegisterConversionFallback(TileID.MushroomGrass, TileID.JungleGrass, BiomeConversionID.GlowingMushroom, BiomeConversionID.Corruption, BiomeConversionID.Crimson);
 
 		RegisterConversionFallback(TileID.CorruptIce, TileID.IceBlock, BiomeConversionID.Corruption);
 		RegisterConversionFallback(TileID.FleshIce, TileID.IceBlock, BiomeConversionID.Crimson);


### PR DESCRIPTION
### What is the bug?
Glowing Mushroom grass normally does not interact with other solutions. It only interacts with Green Solution in turning to Jungle Grass, and that's it. 
However in the games code, Mushroom Grass has been coded to fall back on Jungle Grass during Biome conversions, meaning it can interact with solutions other than green. (In Vanilla, this presents no behavior changes as Corruption and Crimson were coded to be exempt in the fallback registry, the main issue arises when mods get involved)

### How did you fix the bug?
Literally just removed Glowing Mushroom's fall back tile code.

### Are there alternatives to your fix?
Well, other modders if they are so desperate can just do `TileLoader.RegisterConversionFallback(TileID.MushroomGrass, -1);` in their GlobalTile and the problem would be solved. I just prefer on my own end for the bug to be fixed in Vanilla than in my own mod.