### PR TITLE
fix(1.4.5): Check for ` = new Tile();` not gated by null checks

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -88,7 +88,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - "// Sound is played on animation start #ItemTimeOnAllClients" comments around "SoundEngine.PlaySound(item6.UseSound" in MessageBuffer's `ShotAnimationAndSound` code. ShotAnimationAndSound was renamed, we might need to verify that this is still fixed in tmod.
 - ApplyDifficultyAndPlayerScaling needs to be revisited.
 - Need to restore rejected PopupText.rare patch logic in Item.GetPopupRarityColor
-- Check for ` = new Tile();` not gated by null checks. These will all throw exception. Change to `Tile.Clear(TileDataType.All);`
 - WorldGen.StopWaterfallAmbienceAudio might be a better place for some existing patches. Need to verify save and quit stopping waterfall sounds properly.
 - TileLoader.DropCritterChance could be updated with LuckyClover chance. Also Lavafly/HellButterfly chance
 - TileID.Sets.SpreadsCrimson added. Need docs and possibly adjust biome spread logic. SpreadsHallow

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -382,25 +382,21 @@
  		return num;
  	}
  
-@@ -3427,19 +_,14 @@
+@@ -3427,6 +_,7 @@
  			Main.tile[tileX, tileY + 1] = tile4;
  		}
  
--		if (tile.type == 379)
--			tile = new Tile();
--
--		if (tile2.type == 379)
--			tile2 = new Tile();
--
--		if (tile3.type == 379)
--			tile3 = new Tile();
--
--		if (tile4.type == 379)
--			tile4 = new Tile();
--
--		if (DebugOptions.hideWater || !tileCache.active() || tileCache.inActive() || _tileSolidTop[tileCache.type] || (tileCache.halfBrick() && (tile2.liquid > 160 || tile.liquid > 160) && Main.instance.waterfallManager.CheckForWaterfall(tileX, tileY)) || (TileID.Sets.BlocksWaterDrawingBehindSelf[tileCache.type] && tileCache.slope() == 0))
-+		// TML 1.4.5: Tile is now a struct; `= new Tile()` would point to TileId=0 (world pos 0,0) instead of an empty tile.
-+		// Instead, guard each liquid read below with a type != 379 check to preserve the original intent.
++		/*
+ 		if (tile.type == 379)
+ 			tile = new Tile();
+ 
+@@ -3440,6 +_,15 @@
+ 			tile4 = new Tile();
+ 
+ 		if (DebugOptions.hideWater || !tileCache.active() || tileCache.inActive() || _tileSolidTop[tileCache.type] || (tileCache.halfBrick() && (tile2.liquid > 160 || tile.liquid > 160) && Main.instance.waterfallManager.CheckForWaterfall(tileX, tileY)) || (TileID.Sets.BlocksWaterDrawingBehindSelf[tileCache.type] && tileCache.slope() == 0))
++		*/
++
++		// TML `new Tile()` would point to the tile at (0,0) instead of an empty tile. Reimplement the logic with separate bools instead of checking a tile coordinate that could potentially have garbage data in it.
 +		bool tile1IsSand = tile.type == 379;
 +		bool tile2IsSand = tile2.type == 379;
 +		bool tile3IsSand = tile3.type == 379;

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -382,6 +382,70 @@
  		return num;
  	}
  
+@@ -3427,19 +_,14 @@
+ 			Main.tile[tileX, tileY + 1] = tile4;
+ 		}
+ 
+-		if (tile.type == 379)
+-			tile = new Tile();
+-
+-		if (tile2.type == 379)
+-			tile2 = new Tile();
+-
+-		if (tile3.type == 379)
+-			tile3 = new Tile();
+-
+-		if (tile4.type == 379)
+-			tile4 = new Tile();
+-
+-		if (DebugOptions.hideWater || !tileCache.active() || tileCache.inActive() || _tileSolidTop[tileCache.type] || (tileCache.halfBrick() && (tile2.liquid > 160 || tile.liquid > 160) && Main.instance.waterfallManager.CheckForWaterfall(tileX, tileY)) || (TileID.Sets.BlocksWaterDrawingBehindSelf[tileCache.type] && tileCache.slope() == 0))
++		// TML 1.4.5: Tile is now a struct; `= new Tile()` would point to TileId=0 (world pos 0,0) instead of an empty tile.
++		// Instead, guard each liquid read below with a type != 379 check to preserve the original intent.
++		bool tile1IsSand = tile.type == 379;
++		bool tile2IsSand = tile2.type == 379;
++		bool tile3IsSand = tile3.type == 379;
++		bool tile4IsSand = tile4.type == 379;
++
++		if (DebugOptions.hideWater || !tileCache.active() || tileCache.inActive() || _tileSolidTop[tileCache.type] || (tileCache.halfBrick() && ((!tile2IsSand && tile2.liquid > 160) || (!tile1IsSand && tile.liquid > 160)) && Main.instance.waterfallManager.CheckForWaterfall(tileX, tileY)) || (TileID.Sets.BlocksWaterDrawingBehindSelf[tileCache.type] && tileCache.slope() == 0))
+ 			return;
+ 
+ 		int num = 0;
+@@ -3499,7 +_,7 @@
+ 					num = tileCache.liquid;
+ 			}
+ 
+-			if (tile2.liquid > 0 && num3 != 1 && num3 != 3) {
++			if (!tile2IsSand && tile2.liquid > 0 && num3 != 1 && num3 != 3) {
+ 				flag = true;
+ 				switch (tile2.liquidType()) {
+ 					case 0:
+@@ -3520,7 +_,7 @@
+ 					num = tile2.liquid;
+ 			}
+ 
+-			if (tile.liquid > 0 && num3 != 2 && num3 != 4) {
++			if (!tile1IsSand && tile.liquid > 0 && num3 != 2 && num3 != 4) {
+ 				flag2 = true;
+ 				switch (tile.liquidType()) {
+ 					case 0:
+@@ -3541,7 +_,7 @@
+ 					num = tile.liquid;
+ 			}
+ 
+-			if (tile3.liquid > 0 && num3 != 3 && num3 != 4) {
++			if (!tile3IsSand && tile3.liquid > 0 && num3 != 3 && num3 != 4) {
+ 				flag3 = true;
+ 				switch (tile3.liquidType()) {
+ 					case 0:
+@@ -3559,7 +_,7 @@
+ 				}
+ 			}
+ 
+-			if (tile4.liquid > 0 && num3 != 1 && num3 != 2) {
++			if (!tile4IsSand && tile4.liquid > 0 && num3 != 1 && num3 != 2) {
+ 				if (tile4.liquid > 240)
+ 					flag4 = true;
+ 
 @@ -3675,7 +_,8 @@
  
  		bool flag7 = false;


### PR DESCRIPTION
### What is the bug?

In Terraria 1.4.5 / tModLoader's new tile architecture, `Tile` was changed from a **class** to a `readonly partial struct`. The `Tilemap` (`Main.tile`) setter now throws `InvalidOperationException` with the message _"Cannot set Tilemap tiles. Only used to init null tiles in Vanilla (which don't exist anymore)"_ for any assignment of the form `Main.tile[x, y] = new Tile()`.

Additionally, `new Tile()` produces a struct with `TileId = 0`, which does **not** represent an "empty" tile — it points to world position `(0, 0)` in the global tile data arrays. Any read or write through such a struct silently operates on world tile `(0, 0)` instead of a blank tile, producing incorrect rendering behavior.

In `TileDrawing.DrawTile_LiquidBehindTile`, the vanilla pattern:

```csharp
if (tile.type == 379)
    tile = new Tile();
```

was used to treat adjacent sand tiles (type 379) as having no liquid for behind-tile liquid rendering. In the struct-based tile system this pattern reassigns the local variable to a zero-`TileId` struct, causing liquid rendering to silently read from world position `(0, 0)` instead of treating the tile as empty.

### How did you fix the bug?

**`TileDrawing.cs` — `DrawTile_LiquidBehindTile`:**

Replaced the 4 invalid `tile = new Tile()` local reassignments with boolean sand-type flags (`tile1IsSand`, `tile2IsSand`, `tile3IsSand`, `tile4IsSand`) and added `!tileNIsSand &&` guards at each corresponding liquid read site, preserving the original intent without touching world tile data:

```csharp
// Before (broken in struct tile world):
if (tile.type == 379)
    tile = new Tile();
// ... later:
if (tile.liquid > 0 && num3 != 2 && num3 != 4) { ... }

// After:
bool tile1IsSand = tile.type == 379;
// ... later:
if (!tile1IsSand && tile.liquid > 0 && num3 != 2 && num3 != 4) { ... }
```

**`WorldGen.cs` — `GenerateSkyBlockWorld`:**

The one ungated `Main.tile[i, j] = new Tile()` (which would throw) was already present in `src/tModLoader/` as dead code inside a `/* ... */` comment block, with the correct replacement (`Main.tile[i, j].Clear(TileDataType.All)`) already on the next line. No change was needed here.

All other `Main.tile[x, y] = new Tile()` occurrences across the codebase (327 total, spanning `WorldGen.cs`, `NPC.cs`, `Player.cs`, `Projectile.cs`, `Collision.cs`, `Gore.cs`, `Utils.cs`, etc.) are inside `if (Main.tile[x, y] == null)` null-check guards. Since the `Tile == null` operator is overloaded to always return `false`, these branches are dead code that never executes — no changes needed.

### Are there alternatives to your fix?

For the `TileDrawing.cs` case, alternatives considered:

- **`Main.tile[tileX+1, tileY].Clear(TileDataType.Liquid)`** — would permanently remove liquid from sand tiles in the world; incorrect.
- **Restructuring the function** to pass sand-type information through parameters — more invasive, not warranted for a rendering-only fix.
- **Checking `tile.type != 379` inline at every usage** — equivalent to the chosen approach but less readable.

The chosen approach (pre-computed bool flags) is minimal, readable, and semantically equivalent to the original vanilla intent.
