### PR TITLE
[1.4.5] Resolve WorldGenerator._seed PortingNotes TODO

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -14,7 +14,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - We need to add ModItem.SummonPrefix(), add ModPrefix.Summon
 - ShimmerTransforms.IsItemTransformLocked seems to have been split, need to verify RecipeLoader.DecraftAvailable and other logic still applies.
 - Update ModPylon docs to removed danger check from check listing, and remove the ValidTeleportCheck_AnyDanger hook
-- WorldGenerator._seed needs to be internal again. The patch was lost
 - Consider updating FlexibleTileWand.Reload
 - https://github.com/tModLoader/tModLoader/pull/1675 seemed to fix a bug that is apparently now fixed in vanilla. Patches in AWorkshopPublishInfoState deleted. Verify that existing workshop publicity still correctly updates UI without requiring a click.
 - Mount.Dismount now has a ignoreEffect parameter, this might duplicate the skipDust variable used in MountLoader.Dismount. Adjust patches (and docs) accordingly if they should be the same. When is it set? Do modded mounts need to care about when ignoreEffect was true or false?

--- a/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
+++ b/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
@@ -13,15 +13,6 @@
  using Terraria.Utilities;
  
  namespace Terraria.WorldBuilding;
-@@ -318,7 +_,7 @@
- 	}
- 
- 	internal readonly List<GenPass> _passes = new List<GenPass>();
--	private readonly int _seed;
-+	internal readonly int _seed;
- 	private readonly WorldGenConfiguration _configuration;
- 	private readonly GenerationProgress _progress;
- 	private readonly Controller _controller;
 @@ -433,7 +_,10 @@
  		_hashTime.Start();
  		uint[] line_hashes = new uint[Main.maxTilesX];

--- a/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
+++ b/patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch
@@ -13,6 +13,15 @@
  using Terraria.Utilities;
  
  namespace Terraria.WorldBuilding;
+@@ -318,7 +_,7 @@
+ 	}
+ 
+ 	internal readonly List<GenPass> _passes = new List<GenPass>();
+-	private readonly int _seed;
++	internal readonly int _seed;
+ 	private readonly WorldGenConfiguration _configuration;
+ 	private readonly GenerationProgress _progress;
+ 	private readonly Controller _controller;
 @@ -433,7 +_,10 @@
  		_hashTime.Start();
  		uint[] line_hashes = new uint[Main.maxTilesX];


### PR DESCRIPTION
### What is the bug?
After the 1.4.5 patch port, `WorldGenerator._seed` is `private readonly int _seed;`. The previous tModLoader patch elevating this field to `internal` was lost during the port. Tracked in `PortingNotes_1.4.5.md` (line 17): "WorldGenerator._seed needs to be internal again. The patch was lost".

### How did you fix the bug?
~~Re-applied the visibility patch: changed `private readonly int _seed;` to `internal readonly int _seed;` in `src/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs` and regenerated via `setup-cli diff tml`. Result is a single 7-line context hunk in `patches/tModLoader/Terraria/WorldBuilding/WorldGenerator.cs.patch`. Also removed the corresponding line from `PortingNotes_1.4.5.md`.~~

I took another look, seems like the patch isn't actually doing anything useful since the WorldGenerator instance is private anyway. TODO deleted.

~~### Are there alternatives to your fix?
None reasonable. The field needs to be readable by tModLoader code outside the `WorldGenerator` class; `internal` is the minimal scope and matches the previous (lost) patch~~
