### PR TITLE
[1.4.5] Refix Too Many Tooltip Lines Can't Show the Tooltip Line

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -8,7 +8,7 @@
  using Terraria.UI;
  
  namespace Terraria.GameContent.Creative;
-@@ -22,19 +_,33 @@
+@@ -22,19 +_,34 @@
  		private int _unusedResearchLine;
  		private string _search;
  
@@ -21,9 +21,10 @@
  				return true;
  
 +			// Have to reinitialize because ItemLoader.ModifyTooltips resizes the arrays
-+			_toolTipNames = new string[30];
-+			_toolTipLines = new string[30];
-+			_unusedColor = new Color[30];
++			int tooltipCount = _tooltipMaxLines + entry.ToolTip?.Lines ?? 0; // Easy fix to #4772. A full fix would require rewrites of hooks.
++			_toolTipNames = new string[tooltipCount];
++			_toolTipLines = new string[tooltipCount];
++			_unusedColor = new Color[tooltipCount];
 +
  			int numLines = 1;
  			float knockBack = entry.knockBack;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3004,6 +3004,20 @@
  		if (diff == 1)
  			baseColor = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num3), (byte)((float)(int)mcColor.G * num3), (byte)((float)(int)mcColor.B * num3), mouseTextColor);
  
+@@ -17245,6 +_,13 @@
+ 		int numLines = 1;
+ 		string[] mouseTextTooltipLine_Text = _mouseTextTooltipLine_Text;
+ 		Microsoft.Xna.Framework.Color[] mouseTextTooltipLine_Color = _mouseTextTooltipLine_Color;
++
++		int expectedLineCount = _mouseTextTooltip_MaxLines + hoverItem.ToolTip?.Lines ?? 0; // Easy fix to #4772. A full fix would require rewrites of hooks.
++		if (mouseTextTooltipLine_Text.Length < expectedLineCount) {
++			Array.Resize(ref mouseTextTooltipLine_Text, expectedLineCount);
++			Array.Resize(ref mouseTextTooltipLine_Color, expectedLineCount);
++		}
++
+ 		_ = mouseTextColor;
+ 		float num2 = (float)(int)mouseTextColor / 255f;
+ 		for (int i = 0; i < mouseTextTooltipLine_Text.Length; i++) {
 @@ -17252,12 +_,21 @@
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.rej
+++ b/patches/tModLoader/Terraria/Main.cs.rej
@@ -84,14 +84,6 @@
  			if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z) && !oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z)) {
  				text = "";
  			}
-@@ -16095,6 +_,7 @@
- 			hoverItem.knockBack *= 1f + (1f - player[myPlayer].stealth) * 0.5f;
- 
- 		int num2 = 30;
-+		num2 += hoverItem.ToolTip?.Lines ?? 0; // Easy fix to #4772. A full fix would require rewrites of hooks.
- 		int numLines = 1;
- 		string[] array = new string[num2];
- 		bool[] array2 = new bool[num2];
 @@ -16254,15 +_,24 @@
  							break;
  					}

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2300,6 +2300,10 @@ public static class ItemLoader
 		text = new string[numTooltips];
 		oneDropLogo = -1;
 		overrideColor = new Color?[numTooltips];
+		Array.Resize(ref lineColors, numTooltips); // Resize the mouseTextTooltipLine_Color array and assign a default white color to the new elements. Related to #4772 and Commit 6e7c00b
+		for (int i = 30; i < numTooltips; i++) { // 30 is the default size of the array. Main._mouseTextTooltip_MaxLines
+			lineColors[i] = new Color(255, 255, 255);
+		}
 
 		for (int k = 0; k < numTooltips; k++) {
 			text[k] = tooltips[k].Text;

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2297,13 +2297,13 @@ public static class ItemLoader
 		tooltips.RemoveAll(x => !x.Visible);
 
 		numTooltips = tooltips.Count;
+		Array.Resize(ref lineColors, numTooltips); // Resize the mouseTextTooltipLine_Color array and assign a default white color to the new elements. Related to #4772 and Commit 6e7c00b
+		for (int i = text.Length; i < numTooltips; i++) {
+			lineColors[i] = new Color(255, 255, 255);
+		}
 		text = new string[numTooltips];
 		oneDropLogo = -1;
 		overrideColor = new Color?[numTooltips];
-		Array.Resize(ref lineColors, numTooltips); // Resize the mouseTextTooltipLine_Color array and assign a default white color to the new elements. Related to #4772 and Commit 6e7c00b
-		for (int i = 30; i < numTooltips; i++) { // 30 is the default size of the array. Main._mouseTextTooltip_MaxLines
-			lineColors[i] = new Color(255, 255, 255);
-		}
 
 		for (int k = 0; k < numTooltips; k++) {
 			text[k] = tooltips[k].Text;


### PR DESCRIPTION
### What is the bug?

If an item were to draw more than 30 tooltip lines (vanilla default maximum), an index out of bounds of the array error would be thrown.

This bug was fixed in [Commit 6e7c00b](https://github.com/tModLoader/tModLoader/commit/6e7c00b3da4197c48caab6cfaf6b8134ce508827) based on issue #4772, however, 1.4.5 changed how tooltips were drawn and this patch was not applied.

The error would occur in `Main.MouseText_DrawItemTooltip` on line 18407 (accurate at the time of writing this).
```cs
for (int k = 0; k < mouseTextTooltipLine_Text.Length; k++) {
	mouseTextTooltipLine_Color[k] = new Microsoft.Xna.Framework.Color((byte)((float)(int)mouseTextTooltipLine_Color[k].R * num2), (byte)((float)(int)mouseTextTooltipLine_Color[k].G * num2), (byte)((float)(int)mouseTextTooltipLine_Color[k].B * num2), mouseTextColor);
}
```
Earlier in the method, `mouseTextTooltipLine_Text` was resized in `ItemLoader.ModifyTooltips`, but `mouseTextTooltipLine_Color` (new to 1.4.5) was not. Thus, if there were more than 30 tooltip lines, it was trying to assign indexes outside the bounds of `mouseTextTooltipLine_Color`.

### How did you fix the bug?

In `ItemLoader.ModifyTooltips`, resize the `lineColors` array (which is a ref of `mouseTextTooltipLine_Color`), then assign the default value of white to the elements above 30.

### Are there alternatives to your fix?
* I would've used `Main._mouseTextTooltip_MaxLines` for the start of the for loop instead of 30, but it is private.
* The `mouseTextTooltipLine_Text` aka `text` array gets resized in a different way. The contents get copied into a `List<TooltipLine>`. The `text` array is reassigned with the new size. Then it is refilled with the original data that was stored in the `List<TooltipLine>`. A similar thing could be done with the `lineColors` array where the contents are copied, it gets reassigned and filled with the default white color, then gets the original data that was stored.