### PR TITLE
[1.4.5] Fix CanBeTeleportedTo hook for potion/conch teleports

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModPlayer.cs
@@ -1413,7 +1413,7 @@ public abstract class ModPlayer : ModType<Player, ModPlayer>, IIndexed
 	/// <summary>
 	/// Whether or not the player can be teleported to the given coordinates with methods such as Teleportation Potions or the Rod of Discord.
 	/// <para/> The coordinates correspond to the top left corner of the player position after teleporting.
-	/// <para/> This gets called in <see cref="Player.CheckForGoodTeleportationSpot(ref bool, int, int, int, int, Player.RandomTeleportationAttemptSettings)"/> and <see cref="Player.ItemCheck_UseTeleportRod(Item)"/>. The <paramref name="context"/> will have a value of "CheckForGoodTeleportationSpot" or "TeleportRod" respectively indicating which type of teleport is being attempted.
+	/// <para/> This gets called in <see cref="Utils.CheckForGoodTeleportationSpot(ref bool, int, int, int, int, Utils.RandomTeleportationAttemptSettings)"/> and <see cref="Player.ItemCheck_UseTeleportRod(Item)"/>. The <paramref name="context"/> will have a value of "CheckForGoodTeleportationSpot" or "TeleportRod" respectively indicating which type of teleport is being attempted.
 	/// </summary>
 	public virtual bool CanBeTeleportedTo(Vector2 teleportPosition, string context)
 	{

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -8862,6 +8862,56 @@
  		Array.Clear(adjTile, 0, adjTile.Length);
  		hitTile = new HitTile();
  		hitReplace = new HitTile();
+@@ -45686,31 +_,31 @@
+ 			allowSolidTopFloor = true
+ 		};
+ 
+-		Vector2 vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num2, teleportStartY, teleportRangeY, settings);
++		Vector2 vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num2, teleportStartY, teleportRangeY, settings, this);
+ 		if (!canSpawn)
+-			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
++			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
+ 
+ 		if (!canSpawn)
+-			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
++			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
+ 
+ 		if (!canSpawn) {
+ 			bool flag = Main.rand.Next(2) == 0;
+ 			num = (flag ? (num2 * 3) : (Main.maxTilesX - num2 * 3));
+-			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings);
++			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings, this);
+ 			if (!canSpawn)
+-				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
++				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
+ 
+ 			if (!canSpawn)
+-				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
++				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
+ 
+ 			if (!canSpawn) {
+ 				num = (flag ? (Main.maxTilesX - num2 * 3) : (num2 * 3));
+-				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings);
++				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings, this);
+ 				if (!canSpawn)
+-					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
++					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
+ 
+ 				if (!canSpawn)
+-					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
++					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
+ 			}
+ 		}
+ 
+@@ -45749,7 +_,7 @@
+ 			avoidHurtTiles = true,
+ 			maximumFallDistanceFromOrignalPoint = 100,
+ 			attemptsBeforeGivingUp = 1000
+-		});
++		}, this);
+ 
+ 		if (canSpawn) {
+ 			Vector2 newPos = vector;
 @@ -45777,10 +_,19 @@
  		int questsDone = anglerQuestsFinished;
  		float anglerRewardRarityMultiplier = GetAnglerRewardRarityMultiplier(questsDone);

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -8862,56 +8862,22 @@
  		Array.Clear(adjTile, 0, adjTile.Length);
  		hitTile = new HitTile();
  		hitReplace = new HitTile();
-@@ -45686,31 +_,31 @@
- 			allowSolidTopFloor = true
- 		};
- 
--		Vector2 vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num2, teleportStartY, teleportRangeY, settings);
-+		Vector2 vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num2, teleportStartY, teleportRangeY, settings, this);
- 		if (!canSpawn)
--			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
-+			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
- 
- 		if (!canSpawn)
--			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
-+			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
- 
- 		if (!canSpawn) {
- 			bool flag = Main.rand.Next(2) == 0;
- 			num = (flag ? (num2 * 3) : (Main.maxTilesX - num2 * 3));
--			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings);
-+			vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings, this);
- 			if (!canSpawn)
--				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
-+				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
- 
- 			if (!canSpawn)
--				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
-+				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
- 
- 			if (!canSpawn) {
- 				num = (flag ? (Main.maxTilesX - num2 * 3) : (num2 * 3));
--				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings);
-+				vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num3, num3, teleportStartY, teleportRangeY, settings, this);
- 				if (!canSpawn)
--					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings);
-+					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num - num2, num3, teleportStartY, teleportRangeY, settings, this);
- 
- 				if (!canSpawn)
--					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings);
-+					vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, num + num3, num3, teleportStartY, teleportRangeY, settings, this);
- 			}
- 		}
- 
-@@ -45749,7 +_,7 @@
- 			avoidHurtTiles = true,
- 			maximumFallDistanceFromOrignalPoint = 100,
- 			attemptsBeforeGivingUp = 1000
--		});
-+		}, this);
- 
- 		if (canSpawn) {
- 			Vector2 newPos = vector;
+@@ -45673,6 +_,7 @@
+ 		int teleportStartY = Main.UnderworldLayer + 20;
+ 		int teleportRangeY = 80;
+ 		Utils.RandomTeleportationAttemptSettings settings = new Utils.RandomTeleportationAttemptSettings {
++			teleportee = this, // TML
+ 			teleporteeSize = base.Size,
+ 			teleporteeVelocity = velocity,
+ 			teleporteeGravityDirection = gravDir,
+@@ -45742,6 +_,7 @@
+ 		int teleportStartY = 100;
+ 		int underworldLayer = Main.UnderworldLayer;
+ 		Vector2 vector = Utils.CheckForGoodTeleportationSpot(ref canSpawn, teleportStartX, teleportRangeX, teleportStartY, underworldLayer, new Utils.RandomTeleportationAttemptSettings {
++			teleportee = this, // TML
+ 			teleporteeSize = base.Size,
+ 			teleporteeVelocity = velocity,
+ 			teleporteeGravityDirection = gravDir,
 @@ -45777,10 +_,19 @@
  		int questsDone = anglerQuestsFinished;
  		float anglerRewardRarityMultiplier = GetAnglerRewardRarityMultiplier(questsDone);

--- a/patches/tModLoader/Terraria/Player.cs.rej
+++ b/patches/tModLoader/Terraria/Player.cs.rej
@@ -606,6 +606,7 @@
  			}
  		}
  	}
+@@ -43489,11 +_,14 @@
  			if (Main.netMode == 1)
  				NetMessage.SendData(21, -1, -1, null, number, 1f);
  		}

--- a/patches/tModLoader/Terraria/Player.cs.rej
+++ b/patches/tModLoader/Terraria/Player.cs.rej
@@ -606,17 +606,6 @@
  			}
  		}
  	}
-@@ -43304,6 +_,9 @@
- 			if ((settings.avoidWalls && tileSafely.wall > 0) || (settings.avoidAnyLiquid && Collision.WetCollision(vector, num4, height)) || (settings.avoidLava && Collision.LavaCollision(vector, num4, height)) || (settings.avoidHurtTiles && Collision.AnyHurtingTiles(vector, num4, height)) || Collision.SolidCollision(vector, num4, height) || num6 >= settings.maximumFallDistanceFromOrignalPoint - 1)
- 				continue;
- 
-+			if (!CombinedHooks.CanBeTeleportedTo(this, vector, i, j, "CheckForGoodTeleportationSpot"))
-+				continue;
-+
- 			Vector2 vector2 = Vector2.UnitX * 16f;
- 			if (Collision.TileCollision(vector - vector2, vector2, width, height, fallThrough: false, fall2: false, (int)gravDir) != vector2)
- 				continue;
-@@ -43489,11 +_,14 @@
  			if (Main.netMode == 1)
  				NetMessage.SendData(21, -1, -1, null, number, 1f);
  		}

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -18,6 +18,14 @@
  {
  	public delegate bool TileActionAttempt(int x, int y);
  
+@@ -37,6 +_,7 @@
+ 
+ 	public class RandomTeleportationAttemptSettings
+ 	{
++		public Entity teleportee; // TML
+ 		public Vector2 teleporteeSize;
+ 		public Vector2 teleporteeVelocity;
+ 		public float teleporteeGravityDirection;
 @@ -100,10 +_,13 @@
  				continue;
  
@@ -109,22 +117,12 @@
  	public static float Remap(float fromValue, float fromMin, float fromMax, float toMin, float toMax, bool clamped = true) => MathHelper.Lerp(toMin, toMax, GetLerpValue(fromMin, fromMax, fromValue, clamped));
  	public static double Remap(double fromValue, double fromMin, double fromMax, double toMin, double toMax, bool clamped = true) => Lerp(toMin, toMax, GetLerpValue(fromMin, fromMax, fromValue, clamped));
  	public static double EaseOutBounce(double x) => BounceEaseOut(x, 4, 2.0);
-@@ -369,7 +_,7 @@
- 		return true;
- 	}
- 
--	public static Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings)
-+	public static Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings, Player player = null)
- 	{
- 		int num = (int)settings.teleporteeSize.X;
- 		int num2 = (int)settings.teleporteeSize.Y;
-@@ -475,6 +_,10 @@
+@@ -475,6 +_,9 @@
  			if (!(Collision.TileCollision(vector - vector2, vector2, num, num2, fallThrough: false, fall2: false, (int)teleporteeGravityDirection) != vector2)) {
  				vector2 = -Vector2.UnitY * 16f;
  				if (!(Collision.TileCollision(vector - vector2, vector2, num, num2, fallThrough: false, fall2: false, (int)teleporteeGravityDirection) != vector2) && (!Main.dualDungeonsSeed || !UnbreakableWallScan.InsideUnbreakableWalls(new Point(num9, num10)))) {
-+					if (player != null && !CombinedHooks.CanBeTeleportedTo(player, vector, num9, num10, "CheckForGoodTeleportationSpot"))
++					if (settings.teleportee is Player player && !CombinedHooks.CanBeTeleportedTo(player, vector, num9, num10, "CheckForGoodTeleportationSpot"))
 +						continue;
-+
 +
  					canSpawn = true;
  					num5 += num8;

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -1,9 +1,10 @@
 --- src/TerrariaNetCore/Terraria/Utils.cs
 +++ src/tModLoader/Terraria/Utils.cs
-@@ -20,6 +_,7 @@
+@@ -20,6 +_,8 @@
  using Terraria.DataStructures;
  using Terraria.GameContent;
  using Terraria.Localization;
++using Terraria.ModLoader;
 +using Terraria.ModLoader.Engine;
  using Terraria.UI;
  using Terraria.UI.Chat;
@@ -108,6 +109,26 @@
  	public static float Remap(float fromValue, float fromMin, float fromMax, float toMin, float toMax, bool clamped = true) => MathHelper.Lerp(toMin, toMax, GetLerpValue(fromMin, fromMax, fromValue, clamped));
  	public static double Remap(double fromValue, double fromMin, double fromMax, double toMin, double toMax, bool clamped = true) => Lerp(toMin, toMax, GetLerpValue(fromMin, fromMax, fromValue, clamped));
  	public static double EaseOutBounce(double x) => BounceEaseOut(x, 4, 2.0);
+@@ -369,7 +_,7 @@
+ 		return true;
+ 	}
+ 
+-	public static Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings)
++	public static Vector2 CheckForGoodTeleportationSpot(ref bool canSpawn, int teleportStartX, int teleportRangeX, int teleportStartY, int teleportRangeY, RandomTeleportationAttemptSettings settings, Player player = null)
+ 	{
+ 		int num = (int)settings.teleporteeSize.X;
+ 		int num2 = (int)settings.teleporteeSize.Y;
+@@ -475,6 +_,10 @@
+ 			if (!(Collision.TileCollision(vector - vector2, vector2, num, num2, fallThrough: false, fall2: false, (int)teleporteeGravityDirection) != vector2)) {
+ 				vector2 = -Vector2.UnitY * 16f;
+ 				if (!(Collision.TileCollision(vector - vector2, vector2, num, num2, fallThrough: false, fall2: false, (int)teleporteeGravityDirection) != vector2) && (!Main.dualDungeonsSeed || !UnbreakableWallScan.InsideUnbreakableWalls(new Point(num9, num10)))) {
++					if (player != null && !CombinedHooks.CanBeTeleportedTo(player, vector, num9, num10, "CheckForGoodTeleportationSpot"))
++						continue;
++
++
+ 					canSpawn = true;
+ 					num5 += num8;
+ 					break;
 @@ -580,6 +_,10 @@
  		return (t - from) / (to - from);
  	}


### PR DESCRIPTION
### What is the bug?

The `ModPlayer.CanBeTeleportedTo` hook works for Rod of Discord but is **not called** for Demon Conch or Teleportation Potion teleports. This is a regression from 1.4.4, where the hook was placed inside `Player.CheckForGoodTeleportationSpot`. In 1.4.5, vanilla moved that method to `Utils.CheckForGoodTeleportationSpot`, and the hook was lost during the port.

### How did you fix the bug?

Restored the hook inside the retry loop of `Utils.CheckForGoodTeleportationSpot` by:

1. Adding an optional `Player player = null` parameter to `Utils.CheckForGoodTeleportationSpot`
2. Calling `CombinedHooks.CanBeTeleportedTo` before accepting a valid spot (when `player != null`)
3. Passing `this` from all 10 call sites in `Player.cs` (9 in `DemonConch` + 1 in `TeleportationPotion`)

This preserves vanilla's retry semantics: the method tests up to `attemptsBeforeGivingUp` randomly-chosen candidates; if a mod vetoes one candidate, the loop simply continues to the next random candidate rather than hard-failing the entire teleport.

### Are there alternatives to your fix?

Per-call-site hook checks in `Player.cs` would avoid touching `Utils.cs`, but would waste the 1000 internal retry attempts for Teleportation Potion and cause it to hard-fail if the first found spot is vetoed. The central approach matches the original 1.4.4 design.

### Porting notes

- Backward-compatible: `player` defaults to `null`, so non-teleport call sites (`ExtraSpawnPointManager`, `WorldGen`) are unaffected
- No modder action required
- Other teleportation items (Magic Conch, Magic/Ice Mirror, Recall Potion, Potion of Return, etc.) are intentionally not hooked — it was unclear if they should be, so they were left untouched

### Testing

Verified with a test mod that returns `false` from `ModPlayer.CanBeTeleportedTo`:
- ✅ Rod of Discord — blocked (was already working)
- ✅ Teleportation Potion — blocked (restored)
- ✅ Shellphone (Demon Conch / Underworld) — blocked (restored)
