### PR TITLE
1.4.5 recipe groups

### DIFF
--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -19,7 +19,6 @@ namespace ExampleMod.Content
 			ExampleRecipeGroup = null;
 		}
 
-#if COMPILE_ERROR_TODOS
 		public override void AddRecipeGroups() {
 			// Create a recipe group and store it
 			// Language.GetTextValue("LegacyMisc.37") is the word "Any" in English, and the corresponding word in other languages
@@ -43,7 +42,6 @@ namespace ExampleMod.Content
 			ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
 			RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup);
 		}
-#endif
 
 		public override void AddRecipes() {
 			////////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +79,6 @@ namespace ExampleMod.Content
 				// An alternate string-based approach to the above. Try to only use it for other mods' items, because it's slower.
 				.AddIngredient(Mod, "ExampleSword")
 
-#if COMPILE_ERROR_TODOS
 				// RecipeGroups allow you create a recipe that accepts items from a group of similar ingredients. For example, all varieties of Wood are in the vanilla "Wood" Group
 				// Check here for other vanilla groups: https://github.com/tModLoader/tModLoader/wiki/Intermediate-Recipes#using-existing-recipegroups
 				.AddRecipeGroup(RecipeGroupID.Wood)
@@ -92,7 +89,6 @@ namespace ExampleMod.Content
 				// An alternate string-based approach to the above. Try to only use it for other mods' groups, because it's slower.
 				.AddRecipeGroup("Wood")
 				.AddRecipeGroup("ExampleMod:ExampleItem", 2)
-#endif
 
 				// Adds a vanilla tile requirement.
 				// To specify a crafting station, specify a tile. Look up TileIDs: https://github.com/tModLoader/tModLoader/wiki/Vanilla-Tile-IDs

--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -1,4 +1,5 @@
 ﻿using ExampleMod.Common;
+using ExampleMod.Content.Items;
 using ExampleMod.Content.Items.Placeable;
 using ExampleMod.Content.NPCs;
 using Terraria;
@@ -14,33 +15,39 @@ namespace ExampleMod.Content
 	{
 		// A place to store the recipe group so we can easily use it later
 		public static RecipeGroup ExampleRecipeGroup;
+		public static RecipeGroup SilverBarRecipeGroup;
 
 		public override void Unload() {
 			ExampleRecipeGroup = null;
+			SilverBarRecipeGroup = null;
 		}
 
 		public override void AddRecipeGroups() {
-			// Create a recipe group and store it
-			// Language.GetTextValue("LegacyMisc.37") is the word "Any" in English, and the corresponding word in other languages
-			ExampleRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ModContent.ItemType<Items.ExampleItem>())}",
-				ModContent.ItemType<Items.ExampleItem>(), ModContent.ItemType<Items.ExampleDataItem>());
+			// Create a recipe group and store it in a static field so it can easily be used directly from other classes.
+			// The 1st parameter is the key. To avoid name collisions, when a modded items is the iconic or 1st item in a recipe group, name the recipe group: ModName:ItemName
+			// The next parameter is the localization key that will be used to make the "Any Something" display text for this recipe group. Using the item name of the most common item is typical, but sometimes a more generic custom name is appropriate.
+			// The last parameters are the item types that will be in this recipe group. The 1st item is the "icon" of the group, and the rest are just other items that can be used in place of it.
+			ExampleRecipeGroup = RecipeGroup.Register(
+				"ExampleMod:ExampleItem",
+				Lang.GetItemName(ModContent.ItemType<ExampleItem>()).Key,
+				ModContent.ItemType<ExampleItem>(), ModContent.ItemType<ExampleDataItem>()
+			);
 
-			// To avoid name collisions, when a modded items is the iconic or 1st item in a recipe group, name the recipe group: ModName:ItemName
-			RecipeGroup.RegisterGroup("ExampleMod:ExampleItem", ExampleRecipeGroup)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
-
-			// Add an item to an existing Terraria recipeGroup. ExampleCritterItem isn't gold but it serves as an example for this.
-			RecipeGroup.recipeGroups[RecipeGroups.GoldenCritter].ValidItems.Add(ModContent.ItemType<ExampleCritterItem>());
+			// Add an item to an existing Terraria recipe group. ExampleCritterItem isn't a bug but it serves as an example for this.
+			RecipeGroups.Bugs.ValidItems.Add(ModContent.ItemType<ExampleCritterItem>());
 
 			// We also add ExampleSand to the Sand group, which is used in the Glass and Magic Sand Dropper recipes
-			RecipeGroup.recipeGroups[RecipeGroups.Sand].ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
+			RecipeGroups.Sand.ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
 
 			// We can also add ExamplePressurePlate to the pressure plate group, allowing it to be used to craft weighted pressure plates and pressure plate track. Since ExamplePressurePlate is a weighed pressure plate, we'll leave this commented out.
-			//RecipeGroup.recipeGroups[RecipeGroupID.PressurePlate].ValidItems.Add(ModContent.ItemType<ExamplePressurePlate>());
+			//RecipeGroups.PressurePlate.ValidItems.Add(ModContent.ItemType<ExamplePressurePlate>());
 
-			// While an "IronBar" group exists, "SilverBar" does not. tModLoader will merge recipe groups registered with the same name, so if you are registering a recipe group with a vanilla item as the 1st item, you can register it using just the internal item name if you anticipate other mods wanting to use this recipe group for the same concept. By doing this, multiple mods can add to the same group without extra effort. In this case we are adding a SilverBar group. Don't store the RecipeGroup instance, it might not be used, use the same nameof(ItemID.ItemName) or RecipeGroupID returned from RegisterGroup when using Recipe.AddRecipeGroup instead.
-			RecipeGroup SilverBarRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
-			ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
-			RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
+			// While an "IronBar" group exists, "SilverBar" does not. tModLoader will merge recipe groups registered with the same key/name, so if you are registering a recipe group with a vanilla item as the 1st item, you can register it using just the internal item name (ItemID name) if you anticipate other mods wanting to use this recipe group for the same concept. By doing this, multiple mods can add to the same group without extra effort put into cross-mod compatibility code. In this case we are adding a SilverBar group.
+			SilverBarRecipeGroup = RecipeGroup.Register(
+				nameof(ItemID.SilverBar),
+				"ItemName.SilverBar", // Lang.GetItemName(ItemID.SilverBar).Key would also work.
+				ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<ExampleBar>()
+			);
 		}
 
 		public override void AddRecipes() {

--- a/ExampleMod/Content/ExampleRecipes.cs
+++ b/ExampleMod/Content/ExampleRecipes.cs
@@ -26,13 +26,13 @@ namespace ExampleMod.Content
 				ModContent.ItemType<Items.ExampleItem>(), ModContent.ItemType<Items.ExampleDataItem>());
 
 			// To avoid name collisions, when a modded items is the iconic or 1st item in a recipe group, name the recipe group: ModName:ItemName
-			RecipeGroup.RegisterGroup("ExampleMod:ExampleItem", ExampleRecipeGroup);
+			RecipeGroup.RegisterGroup("ExampleMod:ExampleItem", ExampleRecipeGroup)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
 
 			// Add an item to an existing Terraria recipeGroup. ExampleCritterItem isn't gold but it serves as an example for this.
-			RecipeGroup.recipeGroups[RecipeGroupID.GoldenCritter].ValidItems.Add(ModContent.ItemType<ExampleCritterItem>());
+			RecipeGroup.recipeGroups[RecipeGroups.GoldenCritter].ValidItems.Add(ModContent.ItemType<ExampleCritterItem>());
 
 			// We also add ExampleSand to the Sand group, which is used in the Glass and Magic Sand Dropper recipes
-			RecipeGroup.recipeGroups[RecipeGroupID.Sand].ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
+			RecipeGroup.recipeGroups[RecipeGroups.Sand].ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
 
 			// We can also add ExamplePressurePlate to the pressure plate group, allowing it to be used to craft weighted pressure plates and pressure plate track. Since ExamplePressurePlate is a weighed pressure plate, we'll leave this commented out.
 			//RecipeGroup.recipeGroups[RecipeGroupID.PressurePlate].ValidItems.Add(ModContent.ItemType<ExamplePressurePlate>());
@@ -40,7 +40,7 @@ namespace ExampleMod.Content
 			// While an "IronBar" group exists, "SilverBar" does not. tModLoader will merge recipe groups registered with the same name, so if you are registering a recipe group with a vanilla item as the 1st item, you can register it using just the internal item name if you anticipate other mods wanting to use this recipe group for the same concept. By doing this, multiple mods can add to the same group without extra effort. In this case we are adding a SilverBar group. Don't store the RecipeGroup instance, it might not be used, use the same nameof(ItemID.ItemName) or RecipeGroupID returned from RegisterGroup when using Recipe.AddRecipeGroup instead.
 			RecipeGroup SilverBarRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
 			ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
-			RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup);
+			RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
 		}
 
 		public override void AddRecipes() {
@@ -81,9 +81,9 @@ namespace ExampleMod.Content
 
 				// RecipeGroups allow you create a recipe that accepts items from a group of similar ingredients. For example, all varieties of Wood are in the vanilla "Wood" Group
 				// Check here for other vanilla groups: https://github.com/tModLoader/tModLoader/wiki/Intermediate-Recipes#using-existing-recipegroups
-				.AddRecipeGroup(RecipeGroupID.Wood)
+				.AddRecipeGroup(RecipeGroups.Wood)
 				// Just like with AddIngredient, there's a stack parameter with a default value of 1.
-				.AddRecipeGroup(RecipeGroupID.IronBar, 2)
+				.AddRecipeGroup(RecipeGroups.IronBar, 2)
 				// Here is using a mod recipe group. Check out AddRecipeGroups() to see how to register a recipe group.
 				.AddRecipeGroup(ExampleRecipeGroup, 2)
 				// An alternate string-based approach to the above. Try to only use it for other mods' groups, because it's slower.

--- a/ExampleMod/Content/Items/Placeable/ExampleCampfire.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleCampfire.cs
@@ -12,7 +12,7 @@ namespace ExampleMod.Content.Items.Placeable
 
 		public override void AddRecipes() {
 			CreateRecipe()
-				.AddRecipeGroup(RecipeGroupID.Wood, 10)
+				.AddRecipeGroup(RecipeGroups.Wood, 10)
 				.AddIngredient<ExampleTorch>(5)
 				.Register();
 		}

--- a/ExampleMod/Content/Items/Placeable/ExampleCampfire.cs
+++ b/ExampleMod/Content/Items/Placeable/ExampleCampfire.cs
@@ -12,9 +12,7 @@ namespace ExampleMod.Content.Items.Placeable
 
 		public override void AddRecipes() {
 			CreateRecipe()
-#if COMPILE_ERROR_TODOS
 				.AddRecipeGroup(RecipeGroupID.Wood, 10)
-#endif
 				.AddIngredient<ExampleTorch>(5)
 				.Register();
 		}

--- a/ExampleMod/Content/TileEntities/BasicTileEntity.cs
+++ b/ExampleMod/Content/TileEntities/BasicTileEntity.cs
@@ -233,7 +233,7 @@ namespace ExampleMod.Content.TileEntities
 
 		public override void AddRecipes() {
 			CreateRecipe()
-				.AddRecipeGroup(RecipeGroupID.Wood, 9)
+				.AddRecipeGroup(RecipeGroups.Wood, 9)
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
 		}

--- a/ExampleMod/Content/TileEntities/BasicTileEntity.cs
+++ b/ExampleMod/Content/TileEntities/BasicTileEntity.cs
@@ -233,9 +233,7 @@ namespace ExampleMod.Content.TileEntities
 
 		public override void AddRecipes() {
 			CreateRecipe()
-#if COMPILE_ERROR_TODOS
 				.AddRecipeGroup(RecipeGroupID.Wood, 9)
-#endif
 				.AddTile<Tiles.Furniture.ExampleWorkbench>()
 				.Register();
 		}

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 743/743, 100%, missing 0
-ru-RU, 6/743, 1%, missing 737
-zh-Hans, 2/743, 0%, missing 741
+en-US, 744/744, 100%, missing 0
+ru-RU, 6/744, 1%, missing 738
+zh-Hans, 2/744, 0%, missing 742

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -124,6 +124,44 @@ When the portrait setting is set to profile, a close up of the NPC's normal spri
   
 Note: As stated above, if a detailed portrait is not provided, the profile portrait will display if the user has the detailed portrait setting enabled.
 
+### RecipeGroup
+
+`RecipeGroup`s have changed. 
+* 🤖: There is no longer a `RecipeGroupID` class. Instead, the `RecipeGroups` class stores vanilla `RecipeGroup` objects.
+* ⚙️: Creating `RecipeGroup`s has also changed. 
+  * The `RecipeGroup` constructor and `RecipeGroup.RegisterGroup` have been removed. Creating and registering a `RecipeGroup` is now consolidated into the `RecipeGroup.Register` method.
+  * Rather than manually using "LegacyMisc.37" to create the string "Any ItemName", the default way of creating `RecipeGroup`s will now automatically generate that string from a passed in localization key. Custom recipe group display names are also still possible with the other `RecipeGroup.Register` overload.
+* There are several new vanilla `RecipeGroup`s. Replace custom groups with these vanilla groups: `Seashells`, `Stone`, `CobaltBar`, `MythrilBar`, `AdamantiteBar`, `GemCritter`, `MagicMirror`, and `Jellyfish`. If you were referencing vanilla groups by name/key, note that these no longer have spaces: `CloudBalloons`, `BlizzardBalloons, `SandstormBalloons`, `CritterGuides, and `NatureGuides`.
+
+Examples:
+```cs
+// Old
+CreateRecipe()
+	.AddRecipeGroup(RecipeGroupID.Wood, 9)
+	.Register();
+
+RecipeGroup.recipeGroups[RecipeGroupID.Sand].ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
+
+RecipeGroup SilverBarRecipeGroup = new RecipeGroup(
+	() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
+	ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>()
+);
+RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup);
+
+// New
+CreateRecipe()
+	.AddRecipeGroup(RecipeGroups.Wood, 9)
+	.Register();
+
+RecipeGroups.Sand.ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());
+
+SilverBarRecipeGroup = RecipeGroup.Register(
+	nameof(ItemID.SilverBar),
+	"ItemName.SilverBar", // Lang.GetItemName(ItemID.SilverBar).Key would also work.
+	ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<ExampleBar>()
+);
+```
+
 ## Other Changes
 
 * Fishing power bonus now applies to any chair, not just toilets.
@@ -138,6 +176,7 @@ Note: As stated above, if a detailed portrait is not provided, the profile portr
 ### Static Methods
 
 * 💀: `Main.GetPlayerArmPosition` now has a `Player` parameter.
+* ⚙️: `RecipeGroup.RegisterGroup` removed. See [RecipeGroup](#recipegroup) for more information.
 * ⚙️: `Utils.PlotTileArea` -> `Utils.FloodFillTile`. No longer returns `bool` and parameters are now `Point point, float maxDist, TileActionAttempt plot` instead of `int x, int y, TileActionAttempt plot`.
 * 🤖: `WorldGen.CheckTight` -> `WorldGen.CheckStalactite`
 
@@ -174,6 +213,7 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 * ⚙️: `ProjectileID.Sets.DontAttachHideToAlpha` removed. Now true by default. See `Projectile.usesOwnerLight` and `Projectile.drawLayer` for more details.
 * ⚙️: `ProjectileID.Sets.HeldProjDoesNotUsePlayerGfxOffY` removed. `AI()` should use `master.RotatedRelativePoint(master.MountedCenter + ...)` to position held projectiles.
 * 🤖: `ProjectileID.Sets.MinionTargettingFeature` -> `ProjectileID.Sets.MinionTargetingFeature`
+* 🤖: `RecipeGroupID` removed. `RecipeGroup` instances are now stored directly in `RecipeGroups`.
 * 🤖: `TileID.Sets.CountsAsWaterSource` -> `TileID.Sets.CountsAsWaterForCrafting`
 * 🤖: `TileID.Sets.CountsAsHoneySource` -> `TileID.Sets.CountsAsHoneyForCrafting`
 * 🤖: `TileID.Sets.CountsAsLavaSource` -> `TileID.Sets.CountsAsLavaForCrafting`
@@ -206,6 +246,7 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 * ⚙️: `Player.CheckForGoodTeleportationSpot` removed. Use `Utils.CheckForGoodTeleportationSpot` instead.
 * 💀: `Player.DropItems` now has a `gemsOnly` parameter indicating a softcore or creative player that should only drop large gems.
 * ⚙️: `Recipe.FindRecipes` removed. No longer used.
+* ⚙️: `RecipeGroup` constructor removed. See [RecipeGroup](#recipegroup) for more information.
 
 ### Non-Static Fields / Constants / Properties
 

--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -5,7 +5,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - GameModeData.cs no longer exists, patches need to be redistributed
 - NPCSpawnParams.gameModeData no longer exists. This was potentially used in IBestiaryInfoElement.
 - NPCSpawnParams.strengthMultiplierOverride renamed to difficultyOverride. Investigate if behavior changed.
-- RecipeGroupID.cs no longer exists, need to adjust documentation accordingly.
 - NPCHitCount = 58 --> (and others) needs comment explaining what the value should be. Why is it 1 more when no sound 0?
 - Remove all Obsolete methods, including hooks and vanilla changes.
 - Doublecheck methods marked as "Unused": SwitchTilesNew, AddStructure/AddProtectedStructure
@@ -18,7 +17,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - WorldGenerator._seed needs to be internal again. The patch was lost
 - Consider updating FlexibleTileWand.Reload
 - https://github.com/tModLoader/tModLoader/pull/1675 seemed to fix a bug that is apparently now fixed in vanilla. Patches in AWorkshopPublishInfoState deleted. Verify that existing workshop publicity still correctly updates UI without requiring a click.
-- RecipeGroup has changed dramatically. We'll need to adjust how modded groups merge and document the new behaviors and new ctors. The tml added methods might also be superfluous now. 
 - Mount.Dismount now has a ignoreEffect parameter, this might duplicate the skipDust variable used in MountLoader.Dismount. Adjust patches (and docs) accordingly if they should be the same. When is it set? Do modded mounts need to care about when ignoreEffect was true or false?
 - NPC.Spawner class needs docs and hooks (similar to the old NPCSpawnInfo). The intent is that modders can intercept the various stages, and set/override flags to alter vanilla spawn logic.
 - NPCLoader.BuffTownNPC will need to be reworked to facilitate new functionality. "Defeating a boss now also gives each villager a 1.5% attack speed bonus." is a new vanilla effect. Similarly the Advanced Combat Techniques increases health by 250. Dryad immortal on infectedSeed.
@@ -140,8 +138,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
   - needEverythingSeed seems to be replaced by needMechdusa. TODo: Rename Condition.ZenithWorld?
   - Recipe item consumption seems to be in another class now, patches need to be moved. GetIngredientCraftingDiscount also needs to be tweaked to work again for modded RecipeLoader.ConsumeIngredient
     - Hook needs rework to use `Recipe.RequiredItemEntry`
-  - RecipeGroup.Register merge feature needs to be reworked to look up correct GetPlaceholderItemType and merge missing items with Add instead of Union.
-    - Done, but since RecipeGroups no longer have names, the logic currently just checks the 1st item (GetPlaceholderItemType).
   - CraftViaRequest complicates `RecipeItemCreationContext.DestinationStack` I think. Removed for compile, restore if possible. OnCraftHooks also not hooked up.
     - In theory it can be restored, since the `_pendingCrafts` queue remains on the client, and changes to `Main.mouseItem` are forbidden while a craft is pending. Documentation needs to note that the craft could be refunded though, so we likely need `OnCraft` hoook to be in `CraftItem_GrantItem`. We could amend the response packet from the server to send the consumed items, at the cost of quite some bandwidth when rapid crafting
 - ItemSlot flow changed a lot. AccCheck no longer exists, replaced by CanEquipAccessoryInSlot?

--- a/patches/tModLoader/Terraria/ID/RecipeGroups.cs.patch
+++ b/patches/tModLoader/Terraria/ID/RecipeGroups.cs.patch
@@ -1,0 +1,13 @@
+--- src/TerrariaNetCore/Terraria/ID/RecipeGroups.cs
++++ src/tModLoader/Terraria/ID/RecipeGroups.cs
+@@ -10,8 +_,10 @@
+ 	public static RecipeGroup Butterflies;
+ 	public static RecipeGroup Fireflies;
+ 	public static RecipeGroup Snails;
++	/* Never actually assigned, so commented out.
+ 	public static RecipeGroup FishForDinner;
+ 	public static RecipeGroup GoldenCritter;
++	*/
+ 	public static RecipeGroup Dragonflies;
+ 	public static RecipeGroup Turtles;
+ 	public static RecipeGroup Fruit;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1871,6 +1871,16 @@
  		for (int i = 1; i < ProjectileID.Count; i++) {
  			Projectile obj = new Projectile();
  			obj.SetDefaults(i);
+@@ -5672,7 +_,9 @@
+ 				projHook[i] = true;
+ 		}
+ 
++		/* TML: Moved into Recipe.SetupRecipes();
+ 		Recipe.SetupRecipeGroups();
++		*/
+ 		ConditionalDialogue.Init();
+ 		ArmorSetBonuses.Initialize();
+ 		ArmorSetBonuses.BuildLookup();
 @@ -5698,11 +_,18 @@
  		}
  

--- a/patches/tModLoader/Terraria/Recipe.TML.cs
+++ b/patches/tModLoader/Terraria/Recipe.TML.cs
@@ -121,36 +121,29 @@ public partial class Recipe
 	public Recipe AddIngredient<T>(int stack = 1) where T : ModItem
 		=> AddIngredient(ModContent.ItemType<T>(), stack);
 
-	/*
 	/// <summary>
-	/// Adds a recipe group ingredient to this recipe with the given RecipeGroup name and stack size.
+	/// Adds a recipe group ingredient to this recipe with the given RecipeGroup key and stack size. This overload is intended for using modded recipe groups in situations where a reference to the <see cref="RecipeGroup"/> object itself isn't accessible, but it is usually safer to use the other overloads if at all possible.
 	/// <br/> Recipe groups allow a recipe to use alternate ingredients without making multiple recipes. For example the "IronBar" group accepts either <see cref="ItemID.IronBar"/> or <see cref="ItemID.LeadBar"/>. The <see href="https://github.com/tModLoader/tModLoader/wiki/Intermediate-Recipes#recipe-groups">Recipe Groups wiki guide</see> has more information.
-	/// <br/> To use a vanilla recipe group, use <see cref="AddRecipeGroup(int, int)"/> using a <see cref="RecipeGroupID"/> entry instead.
+	/// <br/> To use a vanilla recipe group, use <see cref="AddRecipeGroup(RecipeGroup, int)"/> using a <see cref="RecipeGroups"/> entry instead.
 	/// </summary>
 	/// <param name="name">The name.</param>
 	/// <param name="stack">The stack.</param>
 	/// <exception cref="RecipeException">A recipe group with the name " + name + " does not exist.</exception>
 	public Recipe AddRecipeGroup(string name, int stack = 1)
 	{
-		if (!RecipeGroup.recipeGroupIDs.ContainsKey(name))
+		var group = RecipeGroup.recipeGroups.Values.SingleOrDefault(x => x.Key == name);
+
+		if (group == null)
 			throw new RecipeException($"A recipe group with the name {name} does not exist.");
 
-		int id = RecipeGroup.recipeGroupIDs[name];
-		var group = RecipeGroup.recipeGroups[id];
-
-		AddIngredient(group.IconicItemId, stack);
-		AddGroup(id);
-
-		return this;
+		return AddRecipeGroup(group, stack);
 	}
-	*/
 
 	/// <summary>
-	/// Adds a recipe group ingredient to this recipe with the given RecipeGroupID and stack size.
-	/// <br/> Recipe groups allow a recipe to use alternate ingredients without making multiple recipes. For example the <see cref="RecipeGroupID.IronBar"/> group accepts either <see cref="ItemID.IronBar"/> or <see cref="ItemID.LeadBar"/>. The <see href="https://github.com/tModLoader/tModLoader/wiki/Intermediate-Recipes#recipe-groups">Recipe Groups wiki guide</see> has more information.
-	/// <br/> Vanilla recipe group IDs can be found in <see cref="RecipeGroupID"/> and modded recipe group IDs will be returned from <see cref="RecipeGroup.RegisterGroup(string, RecipeGroup)"/>. <see cref="AddRecipeGroup(string, int)"/> can be used instead if the ID number is not known but the name is known.
+	/// Adds a recipe group ingredient to this recipe with the given <see cref="RecipeGroup.RegisteredId"/> and stack size. Using the <see cref="AddRecipeGroup(RecipeGroup, int)"/> method is usually preferred.
+	/// <br/> Recipe groups allow a recipe to use alternate ingredients without making multiple recipes. For example the <see cref="RecipeGroups.IronBar"/> group accepts either <see cref="ItemID.IronBar"/> or <see cref="ItemID.LeadBar"/>. The <see href="https://github.com/tModLoader/tModLoader/wiki/Intermediate-Recipes#recipe-groups">Recipe Groups wiki guide</see> has more information.
 	/// </summary>
-	/// <param name="recipeGroupId">The RecipeGroupID.</param>
+	/// <param name="recipeGroupId">A <see cref="RecipeGroup.RegisteredId"/>.</param>
 	/// <param name="stack">The stack.</param>
 	/// <exception cref="RecipeException">A recipe group with the ID " + recipeGroupID + " does not exist.</exception>
 	public Recipe AddRecipeGroup(int recipeGroupId, int stack = 1)

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -267,10 +267,11 @@
  				RequiredItemEntry requiredItemEntry = recipe.requiredItemQuickLookup[j];
  				if (requiredItemEntry.itemIdOrRecipeGroup == 0)
  					break;
-@@ -434,6 +_,7 @@
+@@ -434,6 +_,8 @@
  		RecipeGroups.Fragment = new RecipeGroup(Lang.misc[51].Key, 3458, 3456, 3457, 3459).Register();
  		RecipeGroups.PressurePlate = new RecipeGroup(Lang.misc[38].Key, 542, 852, 543, 541, 1151, 529, 853, 4261).Register();
  		RecipeGroups.Jellyfish = new RecipeGroup("Misc.Jellyfish", 2436, 2437, 2438).Register();
++		RecipeGroup.AssignKeysToVanillaGroups(); // TML
 +		RecipeGroupHelper.AddRecipeGroups();
  	}
  

--- a/patches/tModLoader/Terraria/Recipe.cs.rej
+++ b/patches/tModLoader/Terraria/Recipe.cs.rej
@@ -204,25 +204,6 @@
  			if (!player.adjTile[tempRec.requiredTile[i]])
  				return false;
  		}
-@@ -603,13 +_,13 @@
- 		RecipeGroupID.Fruit = RecipeGroup.RegisterGroup("Fruit", rec);
- 		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Language.GetTextValue("Misc.Balloon"), 3738, 3736, 3737);
- 		RecipeGroupID.Balloons = RecipeGroup.RegisterGroup("Balloons", rec);
--		rec = new RecipeGroup(() => "replaceme wood", 9, 619, 620, 621, 911, 1729, 2504, 2503, 5215);
-+		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Lang.GetItemNameValue(ItemID.Wood), 9, 619, 620, 621, 911, 1729, 2504, 2503, 5215);
- 		RecipeGroupID.Wood = RecipeGroup.RegisterGroup("Wood", rec);
--		rec = new RecipeGroup(() => "replaceme sand", 169, 408, 1246, 370, 3272, 3338, 3274, 3275);
-+		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Lang.GetItemNameValue(ItemID.SandBlock), 169, 408, 1246, 370, 3272, 3338, 3274, 3275);
- 		RecipeGroupID.Sand = RecipeGroup.RegisterGroup("Sand", rec);
--		rec = new RecipeGroup(() => "replaceme ironbar", 22, 704);
-+		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Lang.GetItemNameValue(ItemID.IronBar), 22, 704);
- 		RecipeGroupID.IronBar = RecipeGroup.RegisterGroup("IronBar", rec);
--		rec = new RecipeGroup(() => "replaceme fragment", 3458, 3456, 3457, 3459);
-+		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Lang.misc[51].Value, 3458, 3456, 3457, 3459);
- 		RecipeGroupID.Fragment = RecipeGroup.RegisterGroup("Fragment", rec);
--		rec = new RecipeGroup(() => "replaceme pressureplate", 852, 543, 542, 541, 1151, 529, 853, 4261);
-+		rec = new RecipeGroup(() => Lang.misc[37].Value + " " + Lang.misc[38].Value, 852, 543, 542, 541, 1151, 529, 853, 4261);
- 		RecipeGroupID.PressurePlate = RecipeGroup.RegisterGroup("PressurePlate", rec);
 @@ -628,4 +_,5 @@
  
 +		/*

--- a/patches/tModLoader/Terraria/RecipeGroup.TML.cs
+++ b/patches/tModLoader/Terraria/RecipeGroup.TML.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Terraria.GameContent;
+using Terraria.ID;
+
+namespace Terraria;
+
+public partial class RecipeGroup
+{
+	/// <summary>
+	/// A unique key for this RecipeGroup.
+	/// </summary>
+	public string Key { get; internal set; } // internal set so we can set it for vanilla groups without large patches.
+
+	// Modded API: Forces assigning a Key parameter to facilitate ad hoc merging of recipe groups.
+	/// <summary>
+	/// Creates and registers a RecipeGroup with the given key, group descriptor key, and valid items. If an existing RecipeGroup with the same <paramref name="key"/> exists, the valid items will be merged into the existing group instead of creating a new one.
+	/// <br/><br/> The <paramref name="groupDescriptorKey"/> is a localization key that will be interpolated into the "CombineFormat.RecipeGroup" key, which in English will result in "Any [groupDescriptorKeyValue]". To deviate from this format, use <see cref="Register(string, Func{string}, int[])"/> instead and provide a custom <c>Func&lt;string&gt; getName</c> function.
+	/// <br/><br/> The first item in the <paramref name="validItems"/> array will be used as the placeholder item for the group.
+	/// </summary>
+	/// <param name="key">The unique key for the RecipeGroup.</param>
+	/// <param name="groupDescriptorKey">The key for the group's descriptor text.</param>
+	/// <param name="validItems">The valid items for the group.</param>
+	/// <returns>The registered RecipeGroup.</returns>
+	public static RecipeGroup Register(string key, string groupDescriptorKey, params int[] validItems) => new RecipeGroup(groupDescriptorKey, validItems) { Key = key }.Register();
+
+	/// <summary>
+	/// Creates and registers a RecipeGroup with the given key, name function, and valid items. If an existing RecipeGroup with the same <paramref name="key"/> exists, the valid items will be merged into the existing group instead of creating a new one.
+	/// <br/><br/> The <paramref name="getName"/> function is the display value. When using <see cref="Register(string, string, int[])"/> the display value will automatically be "Any [groupDescriptorKeyValue]", but this function provides complete control over the display value.
+	/// <br/><br/> The first item in the <paramref name="validItems"/> array will be used as the placeholder item for the group.
+	/// </summary>
+	/// <param name="key">The unique key for the RecipeGroup.</param>
+	/// <param name="getName">A function that will return the display value.</param>
+	/// <param name="validItems">The valid items for the group.</param>
+	/// <returns>The registered RecipeGroup.</returns>
+	public static RecipeGroup Register(string key, Func<string> getName, params int[] validItems) => new RecipeGroup(getName, validItems) { Key = key }.Register();
+
+	public static void AssignKeysToVanillaGroups()
+	{
+		/* These RecipeGroup don't register, so they aren't suitable for use in recipes anyway since they have no RegisteredId. If we wanted, we'd need to register and assign a key, which might look similar to this.
+		ConditionalDialogue.ItemGroups.Ore = new RecipeGroup("RecipeGroups.Ore", 699, 12, 11, 700, 14, 701, 13, 702) { Key = "Ore" }.Register();
+		ConditionalDialogue.ItemGroups.Ore.Key = "Ore";
+		ConditionalDialogue.ItemGroups.Bars.Key = "Bars";
+		ConditionalDialogue.ItemGroups.Anvils.Key = "Anvils";
+		ConditionalDialogue.ItemGroups.Whips.Key = "Whips";
+		ConditionalDialogue.ItemGroups.Mounts.Key = "Mounts";
+		*/
+
+		// Could use reflection, but this should be faster.
+		RecipeGroups.Birds.Key = "Birds";
+		RecipeGroups.Scorpions.Key = "Scorpion";
+		RecipeGroups.Squirrels.Key = "Squirrel";
+		RecipeGroups.Bugs.Key = "Bugs";
+		RecipeGroups.Ducks.Key = "Ducks";
+		RecipeGroups.Butterflies.Key = "Butterflies";
+		RecipeGroups.Fireflies.Key = "Fireflies";
+		RecipeGroups.Snails.Key = "Snails";
+		RecipeGroups.Dragonflies.Key = "Dragonflies";
+		RecipeGroups.Turtles.Key = "Turtles";
+		RecipeGroups.Macaws.Key = "Macaws";
+		RecipeGroups.Cockatiels.Key = "Cockatiels";
+		RecipeGroups.CloudBalloons.Key = "CloudBalloons";
+		RecipeGroups.BlizzardBalloons.Key = "BlizzardBalloons";
+		RecipeGroups.SandstormBalloons.Key = "SandstormBalloons";
+		RecipeGroups.CritterGuides.Key = "CritterGuides";
+		RecipeGroups.NatureGuides.Key = "NatureGuides";
+		RecipeGroups.Seashells.Key = "Seashells";
+		RecipeGroups.Fruit.Key = "Fruit";
+		RecipeGroups.Balloons.Key = "Balloons";
+		RecipeGroups.CobaltBar.Key = "CobaltBar";
+		RecipeGroups.MythrilBar.Key = "MythrilBar";
+		RecipeGroups.GemCritter.Key = "GemCritter";
+		RecipeGroups.MagicMirror.Key = "MagicMirror";
+		RecipeGroups.Wood.Key = "Wood";
+		RecipeGroups.Stone.Key = "Stone";
+		RecipeGroups.Sand.Key = "Sand";
+		RecipeGroups.IronBar.Key = "IronBar";
+		RecipeGroups.Fragment.Key = "Fragment";
+		RecipeGroups.PressurePlate.Key = "PressurePlate";
+		RecipeGroups.Jellyfish.Key = "Jellyfish";
+	}
+}

--- a/patches/tModLoader/Terraria/RecipeGroup.TML.cs
+++ b/patches/tModLoader/Terraria/RecipeGroup.TML.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using Terraria.GameContent;
+using System.Linq;
+using System.Reflection;
 using Terraria.ID;
 
 namespace Terraria;
@@ -36,46 +37,11 @@ public partial class RecipeGroup
 
 	public static void AssignKeysToVanillaGroups()
 	{
-		/* These RecipeGroup don't register, so they aren't suitable for use in recipes anyway since they have no RegisteredId. If we wanted, we'd need to register and assign a key, which might look similar to this.
-		ConditionalDialogue.ItemGroups.Ore = new RecipeGroup("RecipeGroups.Ore", 699, 12, 11, 700, 14, 701, 13, 702) { Key = "Ore" }.Register();
-		ConditionalDialogue.ItemGroups.Ore.Key = "Ore";
-		ConditionalDialogue.ItemGroups.Bars.Key = "Bars";
-		ConditionalDialogue.ItemGroups.Anvils.Key = "Anvils";
-		ConditionalDialogue.ItemGroups.Whips.Key = "Whips";
-		ConditionalDialogue.ItemGroups.Mounts.Key = "Mounts";
-		*/
+		// The RecipeGroup in ConditionalDialogue don't register, so they aren't suitable for use in recipes anyway since they have no RegisteredId. They also are not currently reinitialized, so changes will persist between mod reloads.
+		// If we wanted to support them, they'd have to be registered and we'd need to make sure they are reset on mod reload, but they aren't used anywhere anyway yet.
 
-		// Could use reflection, but this should be faster.
-		RecipeGroups.Birds.Key = "Birds";
-		RecipeGroups.Scorpions.Key = "Scorpion";
-		RecipeGroups.Squirrels.Key = "Squirrel";
-		RecipeGroups.Bugs.Key = "Bugs";
-		RecipeGroups.Ducks.Key = "Ducks";
-		RecipeGroups.Butterflies.Key = "Butterflies";
-		RecipeGroups.Fireflies.Key = "Fireflies";
-		RecipeGroups.Snails.Key = "Snails";
-		RecipeGroups.Dragonflies.Key = "Dragonflies";
-		RecipeGroups.Turtles.Key = "Turtles";
-		RecipeGroups.Macaws.Key = "Macaws";
-		RecipeGroups.Cockatiels.Key = "Cockatiels";
-		RecipeGroups.CloudBalloons.Key = "CloudBalloons";
-		RecipeGroups.BlizzardBalloons.Key = "BlizzardBalloons";
-		RecipeGroups.SandstormBalloons.Key = "SandstormBalloons";
-		RecipeGroups.CritterGuides.Key = "CritterGuides";
-		RecipeGroups.NatureGuides.Key = "NatureGuides";
-		RecipeGroups.Seashells.Key = "Seashells";
-		RecipeGroups.Fruit.Key = "Fruit";
-		RecipeGroups.Balloons.Key = "Balloons";
-		RecipeGroups.CobaltBar.Key = "CobaltBar";
-		RecipeGroups.MythrilBar.Key = "MythrilBar";
-		RecipeGroups.GemCritter.Key = "GemCritter";
-		RecipeGroups.MagicMirror.Key = "MagicMirror";
-		RecipeGroups.Wood.Key = "Wood";
-		RecipeGroups.Stone.Key = "Stone";
-		RecipeGroups.Sand.Key = "Sand";
-		RecipeGroups.IronBar.Key = "IronBar";
-		RecipeGroups.Fragment.Key = "Fragment";
-		RecipeGroups.PressurePlate.Key = "PressurePlate";
-		RecipeGroups.Jellyfish.Key = "Jellyfish";
+		foreach (var fieldInfo in typeof(RecipeGroups).GetFields(BindingFlags.Static | BindingFlags.Public).Where(f => f.FieldType == typeof(RecipeGroup))) {
+			(fieldInfo.GetValue(null) as RecipeGroup).Key = fieldInfo.Name;
+		}
 	}
 }

--- a/patches/tModLoader/Terraria/RecipeGroup.cs.patch
+++ b/patches/tModLoader/Terraria/RecipeGroup.cs.patch
@@ -1,11 +1,42 @@
 --- src/TerrariaNetCore/Terraria/RecipeGroup.cs
 +++ src/tModLoader/Terraria/RecipeGroup.cs
-@@ -58,6 +_,16 @@
+@@ -6,7 +_,7 @@
+ 
+ namespace Terraria;
+ 
+-public class RecipeGroup
++public partial class RecipeGroup
+ {
+ 	public static readonly int FakeItemIdOffset = 1000000;
+ 	public static LocalizedText DefaultCombineFormat = Language.GetText("CombineFormat.RecipeGroup");
+@@ -25,12 +_,13 @@
+ 		return () => DefaultCombineFormat.Format(text);
+ 	}
+ 
++	// TML: ctors are now internal to force modders to use static factory method approach
+-	public RecipeGroup(string groupDescriptorKey, params int[] validItems)
++	internal RecipeGroup(string groupDescriptorKey, params int[] validItems)
+ 		: this(WithDefaultCombineFormat(groupDescriptorKey), validItems)
+ 	{
+ 	}
+ 
+-	public RecipeGroup(Func<string> getName, params int[] validItems)
++	internal RecipeGroup(Func<string> getName, params int[] validItems)
+ 	{
+ 		RegisteredId = -1;
+ 		GetText = getName;
+@@ -53,10 +_,20 @@
+ 
+ 	public override string ToString() => GetText();
+ 
+-	public RecipeGroup Register()
++	internal RecipeGroup Register()
+ 	{
  		if (RegisteredId >= 0)
  			throw new Exception("Already registered");
- 
++
 +		// TML: Handle registering to an existing group by merging items and keeping the original group.
-+		var existingRecipeGroup = recipeGroups.Values.FirstOrDefault(x => x.GetPlaceholderItemType() == this.GetPlaceholderItemType());
++		var existingRecipeGroup = recipeGroups.Values.FirstOrDefault(x => x.Key == Key);
 +		if (existingRecipeGroup != null) {
 +			foreach (var item in this.Items) {
 +				if(!existingRecipeGroup.ValidItems.Contains(item))
@@ -13,7 +44,6 @@
 +			}
 +			return existingRecipeGroup;
 +		}
-+
+ 
  		int key = (RegisteredId = nextRecipeGroupIndex++);
  		recipeGroups.Add(key, this);
- 		return this;

--- a/patches/tModLoader/Terraria/RecipeGroup.cs.patch
+++ b/patches/tModLoader/Terraria/RecipeGroup.cs.patch
@@ -25,7 +25,7 @@
  	{
  		RegisteredId = -1;
  		GetText = getName;
-@@ -53,10 +_,20 @@
+@@ -53,10 +_,22 @@
  
  	public override string ToString() => GetText();
  
@@ -36,13 +36,15 @@
  			throw new Exception("Already registered");
 +
 +		// TML: Handle registering to an existing group by merging items and keeping the original group.
-+		var existingRecipeGroup = recipeGroups.Values.FirstOrDefault(x => x.Key == Key);
-+		if (existingRecipeGroup != null) {
-+			foreach (var item in this.Items) {
-+				if(!existingRecipeGroup.ValidItems.Contains(item))
-+					existingRecipeGroup.Add(item);
++		if (!string.IsNullOrWhiteSpace(Key)) {
++			var existingRecipeGroup = recipeGroups.Values.FirstOrDefault(x => x.Key == Key);
++			if (existingRecipeGroup != null) {
++				foreach (var item in this.Items) {
++					if (!existingRecipeGroup.ValidItems.Contains(item))
++						existingRecipeGroup.Add(item);
++				}
++				return existingRecipeGroup;
 +			}
-+			return existingRecipeGroup;
 +		}
  
  		int key = (RegisteredId = nextRecipeGroupIndex++);

--- a/tModPorter/tModPorter.Tests/TestData/RecipeGroupTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeGroupTest.Expected.cs
@@ -1,0 +1,48 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+public class RecipeGroupTest : ModSystem
+{
+	public static RecipeGroup GelLike;
+
+	public override void AddRecipeGroups()
+	{
+		// not-yet-implemented
+		GelLike = RecipeGroup.Register("TestMod:Gels", "Gel-like items", ItemID.Gel, ItemID.GelDye);
+
+		RecipeGroup SilverBarRecipeGroup = RecipeGroup.Register(nameof(ItemID.SilverBar), Lang.GetItemNameValue(ItemID.SilverBar), ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
+		// instead-expect
+#if COMPILE_ERROR
+		GelLike = new RecipeGroup(
+			() => $"{Language.GetTextValue("LegacyMisc.37")} Gel-like items",
+			ItemID.Gel, ItemID.GelDye
+		);
+		RecipeGroup.RegisterGroup("TestMod:Gels", GelLike)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
+
+		RecipeGroup SilverBarRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
+		ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
+		RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup)/* tModPorter Note: Removed. Replace this and "new RecipeGroup()" with RecipeGroup.Register */;
+#endif
+
+		// not-yet-implemented
+		RecipeGroups.Sand.ValidItems.Add(ItemID.SandstoneBrick);
+		// instead-expect
+#if COMPILE_ERROR
+		RecipeGroup.recipeGroups[RecipeGroups.Sand].ValidItems.Add(ItemID.SandstoneBrick);
+#endif
+	}
+
+	public override void AddRecipes()
+	{
+		Recipe.Create(ItemID.Gel)
+			.AddRecipeGroup(RecipeGroups.Wood)
+			.AddRecipeGroup(RecipeGroups.IronBar, 2)
+			.AddRecipeGroup(GelLike, 2)
+			.AddRecipeGroup("Wood")
+			.AddRecipeGroup("TestMod:Gels", 2)
+			.AddRecipeGroup(nameof(ItemID.SilverBar))
+			.Register();
+	}
+}

--- a/tModPorter/tModPorter.Tests/TestData/RecipeGroupTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RecipeGroupTest.cs
@@ -1,0 +1,36 @@
+﻿using Terraria;
+using Terraria.ID;
+using Terraria.Localization;
+using Terraria.ModLoader;
+
+public class RecipeGroupTest : ModSystem
+{
+	public static RecipeGroup GelLike;
+
+	public override void AddRecipeGroups()
+	{
+		GelLike = new RecipeGroup(
+			() => $"{Language.GetTextValue("LegacyMisc.37")} Gel-like items",
+			ItemID.Gel, ItemID.GelDye
+		);
+		RecipeGroup.RegisterGroup("TestMod:Gels", GelLike);
+
+		RecipeGroup SilverBarRecipeGroup = new RecipeGroup(() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
+		ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>());
+		RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup);
+
+		RecipeGroup.recipeGroups[RecipeGroupID.Sand].ValidItems.Add(ItemID.SandstoneBrick);
+	}
+
+	public override void AddRecipes()
+	{
+		Recipe.Create(ItemID.Gel)
+			.AddRecipeGroup(RecipeGroupID.Wood)
+			.AddRecipeGroup(RecipeGroupID.IronBar, 2)
+			.AddRecipeGroup(GelLike, 2)
+			.AddRecipeGroup("Wood")
+			.AddRecipeGroup("TestMod:Gels", 2)
+			.AddRecipeGroup(nameof(ItemID.SilverBar))
+			.Register();
+	}
+}

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -353,6 +353,7 @@ public static partial class Config
 		RefactorStaticMember("Terraria.Player", "RandomTeleportationAttemptSettings", Removed("Use Utils.RandomTeleportationAttemptSettings instead and populate all the relevant new fields"));
 
 		RefactorStaticMethodCall("Terraria.Chest", "FindChestByGuessing", Removed("Use Chest.FindChest with the top left tile coordinate"));
+		RefactorStaticMethodCall("Terraria.RecipeGroup", "RegisterGroup", Removed("Replace this and \"new RecipeGroup()\" with RecipeGroup.Register"));
 
 		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", RemoveParameter(1, "noMatCheck", "bool"));
 		RefactorInstanceMethodCall("Terraria.Tile", "water", GetterSetterToProperty("LiquidType", "Terraria.ID.LiquidID", "Water"));
@@ -368,6 +369,8 @@ public static partial class Config
 
 		ChangeStaticFieldType("Terraria.Main", "item",        from: "Terraria.Item", to: "Terraria.WorldItem");
 		ChangeStaticFieldType("Terraria.Main", "ActiveItems", from: "Terraria.Item", to: "Terraria.WorldItem");
+
+		RenameType("Terraria.ID.RecipeGroupID", "Terraria.ID.RecipeGroups");
 	}
 
 	private static void AddTextureRenames() {


### PR DESCRIPTION
# Description

Restores and refines the 1.4.4 `RecipeGroup` functionality.

# Porting Notes

`RecipeGroup`s have changed. 
* 🤖: There is no longer a `RecipeGroupID` class. Instead, the `RecipeGroups` class stores vanilla `RecipeGroup` objects.
* ⚙️: Creating `RecipeGroup`s has also changed. 
  * The `RecipeGroup` constructor and `RecipeGroup.RegisterGroup` have been removed. Creating and registering a `RecipeGroup` is now consolidated into the `RecipeGroup.Register` method.
  * Rather than manually using "LegacyMisc.37" to create the string "Any ItemName", the default way of creating `RecipeGroup`s will now automatically generate that string from a localization key (eg `ItemName.IronBar` or `RecipeGroup.Critter`). Custom recipe group display names are also still possible with the other `RecipeGroup.Register` overload that takes a `Func<string>` for the name.
* There are several new vanilla `RecipeGroup`s. Replace custom groups with these vanilla groups: `Seashells`, `Stone`, `CobaltBar`, `MythrilBar`, `AdamantiteBar`, `GemCritter`, `MagicMirror`, and `Jellyfish`. If you were referencing vanilla groups by name/key, note that these no longer have spaces: `CloudBalloons`, `BlizzardBalloons, `SandstormBalloons`, `CritterGuides, and `NatureGuides`.

Examples:
```cs
// Old
CreateRecipe()
	.AddRecipeGroup(RecipeGroupID.Wood, 9)
	.Register();

RecipeGroup.recipeGroups[RecipeGroupID.Sand].ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());

RecipeGroup SilverBarRecipeGroup = new RecipeGroup(
	() => $"{Language.GetTextValue("LegacyMisc.37")} {Lang.GetItemNameValue(ItemID.SilverBar)}",
	ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<Items.Placeable.ExampleBar>()
);
RecipeGroup.RegisterGroup(nameof(ItemID.SilverBar), SilverBarRecipeGroup);

// New
CreateRecipe()
	.AddRecipeGroup(RecipeGroups.Wood, 9)
	.Register();

RecipeGroups.Sand.ValidItems.Add(ModContent.ItemType<ExampleSandBlock>());

SilverBarRecipeGroup = RecipeGroup.Register(
	nameof(ItemID.SilverBar), // merge key, groups registered with the same key will be merged
	"ItemName.SilverBar", // Lang.GetItemName(ItemID.SilverBar).Key would also work.
	ItemID.SilverBar, ItemID.TungstenBar, ModContent.ItemType<ExampleBar>()
);
```

# Discussion
* tModPorter handles `RecipeGroupID.Wood` to `RecipeGroups.Wood`, and adds a comment to `RecipeGroup.RegisterGroup` about the new approach. Anything more will probably be too complicated to implement.
* Like in 1.4.4, `FishForDinner` and `GoldenCritter` are unused. I've commented them out rather than risk null exceptions.
* I've added `Key`/internal names to the vanilla `RecipeGroup`s based on their field names. This seems sensible. It does mean that `recipe.AddRecipeGroup("Wood")` is valid still, even though we would want modders to use the `RecipeGroups` fields instead.