### PR TITLE
Tooltip line color changes

### DIFF
--- a/ExampleMod/Common/GlobalItems/WeaponWithGrowingDamage.cs
+++ b/ExampleMod/Common/GlobalItems/WeaponWithGrowingDamage.cs
@@ -105,9 +105,9 @@ namespace ExampleMod.Common.GlobalItems
 
 		public override void ModifyTooltips(Item item, List<TooltipLine> tooltips) {
 			if (experience > 0) {
-				tooltips.Add(new TooltipLine(Mod, "level", LevelText.Format(level)) { OverrideColor = Color.LightGreen });
+				tooltips.Add(new TooltipLine(Mod, "level", LevelText.Format(level)) { Color = Color.LightGreen });
 				int nextLevelExperience = (level + 1) * experiencePerLevel - experience;
-				tooltips.Add(new TooltipLine(Mod, "experience", ExperienceText.Format(experience, nextLevelExperience)) { OverrideColor = Color.White });
+				tooltips.Add(new TooltipLine(Mod, "experience", ExperienceText.Format(experience, nextLevelExperience)) { Color = Color.White });
 			}
 		}
 

--- a/ExampleMod/Content/Items/ExampleDataItem.cs
+++ b/ExampleMod/Content/Items/ExampleDataItem.cs
@@ -19,7 +19,7 @@ namespace ExampleMod.Content.Items
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			TooltipLine tooltip = new TooltipLine(Mod, "ExampleMod: HotPotato", CountdownText.Format(Math.Round(timer / 60f, 1))) { OverrideColor = Color.Red };
+			TooltipLine tooltip = new TooltipLine(Mod, "ExampleMod: HotPotato", CountdownText.Format(Math.Round(timer / 60f, 1))) { Color = Color.Red };
 			tooltips.Add(tooltip);
 		}
 

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -49,7 +49,7 @@ namespace ExampleMod.Content.Items
 				return;
 
 			for (int i = 0; i < colors.Length; i++) {
-				TooltipLine tooltipLine = new TooltipLine(Mod, "EM" + i, EMText.Format(i)) { OverrideColor = colors[i] };
+				TooltipLine tooltipLine = new TooltipLine(Mod, "EM" + i, EMText.Format(i)) { Color = colors[i] };
 				tooltips.Add(tooltipLine);
 			}
 		}

--- a/ExampleMod/Content/Items/ExampleStackableDurabilityItem.cs
+++ b/ExampleMod/Content/Items/ExampleStackableDurabilityItem.cs
@@ -64,7 +64,7 @@ namespace ExampleMod.Content.Items
 		}
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips) {
-			tooltips.Add(new TooltipLine(Mod, "ExampleStackableDurabilityItem", DurabilityText.Format((int)(durability * 100))) { OverrideColor = Color.LightGreen });
+			tooltips.Add(new TooltipLine(Mod, "ExampleStackableDurabilityItem", DurabilityText.Format((int)(durability * 100))) { Color = Color.LightGreen });
 		}
 
 		private static float WeightedAverage(float durability1, int stack1, float durability2, int stack2) {

--- a/ExampleMod/Content/Items/ExampleTooltipsItem.cs
+++ b/ExampleMod/Content/Items/ExampleTooltipsItem.cs
@@ -42,14 +42,14 @@ namespace ExampleMod.Content.Items
 			tooltips.Add(line);
 
 			line = new TooltipLine(Mod, "Face", FaceText.Value) {
-				OverrideColor = new Color(100, 100, 255)
+				Color = new Color(100, 100, 255)
 			};
 			tooltips.Add(line);
 
 			// Here we give the item name a rainbow effect.
 			foreach (TooltipLine line2 in tooltips) {
 				if (line2.Mod == "Terraria" && line2.Name == "ItemName") {
-					line2.OverrideColor = Main.DiscoColor;
+					line2.Color = Main.DiscoColor;
 				}
 			}
 

--- a/ExampleMod/Content/Items/Tools/ExampleMagicMirror.cs
+++ b/ExampleMod/Content/Items/Tools/ExampleMagicMirror.cs
@@ -66,7 +66,7 @@ namespace ExampleMod.Content.Items.Tools
 					int index = (int)((Main.GameUpdateCount / 60) % numColors);
 					int nextIndex = (index + 1) % numColors;
 
-					line2.OverrideColor = Color.Lerp(itemNameCycleColors[index], itemNameCycleColors[nextIndex], fade);
+					line2.Color = Color.Lerp(itemNameCycleColors[index], itemNameCycleColors[nextIndex], fade);
 				}
 			}
 		}

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -53,11 +53,11 @@ namespace ExampleMod.Content.Prefixes
 			// This results in "+1 Power" for ExamplePrefix and "+2 Power" for ExampleDerivedPrefix.
 			// Power isn't an actual stat, the effects of Power are already shown in the "+X% damage" tooltip, so this example is purely educational.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesome", PowerTooltip.Format(Power)) {
-				IsModifier = true, // Sets the color to the positive modifier color.
+				IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true, // Sets the color to the positive modifier color.
 			};
 			// This localization is not shared with the inherited classes. ExamplePrefix and ExampleDerivedPrefix have their own translations for this line.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
-				IsModifier = true,
+				IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true,
 			};
 			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense". Note that IsModifierBad is used for this bad modifier.
 			/*yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -59,10 +59,9 @@ namespace ExampleMod.Content.Prefixes
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
 				Color = Terraria.ID.Colors.PrefixGood,
 			};
-			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense". Note that IsModifierBad is used for this bad modifier.
+			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense".
 			/*yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {
-				IsModifier = true,
-				IsModifierBad = true,
+				Color = Terraria.ID.Colors.PrefixBad,
 			};*/
 		}
 

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -53,15 +53,11 @@ namespace ExampleMod.Content.Prefixes
 			// This results in "+1 Power" for ExamplePrefix and "+2 Power" for ExampleDerivedPrefix.
 			// Power isn't an actual stat, the effects of Power are already shown in the "+X% damage" tooltip, so this example is purely educational.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesome", PowerTooltip.Format(Power)) {
-#if COMPILE_ERROR_TODOS
 				IsModifier = true, // Sets the color to the positive modifier color.
-#endif
 			};
 			// This localization is not shared with the inherited classes. ExamplePrefix and ExampleDerivedPrefix have their own translations for this line.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
-#if COMPILE_ERROR_TODOS
 				IsModifier = true,
-#endif
 			};
 			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense". Note that IsModifierBad is used for this bad modifier.
 			/*yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {

--- a/ExampleMod/Content/Prefixes/ExamplePrefix.cs
+++ b/ExampleMod/Content/Prefixes/ExamplePrefix.cs
@@ -53,11 +53,11 @@ namespace ExampleMod.Content.Prefixes
 			// This results in "+1 Power" for ExamplePrefix and "+2 Power" for ExampleDerivedPrefix.
 			// Power isn't an actual stat, the effects of Power are already shown in the "+X% damage" tooltip, so this example is purely educational.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesome", PowerTooltip.Format(Power)) {
-				IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true, // Sets the color to the positive modifier color.
+				Color = Terraria.ID.Colors.PrefixGood, // Sets the color to the positive modifier color.
 			};
 			// This localization is not shared with the inherited classes. ExamplePrefix and ExampleDerivedPrefix have their own translations for this line.
 			yield return new TooltipLine(Mod, "PrefixWeaponAwesomeDescription", AdditionalTooltip.Value) {
-				IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true,
+				Color = Terraria.ID.Colors.PrefixGood,
 			};
 			// If possible and suitable, try to reuse the name identifier and translation value of Terraria prefixes. For example, this code uses the vanilla translation for the word defense, resulting in "-5 defense". Note that IsModifierBad is used for this bad modifier.
 			/*yield return new TooltipLine(Mod, "PrefixAccDefense", "-5" + Lang.tip[25].Value) {

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -170,6 +170,8 @@ SilverBarRecipeGroup = RecipeGroup.Register(
 * Shaders no longer need to declare every possible input, missing inputs will be ignored now.
 * Dungeon generation has changed. Multiple dungeons can now generate under some secret seeds. Most dungeon related fields that used to be static fields in `Terraria.WorldBuilding.GenVars` are now instance fields in `Terraria.GameContent.Generation.Dungeon.DungeonGenVars`, accessed through the `GenVars.CurrentDungeonGenVars` property to access the data for the currently generating dungeon index.
   * For example: `GenVars.dungeonSide` -> `GenVars.CurrentDungeonGenVars.dungeonSide`. Many of the fields have been renamed or have changed meaning, it would be wise to study the decompiled code if in doubt about any of the changes.
+* The "SocialDesc" tooltip line no longer exists. The "Social" tooltip line (now "Equipped in social slot") will now only show for items that are neither `Item.vanity` or `Item.hasVanityEffects`.
+  * `Item.hasVanityEffects` is now used. It was previously unused. Set this for accessories that have vanity effects to prevent the "Social" tooltip line from appearing and suggesting the item has no effect in vanity slots.
 
 ## Renamed, Moved, or Removed Members
 

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -288,3 +288,6 @@ All classes are in the `Terraria.ModLoader` or `Terraria` namespaces unless othe
   * 💀: `PlayerFloorX` and `PlayerFloorY` are no longer tracked by `NPC.Spawner`. Vanilla code no longer uses player floor tiles for spawning logic.
   * 💀: Using the `Player` fields such as `Player.ZoneJungle` is no longer recommended since `NPC.Spawner` contains its own version of those flags. These are used for custom spawning logic such as the dual dungeons secret seed. Failure to migrate to using these new fields will result in incorrect spawning logic.
   * There are many other new fields in `NPC.Spawner` that might prove useful, such as `hardDungeon`.
+* `TooltipLine` and `DrawableTooltipLine` changes:
+  * ⚙️: `(TooltipLine|DrawableTooltipLine).IsModifier` and `(TooltipLine|DrawableTooltipLine).IsModifierBad` are removed. Set `TooltipLine.Color` directly to `Terraria.ID.Colors.PrefixGood` or `Terraria.ID.Colors.PrefixBad`. If you previously needed to determine if tooltip lines were for prefixes, now check `TooltipLine.Color` against those colors or maybe see if `TooltipLine.Name` starts with "Prefix".
+  * ⚙️: `TooltipLine.OverrideColor` has been renamed to `Color`. It is no longer nullable. `DrawableTooltipLine.OverrideColor` has been removed, leaving just `DrawableTooltipLine.Color`.

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -170,8 +170,12 @@ SilverBarRecipeGroup = RecipeGroup.Register(
 * Shaders no longer need to declare every possible input, missing inputs will be ignored now.
 * Dungeon generation has changed. Multiple dungeons can now generate under some secret seeds. Most dungeon related fields that used to be static fields in `Terraria.WorldBuilding.GenVars` are now instance fields in `Terraria.GameContent.Generation.Dungeon.DungeonGenVars`, accessed through the `GenVars.CurrentDungeonGenVars` property to access the data for the currently generating dungeon index.
   * For example: `GenVars.dungeonSide` -> `GenVars.CurrentDungeonGenVars.dungeonSide`. Many of the fields have been renamed or have changed meaning, it would be wise to study the decompiled code if in doubt about any of the changes.
-* The "SocialDesc" tooltip line no longer exists. The "Social" tooltip line (now "Equipped in social slot") will now only show for items that are neither `Item.vanity` or `Item.hasVanityEffects`.
-  * `Item.hasVanityEffects` is now used. It was previously unused. Set this for accessories that have vanity effects to prevent the "Social" tooltip line from appearing and suggesting the item has no effect in vanity slots.
+* Several item tooltip line changes:
+  * The "SocialDesc" tooltip line no longer exists. The "Social" tooltip line (now "Equipped in social slot") will now only show for items that are neither `Item.vanity` or `Item.hasVanityEffects`.
+    * `Item.hasVanityEffects` is now used. It was previously unused. Set this for accessories that have vanity effects to prevent the "Social" tooltip line from appearing and suggesting the item has no effect in vanity slots.
+  * There are new tooltip lines: "Wireable", "Container", "WireTrigger", "WizardHatDuringAnniversary", "BurningBlock", "MechSummonDuringEverything", "MechdusaSummonNotDuringEverything", "PrefixArmorPenetration", "PrefixTagDamage", "SetBonusSinglePiece", and "JourneyResearchTeammate".
+  * The "SetBonus" tooltip has changed. It now automatically displays partial sets and adjusts the color to indicate if the set is complete.
+  * The "SetBonusSinglePiece" tooltip shows the set bonus that would be applied if the unequipped equipment were equipped.
 
 ## Renamed, Moved, or Removed Members
 

--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -100,7 +100,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Double check new DoScrollingInInventory logic against PlayerInput.MouseInModdedUI
 - Patches checking ActiveWorldFileData being null and initializing it might be superfluous now. Seems like there were some vanilla changes.
 - MapRenderer class now contains what was Main.mapSectionTexture and mapTarget. Most static fields there should probably be public.
-- New vanilla TooltipLine options. Need to add to docs and decide on name (is there a wiki page as well?): CommonItemTooltip.ItemUnlockedByTeammate, armorPenetration, bonusTagDamage, check for others.
 - DrawBlockReplacementIcon return changed from void to bool. Does that affect how the builders toggle works? Did vanilla behavior change? New state bool in logic, and DoStatefulTickSound
 - See updated `toolTipNames[numLines] = "UseMana";` patch. Look into IsSpaceGun and GetManaCost, might need updates. 
 - Double check PlayerLoader.ModifyZoom logic. Seems like there is only 1 callsite now, code was cleaned up?
@@ -122,7 +121,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - GameTipsDisplay patches need to be redone
 - Main.OpenPlayerSelectFromNet changed how our patches can be implemented for invite joining. Need to be reimplemented.
 - DrawColorCodedStringWithShadow methods no longer return Vector2 string size. Is this because of some reason? All patches in ChatManager need to be revisited.
-- Tooltip methods, like MouseText_DrawItemTooltip_GetLinesInfo, seemed to have changed a lot. Revisit patches.
 - Paladin shield patches might have been mixed up. Double Check.
 - Missing Actuator/849 ConsumeItem patch. Is this a vanilla bug or is the stack now consumed elsewhere?
 - New GetItemManaUsageDetails and ItemCheck_PayMana_X methods split mana costs into multiple methods. Should be able to remove a lot of Player.TML.cs patches and use them directly.
@@ -157,6 +155,7 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Make a checklist of all TML hooks and have others QC each method behavior?
 - ItemID.Sets.BonusAttackSpeedMultiplier renamed to BonusMeleeSpeedMultiplier. tModPorter done. (double check that this doesn't only apply to melee weapons. I think it isn't limited currently)
 - Run NPCShopDatabase.Test tests.
+- Player.setBonus is unused by vanilla. We will likely remove it (and comment out UpdateArmorSetsOld since it is misleading) and migrate all ExampleMod set bonuses to the new system. We'll need examples of various common set bonus setups (multiple helments, partial sets, typical head/chest/leg set, etc.)
 
 # New Fields that might need more documentation
 

--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -100,7 +100,7 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Double check new DoScrollingInInventory logic against PlayerInput.MouseInModdedUI
 - Patches checking ActiveWorldFileData being null and initializing it might be superfluous now. Seems like there were some vanilla changes.
 - MapRenderer class now contains what was Main.mapSectionTexture and mapTarget. Most static fields there should probably be public.
-- New vanilla TooltipLine options. Need to add to docs and decide on name (is there a wiki page as well?): CommonItemTooltip.ItemUnlockedByTeammate, armorPenetration, bonusTagDamage, check for others. Seems like "Social" and "SocialDesc" logic changed, compare tooltips to 1.4.4 and adjust.
+- New vanilla TooltipLine options. Need to add to docs and decide on name (is there a wiki page as well?): CommonItemTooltip.ItemUnlockedByTeammate, armorPenetration, bonusTagDamage, check for others.
 - DrawBlockReplacementIcon return changed from void to bool. Does that affect how the builders toggle works? Did vanilla behavior change? New state bool in logic, and DoStatefulTickSound
 - See updated `toolTipNames[numLines] = "UseMana";` patch. Look into IsSpaceGun and GetManaCost, might need updates. 
 - Double check PlayerLoader.ModifyZoom logic. Seems like there is only 1 callsite now, code was cleaned up?

--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -32,7 +32,7 @@
  			entry.stack = 1;
 -			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedColor);
 +			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedColor, _toolTipNames, out _);
-+			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedColor, ref _unusedYoyoLogo, out _, -1);
++			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedColor, ref _unusedYoyoLogo, -1);
  			entry.stack = stack;
 +
 +			/*

--- a/patches/tModLoader/Terraria/ID/Colors.TML.cs
+++ b/patches/tModLoader/Terraria/ID/Colors.TML.cs
@@ -6,4 +6,7 @@ partial class Colors
 {
 	public static readonly Color RarityDarkRed = new Color(255, 40, 100);
 	public static readonly Color RarityDarkPurple = new Color(180, 40, 255);
+
+	public static readonly Color PrefixBad = new Color(190, 120, 120);
+	public static readonly Color PrefixGood = new Color(120, 190, 120);
 }

--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -742,8 +742,8 @@
  	public bool newAndShiny;
 +
 +	/// <summary>
-+	/// If <see langword="true"/>, this item has vanity effects even though it doesn't use equipment slots.
-+	/// <br/> Unused in vanilla, as the system it was used for was removed in 1.4.4.
++	/// If <see langword="true"/>, this item has vanity effects even though it doesn't necessarily use equipment slots.
++	/// <br/> This will prevent the "Social" tooltip line from appearing and suggesting the item has no effect in vanity slots.
 +	/// </summary>
  	[Old("This is used to allow items to be discerned as vanity even if they didn't have visual slots to poll against")]
  	public bool hasVanityEffects;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3165,7 +3165,7 @@
  		if (diff == 1)
  			result = new Microsoft.Xna.Framework.Color(mcColor.R, mcColor.G, mcColor.B);
  
-@@ -17480,30 +_,50 @@
+@@ -17480,30 +_,49 @@
  		return result;
  	}
  
@@ -3196,7 +3196,6 @@
  		if (item.social && !item.vanity && !item.hasVanityEffects) {
  			toolTipLine[numLines] = Lang.tip[61].Value;
 +			toolTipNames[numLines] = "Social";
-+			//toolTipNames[numLines] = "SocialDesc";
  			numLines++;
  		}
  

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3381,7 +3381,7 @@
  			numLines++;
  		}
  
-@@ -17663,39 +_,54 @@
+@@ -17663,54 +_,72 @@
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.RestoresLifeRange", healLife, num6);
  			}
  			else {
@@ -3438,6 +3438,24 @@
  			numLines++;
  		}
  
+ 		if ((item.createTile > -1 && (TileID.Sets.Wiring.IsATrigger[item.createTile] || TileID.Sets.Wiring.IsAMechanism[item.createTile])) & (item.createTile != 105 || ItemID.Sets.IsWireableStatue[item.type])) {
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.Wireable");
++			toolTipNames[numLines] = "Wireable";
+ 			numLines++;
+ 		}
+ 
+ 		if (item.createTile == 21 || item.createTile == 467) {
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.Container");
++			toolTipNames[numLines] = "Container";
+ 			numLines++;
+ 		}
+ 
+ 		if (item.createTile == 441 || item.createTile == 468) {
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.WireTrigger");
++			toolTipNames[numLines] = "WireTrigger";
+ 			numLines++;
+ 		}
+ 
 @@ -17718,10 +_,12 @@
  			for (int i = 0; i < item.ToolTip.Lines; i++) {
  				if (i == 0 && ItemID.Sets.UsesCursedByPlanteraTooltip[item.type] && !NPC.downedPlantBoss) {
@@ -3451,7 +3469,35 @@
  					numLines++;
  				}
  			}
-@@ -17754,16 +_,19 @@
+@@ -17729,11 +_,13 @@
+ 
+ 		if (tenthAnniversaryWorld && item.type == 238) {
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.WizardHatDuringAnniversary");
++			toolTipNames[numLines] = "WizardHatDuringAnniversary";
+ 			numLines++;
+ 		}
+ 
+ 		if (getGoodWorld && item.type == 1127) {
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.BurningBlock");
++			toolTipNames[numLines] = "BurningBlock";
+ 			numLines++;
+ 		}
+ 
+@@ -17741,6 +_,7 @@
+ 			if (item.type == 556 || item.type == 557 || item.type == 544) {
+ 				numLines--;
+ 				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.MechSummonDuringEverything");
++				toolTipNames[numLines] = "MechSummonDuringEverything";
+ 				numLines++;
+ 			}
+ 		}
+@@ -17749,21 +_,25 @@
+ 			toolTipLine[numLines] = "";
+ 			numLines--;
+ 			toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.MechdusaSummonNotDuringEverything");
++			toolTipNames[numLines] = "MechdusaSummonNotDuringEverything";
+ 			numLines++;
+ 		}
  
  		if ((item.type == 3818 || item.type == 3819 || item.type == 3820 || item.type == 3824 || item.type == 3825 || item.type == 3826 || item.type == 3829 || item.type == 3830 || item.type == 3831 || item.type == 3832 || item.type == 3833 || item.type == 3834) && !player[myPlayer].downedDD2EventAnyDifficulty) {
  			toolTipLine[numLines] = Lang.misc[104].Value;
@@ -3527,7 +3573,7 @@
  				numLines++;
  			}
  
-@@ -17868,6 +_,7 @@
+@@ -17868,12 +_,14 @@
  					toolTipLine[numLines] = num13 + Lang.tip[45].Value;
  
  				lineColors[numLines] = ((num13 < 0.0) ? color : color2);
@@ -3535,6 +3581,21 @@
  				numLines++;
  			}
  
+ 			if (item2.armorPenetration != item.armorPenetration) {
+ 				int num14 = item.armorPenetration - item2.armorPenetration;
+ 				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.PrefixArmorPenetration", num14);
++				toolTipNames[numLines] = "PrefixArmorPenetration";
+ 				lineColors[numLines] = ((num14 < 0) ? color : color2);
+ 				numLines++;
+ 			}
+@@ -17881,6 +_,7 @@
+ 			if (item2.bonusTagDamage != item.bonusTagDamage) {
+ 				int num15 = item.bonusTagDamage - item2.bonusTagDamage;
+ 				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.PrefixTagDamage", num15);
++				toolTipNames[numLines] = "PrefixTagDamage";
+ 				lineColors[numLines] = ((num15 < 0) ? color : color2);
+ 				numLines++;
+ 			}
 @@ -17888,116 +_,137 @@
  			if (item.prefix == 62) {
  				toolTipLine[numLines] = "+1" + Lang.tip[25].Value;
@@ -3673,6 +3734,22 @@
  		}
  
  		if (true) {
+@@ -18006,6 +_,7 @@
+ 				if (!item.wornArmor) {
+ 					toolTipLine[numLines] = array[0].GetTooltipForSinglePiece(item.type);
+ 					lineColors[numLines] = new Microsoft.Xna.Framework.Color(130, 130, 130, 190);
++					toolTipNames[numLines] = "SetBonusSinglePiece";
+ 					numLines++;
+ 				}
+ 				else {
+@@ -18032,6 +_,7 @@
+ 					}
+ 
+ 					toolTipLine[numLines] = armorSetBonus.GetTooltipForWornArmor(context, result);
++					toolTipNames[numLines] = "SetBonus";
+ 					lineColors[numLines] = (result.Complete ? Microsoft.Xna.Framework.Color.LimeGreen : new Microsoft.Xna.Framework.Color(130, 130, 130));
+ 					numLines++;
+ 				}
 @@ -18039,17 +_,23 @@
  
  			if (player[myPlayer].setBonus != "") {
@@ -3710,7 +3787,7 @@
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.ItemUnlockedByTeammate", teammateName);
 +				lineColors[numLines] = Colors.JourneyMode;
  				researchLine = numLines;
-+				// toolTipNames[numLines] = "JourneyResearchTeammate";
++				toolTipNames[numLines] = "JourneyResearchTeammate";
  				numLines++;
  			}
 +		}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3079,19 +3079,6 @@
  					if (m == 4)
  						color = new Microsoft.Xna.Framework.Color(num11, num11, num11, num11);
  
-@@ -17314,10 +_,10 @@
- 							num12++;
- 							break;
- 						case 2:
--							num13--;
-+							num12--;
- 							break;
- 						case 3:
--							num13++;
-+							num12++;
- 							break;
- 					}
- 
 @@ -17326,17 +_,29 @@
  			}
  			else {
@@ -3156,6 +3143,22 @@
  			result = new Microsoft.Xna.Framework.Color(255, (byte)(masterColor * 200f), 0);
  
  		if (rare == -12)
+@@ -17468,9 +_,15 @@
+ 		if (rare == 10)
+ 			result = new Microsoft.Xna.Framework.Color(255, 40, 100);
+ 
++		/*
+ 		if (rare >= 11)
++		*/
++		if (rare == 11)
+ 			result = new Microsoft.Xna.Framework.Color(180, 40, 255);
+ 
++		if (rare > 11)
++			result = RarityLoader.GetRarity(rare).RarityColor;
++
+ 		if (diff == 1)
+ 			result = new Microsoft.Xna.Framework.Color(mcColor.R, mcColor.G, mcColor.B);
+ 
 @@ -17480,30 +_,50 @@
  		return result;
  	}

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3042,7 +3042,7 @@
  		int num3 = 0;
  		for (int j = 0; j < numLines; j++) {
  			Vector2 stringSize = ChatManager.GetStringSize(FontAssets.MouseText.Value, mouseTextTooltipLine_Text[j], Vector2.One);
-@@ -17292,17 +_,36 @@
+@@ -17292,19 +_,42 @@
  		}
  
  		for (int k = 0; k < mouseTextTooltipLine_Text.Length; k++) {
@@ -3060,11 +3060,12 @@
  			if (l == yoyoLogo) {
 +			*/
 +			if (drawableLines[l].Mod == "Terraria" && drawableLines[l].Name == "OneDropLogo") {
++				/*
  				float num10 = 1f;
  				int num11 = (int)((float)(int)mouseTextColor * num10);
++				*/
  				Microsoft.Xna.Framework.Color color = Microsoft.Xna.Framework.Color.Black;
 +
-+				drawableLines[l].Color = new Color(num11, num11, num11, num11);
 +				if (!ItemLoader.PreDrawTooltipLine(HoverItem, drawableLines[l], ref num3) || !globalCanDraw)
 +					goto PostDraw;
 +
@@ -3077,8 +3078,13 @@
 +					int num13 = drawableLines[l].Y;
 +
  					if (m == 4)
++						color = drawableLines[l].Color;
++						/*
  						color = new Microsoft.Xna.Framework.Color(num11, num11, num11, num11);
++						*/
  
+ 					switch (m) {
+ 						case 0:
 @@ -17326,17 +_,29 @@
  			}
  			else {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3036,13 +3036,17 @@
  		Vector2 zero = Vector2.Zero;
 +
 +		// TML's abstractions over tooltip arrays.
-+		List<TooltipLine> lines = ItemLoader.ModifyTooltips(HoverItem, ref numLines, tooltipNames, ref mouseTextTooltipLine_Text, ref mouseTextTooltipLine_Color, ref yoyoLogo, out Color?[] overrideColor, prefixlineIndex);
-+		List<DrawableTooltipLine> drawableLines = lines.Select((TooltipLine x, int i) => new DrawableTooltipLine(x, i, 0, 0, Color.White)).ToList();
++		List<TooltipLine> lines = ItemLoader.ModifyTooltips(HoverItem, ref numLines, tooltipNames, ref mouseTextTooltipLine_Text, ref mouseTextTooltipLine_Color, ref yoyoLogo, prefixlineIndex);
++		List<DrawableTooltipLine> drawableLines = lines.Select((TooltipLine x, int i) => new DrawableTooltipLine(x, i, 0, 0, mouseTextTooltipLine_Color[i])).ToList();
 +
  		int num3 = 0;
  		for (int j = 0; j < numLines; j++) {
  			Vector2 stringSize = ChatManager.GetStringSize(FontAssets.MouseText.Value, mouseTextTooltipLine_Text[j], Vector2.One);
-@@ -17295,14 +_,32 @@
+@@ -17292,17 +_,36 @@
+ 		}
+ 
+ 		for (int k = 0; k < mouseTextTooltipLine_Text.Length; k++) {
++			// TODO: Some way for mods to bypass mouseTextColor pulsing for a TooltipLine. Apply to UnloadedPrefix once implemented.
  			mouseTextTooltipLine_Color[k] = new Microsoft.Xna.Framework.Color((byte)((float)(int)mouseTextTooltipLine_Color[k].R * num2), (byte)((float)(int)mouseTextTooltipLine_Color[k].G * num2), (byte)((float)(int)mouseTextTooltipLine_Color[k].B * num2), mouseTextColor);
  		}
  
@@ -3088,32 +3092,21 @@
  							break;
  					}
  
-@@ -17326,17 +_,40 @@
+@@ -17326,17 +_,29 @@
  			}
  			else {
  				Microsoft.Xna.Framework.Color baseColor = mouseTextTooltipLine_Color[l];
 +				/*
  				if (l == researchLine)
-+				*/
-+				if (drawableLines[l].Mod == "Terraria" && drawableLines[l].Name == "JourneyResearch")
  					baseColor = Colors.JourneyMode;
  
-+				/*
  				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, mouseTextTooltipLine_Text[l], new Vector2(X, Y + num7), baseColor, 0f, Vector2.Zero, Vector2.One);
 +				*/
-+				drawableLines[l].Color = baseColor;
-+				Color realLineColor = baseColor;
-+
-+				if (overrideColor[l].HasValue) {
-+					// TODO: Some way for mods to bypass mouseTextColor pulsing for a TooltipLine. Apply to UnloadedPrefix once implemented.
-+					realLineColor = overrideColor[l].Value * num2;
-+					drawableLines[l].OverrideColor = realLineColor;
-+				}
 +
 +				if (!ItemLoader.PreDrawTooltipLine(HoverItem, drawableLines[l], ref num3) || !globalCanDraw)
 +					goto PostDraw;
 +
-+				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, drawableLines[l].Font, drawableLines[l].Text, new Vector2(drawableLines[l].X, drawableLines[l].Y), realLineColor, drawableLines[l].Rotation, drawableLines[l].Origin, drawableLines[l].BaseScale, drawableLines[l].MaxWidth, drawableLines[l].Spread);
++				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, drawableLines[l].Font, drawableLines[l].Text, new Vector2(drawableLines[l].X, drawableLines[l].Y), baseColor, drawableLines[l].Rotation, drawableLines[l].Origin, drawableLines[l].BaseScale, drawableLines[l].MaxWidth, drawableLines[l].Spread);
  			}
  
 +			PostDraw:
@@ -3696,15 +3689,18 @@
  			numLines++;
  		}
  
-@@ -18058,13 +_,28 @@
+@@ -18057,14 +_,31 @@
+ 			string teammateName;
  			if (amountWeHave < amountNeededTotal) {
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.CreativeSacrificeNeeded", amountNeededTotal - amountWeHave);
++				lineColors[numLines] = Colors.JourneyMode;
  				researchLine = numLines;
 +				toolTipNames[numLines] = "JourneyResearch";
  				numLines++;
  			}
  			else if (item.tooltipContext == 29 && LocalPlayerCreativeTracker.ItemSacrifices.TryGetTeammateUnlockCredit(item.type, out teammateName)) {
  				toolTipLine[numLines] = Language.GetTextValue("CommonItemTooltip.ItemUnlockedByTeammate", teammateName);
++				lineColors[numLines] = Colors.JourneyMode;
  				researchLine = numLines;
 +				// toolTipNames[numLines] = "JourneyResearchTeammate";
  				numLines++;

--- a/patches/tModLoader/Terraria/Main.cs.rej
+++ b/patches/tModLoader/Terraria/Main.cs.rej
@@ -109,29 +109,6 @@
  
  					if (rare == -11)
  						black = new Microsoft.Xna.Framework.Color((byte)(255f * num4), (byte)(175f * num4), (byte)(0f * num4), a);
-@@ -16300,9 +_,15 @@
- 					if (rare == 10)
- 						black = new Microsoft.Xna.Framework.Color((byte)(255f * num4), (byte)(40f * num4), (byte)(100f * num4), a);
- 
-+					/*
- 					if (rare >= 11)
-+					*/
-+					if (rare == 11)
- 						black = new Microsoft.Xna.Framework.Color((byte)(180f * num4), (byte)(40f * num4), (byte)(255f * num4), a);
- 
-+					if (rare > 11)
-+						black = RarityLoader.GetRarity(rare).RarityColor * num4;
-+
- 					if (diff == 1)
- 						black = new Microsoft.Xna.Framework.Color((byte)((float)(int)mcColor.R * num4), (byte)((float)(int)mcColor.G * num4), (byte)((float)(int)mcColor.B * num4), a);
- 
-@@ -16318,3 +_,6 @@
-+				/*
- 				else if (k == numLines - 1) {
-+				*/
-+				else if (drawableLines[k].Mod == "Terraria" && drawableLines[k].Name == "Price") {
- 					black = color;
- 				}
 @@ -31743,8 +_,12 @@
  			textValue = Language.GetTextValue("StardewTalk.PlayerHasColaAndIsHoldingIt");
  

--- a/patches/tModLoader/Terraria/Main.cs.rej
+++ b/patches/tModLoader/Terraria/Main.cs.rej
@@ -84,31 +84,6 @@
  			if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z) && !oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z)) {
  				text = "";
  			}
-@@ -16254,15 +_,24 @@
- 							break;
- 					}
- 
-+					/*
- 					spriteBatch.Draw(TextureAssets.OneDropLogo.Value, new Vector2(num21, num22), null, color2, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
-+					*/
-+					Color drawColor2 = drawableLines[k].OverrideColor ?? drawableLines[k].Color;
-+					spriteBatch.Draw(TextureAssets.OneDropLogo.Value, new Vector2(num21, num22), null, (l != 4) ? color2 : drawColor2, drawableLines[k].Rotation, drawableLines[k].Origin, (drawableLines[k].BaseScale.X + drawableLines[k].BaseScale.Y) / 2f, SpriteEffects.None, 0f);
- 				}
- 			}
- 			else {
- 				Microsoft.Xna.Framework.Color black = Microsoft.Xna.Framework.Color.Black;
- 				black = new Microsoft.Xna.Framework.Color(num4, num4, num4, num4);
-+				/*
- 				if (k == 0) {
-+				*/
-+				if (drawableLines[k].Mod == "Terraria" && drawableLines[k].Name == "ItemName") {
-+					/*
- 					if (rare == -13)
- 						black = new Microsoft.Xna.Framework.Color((byte)(255f * num4), (byte)(masterColor * 200f * num4), 0, a);
-+					*/
- 
- 					if (rare == -11)
- 						black = new Microsoft.Xna.Framework.Color((byte)(255f * num4), (byte)(175f * num4), (byte)(0f * num4), a);
 @@ -31743,8 +_,12 @@
  			textValue = Language.GetTextValue("StardewTalk.PlayerHasColaAndIsHoldingIt");
  

--- a/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Developer/DeveloperItem.cs
@@ -29,7 +29,7 @@ internal abstract class DeveloperItem : ModLoaderModItem
 	public override void ModifyTooltips(List<TooltipLine> tooltips)
 	{
 		var line = new TooltipLine(Mod, "DeveloperSetNote", $"{TooltipBrief}Developer Item") {
-			OverrideColor = Color.OrangeRed
+			Color = Color.OrangeRed
 		};
 		tooltips.Add(line);
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/Patreon/PatreonItem.cs
@@ -46,7 +46,7 @@ internal abstract class PatreonItem : ModLoaderModItem
 	public override void ModifyTooltips(List<TooltipLine> tooltips)
 	{
 		var line = new TooltipLine(Mod, "PatreonThanks", Language.GetTextValue("tModLoader.PatreonSetTooltip")) {
-			OverrideColor = Color.Aquamarine
+			Color = Color.Aquamarine
 		};
 		tooltips.Add(line);
 	}

--- a/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/UnloadedPrefix.cs
@@ -9,7 +9,7 @@ public sealed class UnloadedPrefix : ModPrefix
 	{
 		UnloadedGlobalItem unloadedGlobalItem = item.GetGlobalItem<UnloadedGlobalItem>();
 		yield return new TooltipLine("UnloadedPrefix", this.GetLocalization("Tooltip").Format($"{unloadedGlobalItem.ModPrefixMod}/{unloadedGlobalItem.ModPrefixName}")) {
-			OverrideColor = new(215, 123, 186) // This is the color used in our unloaded textures
+			Color = new(215, 123, 186) // This is the color used in our unloaded textures
 		};
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/DrawableTooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DrawableTooltipLine.cs
@@ -28,16 +28,6 @@ public sealed class DrawableTooltipLine : TooltipLine
 	public readonly int Index;
 
 	/// <summary>
-	/// Whether or not this tooltip gives prefix information. This will make it so that the tooltip is colored either green or red.
-	/// </summary>
-	public new readonly bool IsModifier;
-
-	/// <summary>
-	/// If isModifier is true, this determines whether the tooltip is colored green or red.
-	/// </summary>
-	public new readonly bool IsModifierBad;
-
-	/// <summary>
 	/// The X position where the tooltip would be drawn that is not adjusted by mods.
 	/// </summary>
 	public int OriginalX {
@@ -62,16 +52,6 @@ public sealed class DrawableTooltipLine : TooltipLine
 	/// The Y position where the tooltip would be drawn.
 	/// </summary>
 	public int Y;
-
-	/// <summary>
-	/// The color the tooltip would be drawn in
-	/// </summary>
-	public Color Color { get; internal set; }
-
-	/// <summary>
-	/// If the tooltip line's color was overridden this will hold that color, it will be null otherwise
-	/// </summary>
-	public new Color? OverrideColor { get; internal set; }
 
 	/// <summary>
 	/// Whether the tooltip is a One Drop logo or not. If it is, the tooltip text will be empty.
@@ -111,7 +91,6 @@ public sealed class DrawableTooltipLine : TooltipLine
 	/// <param name="color">The color the tooltip would be drawn in</param>
 	public DrawableTooltipLine(TooltipLine parent, int index, int x, int y, Color color) : base(parent.Mod, parent.Name, parent.Text)
 	{
-		OverrideColor = parent.OverrideColor;
 		OneDropLogo = parent.OneDropLogo;
 		Text = parent.Text;
 

--- a/patches/tModLoader/Terraria/ModLoader/DrawableTooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/DrawableTooltipLine.cs
@@ -54,6 +54,12 @@ public sealed class DrawableTooltipLine : TooltipLine
 	public int Y;
 
 	/// <summary>
+	/// The color the tooltip is drawn in. Defaults to White.
+	/// <para/> The actual final color will be affected slightly by the mouse pulse effect (<see cref="Main.mouseTextColor"/>).
+	/// </summary>
+	public new Color Color { get; internal set; }
+
+	/// <summary>
 	/// Whether the tooltip is a One Drop logo or not. If it is, the tooltip text will be empty.
 	/// </summary>
 	public new readonly bool OneDropLogo;

--- a/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ItemLoader.cs
@@ -2262,7 +2262,7 @@ public static class ItemLoader
 
 	private static HookList HookModifyTooltips = AddHook<Action<Item, List<TooltipLine>>>(g => g.ModifyTooltips);
 
-	public static List<TooltipLine> ModifyTooltips(Item item, ref int numTooltips, string[] names, ref string[] text, ref Color[] lineColors, ref int oneDropLogo, out Color?[] overrideColor, int prefixlineIndex)
+	public static List<TooltipLine> ModifyTooltips(Item item, ref int numTooltips, string[] names, ref string[] text, ref Color[] lineColors, ref int oneDropLogo, int prefixlineIndex)
 	{
 		var tooltips = new List<TooltipLine>();
 
@@ -2297,13 +2297,9 @@ public static class ItemLoader
 		tooltips.RemoveAll(x => !x.Visible);
 
 		numTooltips = tooltips.Count;
-		Array.Resize(ref lineColors, numTooltips); // Resize the mouseTextTooltipLine_Color array and assign a default white color to the new elements. Related to #4772 and Commit 6e7c00b
-		for (int i = text.Length; i < numTooltips; i++) {
-			lineColors[i] = new Color(255, 255, 255);
-		}
 		text = new string[numTooltips];
+		lineColors = new Color[numTooltips];
 		oneDropLogo = -1;
-		overrideColor = new Color?[numTooltips];
 
 		for (int k = 0; k < numTooltips; k++) {
 			text[k] = tooltips[k].Text;
@@ -2312,7 +2308,7 @@ public static class ItemLoader
 				oneDropLogo = k;
 			}
 
-			overrideColor[k] = tooltips[k].OverrideColor;
+			lineColors[k] = tooltips[k].Color;
 		}
 
 		return tooltips;

--- a/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
@@ -28,9 +28,11 @@ public class TooltipLine
 	public string Text;
 
 	/// <summary>
-	/// This completely overrides the color the tooltip is drawn in. If it is set to null (the default value) then the tooltip's color will not be overridden.
+	/// The color the tooltip is drawn in. Defaults to White.
+	/// <para/> <see cref="Terraria.ID.Colors.PrefixGood"/> and <see cref="Terraria.ID.Colors.PrefixBad"/> are the colors used by prefix stat changes.
+	/// <para/> The actual final color will be affected slightly by the mouse pulse effect (<see cref="Main.mouseTextColor"/>).
 	/// </summary>
-	public Color? OverrideColor;
+	public Color Color;
 
 	internal bool OneDropLogo;
 
@@ -105,6 +107,7 @@ public class TooltipLine
 		Mod = mod.Name;
 		Name = name;
 		Text = text;
+		Color = Color.White;
 	}
 
 	internal TooltipLine(string mod, string name, string text)
@@ -112,6 +115,7 @@ public class TooltipLine
 		Mod = mod;
 		Name = name;
 		Text = text;
+		Color = Color.White;
 	}
 
 	internal TooltipLine(string name, string text)
@@ -119,6 +123,7 @@ public class TooltipLine
 		Mod = "Terraria";
 		Name = name;
 		Text = text;
+		Color = Color.White;
 	}
 
 	public bool Visible { get; private set; } = true;

--- a/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
@@ -45,7 +45,6 @@ public class TooltipLine
 	/// <item><description>"FavoriteDesc" - Tells what it means when an item is favorited.</description></item>
 	/// <item><description>"NoTransfer" - Warning that this item cannot be placed inside itself, used by Money Trough and Void Bag/Vault.</description></item>
 	/// <item><description>"Social" - Tells if the item is in a social slot.</description></item>
-	/// <item><description>"SocialDesc" - Tells what it means for an item to be in a social slot.</description></item>
 	/// <item><description>"Damage" - The damage value and type of the weapon.</description></item>
 	/// <item><description>"CritChance" - The critical strike chance of the weapon.</description></item>
 	/// <item><description>"Speed" - The use speed of the weapon.</description></item>

--- a/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TooltipLine.cs
@@ -70,7 +70,14 @@ public class TooltipLine
 	/// <item><description>"Ammo" - Tells if the item is ammo.</description></item>
 	/// <item><description>"Consumable" - Tells if the item is consumable.</description></item>
 	/// <item><description>"Material" - Tells if the item can be used to craft something.</description></item>
+	/// <item><description>"Wireable" - Tells if the item is wireable.</description></item>
+	/// <item><description>"Container" - The "Collects nearby dropped items when signaled" line.</description></item>
+	/// <item><description>"WireTrigger" - The "{InputTrigger_InteractWithTile} when placed to signal" line.</description></item>
 	/// <item><description>"Tooltip#" - A tooltip line of the item. # will be 0 for the first line, 1 for the second, etc.</description></item>
+	/// <item><description>"WizardHatDuringAnniversary" - The "Increases your max number of minions by 1" line.</description></item>
+	/// <item><description>"BurningBlock" - The "Burns you when touched without special protection" line.</description></item>
+	/// <item><description>"MechSummonDuringEverything" - The "'Part of a set'" line.</description></item>
+	/// <item><description>"MechdusaSummonNotDuringEverything" - The "'It has no effect in this world'" line.</description></item>
 	/// <item><description>"EtherianManaWarning" - Warning about how the item can't be used without Etherian Mana until the Eternia Crystal has been defeated.</description></item>
 	/// <item><description>"WellFedExpert" - In expert mode, tells that food increases life regeneration.</description></item>
 	/// <item><description>"BuffTime" - Tells how long the item's buff lasts.</description></item>
@@ -82,16 +89,20 @@ public class TooltipLine
 	/// <item><description>"PrefixSize" - The melee size modifier of the prefix.</description></item>
 	/// <item><description>"PrefixShootSpeed" - The shootSpeed modifier of the prefix.</description></item>
 	/// <item><description>"PrefixKnockback" - The knockback modifier of the prefix.</description></item>
+	/// <item><description>"PrefixArmorPenetration" - The armor penetration modifier of the prefix.</description></item>
+	/// <item><description>"PrefixTagDamage" - The tag damage modifier of the prefix.</description></item>
 	/// <item><description>"PrefixAccDefense" - The defense modifier of the accessory prefix.</description></item>
 	/// <item><description>"PrefixAccMaxMana" - The maximum mana modifier of the accessory prefix.</description></item>
 	/// <item><description>"PrefixAccCritChance" - The critical strike chance modifier of the accessory prefix.</description></item>
 	/// <item><description>"PrefixAccDamage" - The damage modifier of the accessory prefix.</description></item>
 	/// <item><description>"PrefixAccMoveSpeed" - The movement speed modifier of the accessory prefix.</description></item>
 	/// <item><description>"PrefixAccMeleeSpeed" - The melee speed modifier of the accessory prefix.</description></item>
+	/// <item><description>"SetBonusSinglePiece" - The set bonus description from a single piece of armor that is not equipped.</description></item>
 	/// <item><description>"SetBonus" - The set bonus description of the armor set.</description></item>
 	/// <item><description>"Expert" - Tells whether the item is from expert-mode.</description></item>
 	/// <item><description>"Master" - Whether the item is exclusive to Master Mode.</description></item>
 	/// <item><description>"JourneyResearch" - How many more items need to be researched to unlock duplication in Journey Mode.</description></item>
+	/// <item><description>"JourneyResearchTeammate" - The "Research completed by {0}" line.</description></item>
 	/// <item><description>"ModifiedByMods" - Whether the item has been modified by any mods and what mods when holding shift, added by tModLoader.</description></item>
 	/// <item><description>"BestiaryNotes" - Any bestiary notes, used when hovering items in the bestiary.</description></item>
 	/// <item><description>"SpecialPrice" - Tells the alternate currency price of an item.</description></item>

--- a/tModPorter/tModPorter.Tests/TestData/TooltipLineTests.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/TooltipLineTests.Expected.cs
@@ -1,4 +1,5 @@
-using Terraria.ModLoader; 
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader;
 
 public class TooltipLineTests
 {
@@ -7,18 +8,32 @@ public class TooltipLineTests
 		string mod = line.Mod;
 		line.Text = "";
 #if COMPILE_ERROR
-		line.IsModifier = true;
-		line.IsModifierBad = false;
+		line.IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true;
+		line.IsModifierBad/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixBad instead */ = false;
+		line.Color = null;
 #endif
-		line.OverrideColor = null;
 
 		line = new TooltipLine(null, "", "") {
 			Text = "",
 #if COMPILE_ERROR
-			IsModifier = true,
-			IsModifierBad = false,
+			IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true,
+			IsModifierBad/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixBad instead */ = false,
+			Color = null
 #endif
-			OverrideColor = null
 		};
+
+#if COMPILE_ERROR
+		line.IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true;
+		line.IsModifierBad/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixBad instead */ = false;
+		line.Color = null;
+#endif
+
+		DrawableTooltipLine drawableTooltipLine = new DrawableTooltipLine(line, 0, 0, 0, Color.White);
+#if COMPILE_ERROR
+		drawableTooltipLine.IsModifier/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixGood instead */ = true;
+		drawableTooltipLine.IsModifierBad/* tModPorter Note: Removed. Set Color = Terraria.ID.Colors.PrefixBad instead */ = false;
+		drawableTooltipLine.Color = null;
+#endif
+		drawableTooltipLine.Color = Color.White;
 	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/TooltipLineTests.cs
+++ b/tModPorter/tModPorter.Tests/TestData/TooltipLineTests.cs
@@ -1,4 +1,5 @@
-using Terraria.ModLoader; 
+using Microsoft.Xna.Framework;
+using Terraria.ModLoader;
 
 public class TooltipLineTests
 {
@@ -16,5 +17,15 @@ public class TooltipLineTests
 			isModifierBad = false,
 			overrideColor = null
 		};
+
+		line.IsModifier = true;
+		line.IsModifierBad = false;
+		line.OverrideColor = null;
+
+		DrawableTooltipLine drawableTooltipLine = new DrawableTooltipLine(line, 0, 0, 0, Color.White);
+		drawableTooltipLine.IsModifier = true;
+		drawableTooltipLine.IsModifierBad = false;
+		drawableTooltipLine.OverrideColor = null;
+		drawableTooltipLine.Color = Color.White;
 	}
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -589,6 +589,10 @@ public static partial class Config
 
 		RefactorInstanceMember("Terraria.DataStructures.PlayerDrawSet", "heldProjOverHand", Removed("Automatically applied via Projectile.drawLayer value"));
 		RefactorInstanceMember("Terraria.ModLoader.ModProjectile", "DrawHeldProjInFrontOfHeldItemAndArms", Removed("Replace with Projectile.drawLayer = ProjectileDrawLayerID.HeldProjOverHand;"));
+		RefactorInstanceMember("Terraria.ModLoader.TooltipLine", "IsModifier", Removed("Set Color = Terraria.ID.Colors.PrefixGood instead"));
+		RefactorInstanceMember("Terraria.ModLoader.TooltipLine", "IsModifierBad", Removed("Set Color = Terraria.ID.Colors.PrefixBad instead"));
+
+		RenameInstanceField("Terraria.ModLoader.TooltipLine", "OverrideColor", "Color");
 
 		RenameType(from: "Terraria.ModLoader.NPCSpawnInfo", to: "Terraria.NPC+Spawner");
 	}


### PR DESCRIPTION
1.4.5 made some changes to how tooltip line colors are determined, and these changes can be leveraged to simplify the `TooltipLine` and `DrawableTooltipLine` code and corresponding patches to `Main.cs`.

In 1.4.4, tooltip line colors were determined after collecting the tooltip lines based on various hard-coded conditions, such as if the line was the journey mode research line, a bad prefix modifier, or a good prefix modifier. This approach led to the `TooltipLine` needing to contain `IsModifier` and `IsModifierBad` fields as well as a separate `OverrideColor` for bypassing vanilla color choice logic, which happened after lines were collected.

In 1.4.5 now, the colors are calculated as the lines are collected, allowing us to greatly simplify the logic.

Changes: 
* `TooltipLine`'s `Color? OverrideColor` is now `Color Color`.
  * Since it is the line color directly, the old "override" moniker no longer makes sense.
  * `DrawableTooltipLine`'s `public new Color? OverrideColor` was also removed. 
  * `DrawableTooltipLine`'s `public Color Color` is now `public new Color Color { get; internal set; }` to once again prevent changes.
* `TooltipLine.IsModifier` and `TooltipLine.IsModifierBad` were removed in 355f07e. 
  * `Terraria.ID.Colors.PrefixGood` and `Terraria.ID.Colors.PrefixBad` have been added, modders will now set `TooltipLine.Color` directly. 
  * `DrawableTooltipLine`'s `public new readonly bool IsModifier;` and `public new readonly bool IsModifierBad;` were also removed.

Discussion
* Since `TooltipLine.IsModifier` and `TooltipLine.IsModifierBad` have been removed, it is no longer possible to accurately determine if a tooltip line is for a modifier or not, aside from checking the color.
* We'll need to check with modders to see if these changes prevents implementing the same logic as 1.4.4 era mods. Some mods might have been checking `DrawableTooltipLine.Color` and `OverrideColor`, but I can't imagine why.

# Other Changes
* The "SocialDesc" tooltip line has been removed. Docs updated.
* `Item.hasVanityEffects` is now used, it was previously unused by vanilla. Docs updated.

# TODO
- [x] Need to update MigrationGuide with the porting notes for the `TooltipLine`/`DrawableTooltipLine` class changes.