### PR TITLE
[1.4.5] World Item Stack Creation in Shimmer Transform/De-craft Should Respect `maxStack` of Items

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.rej
+++ b/patches/tModLoader/Terraria/Item.cs.rej
@@ -58,31 +58,6 @@
  			IEnumerable<Item> enumerable = recipe.requiredItem;
  			if (recipe.customShimmerResults != null)
  				enumerable = recipe.customShimmerResults;
-@@ -47869,17 +_,22 @@
- 
- 				num15++;
- 				int num16 = num13 * item2.stack;
-+
-+				/* TML: Recipe.alchemy is removed due to being replaced by consume item hooks
- 				if (recipe.alchemy) {
- 					for (int num17 = num16; num17 > 0; num17--) {
- 						if (Main.rand.Next(3) == 0)
- 							num16--;
- 					}
- 				}
-+				*/
-+
-+				RecipeLoader.ConsumeIngredient(recipe, item2.type, ref num16, true);
- 
- 				while (num16 > 0) {
- 					int num18 = num16;
--					if (num18 > 9999)
--						num18 = 9999;
-+					if (num18 > item2.maxStack)
-+						num18 = item2.maxStack;
- 
- 					num16 -= num18;
- 					int num19 = NewItem(GetItemSource_Misc(8), (int)position.X, (int)position.Y, width, height, item2.type);
 @@ -48004,7 +_,7 @@
  		if (Main.netMode == 1) {
  			int num = (int)(position.X + (float)(width / 2)) / 16;

--- a/patches/tModLoader/Terraria/Item.cs.rej
+++ b/patches/tModLoader/Terraria/Item.cs.rej
@@ -49,43 +49,6 @@
  
  			Main.player[Main.myPlayer].AddCoinLuck(base.Center, stack);
  			NetMessage.SendData(146, -1, -1, null, 1, (int)base.Center.X, (int)base.Center.Y, stack);
-@@ -47808,10 +_,34 @@
- 			shimmered = true;
- 		}
- 		else if (ItemID.Sets.ShimmerTransformToItem[shimmerEquivalentType] > 0) {
-+			// Since 1.4.5 seems to add item stacking (April 2024 state of the game) this is likely a temporary fix. All variables are renamed as such so I can read this later. (Copy paste + modify from decrafting code) - Kogsey
--			int num8 = stack;
-+			int stackSize = stack;
- 			SetDefaults(ItemID.Sets.ShimmerTransformToItem[shimmerEquivalentType]);
--			stack = num8;
-+			stack = stackSize;
-+			if (stack > maxStack)
-+				stack = maxStack;
-+			stackSize -= stack;
- 			shimmered = true;
-+			int spawnCount = 0;
-+
-+			while (stackSize > 0) {
-+				spawnCount++;
-+
-+				int newItemIndex = NewItem(GetItemSource_Misc(8), (int)position.X, (int)position.Y, width, height, type);
-+				Item item = Main.item[newItemIndex];
-+				item.stack = stackSize;
-+				if (item.stack > maxStack)
-+					item.stack = maxStack;
-+				stackSize -= item.stack;
-+				item.shimmerTime = 1f;
-+				item.shimmered = true;
-+				item.shimmerWet = true;
-+				item.wet = true;
-+				item.velocity *= 0.1f;
-+				item.playerIndexTheItemIsReservedFor = Main.myPlayer;
-+
-+				NetMessage.SendData(145, -1, -1, null, newItemIndex, 1f);
-+			}
- 		}
- 		else if (type == 4986) {
- 			if (NPC.unlockedSlimeRainbowSpawn)
 @@ -47857,7 +_,7 @@
  			int num13 = FindDecraftAmount();
  			Recipe recipe = Main.recipe[decraftingRecipeIndex];

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -182,7 +182,7 @@
  			IEnumerable<Recipe.RequiredItemEntry> enumerable = recipe.requiredItemQuickLookup;
  			if (recipe.customShimmerResults != null) {
  				enumerable = recipe.customShimmerResults.Select(delegate (Item item) {
-@@ -1538,22 +_,22 @@
+@@ -1538,22 +_,30 @@
  				num7++;
  				int num8 = num6 * item.stack;
  				int num9 = (item.IsRecipeGroup ? item.RecipeGroup.DecraftItemId : item.itemIdOrRecipeGroup);
@@ -197,11 +197,14 @@
 +				RecipeLoader.ConsumeIngredient(recipe, num9, ref num8, true);
  
  				while (num8 > 0) {
--					int num11 = num8;
--					if (num11 > 9999)
--						num11 = 9999;
--
--					num8 -= num11;
++					/*
+ 					int num11 = num8;
+ 					if (num11 > 9999)
+ 						num11 = 9999;
+ 
++
+ 					num8 -= num11;
++					*/
  					int num12 = Item.NewItem(GetItemSource_Misc(ItemSourceID.Shimmer), (int)position.X, (int)position.Y, width, height, num9);
  					WorldItem worldItem = Main.item[num12];
 +					int num11 = Math.Min(num8, worldItem.maxStack);

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -173,7 +173,7 @@
  		}
  		else if (type == 4986) {
  			if (NPC.unlockedSlimeRainbowSpawn)
-@@ -1538,12 +_,15 @@
+@@ -1538,22 +_,22 @@
  				num7++;
  				int num8 = num6 * item.stack;
  				int num9 = (item.IsRecipeGroup ? item.RecipeGroup.DecraftItemId : item.itemIdOrRecipeGroup);
@@ -188,4 +188,16 @@
 +				RecipeLoader.ConsumeIngredient(recipe, num9, ref num8, true);
  
  				while (num8 > 0) {
- 					int num11 = num8;
+-					int num11 = num8;
+-					if (num11 > 9999)
+-						num11 = 9999;
+-
+-					num8 -= num11;
+ 					int num12 = Item.NewItem(GetItemSource_Misc(ItemSourceID.Shimmer), (int)position.X, (int)position.Y, width, height, num9);
+ 					WorldItem worldItem = Main.item[num12];
++					int num11 = Math.Min(num8, worldItem.maxStack);
+ 					worldItem.stack = num11;
++					num8 -= num11;
+ 					worldItem.shimmerTime = 1f;
+ 					worldItem.shimmered = true;
+ 					worldItem.shimmerWet = true;

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -141,6 +141,38 @@
  
  	public static void ShimmerEffect(Vector2 shimmerPositon)
  	{
+@@ -1464,10 +_,29 @@
+ 			stack = 0;
+ 		}
+ 		else if (transformToItem > 0) {
+-			int num = stack;
++			int stackSize = stack;
+ 			SetDefaults(transformToItem);
+-			stack = num;
++			stack = stackSize;
++			if (stack > maxStack)
++				stack = maxStack;
++			stackSize -= stack;
+ 			shimmered = true;
++			while (stackSize > 0) {
++				int newItemIndex = Item.NewItem(GetItemSource_Misc(ItemSourceID.Shimmer), (int)position.X, (int)position.Y, width, height, type);
++				WorldItem worldItem = Main.item[newItemIndex];
++				worldItem.stack = stackSize;
++				if (worldItem.stack > maxStack)
++					worldItem.stack = maxStack;
++				stackSize -= worldItem.stack;
++				worldItem.shimmerTime = 1f;
++				worldItem.shimmered = true;
++				worldItem.shimmerWet = true;
++				worldItem.wet = true;
++				worldItem.velocity *= 0.1f;
++				worldItem.playerIndexTheItemIsReservedFor = Main.myPlayer;
++
++				NetMessage.SendData(145, -1, -1, null, newItemIndex, 1f);
++			}
+ 		}
+ 		else if (type == 4986) {
+ 			if (NPC.unlockedSlimeRainbowSpawn)
 @@ -1538,12 +_,15 @@
  				num7++;
  				int num8 = num6 * item.stack;

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -173,6 +173,15 @@
  		}
  		else if (type == 4986) {
  			if (NPC.unlockedSlimeRainbowSpawn)
+@@ -1519,7 +_,7 @@
+ 		else if (decraftingRecipeIndex >= 0) {
+ 			int num6 = inner.FindDecraftAmount();
+ 			Recipe recipe = Main.recipe[decraftingRecipeIndex];
+-			bool flag = recipe.requiredItem[1].stack > 0;
++			bool flag = recipe.requiredItem.Count > 1 && recipe.requiredItem[1].stack > 0;
+ 			IEnumerable<Recipe.RequiredItemEntry> enumerable = recipe.requiredItemQuickLookup;
+ 			if (recipe.customShimmerResults != null) {
+ 				enumerable = recipe.customShimmerResults.Select(delegate (Item item) {
 @@ -1538,22 +_,22 @@
  				num7++;
  				int num8 = num6 * item.stack;

--- a/patches/tModLoader/Terraria/WorldItem.cs.patch
+++ b/patches/tModLoader/Terraria/WorldItem.cs.patch
@@ -182,7 +182,7 @@
  			IEnumerable<Recipe.RequiredItemEntry> enumerable = recipe.requiredItemQuickLookup;
  			if (recipe.customShimmerResults != null) {
  				enumerable = recipe.customShimmerResults.Select(delegate (Item item) {
-@@ -1538,22 +_,30 @@
+@@ -1538,22 +_,29 @@
  				num7++;
  				int num8 = num6 * item.stack;
  				int num9 = (item.IsRecipeGroup ? item.RecipeGroup.DecraftItemId : item.itemIdOrRecipeGroup);
@@ -202,7 +202,6 @@
  					if (num11 > 9999)
  						num11 = 9999;
  
-+
  					num8 -= num11;
 +					*/
  					int num12 = Item.NewItem(GetItemSource_Misc(ItemSourceID.Shimmer), (int)position.X, (int)position.Y, width, height, num9);


### PR DESCRIPTION
### What is the bug?
When an item stack is shimmer-transformed into another item type with a lower `maxStack`, the resulting item retains the original stack count, producing an **invalid stack** (`stack > maxStack`).

For example, if a modded item with `maxStack = 9999` shimmer-transforms into an item with `maxStack = 10`, dropping a stack of 500 produces a single pile of 500 — which exceeds the new item's `maxStack`. The pile is still pickable and still contains all 500 items, but it is in an invalid state that may confuse inventory logic, stacking behavior, or mods that assume `stack <= maxStack`.

A related issue exists in the decrafting branch of the same method: vanilla hardcodes a `9999` cap when spawning decraft ingredients. If a recipe ingredient has `maxStack < 9999` (common for modded items), decrafting can similarly produce invalid stacks.

### How did you fix the bug?
**Shimmer transform** (`transformToItem > 0` branch):
1. Cap the current stack to the new item's `maxStack` after `SetDefaults`
2. Spawn additional `WorldItem` instances for the overflow, each capped to `maxStack`
3. Set shimmer state on all spawned items and sync via `NetMessage.SendData(145)`

**Decrafting** (`decraftingRecipeIndex >= 0` branch):
1. Spawn the ingredient `WorldItem` first
2. Read its `maxStack` (which reflects the ingredient's actual limit)
3. Cap the spawned stack to `maxStack` instead of hardcoded `9999`

Both fixes mirror the existing pattern already used by the decrafting branch for spawning items.

### Are there alternatives to your fix?
None that preserve valid item state. The vanilla behavior produces an invalid stack.

### Porting notes
- Backward-compatible. No modder action required.
- The shimmer transform fix was originally written for 1.4.4's `Item.GetShimmered()` (see `.rej` hunk `@@ -47808` in `Item.cs.rej`). Vanilla 1.4.5 moved the method to `WorldItem.GetShimmered()`, so the fix was adapted to the new location.
