### PR TITLE
[1.4.5] Boulder Logo ModMenu

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -102,7 +102,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - DrawBlockReplacementIcon return changed from void to bool. Does that affect how the builders toggle works? Did vanilla behavior change? New state bool in logic, and DoStatefulTickSound
 - See updated `toolTipNames[numLines] = "UseMana";` patch. Look into IsSpaceGun and GetManaCost, might need updates. 
 - Double check PlayerLoader.ModifyZoom logic. Seems like there is only 1 callsite now, code was cleaned up?
-- What is Main.boulderLogo? Seems like MenuLoader needs to be updated with a new vanilla menu option?
 - There are new music tracks and some might have been moved. Update SceneEffectPriority enum docs and double check that they are correct for both methods.
 - DrawPlayer_14_2_GlassSlipperSparkles gone?
 - Need to find where ProjectileLoader.DrawHeldProjInFrontOfHeldItemAndArms (ModProjectile.DrawHeldProjInFrontOfHeldItemAndArms) should go. PlayerDrawSet removed heldProjOverHand and there are new fields as well. Seems like `SelectedDrawnProjectile.drawLayer == 8` replaced it in DrawPlayer_31_ProjectileOverArm? ProjectileDrawLayerID.HeldProjOverHand exists.

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -877,15 +877,17 @@
  	public static int SmartInteractProj;
  	public static bool SmartInteractPotionOfReturn;
  	public static List<Microsoft.Xna.Framework.Point> SmartInteractTileCoords = new List<Microsoft.Xna.Framework.Point>();
-@@ -1986,7 +_,7 @@
+@@ -1986,8 +_,8 @@
  	public static bool _shouldUseWindyDayMusic = false;
  	public static bool _shouldUseStormMusic = false;
  	private int lastMusicPlayed = -1;
 -	private bool playOldTile;
 +	public bool playOldTile;
- 	private bool boulderLogo;
+-	private bool boulderLogo;
++	public bool boulderLogo;
  	private static TitleMusicStyle titleMusicStyle = TitleMusicStyle.Current;
  	private static TitleMusicStyle titleMusicStyleRandom = TitleMusicStyle.Current;
+ 	private static float _minWind = 0.34f;
 @@ -2004,12 +_,16 @@
  	public static float ambientLavaY = -1f;
  	public static float ambientLavaStrength;
@@ -5718,7 +5720,7 @@
  			if (starGame)
  				playOldTile = false;
  		}
-@@ -41738,12 +_,17 @@
+@@ -41738,20 +_,30 @@
  				logoScaleSpeed -= 1f;
  		}
  
@@ -5726,8 +5728,11 @@
 +
  		Microsoft.Xna.Framework.Color color2 = new Microsoft.Xna.Framework.Color((byte)((float)(int)color.R * ((float)LogoA / 255f)), (byte)((float)(int)color.G * ((float)LogoA / 255f)), (byte)((float)(int)color.B * ((float)LogoA / 255f)), (byte)((float)(int)color.A * ((float)LogoA / 255f)));
  		Microsoft.Xna.Framework.Color color3 = new Microsoft.Xna.Framework.Color((byte)((float)(int)color.R * ((float)LogoB / 255f)), (byte)((float)(int)color.G * ((float)LogoB / 255f)), (byte)((float)(int)color.B * ((float)LogoB / 255f)), (byte)((float)(int)color.A * ((float)LogoB / 255f)));
- 		if (noTrapsWorld)
+-		if (noTrapsWorld)
++		if (noTrapsWorld) {
  			boulderLogo = true;
++			MenuLoader.ActivateBiggerAndBoulderMenu();
++		}
  
 +		/*
  		if (playOldTile) {
@@ -5736,7 +5741,10 @@
  			spriteBatch.Draw(TextureAssets.Logo3.Value, new Vector2(screenWidth / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.Logo.Width(), TextureAssets.Logo.Height()), color2, logoRotation, new Vector2(TextureAssets.Logo.Width() / 2, TextureAssets.Logo.Height() / 2), logoScale, SpriteEffects.None, 0f);
  			spriteBatch.Draw(TextureAssets.Logo4.Value, new Vector2(screenWidth / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.Logo.Width(), TextureAssets.Logo.Height()), color3, logoRotation, new Vector2(TextureAssets.Logo.Width() / 2, TextureAssets.Logo.Height() / 2), logoScale, SpriteEffects.None, 0f);
  		}
-@@ -41751,7 +_,7 @@
++		/*
+ 		else if (boulderLogo) {
++		*/
++		else if (MenuLoader.MenuBiggerAndBoulder.IsSelected) {
  			spriteBatch.Draw(TextureAssets.Logo5.Value, new Vector2(screenWidth / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.Logo.Width(), TextureAssets.Logo.Height()), color2, logoRotation, new Vector2(TextureAssets.Logo.Width() / 2, TextureAssets.Logo.Height() / 2), logoScale, SpriteEffects.None, 0f);
  			spriteBatch.Draw(TextureAssets.Logo6.Value, new Vector2(screenWidth / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.Logo.Width(), TextureAssets.Logo.Height()), color3, logoRotation, new Vector2(TextureAssets.Logo.Width() / 2, TextureAssets.Logo.Height() / 2), logoScale, SpriteEffects.None, 0f);
  		}

--- a/patches/tModLoader/Terraria/ModLoader/Default/DefaultModMenus.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Default/DefaultModMenus.cs
@@ -45,3 +45,16 @@ internal class MenuOldVanilla : ModMenu
 
 	public override bool PreDrawLogo(SpriteBatch spriteBatch, ref Vector2 logoDrawCenter, ref float logoRotation, ref float logoScale, ref Color drawColor) => false;
 }
+
+/// <summary>
+/// The Bigger and Boulder theme converted into a ModMenu, so that it better fits with the new system.
+/// </summary>
+[Autoload(false)]
+internal class MenuBiggerAndBoulder : ModMenu
+{
+	public override bool IsAvailable => Main.instance.boulderLogo;
+
+	public override string DisplayName => "Bigger and Boulder";
+
+	public override bool PreDrawLogo(SpriteBatch spriteBatch, ref Vector2 logoDrawCenter, ref float logoRotation, ref float logoScale, ref Color drawColor) => false;
+}

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -18,11 +18,13 @@ public static class MenuLoader
 	internal static readonly MenutML MenutML = new MenutML();
 	internal static readonly MenuJourneysEnd MenuJourneysEnd = new MenuJourneysEnd();
 	internal static readonly MenuOldVanilla MenuOldVanilla = new MenuOldVanilla();
+	internal static readonly MenuBiggerAndBoulder MenuBiggerAndBoulder = new MenuBiggerAndBoulder();
 
 	private static readonly List<ModMenu> menus = new List<ModMenu>() {
 		MenutML,
 		MenuJourneysEnd,
-		MenuOldVanilla
+		MenuOldVanilla,
+		MenuBiggerAndBoulder
 	};
 
 	private static readonly int DefaultMenuCount = menus.Count;
@@ -85,6 +87,11 @@ public static class MenuLoader
 	public static void ActivateOldVanillaMenu()
 	{
 		switchToMenu = MenuOldVanilla;
+	}
+
+	public static void ActivateBiggerAndBoulderMenu()
+	{
+		switchToMenu = MenuBiggerAndBoulder;
 	}
 
 	internal static void UpdateAndDrawModMenu(SpriteBatch spriteBatch, GameTime gameTime, Color color, float logoRotation, float logoScale)

--- a/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/MenuLoader.cs
@@ -74,12 +74,17 @@ public static class MenuLoader
 		if (LastSelectedModMenu == MenuOldVanilla.FullName) {
 			Main.instance.playOldTile = true; // If the previous menu was the 1.3.5.3 one, automatically reactivate it.
 		}
+		if (LastSelectedModMenu == MenuBiggerAndBoulder.FullName) {
+			Main.instance.boulderLogo = true;
+		}
 
 		switchToMenu = MenutML;
 		if (ModContent.TryFind(LastSelectedModMenu, out ModMenu value) && value.IsAvailable)
 			switchToMenu = value;
 		if (LastSelectedModMenu == MenuJourneysEnd.FullName)
 			switchToMenu = MenuJourneysEnd;
+		if (LastSelectedModMenu == MenuBiggerAndBoulder.FullName)
+			switchToMenu = MenuBiggerAndBoulder;
 
 		loading = false;
 	}


### PR DESCRIPTION
### What is the new feature?

Made the new boulder logo (`Main.boulderLogo`) into a ModMenu. It could be seen randomly with a 1 in 200 chance or when generating a No Traps world.
* Made `Main.boulderLogo` public.
* Made `MenuBiggerAndBoulder` force activate when generating a No Trap world.

### Why should this be part of tModLoader?

The boulder logo could draw over the tModLoader logo if the conditions were correct.

### Are there alternative designs?

We could make the `MenuBiggerAndBoulder` *not* force activate when generating a No Trap world. It would still be unlocked, but not override the current menu.