### PR TITLE
fix: NixOS mod development support.

### DIFF
--- a/ExampleMod/Properties/launchSettings.json
+++ b/ExampleMod/Properties/launchSettings.json
@@ -1,16 +1,16 @@
 {
-  "profiles": {
-    "Terraria": {
-      "commandName": "Executable",
-      "executablePath": "$(DotNetName)",
-      "commandLineArgs": "$(tMLPath)",
-      "workingDirectory": "$(tMLSteamPath)"
-    },
-    "TerrariaServer": {
-      "commandName": "Executable",
-      "executablePath": "$(DotNetName)",
-      "commandLineArgs": "$(tMLServerPath)",
-      "workingDirectory": "$(tMLSteamPath)"
-    }
-  }
+	"profiles": {
+		"Terraria": {
+			"commandName": "Executable",
+			"executablePath": "$(ExecutablePath)",
+			"commandLineArgs": "$(TmlClientArgs)",
+			"workingDirectory": "$(tMLSteamPath)"
+		},
+		"TerrariaServer": {
+			"commandName": "Executable",
+			"executablePath": "$(ExecutablePath)",
+			"commandLineArgs": "$(TmlServerArgs)",
+			"workingDirectory": "$(tMLSteamPath)"
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/Templates/Properties/launchSettings.json
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/Properties/launchSettings.json
@@ -2,14 +2,14 @@
 	"profiles": {
 		"Terraria": {
 			"commandName": "Executable",
-			"executablePath": "$(DotNetName)",
-			"commandLineArgs": "$(tMLPath)",
+			"executablePath": "$(ExecutablePath)",
+			"commandLineArgs": "$(TmlClientArgs)",
 			"workingDirectory": "$(tMLSteamPath)"
 		},
 		"TerrariaServer": {
 			"commandName": "Executable",
-			"executablePath": "$(DotNetName)",
-			"commandLineArgs": "$(tMLServerPath)",
+			"executablePath": "$(ExecutablePath)",
+			"commandLineArgs": "$(TmlServerArgs)",
 			"workingDirectory": "$(tMLSteamPath)"
 		}
 	}

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -33,14 +33,16 @@
 	</PropertyGroup>
 
 	<!-- Debug/run properties -->
-	<PropertyGroup>
+	<PropertyGroup Condition="!Exists('/etc/NIXOS')">
+		<ExecutablePath>$(DotNetName)</ExecutablePath>
+		<TmlClientArgs>$(tMLPath)</TmlClientArgs>
+		<TmlServerArgs>$(tMLServerPath)</TmlServerArgs>
+	</PropertyGroup>
+	<PropertyGroup Condition=" Exists('/etc/NIXOS')">
 		<!-- NixOS: When starting TML via system .NET, the 'steam-run' wrapper must be used to create a FHS environment. -->
-		<ExecutablePath Condition=" Exists('/etc/NIXOS')">steam-run</ExecutablePath>
-		<ExecutablePath Condition="!Exists('/etc/NIXOS')">$(DotNetName)</ExecutablePath>
-		<TmlClientArgs  Condition=" Exists('/etc/NIXOS')">$(DotNetName) $(tMLPath)</TmlClientArgs>
-		<TmlClientArgs  Condition="!Exists('/etc/NIXOS')">$(tMLPath)</TmlClientArgs>
-		<TmlServerArgs  Condition=" Exists('/etc/NIXOS')">$(DotNetName) $(tMLServerPath)</TmlServerArgs>
-		<TmlServerArgs  Condition="!Exists('/etc/NIXOS')">$(tMLServerPath)</TmlServerArgs>
+		<ExecutablePath>steam-run</ExecutablePath>
+		<TmlClientArgs>$(DotNetName) $(tMLPath)</TmlClientArgs>
+		<TmlServerArgs>$(DotNetName) $(tMLServerPath)</TmlServerArgs>
 	</PropertyGroup>
 
 	<!-- Build/packaging properties -->
@@ -52,7 +54,7 @@
 		<!--
 			NixOS: The 'steam-run' FHS wrapper is purposefully not used for mod builds,
 			as it is not available on non-Steam supported architectures, such as ARM.
-			This is okay, as builds use far less system libraries than clients and servers.
+			This is okay, as builds use fewer system libraries than clients and servers.
 		-->
 		<BuildLaunch>$(DotNetName)</BuildLaunch>
 		<BuildEnvVars Condition="'$(OS)' == 'Windows_NT'"></BuildEnvVars>

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -57,9 +57,11 @@
 			This is okay, as builds use fewer system libraries than clients and servers.
 		-->
 		<BuildLaunch>$(DotNetName)</BuildLaunch>
+		<BuildArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</BuildArch>
 		<BuildEnvVars Condition="'$(OS)' == 'Windows_NT'"></BuildEnvVars>
-		<BuildEnvVars Condition="'$(OS)' == 'Unix'">LD_LIBRARY_PATH=$(tMLSteamPath)/Libraries/Native/Linux</BuildEnvVars>
-		<BuildEnvVars Condition="'$(OS)' == 'OSX'">DYLD_LIBRARY_PATH=$(tMLSteamPath)/Libraries/Native/OSX</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' != 'Arm64'">LD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/Linux</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' == 'Arm64'">LD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/Linux-arm64</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'OSX'">DYLD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/OSX</BuildEnvVars>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(BuildMod)' == 'true'">

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -1,4 +1,8 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project
+	ToolsVersion="14.0"
+	xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+	InitialTargets="TmlCheckForWarnings"
+>
 
 	<!-- Set default values for our build config properties -->
 	<PropertyGroup>
@@ -28,10 +32,32 @@
 		<!-- TML stable version define placeholder -->
 	</PropertyGroup>
 
+	<!-- Debug/run properties -->
+	<PropertyGroup>
+		<!-- NixOS: When starting TML via system .NET, the 'steam-run' wrapper must be used to create a FHS environment. -->
+		<ExecutablePath Condition=" Exists('/etc/NIXOS')">steam-run</ExecutablePath>
+		<ExecutablePath Condition="!Exists('/etc/NIXOS')">$(DotNetName)</ExecutablePath>
+		<TmlClientArgs  Condition=" Exists('/etc/NIXOS')">$(DotNetName) $(tMLPath)</TmlClientArgs>
+		<TmlClientArgs  Condition="!Exists('/etc/NIXOS')">$(tMLPath)</TmlClientArgs>
+		<TmlServerArgs  Condition=" Exists('/etc/NIXOS')">$(DotNetName) $(tMLServerPath)</TmlServerArgs>
+		<TmlServerArgs  Condition="!Exists('/etc/NIXOS')">$(tMLServerPath)</TmlServerArgs>
+	</PropertyGroup>
+
+	<!-- Build/packaging properties -->
 	<PropertyGroup Condition="'$(BuildMod)' == 'true'">
 		<DotNetName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</DotNetName>
 		<DotNetName Condition=" '$(OS)' == 'Unix' ">dotnet</DotNetName>
 		<DotNetName Condition=" '$(DotNetName)' == '' ">dotnet</DotNetName>
+		
+		<!--
+			NixOS: The 'steam-run' FHS wrapper is purposefully not used for mod builds,
+			as it is not available on non-Steam supported architectures, such as ARM.
+			This is okay, as builds use far less system libraries than clients and servers.
+		-->
+		<BuildLaunch>$(DotNetName)</BuildLaunch>
+		<BuildEnvVars Condition="'$(OS)' == 'Windows_NT'"></BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'Unix'">LD_LIBRARY_PATH=$(tMLSteamPath)/Libraries/Native/Linux</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'OSX'">DYLD_LIBRARY_PATH=$(tMLSteamPath)/Libraries/Native/OSX</BuildEnvVars>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(BuildMod)' == 'true'">
@@ -55,8 +81,22 @@
 		<Analyzer Include="$(tMLLibraryPath)/tModCodeAssist/1.0.0/tModCodeAssist.CodeFixes.dll" />
 	</ItemGroup>
 
+	<Target Name="TmlCheckForWarnings">
+		<!-- NixOS only: Check if steam-run is available. -->
+		<Exec Condition="Exists('/etc/NIXOS')" Command="which steam-run &gt;/dev/null" IgnoreExitCode="True">
+			<Output TaskParameter="ExitCode" PropertyName="SteamRunCheck" />
+		</Exec>
+		<!-- NixOS only: Notify the user if steam-run is unavailable. -->
+		<Warning Condition="Exists('/etc/NIXOS') And '$(SteamRunCheck)' != '0'" Text="To debug mods on NixOS, add the 'steam-run' package to your system environment." />
+	</Target>
+
+	<!-- Package the mod after building its code -->
 	<Target Name="BuildMod" AfterTargets="Build" Condition="'$(BuildMod)' == 'true'">
-		<Exec Command="dotnet $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)" WorkingDirectory="$(tMLSteamPath)"/>
+		<Exec
+			Command="$(BuildLaunch) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)"
+			WorkingDirectory="$(tMLSteamPath)"
+			EnvironmentVariables="$(BuildEnvVars)"
+		/>
 	</Target>
 
 </Project>


### PR DESCRIPTION
The tModLoader mod development experience on [NixOS](https://nixos.org) (a very unorthodox non-FHS developer-oriented Linux distribution built on reproducibility and package isolation (which I now live on)) currently suffers from the following issues, which this PR aims to resolve in one go:

### Problem A - LD_LIBRARY_PATH shell script reliance.
Native libraries may fail to resolve their adjacent dependencies without `LD_LIBRARY_PATH` set to point to `./Libraries/Native/Linux`.
This is not a problem for runs from Steam, as well as of the `start-tModLoader.sh` script, both of them invoking `LaunchUtils/EnvironmentFix.sh`.
This is however a problem for building and debugging, as those launches are simple runs of `dotnet tModLoader.dll`.

### Problem B - NixOS's super-isolated .NET SDK.
The system-wide nixpkgs .NET SDKs and runtimes are 'wrapped' to maximize isolation when building packages.
This makes the SDK not affected by `nix-ld`, a linker utility that is often used to make any user shell executions see a classical FHS environment, when it comes to resolution of libraries that is.
Running a client with `nixpkgs#dotnet-sdk_8` will thus result in a crash when looking up `libglvnd` or a similar graphical driver.

### Problem C - First-time EnvironmentFix.
~~This bit affects all Linux systems, not only NixOS, but is only a big deal for CI deployments.
The shell script contains a line that creates a symlink `libSDL2.so` to `libSDL2-2.0.so.0`.
This requires every system to run `start-tModLoaderServer.sh` at least once before `dotnet tModLoader.dll -build ...` would function.~~
- Correction: This seems to be historic, and the symlinking line can definitely be removed from 1.4.5.
  On 1.4.4 meanwhile, the only issue is that the `linux-arm64` folder is missing a `.0` suffix on the SDL file. 

### Solutions for debugging
`steam-run` is a common NixOS utility that alters envvars to setup an environment similar to that of Steam's, or of a classic FHS Linux distribution.
- Make the `tMLMod.targets` file prepend `steam-run` to `launchSettings.json` startups.
	This of course requires it to be globally installed in the system, so the user is best notified if it is missing.
	There are no alternatives to this. If the system SDK is used to run the game, then `steam-run` has to be employed to avoid driver lookup errors.
	**Implemented!**

### Solutions for building
The aforementioned `steam-run` utility is not available on architectures unsupported by Steam, e.g. ARM.
While it is not important to support debugging on ARM, it is important to support building - I personally have an ARM VPS that I use for building TML mods along other things. We better not use `steam-run` for this.
- Preloading natives' dependencies using C# code can fully fix away the reliance on `LD_LIBRARY_PATH` for all contexts.
  However, the implementation of that cannot be made in a way that would not feel hardcoded and/or clunky.
	**Not taken!**
- Modify `tMLMod.targets` to set `LD_LIBRARY_PATH` envvar on all Linux runs of the packaging `<Exec>` block.
	Simple, suffices for building in particular.
	**Implemented!**

### Solutions for first-time runs
~~The reason the symlink is needed in the first place comes from ELF dependency metadata that differs between FNA3D and *some other native*.~~
- ~~Patch all libraries' ELF dependency metadata to share filenames.
  This ritual has the con of complicating the natives update process and being able to be potentially forgotten, breaking CIs.~~
- ~~Move the symlinking to early-ran C# code, before SDL & FNA3D are resolved.~~
- ~~(?) Make C# code run `LaunchUtils/EnvironmentFix.sh`?.~~
- ~~(CI-only) Standardize manually calling `LaunchUtils/EnvironmentFix.sh` or a `FirstTimeSetup.sh` script.
  Leaves the issue still present for non-CI environments.~~
- ~~(?) Create the symlink as part of the build process and ship with it pre-made?
  The latter does not sound very possible when it comes to Steam distribution.~~
