### PR TITLE
[1.4.5] Adds the ability to register unbound default keybi…

### DIFF
--- a/ExampleMod/Common/Systems/KeybindSystem.cs
+++ b/ExampleMod/Common/Systems/KeybindSystem.cs
@@ -9,11 +9,16 @@ namespace ExampleMod.Common.Systems
 		public static ModKeybind RandomBuffKeybind { get; private set; }
 		public static ModKeybind LearningExampleKeybind { get; private set; }
 
+		public static ModKeybind UnboundDefaultKeybind { get; private set; }
+
 		public override void Load() {
 			// Registers a new keybind
 			// We localize keybinds by adding a Mods.{ModName}.Keybind.{KeybindName} entry to our localization files. The actual text displayed to English users is in en-US.hjson
 			RandomBuffKeybind = KeybindLoader.RegisterKeybind(Mod, "RandomBuff", "P");
 			LearningExampleKeybind = KeybindLoader.RegisterKeybind(Mod, "LearningExample", "O");
+
+			//You can also pass in null to create an unbound keybind which displays "Clear" instead of "Reset to .."
+			UnboundDefaultKeybind = KeybindLoader.RegisterKeybind(Mod, "UnboundDefault", null);
 		}
 
 		// Please see ExampleMod.cs' Unload() method for a detailed explanation of the unloading process.

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -72,6 +72,7 @@ Mods: {
 		Keybinds: {
 			RandomBuff.DisplayName: Random Buff
 			LearningExample.DisplayName: Learning Example
+			UnboundDefault.DisplayName: Unbound Default
 		}
 
 		NPCs: {

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -72,6 +72,7 @@ Mods: {
 		Keybinds: {
 			// RandomBuff.DisplayName: Random Buff
 			// LearningExample.DisplayName: Learning Example
+			// UnboundDefault.DisplayName: Unbound Default
 		}
 
 		NPCs: {

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -72,6 +72,7 @@ Mods: {
 		Keybinds: {
 			RandomBuff.DisplayName: 随机增益
 			// LearningExample.DisplayName: Learning Example
+			// UnboundDefault.DisplayName: Unbound Default
 		}
 
 		NPCs: {

--- a/patches/tModLoader/Terraria/GameContent/UI/States/UIManageControls.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/UIManageControls.TML.cs
@@ -100,8 +100,9 @@ public partial class UIManageControls : UIState
 
 				container.Append(left);
 
-				// TODO: Clear instead of Reset to Defaults if no default specified.
-				var right = new UIKeybindingSimpleListItem(() => Lang.menu[86].Value + $" ({defaultKey})", color);
+				var right = string.IsNullOrEmpty(defaultKey)
+					? new UIKeybindingSimpleListItem(() => Language.GetTextValue("tModLoader.ModConfigClear"), color)
+					: new UIKeybindingSimpleListItem(() => Lang.menu[86].Value + $" ({defaultKey})", color);
 
 				right.OnLeftClick += delegate (UIMouseEvent evt, UIElement listeningElement) {
 					string copyableProfileName = GetCopyableProfileName();

--- a/patches/tModLoader/Terraria/GameInput/KeyConfiguration.cs.patch
+++ b/patches/tModLoader/Terraria/GameInput/KeyConfiguration.cs.patch
@@ -23,7 +23,12 @@
 +
 +		// Add mod keybinds
 +		foreach (var current in KeybindLoader.Keybinds) {
-+			KeyStatus.Add(current.FullName, new List<string>());
++			var defaultBindings = new List<string>();
++
++			if (!string.IsNullOrEmpty(current.DefaultBinding))
++				defaultBindings.Add(current.DefaultBinding);
++
++			KeyStatus.Add(current.FullName, defaultBindings);
 +		}
  	}
  
@@ -75,11 +80,11 @@
 +		*/
 +
 +		// Make sure to use indexer and not dict.Add, as some keys are sometimes already added (Vanilla bug, problem for modded)
-+		foreach (KeyValuePair<string, List<string>> item in KeyStatus.Where(x => x.Value.Count > 0)) {
++		foreach (KeyValuePair<string, List<string>> item in KeyStatus.Where(x => x.Value.Count > 0 || KeybindLoader.modKeybinds.ContainsKey(x.Key))) {
 +			dictionary[item.Key] = item.Value.ToList();
 +		}
 +
-+		foreach (KeyValuePair<string, List<string>> item in UnloadedModKeyStatus.Where(x => x.Value.Count > 0)) {
++		foreach (KeyValuePair<string, List<string>> item in UnloadedModKeyStatus.Where(x => x.Value.Count > 0 || x.Key.Contains('/'))) {
 +			dictionary[item.Key] = item.Value.ToList();
  		}
  

--- a/patches/tModLoader/Terraria/ModLoader/KeybindLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/KeybindLoader.cs
@@ -29,7 +29,7 @@ public sealed class KeybindLoader : Loader
 	/// </summary>
 	/// <param name="mod"> The mod that this keybind will belong to. Usually, this would be your mod instance. </param>
 	/// <param name="name"> The internal name of the keybind. The localization key "Mods.{ModName}.Keybinds.{KeybindName}.DisplayName" will be used for the display name. <br/>It is recommended that this not have any spaces. </param>
-	/// <param name="defaultBinding"> The default binding. </param>
+	/// <param name="defaultBinding"> The default binding. <see langword="null"/> or whitespace will register the keybind as unbound by default. </param>
 	public static ModKeybind RegisterKeybind(Mod mod, string name, string defaultBinding)
 	{
 		if (mod == null)
@@ -38,8 +38,7 @@ public sealed class KeybindLoader : Loader
 		if (string.IsNullOrWhiteSpace(name))
 			throw new ArgumentNullException(nameof(name));
 
-		if (string.IsNullOrWhiteSpace(defaultBinding))
-			throw new ArgumentNullException(nameof(defaultBinding));
+		defaultBinding = string.IsNullOrWhiteSpace(defaultBinding) ? string.Empty : defaultBinding;
 
 		return RegisterKeybind(new ModKeybind(mod, name, defaultBinding));
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModKeybind.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModKeybind.cs
@@ -24,7 +24,7 @@ public class ModKeybind // We could make this a ModType later
 	{
 		Mod = mod;
 		Name = name;
-		DefaultBinding = defaultBinding;
+		DefaultBinding = defaultBinding ?? string.Empty;
 		DisplayName = Language.GetOrRegister($"Mods.{Mod.Name}.Keybinds.{Name}.{nameof(DisplayName)}", () => Regex.Replace(Name, "([A-Z])", " $1").Trim());
 	}
 


### PR DESCRIPTION
…nds. Additionally defaults are now automatically applied if they haven't been previously modified

### Worth probably chatting through if we consider this a breaking change as well and should be called out as such? The todo makes me think it was intended?

### What is the bug?

Mod keybinds registered with a default binding were initialized as unbound in input profiles. For example, ExampleMod registers `RandomBuff` with `P` and `LearningExample` with `O`, but those bindings appeared unbound after launch until manually reset.

Mod keybinds also could not intentionally declare an unbound default because `RegisterKeybind(Mod, string, string)` rejected `null`, empty, or whitespace defaults.

### How did you fix the bug?

Mod keybind profile initialization now applies the registered default binding when one exists. Empty defaults remain unbound.

Saved input profiles now preserve loaded and unloaded mod keybind entries even when their binding list is empty. This lets tModLoader distinguish a newly registered keybind that should receive its default from a keybind the player intentionally unbound.

`RegisterKeybind` now normalizes `null`, empty, or whitespace default bindings to `string.Empty`, allowing mods to register keybinds that are unbound by default. The controls UI also shows the clear action for keybinds with no default instead of displaying a reset action with an empty default.

### Are there alternatives to your fix?

One alternative would be a migration that applies defaults to every empty mod keybind entry, but that would overwrite players who intentionally unbound a keybind in existing profiles. Preserving empty mod keybind entries going forward keeps player intent intact while still applying defaults for newly seen keybinds.

<img width="646" height="178" alt="image" src="https://github.com/user-attachments/assets/0cca089d-0465-4eb5-9388-a4804062bb42" />

I tested with the existing 2 keybinds, which properly set. Then I unset them to unbound.
I then created a new keybind and saw it's default populate correctly, while the existing 2 did not and remained unbound to respect users choice.