### PR TITLE
[1.4.5] Restore CanStack, CanStackInWorld, and OnStack hooks for WorldItem stacking

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.rej
+++ b/patches/tModLoader/Terraria/Item.cs.rej
@@ -165,34 +165,6 @@
  				flag3 = true;
  				NPC.TransformCopperSlime(j);
  				break;
-@@ -48669,14 +_,26 @@
- 				num2 *= 2;
- 
- 			if (num < (float)num2) {
-+				if (!ItemLoader.CanStack(this, item))
-+					continue;
-+
-+				if (!ItemLoader.CanStackInWorld(this, item))
-+					continue;
-+
- 				position = (position + item.position) / 2f;
- 				velocity = (velocity + item.velocity) / 2f;
-+
-+				ItemLoader.StackItems(this, item, out _);
-+
-+				/* #OnStackHook
- 				int num3 = item.stack;
- 				if (num3 > maxStack - stack)
- 					num3 = maxStack - stack;
- 
- 				item.stack -= num3;
- 				stack += num3;
-+				*/
-+
- 				if (item.stack <= 0) {
- 					item.SetDefaults();
- 					item.active = false;
-@@ -49077,6 +_,16 @@
  			case 4070:
  				return TextureAssets.Item[type].Frame(1, 4);
  			default:

--- a/patches/tModLoader/Terraria/Item.cs.rej
+++ b/patches/tModLoader/Terraria/Item.cs.rej
@@ -147,6 +147,7 @@
  				flag3 = true;
  				NPC.TransformCopperSlime(j);
  				break;
+@@ -49077,6 +_,16 @@
  			case 4070:
  				return TextureAssets.Item[type].Frame(1, 4);
  			default:

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -68,14 +68,10 @@
  		get {
  			return inner.makeNPC;
  		}
-@@ -201,10 +_,20 @@
+@@ -201,10 +_,26 @@
  		for (int i = myItemIndex + 1; i < 400; i++) {
  			WorldItem worldItem = Main.item[i];
  			if (!worldItem.IsAir && Item.CanStack(inner, worldItem.inner) && worldItem.shimmered == shimmered && worldItem.playerIndexTheItemIsReservedFor == playerIndexTheItemIsReservedFor && !(Math.Abs(position.X - worldItem.position.X) + Math.Abs(position.Y - worldItem.position.Y) > (float)num)) {
--				int num2 = Math.Min(worldItem.stack, maxStack - stack);
--				worldItem.stack -= num2;
--				stack += num2;
--				float amount = (float)num2 / (float)stack;
 +				// TML: Check CanStack first (general compatibility: type, prefix, etc.), then CanStackInWorld (world-specific).
 +				if (!ItemLoader.CanStack(inner, worldItem.inner))
 +					continue;
@@ -90,6 +86,12 @@
 +				ItemLoader.StackItems(inner, worldItem.inner, out int numTransferred);
 +
 +				float amount = (float)numTransferred / (float)stack;
++				/*
+ 				int num2 = Math.Min(worldItem.stack, maxStack - stack);
+ 				worldItem.stack -= num2;
+ 				stack += num2;
+ 				float amount = (float)num2 / (float)stack;
++				*/
  				position = Vector2.Lerp(worldItem.position, position, amount);
  				velocity = Vector2.Lerp(worldItem.velocity, velocity, amount);
  				if (worldItem.stack <= 0)

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -68,7 +68,7 @@
  		get {
  			return inner.makeNPC;
  		}
-@@ -201,10 +_,19 @@
+@@ -201,10 +_,20 @@
  		for (int i = myItemIndex + 1; i < 400; i++) {
  			WorldItem worldItem = Main.item[i];
  			if (!worldItem.IsAir && Item.CanStack(inner, worldItem.inner) && worldItem.shimmered == shimmered && worldItem.playerIndexTheItemIsReservedFor == playerIndexTheItemIsReservedFor && !(Math.Abs(position.X - worldItem.position.X) + Math.Abs(position.Y - worldItem.position.Y) > (float)num)) {
@@ -84,8 +84,9 @@
 +				if (!ItemLoader.CanStackInWorld(this, worldItem))
 +					continue;
 +
-+				// TML: Use StackItems so OnStack fires. This matches 1.4.4 behavior where OnStack
-+				// fired for all stacking contexts (world, inventory, chests).
++				// TML: Use StackItems so OnStack fires. StackItems performs the same stack arithmetic
++				// as the replaced vanilla code (plus favorited transfer and shopCustomPrice nulling,
++				// which were already part of the 1.4.4 behavior via this same method call).
 +				ItemLoader.StackItems(inner, worldItem.inner, out int numTransferred);
 +
 +				float amount = (float)numTransferred / (float)stack;

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -68,6 +68,30 @@
  		get {
  			return inner.makeNPC;
  		}
+@@ -201,10 +_,19 @@
+ 		for (int i = myItemIndex + 1; i < 400; i++) {
+ 			WorldItem worldItem = Main.item[i];
+ 			if (!worldItem.IsAir && Item.CanStack(inner, worldItem.inner) && worldItem.shimmered == shimmered && worldItem.playerIndexTheItemIsReservedFor == playerIndexTheItemIsReservedFor && !(Math.Abs(position.X - worldItem.position.X) + Math.Abs(position.Y - worldItem.position.Y) > (float)num)) {
+-				int num2 = Math.Min(worldItem.stack, maxStack - stack);
+-				worldItem.stack -= num2;
+-				stack += num2;
+-				float amount = (float)num2 / (float)stack;
++				// TML: Check CanStack first (general compatibility: type, prefix, etc.), then CanStackInWorld (world-specific).
++				if (!ItemLoader.CanStack(inner, worldItem.inner))
++					continue;
++
++				// TML: CanStackInWorld is world-only; it does NOT affect inventory/chest stacking.
++				if (!ItemLoader.CanStackInWorld(this, worldItem))
++					continue;
++
++				// TML: Use StackItems so OnStack fires. This matches 1.4.4 behavior where OnStack
++				// fired for all stacking contexts (world, inventory, chests).
++				ItemLoader.StackItems(inner, worldItem.inner, out int numTransferred);
++
++				float amount = (float)numTransferred / (float)stack;
+ 				position = Vector2.Lerp(worldItem.position, position, amount);
+ 				velocity = Vector2.Lerp(worldItem.velocity, velocity, amount);
+ 				if (worldItem.stack <= 0)
 @@ -338,7 +_,10 @@
  		float maxFallSpeed = 7f;
  		if (Main.netMode == 1) {

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -85,13 +85,13 @@
 +				// which were already part of the 1.4.4 behavior via this same method call).
 +				ItemLoader.StackItems(inner, worldItem.inner, out int numTransferred);
 +
-+				float amount = (float)numTransferred / (float)stack;
-+				/*
++				/* #OnStackHook
  				int num2 = Math.Min(worldItem.stack, maxStack - stack);
  				worldItem.stack -= num2;
  				stack += num2;
  				float amount = (float)num2 / (float)stack;
 +				*/
++				float amount = (float)numTransferred / (float)stack;
  				position = Vector2.Lerp(worldItem.position, position, amount);
  				velocity = Vector2.Lerp(worldItem.velocity, velocity, amount);
  				if (worldItem.stack <= 0)


### PR DESCRIPTION
### What is the bug?

In 1.4.5, vanilla moved all in-world item stacking logic from `Item.cs` into the new `WorldItem.TryCombiningIntoNearbyItems()` method. The tModLoader patch that injected `ItemLoader.CanStack`, `ItemLoader.CanStackInWorld`, and `ItemLoader.StackItems` (which fires `OnStack`) failed because its target code no longer exists in `Item.cs`. This left a stale hunk in Item.cs.rej and broke three modding hooks:

| Hook | What broke | Observable effect |
|---|---|---|
| CanStack | Never called during world merging | Mods can't block stacking based on prefix/type |
| CanStackInWorld | Never called during world merging | Mods can't block world-only stacking |
| OnStack | Never called during world merging | No custom effects (dust, sound, etc.) when items merge on the ground |

 Inventory and chest stacking still worked because those paths already call TryStackItems/StackItems separately.

### How did you fix the bug?

 Added the three hook calls to `WorldItem.TryCombiningIntoNearbyItems()` in `src/tModLoader/Terraria/WorldItem.cs`:

 1. `ItemLoader.CanStack(inner, worldItem.inner)` — general compatibility check (type, prefix, etc.)
 2. `ItemLoader.CanStackInWorld(this, worldItem)` — world-specific stacking permission
 3. `ItemLoader.StackItems(inner, worldItem.inner, out int numTransferred)` — performs the transfer and fires `OnStack`

 Also added explanatory TML comments clarifying:
 - Why `CanStack` comes before `CanStackInWorld`
 - Why `CanStackInWorld` is world-only and doesn't affect inventory/chests
 - Why `OnStack` firing in all contexts matches 1.4.4 behavior

 Removed the now-obsolete `@@ -48669` hunk from `Item.cs.rej`.

 ### Are there alternatives to your fix?

 - Call hooks in a different order: `CanStack` → `CanStackInWorld` is the same order as the original 1.4.4 patch. Reversing it would let `CanStackInWorld` run before type/prefix validation, which doesn't make sense.
 - Use manual arithmetic instead of `StackItems`: Would skip `OnStack`, which is exactly the bug we're fixing.
 - Merge `CanStackInWorld` into `CanStack`: These are intentionally separate hooks with different purposes. `CanStack` is for general compatibility; `CanStackInWorld` is specifically for world physics decisions (e.g., "don't merge while this item is exploding").