### PR TITLE
[1.4.5] Specific Happiness Dialogue

### DIFF
--- a/ExampleMod/Common/GlobalNPCs/ExampleNPCHappiness.cs
+++ b/ExampleMod/Common/GlobalNPCs/ExampleNPCHappiness.cs
@@ -10,8 +10,10 @@ namespace ExampleMod.Common.GlobalNPCs
 		public override void SetStaticDefaults() {
 			int examplePersonType = ModContent.NPCType<Content.NPCs.ExamplePerson>(); // Get ExamplePerson's type
 			var guideHappiness = NPCHappiness.Get(NPCID.Guide); // Get the key into The Guide's happiness
+			var zoologistHappiness = NPCHappiness.Get(NPCID.BestiaryGirl); // Get the key into The Zoologist's happiness
 
 			guideHappiness.SetNPCAffection(examplePersonType, AffectionLevel.Love); // Make the Guide love ExamplePerson!
+			zoologistHappiness.SetNPCAffection(examplePersonType, AffectionLevel.Like); // Make the Zoologist like ExamplePerson!
 
 			guideHappiness.SetBiomeAffection<ExampleSurfaceBiome>(AffectionLevel.Love);  // Make the Guide love ExampleSurfaceBiome!
 		}

--- a/ExampleMod/Content/NPCs/ExamplePerson.cs
+++ b/ExampleMod/Content/NPCs/ExamplePerson.cs
@@ -86,15 +86,19 @@ namespace ExampleMod.Content.NPCs
 
 			NPCID.Sets.NPCBestiaryDrawOffset.Add(Type, drawModifiers);
 
-			// Set Example Person's biome and neighbor preferences with the NPCHappiness hook. You can add happiness text and remarks with localization (See an example in ExampleMod/Localization/en-US.lang).
+			// Set Example Person's biome and neighbor preferences with the NPCHappiness hook. You can add happiness text and remarks with localization (See an example in ExampleMod/Localization/en-US.hjson).
 			// NOTE: The following code uses chaining - a style that works due to the fact that the SetXAffection methods return the same NPCHappiness instance they're called on.
 			NPC.Happiness
+				.SetBiomeAffection<ExampleSurfaceBiome>(AffectionLevel.Love) // Example Person likes the Example Surface Biome
 				.SetBiomeAffection<ForestBiome>(AffectionLevel.Like) // Example Person prefers the forest.
 				.SetBiomeAffection<SnowBiome>(AffectionLevel.Dislike) // Example Person dislikes the snow.
-				.SetBiomeAffection<ExampleSurfaceBiome>(AffectionLevel.Love) // Example Person likes the Example Surface Biome
+				.SetBiomeAffection<DesertBiome>(AffectionLevel.Dislike) // Example Person dislikes the desert.
+				// Town NPCs automatically hate the Corruption, Crimson, and Dungeon.
 				.SetNPCAffection(NPCID.Dryad, AffectionLevel.Love) // Loves living near the dryad.
 				.SetNPCAffection(NPCID.Guide, AffectionLevel.Like) // Likes living near the guide.
+				.SetNPCAffection(NPCID.BestiaryGirl, AffectionLevel.Like) // Likes living near the zoologist.
 				.SetNPCAffection(NPCID.Merchant, AffectionLevel.Dislike) // Dislikes living near the merchant.
+				.SetNPCAffection(NPCID.Golfer, AffectionLevel.Dislike) // Dislikes living near the golfer.
 				.SetNPCAffection(NPCID.Demolitionist, AffectionLevel.Hate) // Hates living near the demolitionist.
 			; // < Mind the semicolon!
 

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 749/749, 100%, missing 0
-ru-RU, 6/749, 1%, missing 743
-zh-Hans, 2/749, 0%, missing 747
+en-US, 758/758, 100%, missing 0
+ru-RU, 6/758, 1%, missing 752
+zh-Hans, 2/758, 0%, missing 756

--- a/ExampleMod/Localization/TranslationsNeeded.txt
+++ b/ExampleMod/Localization/TranslationsNeeded.txt
@@ -1,3 +1,3 @@
-en-US, 758/758, 100%, missing 0
-ru-RU, 6/758, 1%, missing 752
-zh-Hans, 2/758, 0%, missing 756
+en-US, 760/760, 100%, missing 0
+ru-RU, 6/760, 1%, missing 754
+zh-Hans, 2/760, 0%, missing 758

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -118,13 +118,12 @@ Mods: {
 					DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
 					LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
 					# We can also give other NPCs specific dialogue text for this Modded NPC.
-					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC)
 					Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					# Zoologist is a special case because she has a second set of dialogue when transformed.
 					BestiaryGirl_LikesNPC: I like the research {NPCName} does.
+					Transformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 				}
-
-				# Zoologist is a special case because she has a second set of dialogue when transformed.
-				TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					AwesomeifyButton: Awesomeify
@@ -1672,3 +1671,6 @@ UI.PlayerIsNotCreativeAndWorldIsCreative: Only Journey characters may enter a Jo
 # For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
 TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
 TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?
+# Zoologist is a special case because she has a second set of dialogue when transformed.
+TownNPCMood_BestiaryGirl.LikeNPC_Golfer: "{NPCName} is my brother, of course I like him!"
+TownNPCMood_BestiaryGirlTransformed.LikeNPC_Golfer: "{NPCName} good family!"

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -89,7 +89,10 @@ Mods: {
 				DisplayName: Example Person
 
 				# This is what displays during all of an NPC's happiness levels.
+				# {NPCName} is a placeholder and will be replaced with the NPC's full name.
+				# {BiomeName} is a placeholder and will be replaced with the biome's name.
 				TownNPCMood: {
+					# The following are dialogue entries that all Town NPCs affected by happiness should have.
 					Content: I feel pretty fine right now.
 					NoHome: I would very much like a house, all the colorful monsters scare me.
 					FarFromHome: Could you please get me back to my house?
@@ -102,11 +105,26 @@ Mods: {
 					HateBiome: It's kind of hard to mod while being attacked by monsters in {BiomeName}.
 					LoveNPC: Do you think {NPCName} notices me?
 					LikeNPC: I can respect {NPCName} as a fellow guide and educator!
-					DislikeNPC: '''"{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is."'''
+					DislikeNPC: "{NPCName} is not very helpful."
 					HateNPC: I hate all the loud noises caused by {NPCName} and his explosives! I just want peace and quiet.
 					LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
+					# Specific dialogue text can be defined as well.
+					# These quotes are optional and will be used instead of the generic dialogue above.
+					# They need to follow the pattern of [AffectionLevel](NPC or Biome)_[NPCInternalName]
+					# Modded NPCs need mod name as well: ExampleMod/ExamplePerson
+					LikeNPC_BestiaryGirl: "{NPCName} likes to research animals the same way I like to research mods."
+					DislikeNPC_Merchant: '''{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is.'''
+					DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
+					LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
+					# We can also give other NPCs specific dialogue text for this Modded NPC.
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					BestiaryGirl_LikesNPC: I like the research {NPCName} does.
 				}
+
+				# Zoologist is a special case because she has a second set of dialogue when transformed.
+				TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					AwesomeifyButton: Awesomeify
@@ -1650,3 +1668,7 @@ Mods: {
 
 # Mods can also override existing translation keys, but these types of changes are better suited to Resource Packs.
 UI.PlayerIsNotCreativeAndWorldIsCreative: Only Journey characters may enter a Journey world, silly.
+# Here is how you can add specific happiness dialogue text for vanilla NPCs talking about biomes or vanilla NPCs talking about vanilla NPCs.
+# For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
+TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
+TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -89,7 +89,10 @@ Mods: {
 				// DisplayName: Example Person
 
 				# This is what displays during all of an NPC's happiness levels.
+				# {NPCName} is a placeholder and will be replaced with the NPC's full name.
+				# {BiomeName} is a placeholder and will be replaced with the biome's name.
 				TownNPCMood: {
+					# The following are dialogue entries that all Town NPCs affected by happiness should have.
 					// Content: I feel pretty fine right now.
 					// NoHome: I would very much like a house, all the colorful monsters scare me.
 					// FarFromHome: Could you please get me back to my house?
@@ -102,11 +105,26 @@ Mods: {
 					// HateBiome: It's kind of hard to mod while being attacked by monsters in {BiomeName}.
 					// LoveNPC: Do you think {NPCName} notices me?
 					// LikeNPC: I can respect {NPCName} as a fellow guide and educator!
-					// DislikeNPC: '''"{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is."'''
+					// DislikeNPC: "{NPCName} is not very helpful."
 					// HateNPC: I hate all the loud noises caused by {NPCName} and his explosives! I just want peace and quiet.
 					// LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					// Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
+					# Specific dialogue text can be defined as well.
+					# These quotes are optional and will be used instead of the generic dialogue above.
+					# They need to follow the pattern of [AffectionLevel](NPC or Biome)_[NPCInternalName]
+					# Modded NPCs need mod name as well: ExampleMod/ExamplePerson
+					// LikeNPC_BestiaryGirl: "{NPCName} likes to research animals the same way I like to research mods."
+					// DislikeNPC_Merchant: '''{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is.'''
+					// DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
+					// LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
+					# We can also give other NPCs specific dialogue text for this Modded NPC.
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					// Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					// BestiaryGirl_LikesNPC: I like the research {NPCName} does.
 				}
+
+				# Zoologist is a special case because she has a second set of dialogue when transformed.
+				// TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					// AwesomeifyButton: Awesomeify
@@ -1650,3 +1668,7 @@ Mods: {
 
 # Mods can also override existing translation keys, but these types of changes are better suited to Resource Packs.
 // UI.PlayerIsNotCreativeAndWorldIsCreative: Only Journey characters may enter a Journey world, silly.
+# Here is how you can add specific happiness dialogue text for vanilla NPCs talking about biomes or vanilla NPCs talking about vanilla NPCs.
+# For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
+// TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
+// TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -118,13 +118,12 @@ Mods: {
 					// DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
 					// LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
 					# We can also give other NPCs specific dialogue text for this Modded NPC.
-					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC)
 					// Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					# Zoologist is a special case because she has a second set of dialogue when transformed.
 					// BestiaryGirl_LikesNPC: I like the research {NPCName} does.
+					// Transformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 				}
-
-				# Zoologist is a special case because she has a second set of dialogue when transformed.
-				// TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					// AwesomeifyButton: Awesomeify
@@ -1672,3 +1671,6 @@ Mods: {
 # For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
 // TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
 // TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?
+# Zoologist is a special case because she has a second set of dialogue when transformed.
+// TownNPCMood_BestiaryGirl.LikeNPC_Golfer: "{NPCName} is my brother, of course I like him!"
+// TownNPCMood_BestiaryGirlTransformed.LikeNPC_Golfer: "{NPCName} good family!"

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -89,7 +89,10 @@ Mods: {
 				// DisplayName: Example Person
 
 				# This is what displays during all of an NPC's happiness levels.
+				# {NPCName} is a placeholder and will be replaced with the NPC's full name.
+				# {BiomeName} is a placeholder and will be replaced with the biome's name.
 				TownNPCMood: {
+					# The following are dialogue entries that all Town NPCs affected by happiness should have.
 					// Content: I feel pretty fine right now.
 					// NoHome: I would very much like a house, all the colorful monsters scare me.
 					// FarFromHome: Could you please get me back to my house?
@@ -102,11 +105,26 @@ Mods: {
 					// HateBiome: It's kind of hard to mod while being attacked by monsters in {BiomeName}.
 					// LoveNPC: Do you think {NPCName} notices me?
 					// LikeNPC: I can respect {NPCName} as a fellow guide and educator!
-					// DislikeNPC: '''"{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is."'''
+					// DislikeNPC: "{NPCName} is not very helpful."
 					// HateNPC: I hate all the loud noises caused by {NPCName} and his explosives! I just want peace and quiet.
 					// LikeNPC_Princess: "{NPCName} is a princess? That is so cool!"
 					// Princess_LovesNPC: "{NPCName} is so square. I love that about them!"
+					# Specific dialogue text can be defined as well.
+					# These quotes are optional and will be used instead of the generic dialogue above.
+					# They need to follow the pattern of [AffectionLevel](NPC or Biome)_[NPCInternalName]
+					# Modded NPCs need mod name as well: ExampleMod/ExamplePerson
+					// LikeNPC_BestiaryGirl: "{NPCName} likes to research animals the same way I like to research mods."
+					// DislikeNPC_Merchant: '''{NPCName} keeps rambling on about "paid mods"... Wish I could convince him how terrible of an idea that is.'''
+					// DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
+					// LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
+					# We can also give other NPCs specific dialogue text for this Modded NPC.
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					// Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					// BestiaryGirl_LikesNPC: I like the research {NPCName} does.
 				}
+
+				# Zoologist is a special case because she has a second set of dialogue when transformed.
+				// TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					// AwesomeifyButton: Awesomeify
@@ -1650,3 +1668,7 @@ Mods: {
 
 # Mods can also override existing translation keys, but these types of changes are better suited to Resource Packs.
 // UI.PlayerIsNotCreativeAndWorldIsCreative: Only Journey characters may enter a Journey world, silly.
+# Here is how you can add specific happiness dialogue text for vanilla NPCs talking about biomes or vanilla NPCs talking about vanilla NPCs.
+# For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
+// TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
+// TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -118,13 +118,12 @@ Mods: {
 					// DislikeBiome_Desert: It's way too hot in {BiomeName}, I'm burning!
 					// LoveBiome_ExampleMod/ExampleSurfaceBiome: "{BiomeName} makes me feel right at home!"
 					# We can also give other NPCs specific dialogue text for this Modded NPC.
-					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC or Biome)
+					# They need to follow the pattern of [NPCInternalName]_[AffectionLevel]s(NPC)
 					// Guide_LovesNPC: I love a fellow educator like {NPCName}.
+					# Zoologist is a special case because she has a second set of dialogue when transformed.
 					// BestiaryGirl_LikesNPC: I like the research {NPCName} does.
+					// Transformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 				}
-
-				# Zoologist is a special case because she has a second set of dialogue when transformed.
-				// TownNPCMoodTransformed.BestiaryGirl_LikesNPC: "{NPCName} research GOOD!"
 
 				Interactions: {
 					// AwesomeifyButton: Awesomeify
@@ -1672,3 +1671,6 @@ Mods: {
 # For the vanilla NPC talking about your Modded NPC, put the dialogue in the Modded NPC's TownNPCMood. See ExamplePerson for details.
 // TownNPCMood_Guide.LoveBiome_ExampleMod/ExampleSurfaceBiome: Somehow, I love the muted colors of {BiomeName}!
 // TownNPCMood_Nurse.DislikeNPC_PartyGirl: I don't like {NPCName}. How can she party all of the time?
+# Zoologist is a special case because she has a second set of dialogue when transformed.
+// TownNPCMood_BestiaryGirl.LikeNPC_Golfer: "{NPCName} is my brother, of course I like him!"
+// TownNPCMood_BestiaryGirlTransformed.LikeNPC_Golfer: "{NPCName} good family!"

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -321,6 +321,23 @@ SilverBarRecipeGroup = RecipeGroup.Register(
   * The "SetBonus" tooltip has changed. It now automatically displays partial sets and adjusts the color to indicate if the set is complete.
   * The "SetBonusSinglePiece" tooltip shows the set bonus that would be applied if the unequipped equipment were equipped.
 * Town NPCs who are homeless have a new "Housing" button that displays their "NoHome" dialogue as well as a hint on what valid housing is. The hint text can be customized through the localization file. If the key `Mods.ModName.NPCs.NPCName.HousingText.HousingRequirements` exists, it will automatically be used over the default text.
+* Town NPCs can now have specific happiness dialogue for other Town NPCs or biomes that work just like the previous `LikeNPC_Princess` and `Princess_LovesNPC`.
+  * For Mod NPCs, the localization keys are scoped in `Mods.{ModName}.NPCs.{ModNPCName}.TownNPCMood`
+    * `{AffectionLevel}NPC_{OtherNPCInternalName}` For specific dialogue for talking about other NPC. Other loved NPCs will use the generic `{AffectionLevel}NPC`.
+      * Example: `LoveNPC_Guide` Would be a specific dialogue for talking about the Guide. 
+      * Modded NPCs will need the full mod name as well. Example: `LoveNPC_ExampleMod/ExamplePerson`.
+    * `{AffectionLevel}Biome_{BiomeName}` For biomes.
+      * Modded Biomes will need the full name. Example: `LoveBiome_ExampleMod/ExampleSurfaceBiome`
+    * `{OtherNPCInternalName}_{AffectionLevel}sNPC` For specific dialogue when another NPC is talking about your Mod NPC.
+      * Example: `Guide_LovesNPC` Would be specific dialogue from the Guide when he is talking about your Mod NPC.
+      * Modded NPCs will need the full mod name, too.  Example: `ExampleMod/ExamplePerson_LovesNPC`.
+  * For vanilla NPCs talking about vanilla NPCs, the localization keys are scoped in `TownNPCMood_{NPCInternalName}` (outside of Mods.ModName)
+    * `{AffectionLevel}NPC_{OtherVanillaNPCInternalName}`
+	  * Example: `TownNPCMood_Guide.LikeNPC_BestiaryGirl` Would be a specific dialogue for when the Guide is talking about the Zoologist. 
+    * `{AffectionLevel}Biome_{BiomeName}` for biomes.
+  * Caveat for the Zoologist: She has two sets of happiness dialogue. A normal one and one for when she is transformed.
+    * In the ModNPC, add Transformed beforehand: `Transformed.BestiaryGirl_{AffectionLevel}NPC`
+	* For vanilla NPCs talking about vanilla NPCs, use BestiaryGirlTransformed: `TownNPCMood_BeastiaryGirlTransformed.{AffectionLevel}NPC_{OtherNPCInternalName}`
 
 ### Example Mod
 

--- a/patches/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs.patch
@@ -1,7 +1,8 @@
 --- src/TerrariaNetCore/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs
 +++ src/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs
-@@ -1,17 +_,67 @@
+@@ -1,17 +_,68 @@
  using System.Collections.Generic;
++using Terraria.ID;
 +using Terraria.ModLoader;
  
  namespace Terraria.GameContent.Personalities;
@@ -68,10 +69,22 @@
  		if (info.npc.type == 663) {
  			List<int> list = new List<int>();
  			for (int i = 0; i < nearbyNPCsByType.Length; i++) {
-@@ -32,6 +_,16 @@
+@@ -26,12 +_,28 @@
+ 				int index = Main.rand.Next(list.Count);
+ 				int npcType = list[index];
+ 				list.RemoveAt(index);
++				/*
+ 				shopHelperInstance.LoveNPCByTypeName(npcType);
++				*/
++				shopHelperInstance.ApplyNpcRelationshipEffect(npcType, AffectionLevel.Love);
+ 			}
+ 		}
  
  		if (info.npc.type != 663 && nearbyNPCsByType[663])
++			/*
  			shopHelperInstance.LikePrincess();
++			*/
++			shopHelperInstance.ApplyNpcRelationshipEffect(NPCID.Princess, AffectionLevel.Like);
 +	}
 +
 +	// [[ Split of the previous method ]]

--- a/patches/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs.patch
@@ -1,8 +1,7 @@
 --- src/TerrariaNetCore/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs
 +++ src/tModLoader/Terraria/GameContent/Personalities/AllPersonalitiesModifier.cs
-@@ -1,17 +_,68 @@
+@@ -1,17 +_,67 @@
  using System.Collections.Generic;
-+using Terraria.ID;
 +using Terraria.ModLoader;
  
  namespace Terraria.GameContent.Personalities;
@@ -84,7 +83,7 @@
 +			/*
  			shopHelperInstance.LikePrincess();
 +			*/
-+			shopHelperInstance.ApplyNpcRelationshipEffect(NPCID.Princess, AffectionLevel.Like);
++			shopHelperInstance.ApplyNpcRelationshipEffect(663, AffectionLevel.Like);
 +	}
 +
 +	// [[ Split of the previous method ]]

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -91,20 +91,86 @@
  		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
  			text += "Transformed";
  
-@@ -166,6 +_,35 @@
+@@ -166,6 +_,101 @@
  		_currentHappiness = _currentHappiness + textValueWith + " ";
  	}
  
++	private void AddHappinessReportText(string textKey, string textKeyInCategory, object substitutes = null)
++	{
++		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
++			textKey += "Transformed";
++
++		string textValueWith = Language.GetTextValueWith(textKey + "." + textKeyInCategory, substitutes);
++		_currentHappiness = _currentHappiness + textValueWith + " ";
++	}
++
 +	// Added by TML.
-+	internal void ApplyNpcRelationshipEffect(int npcType, AffectionLevel affectionLevel)
++	internal void ApplyNpcRelationshipEffect(int otherNpcType, AffectionLevel affectionLevel)
 +	{
 +		if (affectionLevel == 0 || !Enum.IsDefined(affectionLevel)) {
 +			return;
 +		}
 +
++		/*
 +		AddHappinessReportText($"{affectionLevel}NPC", new {
 +			NPCName = NPC.GetFullnameByID(npcType)
 +		});
++		*/
++
++		/*
++
++		If talking to ModNPC
++			Want to use ModNPC's LoveNPC_OtherPerson if exists
++			Else, use generic LoveNPC
++		If talking to Vanilla NPC
++			If talking about a ModNPC
++				Want to use ModNPC's OtherPerson_LoveNPC if exists
++			If talking about a vanilla NPC
++				Want to use TownNPCMood_TalkPerson.LoveNPC_OtherPerson
++			Else, use generic LoveNPC
++
++		*/
++
++		string otherNPCName = NPCID.Search.GetName(otherNpcType); // Get the name of the other Town NPC.
++		ModNPC talkModNPC = _currentNPCBeingTalkedTo.ModNPC; // ModNPC instance of the Town NPC the player is talking to, if it exists.
++	
++		// If the current Town NPC is a ModNPC
++		// Check to see if there is a localization entry for the other Town NPC defined in our current Town NPC.
++		// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.LoveNPC_Guide
++		// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.LoveNPC_MyMod/MyTownNPC
++		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}NPC_{otherNPCName}")) {
++			// If it does exist, add the happiness report.
++			AddHappinessReportText(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}NPC_{otherNPCName}", new {
++				NPCName = NPC.GetFullnameByID(otherNpcType)
++			});
++		}
++		// Vanilla NPC or ModNPC specific dialogue didn't exist.
++		else {
++			ModNPC otherModNPC = ModContent.GetModNPC(otherNpcType); // ModNPC instance of the other Town NPC, if it exists.
++			string talkNPCName = NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID); // Get the name of the Town NPC the player is talking to.
++
++			// Talking about a ModNPC. We want to use the OtherModNPC's entry for the Town NPC the player is talking to, if it exists.
++			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.Guide_LoveNPC
++			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.MyMod/MyTownNPC_LoveNPC
++			if (otherModNPC != null && Language.Exists($"{otherModNPC.GetLocalizationKey("TownNPCMood")}.{talkNPCName}_{affectionLevel}NPC")) {
++				AddHappinessReportText(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}NPC", new {
++					NPCName = NPC.GetFullnameByID(otherNpcType)
++				});
++			}
++			// Try for vanilla NPC talking about another vanilla NPC.
++			// Example: TownNPCMood_Guide.LoveNPC_Merchant
++			else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}NPC_{otherNPCName}")) {
++				AddHappinessReportText($"TownNPCMood_{talkNPCName}", $"{affectionLevel}NPC_{otherNPCName}", new {
++					NPCName = NPC.GetFullnameByID(otherNpcType)
++				});
++			}
++			// If nothing above was true, add the generic dialogue.
++			else {
++				AddHappinessReportText($"{affectionLevel}NPC", new {
++					NPCName = NPC.GetFullnameByID(otherNpcType)
++				});
++			}
++		}
 +
 +		_currentPriceAdjustment *= NPCHappiness.AffectionLevelToPriceMultiplier[affectionLevel];
 +	}

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -88,22 +88,29 @@
  		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
  			text += "Transformed";
  
-@@ -166,6 +_,122 @@
+@@ -166,6 +_,129 @@
  		_currentHappiness = _currentHappiness + textValueWith + " ";
  	}
  
 +	// Added by TML
-+	private void AddHappinessReportTextWithKey(string textKey, string textKeyInCategory, object substitutes = null)
++	private void AddHappinessReportTextWithKey(string textKey, string textKeyInCategory, object substitutes = null, int otherNPCType = 0)
 +	{
-+		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
-+			textKey += "Transformed";
++		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2) {
++			// If the Zoologist is talking about a Mod NPC, use ".Transformed" so the key becomes Mods.ModName.NPCs.NPCName.TownNPCMood.Transformed.BestiaryGirl_AffectionLevelNPC
++			// The reason this check is only in this method and not the other is because the other method is not used for trying to access the otherNPCType's localization keys.
++			if (otherNPCType > NPCID.Count)
++				textKey += ".Transformed";
++			// Else vanilla, the key is TownNPCMood_BestiaryGirlTransformed.AffectionLevelNPC_NPCName
++			else
++				textKey += "Transformed";
++		}
 +
 +		string textValueWith = Language.GetTextValueWith(textKey + "." + textKeyInCategory, substitutes);
 +		_currentHappiness = _currentHappiness + textValueWith + " ";
 +	}
 +
 +	// Added by TML.
-+	internal void ApplyNpcRelationshipEffect(int otherNpcType, AffectionLevel affectionLevel)
++	internal void ApplyNpcRelationshipEffect(int otherNPCType, AffectionLevel affectionLevel)
 +	{
 +		if (affectionLevel == 0 || !Enum.IsDefined(affectionLevel)) {
 +			return;
@@ -112,8 +119,7 @@
 +		/*
 +			If talking to ModNPC
 +				Want to use ModNPC's LoveNPC_OtherPerson if exists
-+				Else, use generic LoveNPC
-+			If talking to Vanilla NPC
++			If talking to Vanilla NPC or ModNPC specific dialogue didn't exist.
 +				If talking about a ModNPC
 +					Want to use ModNPC's OtherPerson_LoveNPC if exists
 +				If talking about a vanilla NPC
@@ -121,7 +127,7 @@
 +				Else, use generic LoveNPC
 +		*/
 +
-+		string otherNPCName = NPCID.Search.GetName(otherNpcType); // Get the name of the other Town NPC.
++		string otherNPCName = NPCID.Search.GetName(otherNPCType); // Get the name of the other Town NPC.
 +		ModNPC talkModNPC = _currentNPCBeingTalkedTo.ModNPC; // ModNPC instance of the Town NPC the player is talking to, if it exists.
 +	
 +		// If the current Town NPC is a ModNPC
@@ -131,12 +137,12 @@
 +		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}NPC_{otherNPCName}")) {
 +			// If it does exist, add the happiness report.
 +			AddHappinessReportTextWithKey(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}NPC_{otherNPCName}", new {
-+				NPCName = NPC.GetFullnameByID(otherNpcType)
++				NPCName = NPC.GetFullnameByID(otherNPCType)
 +			});
 +		}
 +		// Vanilla NPC or ModNPC specific dialogue didn't exist.
 +		else {
-+			ModNPC otherModNPC = ModContent.GetModNPC(otherNpcType); // ModNPC instance of the other Town NPC, if it exists.
++			ModNPC otherModNPC = ModContent.GetModNPC(otherNPCType); // ModNPC instance of the other Town NPC, if it exists.
 +			string talkNPCName = NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID); // Get the name of the Town NPC the player is talking to.
 +
 +			// Talking about a ModNPC. We want to use the OtherModNPC's entry for the Town NPC the player is talking to, if it exists.
@@ -144,20 +150,21 @@
 +			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.MyMod/MyTownNPC_LoveNPC
 +			if (otherModNPC != null && Language.Exists($"{otherModNPC.GetLocalizationKey("TownNPCMood")}.{talkNPCName}_{affectionLevel}sNPC")) {
 +				AddHappinessReportTextWithKey(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}sNPC", new {
-+					NPCName = NPC.GetFullnameByID(otherNpcType)
-+				});
++					NPCName = NPC.GetFullnameByID(otherNPCType)
++				},
++				otherNPCType);
 +			}
 +			// Try for vanilla NPC talking about another vanilla NPC.
 +			// Example: TownNPCMood_Guide.LoveNPC_Merchant
 +			else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}NPC_{otherNPCName}")) {
 +				AddHappinessReportTextWithKey($"TownNPCMood_{talkNPCName}", $"{affectionLevel}NPC_{otherNPCName}", new {
-+					NPCName = NPC.GetFullnameByID(otherNpcType)
++					NPCName = NPC.GetFullnameByID(otherNPCType)
 +				});
 +			}
 +			// If nothing above was true, add the generic dialogue.
 +			else {
 +				AddHappinessReportText($"{affectionLevel}NPC", new {
-+					NPCName = NPC.GetFullnameByID(otherNpcType)
++					NPCName = NPC.GetFullnameByID(otherNPCType)
 +				});
 +			}
 +		}

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -143,8 +143,8 @@
 +			// Talking about a ModNPC. We want to use the OtherModNPC's entry for the Town NPC the player is talking to, if it exists.
 +			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.Guide_LoveNPC
 +			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.MyMod/MyTownNPC_LoveNPC
-+			if (otherModNPC != null && Language.Exists($"{otherModNPC.GetLocalizationKey("TownNPCMood")}.{talkNPCName}_{affectionLevel}NPC")) {
-+				AddHappinessReportTextWithKey(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}NPC", new {
++			if (otherModNPC != null && Language.Exists($"{otherModNPC.GetLocalizationKey("TownNPCMood")}.{talkNPCName}_{affectionLevel}sNPC")) {
++				AddHappinessReportTextWithKey(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}sNPC", new {
 +					NPCName = NPC.GetFullnameByID(otherNpcType)
 +				});
 +			}

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -78,8 +78,7 @@
 +	//TODO: Anything else?
 +	public static string BiomeNameByKey(string biomeNameKey) => Language.GetTextValue(biomeNameKey.StartsWith("Mods.") ? biomeNameKey : "TownNPCMoodBiomes." + biomeNameKey);
  
--	private void AddHappinessReportText(string textKeyInCategory, object substitutes = null)
-+	private void AddHappinessReportText(string textKeyInCategory, object substitutes = null, int otherNPCType = 0)
+ 	private void AddHappinessReportText(string textKeyInCategory, object substitutes = null)
  	{
  		string text = "TownNPCMood_" + NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID);
 +
@@ -89,7 +88,7 @@
  		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
  			text += "Transformed";
  
-@@ -166,6 +_,114 @@
+@@ -166,6 +_,122 @@
  		_currentHappiness = _currentHappiness + textValueWith + " ";
  	}
  
@@ -176,17 +175,25 @@
 +		ModNPC talkModNPC = _currentNPCBeingTalkedTo.ModNPC; // ModNPC instance of the Town NPC the player is talking to, if it exists.
 +		string talkNPCName = NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID); // Get the name of the Town NPC the player is talking to.
 +
++		// Vanilla biomes are just a name. Example: "Forest"
++		// Modded biomes are localization path. Example: "Mods.ExampleMod.Biomes.ExampleSurfaceBiome.TownNPCDialogueName"
++		string biomeName = biomeNameKey;
++		if (biomeNameKey.StartsWith("Mods.")) {
++			string[] splitBiomeName = biomeName.Split('.');
++			biomeName = $"{splitBiomeName[1]}/{splitBiomeName[3]}"; // Construct the ModName/ModBiomeName. Example: "ExampleMod/ExampleSurfaceBiome"
++		}
++
 +		// If the current Town NPC is a ModNPC
 +		// Check to see if there is a localization entry for the biome defined in our current Town NPC.
-+		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}Biome_{biomeNameKey}")) {
++		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}Biome_{biomeName}")) {
 +			// If it does exist, add the happiness report.
-+			AddHappinessReportTextWithKey(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}Biome_{biomeNameKey}", new {
++			AddHappinessReportTextWithKey(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}Biome_{biomeName}", new {
 +				BiomeName = BiomeNameByKey(biomeNameKey)
 +			});
 +		}
 +		// Try for vanilla NPC talking about the biome.
-+		else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}Biome_{biomeNameKey}")) {
-+			AddHappinessReportTextWithKey($"TownNPCMood_{talkNPCName}", $"{affectionLevel}Biome_{biomeNameKey}", new {
++		else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}Biome_{biomeName}")) {
++			AddHappinessReportTextWithKey($"TownNPCMood_{talkNPCName}", $"{affectionLevel}Biome_{biomeName}", new {
 +				BiomeName = BiomeNameByKey(biomeNameKey)
 +			});
 +		}

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -69,7 +69,7 @@
  		new AllPersonalitiesModifier().ModifyShopPrice(info, this);
  		if (_currentHappiness == "")
  			AddHappinessReportText("Content");
-@@ -154,11 +_,23 @@
+@@ -154,11 +_,17 @@
  		return priceAdjustment;
  	}
  
@@ -83,12 +83,6 @@
  	{
  		string text = "TownNPCMood_" + NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID);
 +
-+		/*
-+		if (textKeyInCategory == "Princess_LovesNPC")
-+			text = ModContent.GetModNPC(otherNPCType).GetLocalizationKey("TownNPCMood");
-+		else if (_currentNPCBeingTalkedTo.ModNPC is ModNPC modNPC)
-+			text = modNPC.GetLocalizationKey("TownNPCMood");
-+		*/
 +		if (_currentNPCBeingTalkedTo.ModNPC is ModNPC modNPC)
 +			text = modNPC.GetLocalizationKey("TownNPCMood");
 +

--- a/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ShopHelper.cs.patch
@@ -69,7 +69,7 @@
  		new AllPersonalitiesModifier().ModifyShopPrice(info, this);
  		if (_currentHappiness == "")
  			AddHappinessReportText("Content");
-@@ -154,11 +_,19 @@
+@@ -154,11 +_,23 @@
  		return priceAdjustment;
  	}
  
@@ -83,19 +83,24 @@
  	{
  		string text = "TownNPCMood_" + NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID);
 +
++		/*
 +		if (textKeyInCategory == "Princess_LovesNPC")
 +			text = ModContent.GetModNPC(otherNPCType).GetLocalizationKey("TownNPCMood");
 +		else if (_currentNPCBeingTalkedTo.ModNPC is ModNPC modNPC)
++			text = modNPC.GetLocalizationKey("TownNPCMood");
++		*/
++		if (_currentNPCBeingTalkedTo.ModNPC is ModNPC modNPC)
 +			text = modNPC.GetLocalizationKey("TownNPCMood");
 +
  		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
  			text += "Transformed";
  
-@@ -166,6 +_,101 @@
+@@ -166,6 +_,114 @@
  		_currentHappiness = _currentHappiness + textValueWith + " ";
  	}
  
-+	private void AddHappinessReportText(string textKey, string textKeyInCategory, object substitutes = null)
++	// Added by TML
++	private void AddHappinessReportTextWithKey(string textKey, string textKeyInCategory, object substitutes = null)
 +	{
 +		if (_currentNPCBeingTalkedTo.type == 633 && _currentNPCBeingTalkedTo.altTexture == 2)
 +			textKey += "Transformed";
@@ -112,23 +117,15 @@
 +		}
 +
 +		/*
-+		AddHappinessReportText($"{affectionLevel}NPC", new {
-+			NPCName = NPC.GetFullnameByID(npcType)
-+		});
-+		*/
-+
-+		/*
-+
-+		If talking to ModNPC
-+			Want to use ModNPC's LoveNPC_OtherPerson if exists
-+			Else, use generic LoveNPC
-+		If talking to Vanilla NPC
-+			If talking about a ModNPC
-+				Want to use ModNPC's OtherPerson_LoveNPC if exists
-+			If talking about a vanilla NPC
-+				Want to use TownNPCMood_TalkPerson.LoveNPC_OtherPerson
-+			Else, use generic LoveNPC
-+
++			If talking to ModNPC
++				Want to use ModNPC's LoveNPC_OtherPerson if exists
++				Else, use generic LoveNPC
++			If talking to Vanilla NPC
++				If talking about a ModNPC
++					Want to use ModNPC's OtherPerson_LoveNPC if exists
++				If talking about a vanilla NPC
++					Want to use TownNPCMood_TalkPerson.LoveNPC_OtherPerson
++				Else, use generic LoveNPC
 +		*/
 +
 +		string otherNPCName = NPCID.Search.GetName(otherNpcType); // Get the name of the other Town NPC.
@@ -140,7 +137,7 @@
 +		// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.LoveNPC_MyMod/MyTownNPC
 +		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}NPC_{otherNPCName}")) {
 +			// If it does exist, add the happiness report.
-+			AddHappinessReportText(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}NPC_{otherNPCName}", new {
++			AddHappinessReportTextWithKey(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}NPC_{otherNPCName}", new {
 +				NPCName = NPC.GetFullnameByID(otherNpcType)
 +			});
 +		}
@@ -153,14 +150,14 @@
 +			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.Guide_LoveNPC
 +			// Example: Mods.ExampleMod.NPCs.ExamplePerson.TownNPCMood.MyMod/MyTownNPC_LoveNPC
 +			if (otherModNPC != null && Language.Exists($"{otherModNPC.GetLocalizationKey("TownNPCMood")}.{talkNPCName}_{affectionLevel}NPC")) {
-+				AddHappinessReportText(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}NPC", new {
++				AddHappinessReportTextWithKey(otherModNPC.GetLocalizationKey("TownNPCMood"), $"{talkNPCName}_{affectionLevel}NPC", new {
 +					NPCName = NPC.GetFullnameByID(otherNpcType)
 +				});
 +			}
 +			// Try for vanilla NPC talking about another vanilla NPC.
 +			// Example: TownNPCMood_Guide.LoveNPC_Merchant
 +			else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}NPC_{otherNPCName}")) {
-+				AddHappinessReportText($"TownNPCMood_{talkNPCName}", $"{affectionLevel}NPC_{otherNPCName}", new {
++				AddHappinessReportTextWithKey($"TownNPCMood_{talkNPCName}", $"{affectionLevel}NPC_{otherNPCName}", new {
 +					NPCName = NPC.GetFullnameByID(otherNpcType)
 +				});
 +			}
@@ -182,9 +179,29 @@
 +			return;
 +		}
 +
-+		AddHappinessReportText($"{affectionLevel}Biome", new {
-+			BiomeName = BiomeNameByKey(biomeNameKey)
-+		});
++		ModNPC talkModNPC = _currentNPCBeingTalkedTo.ModNPC; // ModNPC instance of the Town NPC the player is talking to, if it exists.
++		string talkNPCName = NPCID.Search.GetName(_currentNPCBeingTalkedTo.netID); // Get the name of the Town NPC the player is talking to.
++
++		// If the current Town NPC is a ModNPC
++		// Check to see if there is a localization entry for the biome defined in our current Town NPC.
++		if (talkModNPC != null && Language.Exists($"{talkModNPC.GetLocalizationKey("TownNPCMood")}.{affectionLevel}Biome_{biomeNameKey}")) {
++			// If it does exist, add the happiness report.
++			AddHappinessReportTextWithKey(talkModNPC.GetLocalizationKey("TownNPCMood"), $"{affectionLevel}Biome_{biomeNameKey}", new {
++				BiomeName = BiomeNameByKey(biomeNameKey)
++			});
++		}
++		// Try for vanilla NPC talking about the biome.
++		else if (Language.Exists($"TownNPCMood_{talkNPCName}.{affectionLevel}Biome_{biomeNameKey}")) {
++			AddHappinessReportTextWithKey($"TownNPCMood_{talkNPCName}", $"{affectionLevel}Biome_{biomeNameKey}", new {
++				BiomeName = BiomeNameByKey(biomeNameKey)
++			});
++		}
++		// Else, generic biome dialogue.
++		else {
++			AddHappinessReportText($"{affectionLevel}Biome", new {
++				BiomeName = BiomeNameByKey(biomeNameKey)
++			});
++		}
 +
 +		_currentPriceAdjustment *= NPCHappiness.AffectionLevelToPriceMultiplier[affectionLevel];
 +	}
@@ -193,49 +210,6 @@
  	public void LikeBiome(string nameKey)
  	{
  		AddHappinessReportText("LikeBiome", new {
-@@ -210,25 +_,38 @@
- 
- 		_currentPriceAdjustment *= 0.94f;
- 	}
-+	*/
- 
-+	//TML: Made internal.
--	public void LoveNPCByTypeName(int npcType)
-+	internal void LoveNPCByTypeName(int npcType)
- 	{
-+		if (npcType >= NPCID.Count && _currentNPCBeingTalkedTo.type == 663) {
-+			// Princess text for liking modded npcs located with the text for the modnpc itself, not with the princess text. Revisit this if https://github.com/tModLoader/tModLoader/issues/3493 is ever implemented.
-+			AddHappinessReportText("Princess_LovesNPC", new {
-+				NPCName = NPC.GetFullnameByID(npcType)
-+			}, npcType);
-+			goto PriceAdjustment;
-+		}
-+
- 		AddHappinessReportText("LoveNPC_" + NPCID.Search.GetName(npcType), new {
- 			NPCName = NPC.GetFullnameByID(npcType)
- 		});
- 
--		_currentPriceAdjustment *= 0.88f;
-+		PriceAdjustment:
-+		_currentPriceAdjustment *= NPCHappiness.AffectionLevelToPriceMultiplier[AffectionLevel.Love];
- 	}
- 
-+	//TML: Made internal.
--	public void LikePrincess()
-+	internal void LikePrincess()
- 	{
- 		AddHappinessReportText("LikeNPC_Princess", new {
- 			NPCName = NPC.GetFullnameByID(663)
- 		});
- 
--		_currentPriceAdjustment *= 0.94f;
-+		_currentPriceAdjustment *= NPCHappiness.AffectionLevelToPriceMultiplier[AffectionLevel.Like];
- 	}
- 
-+	/*
- 	public void LoveNPC(int npcType)
- 	{
- 		AddHappinessReportText("LoveNPC", new {
 @@ -255,6 +_,7 @@
  
  		_currentPriceAdjustment *= 1.12f;

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -1184,6 +1184,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "Ich mag {NPCName}.",
-		"Princess_LovesNPC": "Ich mag {NPCName}."
+		"Princess_LovesNPC": "Ich liebe {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -1185,6 +1185,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "I like {NPCName}.",
-		"Princess_LovesNPC": "I like {NPCName}."
+		"Princess_LovesNPC": "I love {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -1184,6 +1184,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "Me gusta {NPCName}.",
-		"Princess_LovesNPC": "Me gusta {NPCName}."
+		"Princess_LovesNPC": "Adoro a {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -1183,7 +1183,7 @@
 		// "ModLoader.Items.Zeph_Wings.DisplayName": "Zeph's Wings"
 	},
 	"TownNPCMood": {
-		// "LikeNPC_Princess": "I like {NPCName}.",
-		// "Princess_LovesNPC": "I like {NPCName}."
+		"LikeNPC_Princess": "J'aime bien {NPCName}.",
+		"Princess_LovesNPC": "J'adore {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -1185,7 +1185,7 @@
 		// "ModLoader.Items.Zeph_Wings.DisplayName": "Zeph's Wings"
 	},
 	"TownNPCMood": {
-		// "LikeNPC_Princess": "I like {NPCName}.",
-		// "Princess_LovesNPC": "I like {NPCName}."
+		"LikeNPC_Princess": "Mi piace {NPCName}.",
+		"Princess_LovesNPC": "Adoro {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -1184,6 +1184,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "Eu gosto de {NPCName}.",
-		"Princess_LovesNPC": "Eu gosto de {NPCName}."
+		"Princess_LovesNPC": "Eu adoro {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -1184,6 +1184,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "Мне нравится {NPCName}.",
-		"Princess_LovesNPC": "Мне нравится {NPCName}."
+		"Princess_LovesNPC": "Я люблю {NPCName}."
 	}
 }

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -1186,6 +1186,6 @@
 	},
 	"TownNPCMood": {
 		"LikeNPC_Princess": "我喜欢 {NPCName}。",
-		"Princess_LovesNPC": "我喜欢 {NPCName}。"
+		"Princess_LovesNPC": "我非常喜欢 {NPCName}。"
 	}
 }


### PR DESCRIPTION
### What is the new feature?

Allows for modders to define happiness dialogue for specific NPCs or biomes instead of using the generic dialogue. This works exactly like the already existing `LikeNPC_Princess` and `Princess_LovesNPC`. Modders can add specific dialogue through the localization file without having to write any code. Implements #3493 

This supports Mod NPCs talking about Mod NPCs, Mod NPCs talking about vanilla NPCs, vanilla NPCs talking about Mod NPCs, and even vanilla NPCs talking about vanilla NPCs.

* For Mod NPCs. In `Mods.{ModName}.NPCs.{ModNPCName}.TownNPCMood`
  * `{AffectionLevel}NPC_{OtherNPCInternalName}` For specific dialogue for talking about other NPC. Other loved NPCs will use the generic `{AffectionLevel}NPC`.
    * Example: `LoveNPC_Guide` Would be a specific dialogue for talking about the Guide. 
    * Modded NPCs will need the full mod name as well. Example: `LoveNPC_ExampleMod/ExamplePerson`.
  * `{AffectionLevel}Biome_{BiomeName}` For biomes.
    * Modded Biomes will need the full name. Example: `LoveBiome_ExampleMod/ExampleSurfaceBiome`
  * `{OtherNPCInternalName}_{AffectionLevel}sNPC` For specific dialogue when another NPC is talking about your Mod NPC.
    * Example: `Guide_LovesNPC` Would be specific dialogue from the Guide when he is talking about your Mod NPC.
    * Modded NPCs will need the full mod name, too.  Example: `ExampleMod/ExamplePerson_LovesNPC`.
* For vanilla NPCs talking about vanilla NPCs. In `TownNPCMood_{NPCInternalName}`
  * `{AffectionLevel}NPC_{OtherVanillaNPCInternalName}`
    * Example: `TownNPCMood_Guide.LikeNPC_BestiaryGirl` Would be a specific dialogue for when the Guide is talking about the Zoologist. 
  * `{AffectionLevel}Biome_{BiomeName}` for biomes.

* **Caveat for the Zoologist**
  * The Zoologist has two sets of happiness dialogue. A normal one and one for when she is transformed.
  * For Mod NPCs, the normal dialogue works like above. For the transformed dialogue, it needs to be in the TownNPCMood.Transformed scope.
    * Example `Mods.{ModName}.NPCs.{ModNPCName}.TownNPCMood.Transformed.BestiaryGirl_LikeNPC`
  * For vanilla NPCs talking about vanilla NPCs. In `TownNPCMood_{NPCInternalName}Transformed`
    * Example: `TownNPCMood_BeastiaryGirlTransformed.LikeNPC_Golfer`

* I updated the tModLoader localization for tModLoader.json, to change the `Princess_LovesNPC` from incorrectly saying "like" to "love".
  * The other languages are from vanilla's generic TownNPCMood localization entries.

### Why should this be part of tModLoader?

Allows extra customization and flexibility for modders when writing their Town NPC's happiness dialogue. I've seen several people ask how to do this in the mod-programming-help channel.

### Are there alternative designs?

* The new system works for the Princess dialogue, so no more special case needed.
  * I changed `GameContent/Personalities/AllPersonalitiesModifier.ModifyShopPrice_Relationships()` to use `ShopHelper.ApplyNpcRelationshipEffect` which handles the specific dialogue instead of the vanilla `ShopHelper.LoveNPCByTypeName` and `ShopHelper.LikePrincess` methods. This allowed me to comment out those two vanilla methods because they were unused.
* I renamed the parameter in `ShopHelper.ApplyNpcRelationshipEffect(int npcType, AffectionLevel affectionLevel)` to `(int otherNPCType, AffectionLevel affectionLevel)`. 
  * This is a method added by TML, so I figured it would be safe to rename a parameter here.
  * I felt like `otherNPCType` was more clear. Was npcType the NPC the player is talking to? Or was it the npcType that the NPC that the player is talking to is talking about? (It is the latter)
* I added `ShopHelper.AddHappinessReportTextWithKey(string textKey, string textKeyInCategory, object substitutes = null)` to allow me to change the scope of the localization path in `ApplyNpcRelationshipEffect`

### Sample usage for the new feature

* Pink highlighting: generic dialogue
* Yellow highlighting: specific dialogue
* Purple highlighting: specific dialogue added by another mod
* Orange highlighting: Princess dialogue
<img width="640" height="245" alt="image" src="https://github.com/user-attachments/assets/f538b6a5-0b73-4ff3-9e5c-80e79f28b21b" />
<img width="631" height="183" alt="image" src="https://github.com/user-attachments/assets/753bb681-efe2-49bc-9876-da3c6ba57466" />
<img width="636" height="153" alt="image" src="https://github.com/user-attachments/assets/c58f9dfe-6766-41af-ace7-073d48ac1d70" />
<img width="626" height="201" alt="image" src="https://github.com/user-attachments/assets/12297bc0-254d-49dc-ae67-284bf05e4fb6" />
<img width="629" height="238" alt="image" src="https://github.com/user-attachments/assets/7c3f6302-8974-4030-a970-63855f4bad88" />


### ExampleMod updates

* Changed some happiness opinions:
  * +Example Person dislikes Desert
  * +Example Person likes Zoologist
  * +Example Person dislikes Golfer
  * +Zoologist like Example Person
* Added dialogue for:
  * Example Person likes Zoologist
    * Included transformed quote.
  * Example Person dislikes Merchant
  * Example Person dislike Desert
  * Example Person loves ExampleSurfaceBiome
  * Guide loves Example Person
  * Zoologist likes Example Person
    * Included transformed quote.
  * Guide loves ExampleSurfaceBiome
  * Nurse dislikes Party Girl
  * Zoologist likes Golfer
    * Included transformed quote.

### Porting Notes

None! This system is entirely optional! (Detours/IL edit/reflection may need to be updated for ShopHelper.AddHappinessReportText and maybe ShopHelper.ApplyNpcRelationshipEffect)
