### PR TITLE
Move solution files to suitable root directories

### DIFF
--- a/patches/Terraria/Terraria.sln
+++ b/patches/Terraria/Terraria.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "..\src\Terraria\Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "..\src\Terraria\ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/patches/TerrariaNetCore/TerrariaNetCore.sln
+++ b/patches/TerrariaNetCore/TerrariaNetCore.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.4.11626.88 stable
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "..\src\TerrariaNetCore\Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "..\src\TerrariaNetCore\ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "..\FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "..\..\FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "..\tModBuildTasks\tModLoader.BuildTasks.csproj", "{0FBF234A-8665-44FD-9B2C-88A2E43006F8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "..\..\tModBuildTasks\tModLoader.BuildTasks.csproj", "{0FBF234A-8665-44FD-9B2C-88A2E43006F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/patches/TerrariaNetCore/removed_files.list
+++ b/patches/TerrariaNetCore/removed_files.list
@@ -1,6 +1,7 @@
 ReLogic/Localization/IME/Windows/Imm.cs
 ReLogic/Localization/IME/Windows/NativeMethods.cs
 ReLogic/Localization/IME/WindowsIme.cs
+Terraria.sln
 Terraria/Libraries/CsvHelper/CsvHelper.dll
 Terraria/Libraries/DotNetZip/Ionic.Zip.CF.dll
 Terraria/Libraries/JSON.NET/Newtonsoft.Json.dll

--- a/patches/tModLoader/removed_files.list
+++ b/patches/tModLoader/removed_files.list
@@ -13,3 +13,4 @@ Terraria/Libraries/Common/Newtonsoft.Json.dll
 Terraria/Libraries/FNA/FNA.dll
 Terraria/Libraries/Mono/Steamworks.NET.dll
 Terraria/Libraries/Mono/System.Windows.Forms.dll
+TerrariaNetCore.sln

--- a/tModLoader.sln
+++ b/tModLoader.sln
@@ -3,27 +3,27 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.4.11626.88 stable
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "..\src\tModLoader\Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Terraria", "src\tModLoader\Terraria\Terraria.csproj", "{4EFE2B31-D61A-4C07-BAD2-991D3633C237}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "..\src\tModLoader\ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReLogic", "src\tModLoader\ReLogic\ReLogic.csproj", "{FD2AC3B2-3EA4-4331-ABC5-D3AA05035242}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "..\FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleMod", "..\ExampleMod\ExampleMod.csproj", "{F646F0CE-2C51-4610-B097-F16FB58CECC5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleMod", "ExampleMod\ExampleMod.csproj", "{F646F0CE-2C51-4610-B097-F16FB58CECC5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter", "..\tModPorter\tModPorter\tModPorter.csproj", "{2667C978-80E3-4D97-9F64-E519BA578BC1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter", "tModPorter\tModPorter\tModPorter.csproj", "{2667C978-80E3-4D97-9F64-E519BA578BC1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter.Tests", "..\tModPorter\tModPorter.Tests\tModPorter.Tests.csproj", "{97334941-ACE4-4BB2-A8E6-7F239722EA24}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter.Tests", "tModPorter\tModPorter.Tests\tModPorter.Tests.csproj", "{97334941-ACE4-4BB2-A8E6-7F239722EA24}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoaderTests", "..\test\tModLoaderTests.csproj", "{D7D3267F-5E12-47C8-A853-5BA8D0F15890}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoaderTests", "test\tModLoaderTests.csproj", "{D7D3267F-5E12-47C8-A853-5BA8D0F15890}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "..\tModBuildTasks\tModLoader.BuildTasks.csproj", "{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModLoader.BuildTasks", "tModBuildTasks\tModLoader.BuildTasks.csproj", "{3032A76C-7FC4-4E28-BB62-A8E632FCE79D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist", "..\tModCodeAssist\tModCodeAssist\tModCodeAssist.csproj", "{8513EE0F-F1EF-542F-5F04-FE610246A347}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist", "tModCodeAssist\tModCodeAssist\tModCodeAssist.csproj", "{8513EE0F-F1EF-542F-5F04-FE610246A347}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist.CodeFixes", "..\tModCodeAssist\tModCodeAssist.CodeFixes\tModCodeAssist.CodeFixes.csproj", "{E84567FB-E48C-D04A-0287-70C5A405040B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist.CodeFixes", "tModCodeAssist\tModCodeAssist.CodeFixes\tModCodeAssist.CodeFixes.csproj", "{E84567FB-E48C-D04A-0287-70C5A405040B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist.Tests", "..\tModCodeAssist\tModCodeAssist.Tests\tModCodeAssist.Tests.csproj", "{056DA6CC-A753-0D1A-777F-02C12C756543}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tModCodeAssist.Tests", "tModCodeAssist\tModCodeAssist.Tests\tModCodeAssist.Tests.csproj", "{056DA6CC-A753-0D1A-777F-02C12C756543}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
### What is the new feature?

`tModLoader.sln` moved to respository root
`Terraria.sln` moved to `src/Terraria`
`TerrariaNetCore.sln` moved to `src/TerrariaNetCore`

This will break developers shortcut paths and reset their local `.vs` folder state stores, but after that everything should be fine again.

A followup PR will look at renaming the `solutions` directory to something like `buildextras`

### Why should this be part of tModLoader?

Rider and VS Code both have some features that strongly prefer the opened `.sln` file to be at the root of all the 'working files' for the solution. 

Note that `TerrariaNetCore.sln` uses `FNA` so it may be better served at the repo root per that rule, but it's a tradeoff between further cluttering the base directory. 

### Are there alternative designs?

Move `TerrariaNetCore.sln` to the root directory.