### PR TITLE
Add TileLoader.SetGlow hook and add its example

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleBar.cs
+++ b/ExampleMod/Content/Tiles/ExampleBar.cs
@@ -1,5 +1,7 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -32,6 +34,13 @@ namespace ExampleMod.Content.Tiles
 				WorldGen.KillTile(i, j);
 			}
 			return true;
+		}
+
+		public override void SetGlow(int i, int j, int type, int width, int offsetY, int height, short tileFrameX, short tileFrameY, ref Texture2D glowTexture, ref Rectangle glowSourceRect, ref Color glowColor) {
+			// This function can produce an effect similar to Illuminant Coating
+			glowTexture = TextureAssets.Tile[Type].Value;
+			glowSourceRect = new Rectangle(tileFrameX, tileFrameY, width, height);
+			glowColor = Main.DiscoColor * 0.5f;
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -532,7 +532,7 @@
  				tileFrameY = (short)(22 * palmTreeBiome);
  				break;
  			}
-@@ -4848,9 +_,16 @@
+@@ -4848,9 +_,17 @@
  					glowColor = _meteorGlow;
  				}
  
@@ -546,6 +546,7 @@
 +		TileLoader.SetSpriteEffects(x, y, typeCache, ref tileSpriteEffect);
 +		TileLoader.SetDrawPositions(x, y, ref tileWidth, ref tileTop, ref tileHeight, ref tileFrameX, ref tileFrameY);
 +		TileLoader.SetAnimationFrame(typeCache, x, y, ref addFrX, ref addFrY);
++		TileLoader.SetGlow(x, y, typeCache, tileWidth, tileTop, tileHeight, tileFrameX, tileFrameY, ref glowTexture, ref glowSourceRect, ref glowColor);
  	}
  
  	private bool IsWindBlocked(int x, int y)

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -151,6 +151,25 @@ public abstract class GlobalTile : GlobalBlockType
 	{
 	}
 
+	/// <summary>
+	/// Allow you to adjust the glow of the tile.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	/// <param name="type">The tile type</param>
+	/// <param name="width"></param>
+	/// <param name="offsetY"></param>
+	/// <param name="height"></param>
+	/// <param name="tileFrameX"></param>
+	/// <param name="tileFrameY"></param>
+	/// <param name="glowTexture"></param>
+	/// <param name="glowSourceRect"></param>
+	/// <param name="glowColor"></param>
+	public virtual void SetGlow(int i, int j, int type, int width, int offsetY, int height, short tileFrameX, short tileFrameY, ref Texture2D glowTexture, ref Rectangle glowSourceRect, ref Color glowColor)
+	{
+
+	}
+
 	/// <inheritdoc cref="ModTile.DrawEffects(int, int, SpriteBatch, ref TileDrawInfo)"/>
 	public virtual void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -395,6 +395,25 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Allow you to adjust the glow of the tile.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	/// <param name="type">The tile type</param>
+	/// <param name="width"></param>
+	/// <param name="offsetY"></param>
+	/// <param name="height"></param>
+	/// <param name="tileFrameX"></param>
+	/// <param name="tileFrameY"></param>
+	/// <param name="glowTexture"></param>
+	/// <param name="glowSourceRect"></param>
+	/// <param name="glowColor"></param>
+	public virtual void SetGlow(int i, int j, int type, int width, int offsetY, int height, short tileFrameX, short tileFrameY, ref Texture2D glowTexture, ref Rectangle glowSourceRect, ref Color glowColor)
+	{
+
+	}
+
+	/// <summary>
 	/// Animates an individual tile. <paramref name="i"/> and <paramref name="j"/> are the coordinates of the Tile in question. <paramref name="frameXOffset"/> and <paramref name="frameYOffset"/> should be used to specify an offset from the tiles <see cref="Tile.TileFrameX"/> and <see cref="Tile.TileFrameY"/>. <c>frameYOffset = modTile.AnimationFrameHeight * Main.tileFrame[type];</c> will already be set before this hook is called, taking into account the TileID-wide animation set via <see cref="AnimateTile(ref int, ref int)"/>.
 	/// <para/> Use this hook for off-sync animations (lightning bug in a bottle), state specific animations (campfires), temporary animations (trap chests), or TileEntities to achieve unique animation behaviors without having to manually draw the tile via <see cref="ModBlockType.PreDraw(int, int, SpriteBatch)"/>.
 	/// </summary>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -76,6 +76,8 @@ public static class TileLoader
 	private delegate void DelegateSetSpriteEffects(int i, int j, int type, ref SpriteEffects spriteEffects);
 	private static DelegateSetSpriteEffects[] HookSetSpriteEffects;
 	private static Action[] HookAnimateTile;
+	private delegate void DelegateSetGlow(int i, int j, int type, int width, int offsetY, int height, short tileFrameX, short tileFrameY, ref Texture2D glowTexture, ref Rectangle glowSourceRect, ref Color glowColor);
+	private static DelegateSetGlow[] HookSetGlow;
 	private static Func<int, int, int, SpriteBatch, bool>[] HookPreDraw;
 	private delegate void DelegateDrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData);
 	private static DelegateDrawEffects[] HookDrawEffects;
@@ -239,6 +241,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook(ref HookIsTileSpelunkable, globalTiles, g => g.IsTileSpelunkable);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateSetSpriteEffects>(ref HookSetSpriteEffects, globalTiles, g => g.SetSpriteEffects);
 		ModLoader.BuildGlobalHook(ref HookAnimateTile, globalTiles, g => g.AnimateTile);
+		ModLoader.BuildGlobalHook(ref HookSetGlow, globalTiles, g => g.SetGlow);
 		ModLoader.BuildGlobalHook(ref HookPreDraw, globalTiles, g => g.PreDraw);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateDrawEffects>(ref HookDrawEffects, globalTiles, g => g.DrawEffects);
 		ModLoader.BuildGlobalHook(ref HookEmitParticles, globalTiles, g => g.EmitParticles);
@@ -1013,6 +1016,14 @@ public static class TileLoader
 		if (modTile != null) {
 			frameYOffset = modTile.AnimationFrameHeight * Main.tileFrame[type];
 			modTile.AnimateIndividualTile(type, i, j, ref frameXOffset, ref frameYOffset);
+		}
+	}
+
+	public static void SetGlow(int i, int j, int type, int width, int offsetY, int height, short tileFrameX, short tileFrameY, ref Texture2D glowTexture, ref Rectangle glowSourceRect, ref Color glowColor)
+	{
+		GetTile(type)?.SetGlow(i, j, type, width, offsetY, height, tileFrameX, tileFrameY, ref glowTexture, ref glowSourceRect, ref glowColor);
+		foreach (var hook in HookSetGlow) {
+			hook(i, j, type, width, offsetY, height, tileFrameX, tileFrameY, ref glowTexture, ref glowSourceRect, ref glowColor);
 		}
 	}
 


### PR DESCRIPTION
### What is the new feature?
Added SetGlow function, which can be used to create glow effects for tiles

### Why should this be part of tModLoader?
In the vanilla, the glow effect can be created, but the related code uses special judgment. After adding this function, similar effects can be written to the vanilla without using on or il

### Are there alternative designs?
I don't have any better ideas

### Sample usage for the new feature
Added corresponding examples in the ExampleBar

### ExampleMod updates
Added corresponding examples in the ExampleBar