### PR TITLE
Expand BossLoot hook to include heart and potion drop amount 

### DIFF
--- a/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
+++ b/ExampleMod/Content/NPCs/MinionBoss/MinionBossBody.cs
@@ -243,9 +243,10 @@ namespace ExampleMod.Content.NPCs.MinionBoss
 			*/
 		}
 
-		public override void BossLoot(ref int potionType) {
-			// Here you'd want to change the potion type that drops when the boss is defeated. Because this boss is early pre-hardmode, we keep it unchanged
+		public override void BossLoot(ref int potionType, ref int potionStack, ref int heartStack) {
+			// Here you'd want to change the potion type, the amount of potions and the amount of hearts that drops when the boss is defeated. Because this boss is early pre-hardmode, we keep it unchanged
 			// (Lesser Healing Potion). If you wanted to change it, simply write "potionType = ItemID.HealingPotion;" or any other potion type
+			// Same goes for the potionStack and heartStack, simply write "heartStack = amount_desired;" or "potionStack = amount_desired;".
 		}
 
 		public override bool CanHitPlayer(Player target, ref int cooldownSlot) {

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -447,13 +447,17 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	{
 	}
 
+	[OriginalOverload]
 	[Obsolete("Use BossLoot(ref int potionType) instead. The name can be changed by modifying DeathMessage")]
 	public virtual void BossLoot(ref string name, ref int potionType)
 	{
 	}
-
+	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.")]
+	public virtual void BossLoot(ref int potionType)
+	{
+	}
 	/// <summary>
-	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops.
+	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops, the amount of potions and the amount of hearts.
 	/// <para/> Called in single player or on the server only.
 	/// </summary>
 	public virtual void BossLoot(ref int potionType, ref int potionStack, ref int heartStack)

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -456,7 +456,7 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops.
 	/// <para/> Called in single player or on the server only.
 	/// </summary>
-	public virtual void BossLoot(ref int potionType)
+	public virtual void BossLoot(ref int potionType, ref int potionStack, ref int heartStack)
 	{
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -447,19 +447,18 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	{
 	}
 
-	[OriginalOverload]
-	[Obsolete("Use BossLoot(ref int potionType) instead. The name can be changed by modifying DeathMessage")]
+	[Obsolete("Use BossLoot(ref int potionType) instead. The name can be changed by modifying DeathMessage", error: true)]
 	public virtual void BossLoot(ref string name, ref int potionType)
 	{
 	}
 
-	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.")]
+	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.", error: true)]
 	public virtual void BossLoot(ref int potionType)
 	{
 	}
 
 	/// <summary>
-	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops, the amount of potions and the amount of hearts.
+	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops, the amount of potions, and the amount of hearts.
 	/// <para/> Called in single player or on the server only.
 	/// </summary>
 	public virtual void BossLoot(ref int potionType, ref int potionStack, ref int heartStack)

--- a/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModNPC.cs
@@ -452,10 +452,12 @@ public abstract class ModNPC : ModType<NPC, ModNPC>, ILocalizedModType
 	public virtual void BossLoot(ref string name, ref int potionType)
 	{
 	}
+
 	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.")]
 	public virtual void BossLoot(ref int potionType)
 	{
 	}
+
 	/// <summary>
 	/// Allows you to customize what happens when this boss dies, as well as letting you modify the type of potion it drops, the amount of potions and the amount of hearts.
 	/// <para/> Called in single player or on the server only.

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -567,10 +567,14 @@ public static class NPCLoader
 			g.ModifyGlobalLoot(globalLoot);
 		}
 	}
-
-	public static void BossLoot(NPC npc, ref string name, ref int potionType, ref int potionStack, ref int heartStack)
+	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.")]
+	public static void BossLoot(NPC npc, ref string name, ref int potionType)
 	{
 		npc.ModNPC?.BossLoot(ref name, ref potionType);
+		npc.ModNPC?.BossLoot(ref potionType);
+	}
+	public static void BossLoot(NPC npc, ref string name, ref int potionType, ref int potionStack, ref int heartStack)
+	{
 		npc.ModNPC?.BossLoot(ref potionType, ref potionStack, ref heartStack);
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -568,10 +568,10 @@ public static class NPCLoader
 		}
 	}
 
-	public static void BossLoot(NPC npc, ref string name, ref int potionType)
+	public static void BossLoot(NPC npc, ref string name, ref int potionType, ref int potionStack, ref int heartStack)
 	{
 		npc.ModNPC?.BossLoot(ref name, ref potionType);
-		npc.ModNPC?.BossLoot(ref potionType);
+		npc.ModNPC?.BossLoot(ref potionType, ref potionStack, ref heartStack);
 	}
 
 	private static HookList HookCanFallThroughPlatforms = AddHook<Func<NPC, bool?>>(g => g.CanFallThroughPlatforms);

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -575,7 +575,7 @@ public static class NPCLoader
 		npc.ModNPC?.BossLoot(ref potionType);
 	}
 
-	public static void BossLoot(NPC npc, ref string name, ref int potionType, ref int potionStack, ref int heartStack)
+	public static void BossLoot(NPC npc, ref int potionType, ref int potionStack, ref int heartStack)
 	{
 		npc.ModNPC?.BossLoot(ref potionType, ref potionStack, ref heartStack);
 	}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -567,12 +567,14 @@ public static class NPCLoader
 			g.ModifyGlobalLoot(globalLoot);
 		}
 	}
+
 	[Obsolete("BossLoot has now parameters to control the amount of potions and hearts.")]
 	public static void BossLoot(NPC npc, ref string name, ref int potionType)
 	{
 		npc.ModNPC?.BossLoot(ref name, ref potionType);
 		npc.ModNPC?.BossLoot(ref potionType);
 	}
+
 	public static void BossLoot(NPC npc, ref string name, ref int potionType, ref int potionStack, ref int heartStack)
 	{
 		npc.ModNPC?.BossLoot(ref potionType, ref potionStack, ref heartStack);

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2083,7 +2083,7 @@
  	{
  		int stack = Main.rand.Next(5, 16);
  		int num = 28;
-@@ -65859,8 +_,14 @@
+@@ -65859,8 +_,16 @@
  		else if (type == 398)
  			num = 3544;
  

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2083,15 +2083,22 @@
  	{
  		int stack = Main.rand.Next(5, 16);
  		int num = 28;
-@@ -65859,6 +_,8 @@
+@@ -65859,8 +_,14 @@
  		else if (type == 398)
  			num = 3544;
  
-+		NPCLoader.BossLoot(this, ref typeName, ref num);
+-		Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
 +
- 		Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
++
  		int num2 = Main.rand.Next(5) + 5;
++
++		NPCLoader.BossLoot(this, ref typeName, ref num, ref stack, ref num2);
++
++		Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
++		// int num2 = Main.rand.Next(5) + 5;
  		for (int i = 0; i < num2; i++) {
+ 			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, 58);
+ 		}
 @@ -65876,10 +_,27 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2083,21 +2083,19 @@
  	{
  		int stack = Main.rand.Next(5, 16);
  		int num = 28;
-@@ -65859,8 +_,16 @@
+@@ -65859,8 +_,14 @@
  		else if (type == 398)
  			num = 3544;
  
 -		Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
-+
-+
  		int num2 = Main.rand.Next(5) + 5;
 +
-+		NPCLoader.BossLoot(this, ref typeName, ref num, ref stack, ref num2);
-+		if (stack > 0 && num > 0) {
-+			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
-+		}
++		NPCLoader.BossLoot(this, ref typeName, ref num);
++		NPCLoader.BossLoot(this, ref num, ref stack, ref num2);
 +
-+		// int num2 = Main.rand.Next(5) + 5;
++		if (stack > 0 && num > 0)
++			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
++
  		for (int i = 0; i < num2; i++) {
  			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, 58);
  		}

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2093,8 +2093,10 @@
  		int num2 = Main.rand.Next(5) + 5;
 +
 +		NPCLoader.BossLoot(this, ref typeName, ref num, ref stack, ref num2);
++		if (stack > 0 && num > 0) {
++			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
++		}
 +
-+		Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, num, stack);
 +		// int num2 = Main.rand.Next(5) + 5;
  		for (int i = 0; i < num2; i++) {
  			Item.NewItem(GetItemSource_Loot(), (int)position.X, (int)position.Y, width, height, 58);

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.Expected.cs
@@ -116,4 +116,6 @@ public class ModNPCTest : ModNPC
 
 		NPCID.Sets.SearchSpawnSlotsInReverse[Type] = true;
 	}
+
+	public override void BossLoot(ref int potionType, ref int potionStack, ref int heartStack) { }
 }

--- a/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModNPCTest.cs
@@ -91,4 +91,6 @@ public class ModNPCTest : ModNPC
 
 		NPCID.Sets.SpawnFromLastEmptySlot[Type] = true;
 	}
+
+	public override void BossLoot(ref int potionType) { }
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -603,5 +603,7 @@ public static partial class Config
 		RenameInstanceField("Terraria.ModLoader.TooltipLine", "OverrideColor", "Color");
 
 		RenameType(from: "Terraria.ModLoader.NPCSpawnInfo", to: "Terraria.NPC+Spawner");
+
+		ChangeHookSignature("Terraria.ModLoader.ModNPC", "BossLoot");
 	}
 }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -554,6 +554,7 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.ModTree", "SetTreeFoliageSettings");
 
 		// 1.4.5
+		ChangeHookSignature("Terraria.ModLoader.ModNPC", "BossLoot");
 		ChangeHookSignature("Terraria.ModLoader.ModNPC", "SpawnChance").RenameParameter("spawnInfo", "spawner");
 		ChangeHookSignature("Terraria.ModLoader.ModNPC", "OnChatButtonClicked", comment: "Suggestion: Previously this was used to assign a shop to a button, but that is now handled by RegisterChatButtons. If that is all this was used for, remove this hook");
 		ChangeHookSignature("Terraria.ModLoader.GlobalNPC", "EditSpawnPool").RenameParameter("spawnInfo", "spawner");
@@ -603,7 +604,5 @@ public static partial class Config
 		RenameInstanceField("Terraria.ModLoader.TooltipLine", "OverrideColor", "Color");
 
 		RenameType(from: "Terraria.ModLoader.NPCSpawnInfo", to: "Terraria.NPC+Spawner");
-
-		ChangeHookSignature("Terraria.ModLoader.ModNPC", "BossLoot");
 	}
 }


### PR DESCRIPTION
### What is the new feature?
Allows mods to modify the amount of potions and hearts dropped from a boss loot (#5135).
### Why should this be part of tModLoader?
Currently mods need to workaround the current implementation to be able to specify the amount of hearts and potions dropped by a boss when killed, that usually causes buggy behavior or unexpected side effects.
### Are there alternative designs?
Instead of dropping a amount of single hearts, it could be just a one or a few hearts with a more dense stack.
### Sample usage for the new feature
```C#
public override void BossLoot(ref int potionType, ref int potionStack, ref int heartStack) {
	potionStack = 50;
	heartStack = 99;
}
```
### ExampleMod updates
Incremented the BossLoot comment to cover the new feature at the MinionBossBody Class

### Porting Notes
It should work as it is. The feature shouldn't affect existing mods.
