### PR TITLE
[1.4.5] Restore OnStack hooks

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
@@ -8,15 +8,14 @@
  
  namespace Terraria.GameContent;
  
-@@ -295,8 +_,10 @@
+@@ -295,8 +_,11 @@
  
  		int numToTransfer = t.NumToTransfer;
  		if (numToTransfer != 0) {
-+			// TML: Use StackItems so OnStack hook fires.
--			src.stack -= numToTransfer;
-+			// src.stack -= numToTransfer;
--			dst.stack += numToTransfer;
-+			// dst.stack += numToTransfer;
++			/* TML: Use StackItems so OnStack hook fires.
+ 			src.stack -= numToTransfer;
+ 			dst.stack += numToTransfer;
++			*/
 +			ItemLoader.StackItems(dst.inner, src.inner, out _, numToTransfer: numToTransfer);
  			if (src.stack <= 0)
  				src.TurnToAir();

--- a/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
@@ -1,0 +1,21 @@
+--- src/TerrariaNetCore/Terraria/GameContent/EmergencyStacking.cs
++++ src/tModLoader/Terraria/GameContent/EmergencyStacking.cs
+@@ -3,6 +_,7 @@
+ using System.Linq;
+ using Microsoft.Xna.Framework;
+ using Terraria.ID;
++using Terraria.ModLoader;
+ 
+ namespace Terraria.GameContent;
+ 
+@@ -295,8 +_,8 @@
+ 
+ 		int numToTransfer = t.NumToTransfer;
+ 		if (numToTransfer != 0) {
+-			src.stack -= numToTransfer;
+-			dst.stack += numToTransfer;
++			// TML: Use StackItems so OnStack hook fires.
++			ItemLoader.StackItems(dst.inner, src.inner, out _, numToTransfer: numToTransfer);
+ 			if (src.stack <= 0)
+ 				src.TurnToAir();
+ 

--- a/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/EmergencyStacking.cs.patch
@@ -8,13 +8,15 @@
  
  namespace Terraria.GameContent;
  
-@@ -295,8 +_,8 @@
+@@ -295,8 +_,10 @@
  
  		int numToTransfer = t.NumToTransfer;
  		if (numToTransfer != 0) {
--			src.stack -= numToTransfer;
--			dst.stack += numToTransfer;
 +			// TML: Use StackItems so OnStack hook fires.
+-			src.stack -= numToTransfer;
++			// src.stack -= numToTransfer;
+-			dst.stack += numToTransfer;
++			// dst.stack += numToTransfer;
 +			ItemLoader.StackItems(dst.inner, src.inner, out _, numToTransfer: numToTransfer);
  			if (src.stack <= 0)
  				src.TurnToAir();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5028,6 +5028,16 @@
  
  	public static bool LocalPlayerHasPendingInventoryActions()
  	{
+@@ -36799,7 +_,8 @@
+ 
+ 	public static void CraftItem_GrantItem(Recipe recipe, Item result, bool quickCraft)
+ 	{
+-		result.stack += mouseItem.stack;
++		// TML: Use StackItems so OnStack hook fires.
++		ItemLoader.StackItems(result, mouseItem, out _);
+ 		mouseItem = result;
+ 		if (quickCraft && !mouseItem.IsAir) {
+ 			if (CraftingRequests.HasPendingRequests) {
 @@ -37026,6 +_,10 @@
  					if (item[i].expert)
  						rare = -12;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5028,14 +5028,16 @@
  
  	public static bool LocalPlayerHasPendingInventoryActions()
  	{
-@@ -36799,7 +_,10 @@
+@@ -36799,7 +_,12 @@
  
  	public static void CraftItem_GrantItem(Recipe recipe, Item result, bool quickCraft)
  	{
 +		/* TML: Use StackItems so OnStack hook fires.
  		result.stack += mouseItem.stack;
 +		*/
-+		ItemLoader.StackItems(result, mouseItem, out _);
++		if (mouseItem.stack > 0)
++			ItemLoader.StackItems(result, mouseItem, out _);
++
  		mouseItem = result;
  		if (quickCraft && !mouseItem.IsAir) {
  			if (CraftingRequests.HasPendingRequests) {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5028,12 +5028,13 @@
  
  	public static bool LocalPlayerHasPendingInventoryActions()
  	{
-@@ -36799,7 +_,8 @@
+@@ -36799,7 +_,9 @@
  
  	public static void CraftItem_GrantItem(Recipe recipe, Item result, bool quickCraft)
  	{
--		result.stack += mouseItem.stack;
 +		// TML: Use StackItems so OnStack hook fires.
+-		result.stack += mouseItem.stack;
++		// result.stack += mouseItem.stack;
 +		ItemLoader.StackItems(result, mouseItem, out _);
  		mouseItem = result;
  		if (quickCraft && !mouseItem.IsAir) {

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -5028,13 +5028,13 @@
  
  	public static bool LocalPlayerHasPendingInventoryActions()
  	{
-@@ -36799,7 +_,9 @@
+@@ -36799,7 +_,10 @@
  
  	public static void CraftItem_GrantItem(Recipe recipe, Item result, bool quickCraft)
  	{
-+		// TML: Use StackItems so OnStack hook fires.
--		result.stack += mouseItem.stack;
-+		// result.stack += mouseItem.stack;
++		/* TML: Use StackItems so OnStack hook fires.
+ 		result.stack += mouseItem.stack;
++		*/
 +		ItemLoader.StackItems(result, mouseItem, out _);
  		mouseItem = result;
  		if (quickCraft && !mouseItem.IsAir) {

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -261,6 +261,17 @@
  	}
  
  	private static void Extractinator(int sourceX, int sourceY)
+@@ -2470,8 +_,8 @@
+ 		if (worldItem.stack + item.stack > item.maxStack)
+ 			num = item.maxStack - item.stack;
+ 
+-		worldItem.stack -= num;
+-		item.stack += num;
++		// TML: Use StackItems so OnStack hook fires.
++		ItemLoader.StackItems(item, worldItem.inner, out _, numToTransfer: num);
+ 		if (worldItem.stack <= 0) {
+ 			worldItem.TurnToAir();
+ 			return true;
 @@ -2824,7 +_,7 @@
  		return false;
  	}

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -261,13 +261,15 @@
  	}
  
  	private static void Extractinator(int sourceX, int sourceY)
-@@ -2470,8 +_,8 @@
+@@ -2470,8 +_,10 @@
  		if (worldItem.stack + item.stack > item.maxStack)
  			num = item.maxStack - item.stack;
  
--		worldItem.stack -= num;
--		item.stack += num;
 +		// TML: Use StackItems so OnStack hook fires.
+-		worldItem.stack -= num;
++		// worldItem.stack -= num;
+-		item.stack += num;
++		// item.stack += num;
 +		ItemLoader.StackItems(item, worldItem.inner, out _, numToTransfer: num);
  		if (worldItem.stack <= 0) {
  			worldItem.TurnToAir();

--- a/patches/tModLoader/Terraria/Wiring.cs.patch
+++ b/patches/tModLoader/Terraria/Wiring.cs.patch
@@ -261,15 +261,14 @@
  	}
  
  	private static void Extractinator(int sourceX, int sourceY)
-@@ -2470,8 +_,10 @@
+@@ -2470,8 +_,11 @@
  		if (worldItem.stack + item.stack > item.maxStack)
  			num = item.maxStack - item.stack;
  
-+		// TML: Use StackItems so OnStack hook fires.
--		worldItem.stack -= num;
-+		// worldItem.stack -= num;
--		item.stack += num;
-+		// item.stack += num;
++		/* TML: Use StackItems so OnStack hook fires.
+ 		worldItem.stack -= num;
+ 		item.stack += num;
++		*/
 +		ItemLoader.StackItems(item, worldItem.inner, out _, numToTransfer: num);
  		if (worldItem.stack <= 0) {
  			worldItem.TurnToAir();


### PR DESCRIPTION
### What is the bug?

In 1.4.5, three stacking code paths were refactored or introduced without calling `ItemLoader.StackItems`, causing the `OnStack` mod hook to be silently bypassed:

1. **Crafting merge (`Main.CraftItem_GrantItem`)**: When crafting an item while already holding a matching stack on the mouse cursor, vanilla merged the result via raw `result.stack += mouseItem.stack`. This skipped `GlobalItem.OnStack` and `ModItem.OnStack`.

2. **Wiring hopper (`Wiring.TryAddingToStack`)**: When a hopper sucks a `WorldItem` into a chest, the vanilla code performed raw `stack -=` / `stack +=` without invoking the hook.

3. **Emergency stacking (`EmergencyStacking.DoTransfer`)**: The new 1.4.5 emergency stacking system performs deferred world-item-to-world-item transfers using raw arithmetic, bypassing `OnStack` entirely.

### How did you fix the bug?

Replaced the raw stack arithmetic in all three locations with `ItemLoader.StackItems(...)`:

| File | Change |
|------|--------|
| `Main.cs` | `if (mouseItem.stack > 0) ItemLoader.StackItems(result, mouseItem, out _);` |
| `Wiring.cs` | `ItemLoader.StackItems(item, worldItem.inner, out _, numToTransfer: num);` |
| `EmergencyStacking.cs` | `ItemLoader.StackItems(dst.inner, src.inner, out _, numToTransfer: numToTransfer);` |

An explicit `if (mouseItem.stack > 0)` guard was added in `CraftItem_GrantItem` because `StackItems` unconditionally calls `OnStack` even for a 0-transfer. When creating the first item, `mouseItem` is empty, so the original vanilla `result.stack += mouseItem.stack` was a harmless no-op, but calling `StackItems` would incorrectly fire `OnStack` with 0 items.

### Are there alternatives to your fix?

- **Move the guard into `ItemLoader.StackItems` / `TryStackItems`**: The `if (mouseItem.stack > 0)` guard could theoretically be absorbed into `StackItems` itself. However, most other call sites already have equivalent preconditions (e.g. `TryStackItems` bails on `!CanStack`, `PickupItemIntoMouse` passes `numToTransfer: 1`, `DoTransfer` already checks `numToTransfer != 0`). Adding a guard inside `StackItems` would be redundant for every existing caller except `CraftItem_GrantItem`, which is uniquely shaped by vanilla's unconditional `+=`.

- **IL-patch `Item.stack` writes**: One could try to intercept every `stack +=` / `stack -=` in vanilla. This is infeasible — `Item.stack` is a public field, not a property, and there are dozens of unrelated sites (crafting consumption, ammo use, projectile spawning, etc.) that write to it. Patching each call site individually is the pragmatic approach already used throughout tML.

- **Add `OnStack` to `Item.stack` property**: Would require converting `stack` from a field to a property, which is a breaking change for every mod and every vanilla patch.

### Additional Notes

Some of the call sites touched in this PR (and others in the codebase) still use `Item.CanStack` instead of `ItemLoader.CanStack` when filtering candidates for stacking. These were explicitly left untouched because I am working on the `CanStack` refactor (discussed in #5149 ), which will merge `Item.CanStack` and `ItemLoader.CanStack` into a single centralized check. That refactor will fix the remaining bypasses holistically rather than papering over them one at a time.
