### PR TITLE
[1.4.5] Move Mod Warning Icon to the Left on Worlds 

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UIWorldListItem.TML.cs
@@ -48,6 +48,9 @@ public partial class UIWorldListItem : AWorldListItem
 		};
 
 		float topRightButtonsLeftPixels = 0f;
+		if (_hasBeenPlayedByActivePlayer || _isNewlyGenerated)
+			topRightButtonsLeftPixels -= 24;
+
 		warningLabel.Top.Set(3f, 0f);
 
 		Append(warningLabel);


### PR DESCRIPTION
### What is the bug?

1.4.5 added the newly generated and played flag on the right side of world selection menu. This meant tModLoader's warning about missing or new mods overlapped with those.

### How did you fix the bug?

Moved tModLoader's warning left if the newly generated or played flag was present.

<img width="731" height="230" alt="image" src="https://github.com/user-attachments/assets/e167db79-4878-4f3e-9b41-d88a38edefe9" />

### Are there alternatives to your fix?

Unlikely. Though, the newly generated and played flag tooltips appear at the bottom of the world (next to the trash can icon) instead of to the left of the symbol like the warning icon. We could change where the warning tooltip is shown for consistency, or just leave it how it is because it's pretty minor.