### PR TITLE
[1.4.5] Restore ItemLoader.Update and PostUpdate hooks for WorldItem

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -79,7 +79,7 @@ Once all patches are fixed, these items need to be fixed or double checked:
   - "This is unused, replaced with this.ArmorPenetration." patch might be incorrect as well. Nearby switch table also changed a lot, might need to apply them elsewhere.
 - Vanilla CanHavePrefixes logic changed, might be able to use it rather than tml changes.
   - #StackablePrefixWeapons needs to be searched for and removed
-- Item Shimmer/Update/CheckLavaDeath/MoveInWorld/GetPickedUpByMonsters_Special/FindOwner/getRect/GetShimmered/CombineWithNearbyItems/related methods have moved to World Item. Need to move docs/patches over.
+- Item Shimmer/CheckLavaDeath/GetPickedUpByMonsters_Special/FindOwner/getRect/GetShimmered/CombineWithNearbyItems/related methods have moved to World Item. Need to move docs/patches over.
 - ModPylon.DrawMapIcon needs to support new vanilla options (DrawClamped when fullscreen it seems.)
 - ItemSlot has new flip parameter, what is it used for? PreDrawInInventory needs flip parameter. (and itemFade parameter? And secondColor?)
 - "// Sound is played on animation start #ItemTimeOnAllClients" comments around "SoundEngine.PlaySound(item6.UseSound" in MessageBuffer's `ShotAnimationAndSound` code. ShotAnimationAndSound was renamed, we might need to verify that this is still fixed in tmod.

--- a/patches/tModLoader/Terraria/Item.cs.rej
+++ b/patches/tModLoader/Terraria/Item.cs.rej
@@ -129,15 +129,6 @@
  				gravity = 0f;
  				velocity.X = 0f;
  				velocity.Y = 0f;
-@@ -48124,6 +_,8 @@
- 			timeSinceItemSpawned += num7;
- 		}
- 
-+		ItemLoader.PostUpdate(this);
-+
- 		if (Main.netMode == 2 && playerIndexTheItemIsReservedFor != Main.myPlayer) {
- 			timeSinceTheItemHasBeenReservedForSomeone++;
- 			if (timeSinceTheItemHasBeenReservedForSomeone >= 300) {
 @@ -48274,7 +_,7 @@
  
  			NetMessage.SendData(21, -1, -1, null, i);
@@ -147,15 +138,6 @@
  			active = false;
  			type = 0;
  			stack = 0;
-@@ -48285,6 +_,8 @@
- 
- 	private void MoveInWorld(float gravity, float maxFallSpeed, ref Vector2 wetVelocity, int i)
- 	{
-+		ItemLoader.Update(this, ref gravity, ref maxFallSpeed);
-+
- 		if (!shimmered && ItemID.Sets.ItemNoGravity[type]) {
- 			velocity.X *= 0.95f;
- 			if ((double)velocity.X < 0.1 && (double)velocity.X > -0.1)
 @@ -48553,7 +_,7 @@
  		Rectangle hitbox = base.Hitbox;
  		for (int j = 0; j < 200; j++) {

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -88,6 +88,24 @@
  
  					if (Main.rand.Next(num3) == 0 && Main.rand.NextFloat() < Main.maxRaining) {
  						int num4 = stack;
+@@ -485,6 +_,8 @@
+ 		if (timeSinceItemSpawned < 2147483547)
+ 			timeSinceItemSpawned++;
+ 
++		ItemLoader.PostUpdate(this);
++
+ 		if (noGrabDelay > 0)
+ 			noGrabDelay--;
+ 	}
+@@ -687,6 +_,8 @@
+ 
+ 	private void MoveInWorld(float gravity, float maxFallSpeed, ref Vector2 wetVelocity, int i)
+ 	{
++		ItemLoader.Update(this, ref gravity, ref maxFallSpeed);
++
+ 		if (!shimmered && ItemID.Sets.ItemNoGravity[type]) {
+ 			velocity.X *= 0.95f;
+ 			if ((double)velocity.X < 0.1 && (double)velocity.X > -0.1)
 @@ -1413,7 +_,11 @@
  	}
  


### PR DESCRIPTION
 ### What is the bug?

 In 1.4.5, vanilla moved all in-world item physics from Item.MoveInWorld() and Item.Update() into the new WorldItem class. The tModLoader patches that injected ItemLoader.Update and ItemLoader.PostUpdate into those methods failed because the target methods no longer exist in Item.cs. This left behind two stale hunks in patches/tModLoader/Terraria/Item.cs.rej and broke modded items' ability to:
 - Modify gravity and max fall speed while lying in the world
 - Run custom logic every tick via PostUpdate (e.g., spawning dust or emitting light)

 ### How did you fix the bug?

 - Added ItemLoader.Update(this, ref gravity, ref maxFallSpeed); at the very start of WorldItem.MoveInWorld(), before vanilla's gravity logic runs. This restores the pre-1.4.5 behavior where mods can override gravity and fall speed.
 - Added ItemLoader.PostUpdate(this); inside WorldItem.UpdateItem(), immediately after timeSinceItemSpawned++. This restores the post-update hook so mods can run per-tick logic on world items.
 - Removed the two now-obsolete rejected patch hunks from Item.cs.rej since the hooks now live in WorldItem.cs.patch.

 ### Are there alternatives to your fix?

 - Placing the hooks back in Item.cs: This is not viable. Item no longer has position, velocity, or MoveInWorld() in 1.4.5, so the hooks must live in WorldItem where the actual world state exists.
 - Calling Update later inside MoveInWorld: We deliberately placed it at the top, before vanilla checks ItemID.Sets.ItemNoGravity. This allows a mod to set gravity = 0 and have it take effect on the same frame, matching pre-1.4.5 behavior.
 - Calling PostUpdate elsewhere in UpdateItem: The current placement (after timeSinceItemSpawned++) mirrors the original location in Item.Update() and is the natural point where all vanilla update work for the tick is complete.