### PR TITLE
Grab Bag Updates

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -1183,4 +1183,10 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.CapricornLegs, ItemDropRule.Common(ItemID.CapricornTail));
 		RegisterToItem(ItemID.CapricornTail, ItemDropRule.Common(ItemID.CapricornLegs));
 	}
+
+	private void RegisterHugeDragonEgg()
+	{
+		RegisterToItem(ItemID.PalworldChilletEgg, ItemDropRule.Common(ItemID.PalworldPetChillet));
+		RegisterToItem(ItemID.PalworldChilletEgg, ItemDropRule.Common(ItemID.PalworldPetChilletIgnis));
+	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -247,8 +247,8 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.Common(ItemID.ShrimpyTruffle));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.DukeFishronMask, 7));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.FishronWings, 10));
-		RegisterToItem(item, new LeadingConditionRule(new Conditions.NotRemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.BubbleGun));
-		RegisterToItem(item, new LeadingConditionRule(new Conditions.RemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.AquaScepter));
+		RegisterToItem(item, new LeadingConditionRule(new Conditions.NotRemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.BubbleGun));
+		RegisterToItem(item, new LeadingConditionRule(new Conditions.RemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.AquaScepter));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.DukeFishron));
 	}
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -223,7 +223,7 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.Common(ItemID.LunarOre, 1, 90, 110));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.MeowmereMinecart, 10));
 		RegisterToItem(item, ItemDropRule.ByCondition(new Conditions.NoPortalGun(), ItemID.PortalGun));
-		RegisterToItem(item, new FromOptionsWithoutRepeatsDropRule(2, ItemID.Meowmere, ItemID.Terrarian, ItemID.StarWrath, ItemID.SDMG, ItemID.Celeb2, ItemID.LastPrism, ItemID.LunarFlareBook, ItemID.RainbowCrystalStaff, ItemID.MoonlordTurretStaff));
+		RegisterToItem(item, new FromOptionsWithoutRepeatsDropRule(2, ItemID.Meowmere, ItemID.Terrarian, ItemID.StarWrath, ItemID.SDMG, ItemID.Celeb2, ItemID.LastPrism, ItemID.LunarFlareBook, ItemID.RainbowCrystalStaff, ItemID.MoonlordTurretStaff, ItemID.MoonLordWhip));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.MoonLordCore));
 
 		item = ItemID.BossBagBetsy;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -1186,7 +1186,11 @@ partial class ItemDropDatabase
 
 	private void RegisterHugeDragonEgg()
 	{
-		RegisterToItem(ItemID.PalworldChilletEgg, ItemDropRule.Common(ItemID.PalworldPetChillet));
-		RegisterToItem(ItemID.PalworldChilletEgg, ItemDropRule.Common(ItemID.PalworldPetChilletIgnis));
+		IItemDropRule[] rules = new IItemDropRule[]
+		{
+			ItemDropRule.NotScalingWithLuck(ItemID.PalworldPetChillet, 2),
+			ItemDropRule.NotScalingWithLuck(ItemID.PalworldPetChilletIgnis, 2),
+		};
+		RegisterToItem(ItemID.PalworldChilletEgg, rules);
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -146,10 +146,10 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.Common(ItemID.EoCShield));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.EyeMask, 7));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.Binoculars, 30));
-		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCrimson, ItemID.CrimtaneOre, 1, 30, 87));
+		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCrimson, ItemID.CrimtaneOre, 1, 30, 90));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCrimson, ItemID.CrimsonSeeds, 1, 1, 3));
-		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.UnholyArrow, 1, 20, 49));
-		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.DemoniteOre, 1, 30, 87));
+		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.UnholyArrow, 1, 20, 50));
+		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.DemoniteOre, 1, 30, 90));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.CorruptSeeds, 1, 1, 3));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.EyeofCthulhu));
 

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -980,6 +980,8 @@ partial class ItemDropDatabase
 
 		RegisterToItem(ItemID.LockBox, new OneFromRulesRule(1, goldenLockBoxList));
 		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.ShadowKey, 3));
+		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.DeadCellsRamRune, 8));
+		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.MoonLordBody, 5));
 	}
 
 	private void RegisterHerbBag()

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -116,7 +116,7 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.ThornHook, 10));
 		IItemDropRule itemDropRuleGrenadeLauncher = ItemDropRule.Common(ItemID.GrenadeLauncher);
 		itemDropRuleGrenadeLauncher.OnSuccess(ItemDropRule.Common(ItemID.RocketI, 1, 50, 149), hideLootReport: true);
-		RegisterToItem(item, new OneFromRulesRule(1, itemDropRuleGrenadeLauncher, ItemDropRule.Common(ItemID.VenusMagnum), ItemDropRule.Common(ItemID.NettleBurst), ItemDropRule.Common(ItemID.LeafBlower), ItemDropRule.Common(ItemID.FlowerPow), ItemDropRule.Common(ItemID.WaspGun), ItemDropRule.Common(ItemID.Seedler)));
+		RegisterToItem(item, new OneFromRulesRule(1, itemDropRuleGrenadeLauncher, ItemDropRule.Common(ItemID.VenusMagnum), ItemDropRule.Common(ItemID.NettleBurst), ItemDropRule.Common(ItemID.LeafBlower), ItemDropRule.Common(ItemID.FlowerPow), ItemDropRule.Common(ItemID.WaspGun), ItemDropRule.Common(ItemID.Seedler), ItemDropRule.Common(ItemID.FlowerWhip)));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.Plantera));
 
 		item = ItemID.SkeletronPrimeBossBag;

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -1188,8 +1188,8 @@ partial class ItemDropDatabase
 	{
 		IItemDropRule[] rules = new IItemDropRule[]
 		{
-			ItemDropRule.NotScalingWithLuck(ItemID.PalworldPetChillet, 2),
-			ItemDropRule.NotScalingWithLuck(ItemID.PalworldPetChilletIgnis, 2),
+			ItemDropRule.Common(ItemID.PalworldPetChillet),
+			ItemDropRule.Common(ItemID.PalworldPetChilletIgnis),
 		};
 		RegisterToItem(ItemID.PalworldChilletEgg, rules);
 	}

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -148,7 +148,7 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.Binoculars, 30));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCrimson, ItemID.CrimtaneOre, 1, 30, 90));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCrimson, ItemID.CrimsonSeeds, 1, 1, 3));
-		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.UnholyArrow, 1, 20, 50));
+		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.UnholyArrow, 1, 20, 50));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.DemoniteOre, 1, 30, 90));
 		RegisterToItem(item, ItemDropRule.ByCondition(conditionIsCorruption, ItemID.CorruptSeeds, 1, 1, 3));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.EyeofCthulhu));
@@ -247,8 +247,8 @@ partial class ItemDropDatabase
 		RegisterToItem(item, ItemDropRule.Common(ItemID.ShrimpyTruffle));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.DukeFishronMask, 7));
 		RegisterToItem(item, ItemDropRule.NotScalingWithLuck(ItemID.FishronWings, 10));
-		RegisterToItem(item, new LeadingConditionRule(new Conditions.NotRemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.BubbleGun));
-		RegisterToItem(item, new LeadingConditionRule(new Conditions.RemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.Flairon, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.AquaScepter));
+		RegisterToItem(item, new LeadingConditionRule(new Conditions.NotRemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.FlaironFlail, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.BubbleGun));
+		RegisterToItem(item, new LeadingConditionRule(new Conditions.RemixSeed())).OnSuccess(ItemDropRule.OneFromOptions(1, ItemID.EelWhip, ItemID.FlaironFlail, ItemID.Tsunami, ItemID.RazorbladeTyphoon, ItemID.TempestStaff, ItemID.AquaScepter));
 		RegisterToItem(item, ItemDropRule.CoinsBasedOnNPCValue(NPCID.DukeFishron));
 	}
 
@@ -981,7 +981,7 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.LockBox, new OneFromRulesRule(1, goldenLockBoxList));
 		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.ShadowKey, 3));
 		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.DeadCellsRamRune, 8));
-		RegisterToItem(ItemID.LockBox, ItemDropRule.NotScalingWithLuck(ItemID.MoonLordBody, 5));
+		RegisterToItem(ItemID.LockBox, ItemDropRule.ByCondition(new Conditions.ForTheWorthyIsUp(), ItemID.MoonLordBody, 5));
 	}
 
 	private void RegisterHerbBag()
@@ -1186,11 +1186,6 @@ partial class ItemDropDatabase
 
 	private void RegisterHugeDragonEgg()
 	{
-		IItemDropRule[] rules = new IItemDropRule[]
-		{
-			ItemDropRule.Common(ItemID.PalworldPetChillet),
-			ItemDropRule.Common(ItemID.PalworldPetChilletIgnis),
-		};
-		RegisterToItem(ItemID.PalworldChilletEgg, rules);
+		RegisterToItem(ItemID.PalworldChilletEgg, ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.PalworldPetChillet, ItemID.PalworldPetChilletIgnis));
 	}
 }

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -46,7 +46,7 @@
  	{
  		if (_entriesByNpcNetId.ContainsKey(npcNetId))
  			_entriesByNpcNetId[npcNetId].Remove(entry);
-@@ -143,6 +_,30 @@
+@@ -143,6 +_,31 @@
  		RegisterMimic();
  		RegisterEclipse();
  		RegisterBloodMoonFishing();
@@ -62,6 +62,7 @@
 +		RegisterCanOfWorms();
 +		RegisterOyster();
 +		RegisterCapricorns();
++		RegisterHugeDragonEgg();
 +
 +		NPCLoader.ModifyGlobalLoot(new GlobalLoot(this));
 +


### PR DESCRIPTION
### What is the bug?
Loot drops from grab bags needed updating to 1.4.5 standard drops.  
This includes: Plantera, Duke Fishron, Moonlord, Eye of Cthulu.  
Golden Lock box drops also needed updating to add the Moon Lord Torso and the Ram Rune.  
Huge Dragon Egg needed to be added to the item drop database.  

### How did you fix the bug?
Plantera whip added to boss bag.  
Duke Fishron whip added to boss bag.  
Moon lord whip added to boss bag.  
Eye of cthulu max ore increased from 87 to 90.  
Eye of cthulu unholy arrow max increased from 49 to 50.  
Golden lock box drops now include MoonLordBody and DeadCellsRamRune items.  
Huge Dragon Egg method for registering in the database added. This method just registers the drops for the egg which are the Palworld Chillet and Palworld Chillet Ignis.

### Are there alternatives to your fix?
I think not.

### Notes
I am not totally sure on the Huge Dragon Egg drop chances being what they are supposed to be. It is supposed to drop one or the other items. Please double check that code in your reviews.