### PR TITLE
[1.4.5] Restore Petting Settings

### DIFF
--- a/patches/tModLoader/Terraria/ID/NPCID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/NPCID.TML.cs
@@ -158,13 +158,13 @@ public partial class NPCID
 		/// </remarks>
 		public static int[] InvasionSlotCount = Factory.CreateIntSet(1, 216, 5, 395, 10, 491, 10, 471, 10, 472, 0, 387, 0);
 
-		// IDs taken from Player.GetPettingInfo
+		// IDs taken from NPC.GetPettingInfo
 		/// <summary>
 		/// While petting, the number of pixels away the player stands from the NPC. Defaults to 36 pixels.
 		/// </summary>
 		public static int[] PlayerDistanceWhilePetting = Factory.CreateIntSet(36, TownCat, 28, TownBunny, 24, TownSlimeBlue, 26, TownSlimeGreen, 26, TownSlimeOld, 26, TownSlimePurple, 26, TownSlimeRainbow, 26, TownSlimeYellow, 26, TownSlimeRed, 22, TownSlimeCopper, 20);
 
-		// IDs taken from Player.GetPettingInfo
+		// IDs taken from NPC.GetPettingInfo
 		/// <summary>
 		/// While petting, the player's arm will be angled up by default. If the NPC is in this set, the player's armor will be angled down instead. Defaults to false.
 		/// </summary>

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2234,6 +2234,24 @@
  				nPC.townNpcVariationIndex = profile.RollVariation();
  				nPC.GivenName = profile.GetNameForVariant(nPC);
  			}
+@@ -67389,6 +_,9 @@
+ 	public PlayerPettingInfo GetPettingInfo(Player player)
+ 	{
+ 		int num = ((base.Center.X > player.Center.X) ? 1 : (-1));
++		int num2 = NPCID.Sets.PlayerDistanceWhilePetting[type];
++		bool isPetSmall = NPCID.Sets.IsPetSmallForPetting[type];
++		/*
+ 		int num2 = 36;
+ 		bool isPetSmall = false;
+ 		switch (type) {
+@@ -67418,6 +_,7 @@
+ 				num2 = 20;
+ 				break;
+ 		}
++		*/
+ 
+ 		return new PlayerPettingInfo(this, new Vector2(-num * num2, 0f), isPetSmall);
+ 	}
 @@ -67455,7 +_,7 @@
  
  	public bool RerollVariation()

--- a/patches/tModLoader/Terraria/Player.cs.rej
+++ b/patches/tModLoader/Terraria/Player.cs.rej
@@ -250,24 +250,6 @@
  		Offset = ClampHotbarOffset(Offset);
  		selectedItem += Offset;
  		if (Offset != 0) {
-@@ -25243,6 +_,9 @@
- 	{
- 		NPC nPC = Main.npc[animalNpcIndex];
- 		targetDirection = ((nPC.Center.X > base.Center.X) ? 1 : (-1));
-+		int num = NPCID.Sets.PlayerDistanceWhilePetting[nPC.type];
-+		isPetSmall = NPCID.Sets.IsPetSmallForPetting[nPC.type];
-+		/*
- 		int num = 36;
- 		isPetSmall = false;
- 		switch (nPC.type) {
-@@ -25272,6 +_,7 @@
- 				num = 20;
- 				break;
- 		}
-+		*/
- 
- 		playerPositionWhenPetting = nPC.Bottom + new Vector2(-targetDirection * num, 0f);
- 	}
 @@ -26230,7 +_,10 @@
  			cursorItemIconID = 3747;
  		}


### PR DESCRIPTION
### What is the bug?
The patches for `NPCID.Sets.PlayerDistanceWhilePetting` and `NPCID.Sets.IsPetSmallForPetting` weren't applied because `Player.GetPettingInfo` was removed and replaced with `NPC.GetPettingInfo` (and `Projectile.GetPettingInfo`).

### How did you fix the bug?
Moved the patches to `NPC.GetPettingInfo`.

### Are there alternatives to your fix?
No, unless we want to make a `ProjectileID.Sets` version.
