### PR TITLE
[1.4.5] Move blockLoot.Clear to latest possible place

### DIFF
--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -439,6 +439,7 @@ All classes are in the `Terraria.ModLoader` or `Terraria` namespaces unless othe
 * ⚙️: `(ModProjectile|GlobalProjectile).PreDraw/PreDrawExtras/PostDraw` now has a `Player` parameter. Use this instead of `Main.player[Projectile.owner]` to properly support rendering projectiles to custom `Player` instances, such as Mannequins.
 * ⚙️: `ModPylon.ValidTeleportCheck_AnyDanger` and `GlobalPylon.ValidTeleportCheck_PreAnyDanger` have been removed. Pylons no longer check for danger when teleporting.
 * 🤖: `ModTile.AddToArray` is no longer used for `TileID.Sets.RoomNeeds` entries since `TileID.Sets.RoomNeeds` fields have changed to typical ID sets.
+* `NPCLoader.blockLoot` can now affect all drops such as coins, hearts, etherian mana, and skyblock specific drops. Before it could only affect loot table drops.
 * ⚙️: `NPCSpawnInfo` is no longer used, it has been replaced by `NPC.Spawner` in functionality.
   * 🤖: The following fields changed from `NPCSpawnInfo` to `NPC.Spawner`: `DesertCave` -> `spawnUndergroundDesert`, `Granite` -> `nearGranite`, `Invasion` -> `invaders`, `Lihzahrd` -> `ZoneLihzhardTemple`, `Marble` -> `nearMarble`, `PlayerInTown` -> `spawnFriendly`, `PlayerSafe` -> `noWorms`, `Sky` -> `skyMob`, `SpiderCave` -> `spawnSpider`, `Water` -> `waterTile`
   * ⚙️: `PlanteraDefeated` removed, use `NPC.downedPlantBoss && Main.hardMode` instead.

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -546,8 +546,6 @@ public static class NPCLoader
 		foreach (var g in HookOnKill.Enumerate(npc)) {
 			g.OnKill(npc);
 		}
-
-		blockLoot.Clear();
 	}
 
 	private static HookList HookModifyNPCLoot = AddHook<Action<NPC, NPCLoot>>(g => g.ModifyNPCLoot);

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -2073,6 +2073,16 @@
  		DoDeathEvents(closestPlayer);
  		if (SpecialSeedFeatures.Mechdusa) {
  			int num = type;
+@@ -65786,6 +_,9 @@
+ 
+ 		NPCLoot_DropMoney(closestPlayer);
+ 		NPCLoot_DropHeals(closestPlayer);
++
++		// TML: needs to be at the end of NPCLoot to encapsulate every drop within it
++		NPCLoader.blockLoot.Clear();
+ 	}
+ 
+ 	public bool IsNPCValidForBestiaryKillCredit()
 @@ -65830,7 +_,8 @@
  		WoFKilledToday = false;
  	}


### PR DESCRIPTION
### What is the new feature?
`NPCLoader.blockLoot` is a convenient way for modders to blacklist certain items from being dropped dynamically, via `NPCLoader.blockLoot.Add(itemtype)` in the `PreKill` or `OnKill` hooks.

The PR expands the window where the blacklist can be populated and is active.

### Why should this be part of tModLoader?
Certain items are dropped after of the `OnKill` context (which is where the list is currently cleared), such as:
* Coins
* Potions/Hearts from bosses (these can now be controlled by modders for modded bosses as of a recent PR, but not vanilla bosses)
* Hearts/Mana
* OOA Etherian Mana
* Skyblock specific drops

A common thing among all of these above is that they are not implemented with the `NPCLoot/ItemDropDatabase` system hence why modders cannot simply disable/remove the rules as they don't exist. With this PR one can now blacklist these drops, see the example below.

And finally, as per `NPCLoader.blockLoot` documentation: "This list will be cleared whenever NPCLoot ends". Which it currently doesn't, so this PR fixes it.

### Are there alternative designs?
* This PR is made on 1.4.5 as it is changing behavior and will possibly lead to side effects not accounted by the modders. Alternatively can be made on 1.4.4 but with side effects.
* Modders could still be able to filter items out via detouring `Item.NewItem` or any of the associated methods for dropping coins/hearts/mana etc., but this solution has the least friction.
* The `Clear()` could be added after the `NPCLoot` invocation sites instead, but there are several in vanilla, and mods can call the method themselves aswell, so it's best to keep it inside the method.

### Sample usage for the new feature
```cs
public override bool PreKill(NPC npc) {
    if (npc.netID == NPCID.GreenSlime) {
        NPCLoader.blockLoot.Add(ItemID.Gel); //Possible before
        NPCLoader.blockLoot.Add(ItemID.CopperCoin); //Not possible before
    }
    return true;
}
```

### ExampleMod updates
None, it already has blockLoot examples, this niche interaction is not needed to be expanded upon in my opinion, as it's quite obvious that the previous behavior was not working as intended.

### Porting Notes
If you are using `NPCLoader.blockLoot.Add()` to blacklist drops, keep in mind that it will now encapsulate all NPC drops including coins, hearts/mana, etherian mana, etc.
