### PR TITLE
[1.4.5] Automatically Register NoHome for Town Pets

### DIFF
--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -321,6 +321,7 @@ SilverBarRecipeGroup = RecipeGroup.Register(
   * The "SetBonus" tooltip has changed. It now automatically displays partial sets and adjusts the color to indicate if the set is complete.
   * The "SetBonusSinglePiece" tooltip shows the set bonus that would be applied if the unequipped equipment were equipped.
 * Town NPCs who are homeless have a new "Housing" button that displays their "NoHome" dialogue as well as a hint on what valid housing is. The hint text can be customized through the localization file. If the key `Mods.ModName.NPCs.NPCName.HousingText.HousingRequirements` exists, it will automatically be used over the default text.
+  * The `Mods.{ModName}.NPCs.{ModNPCName}.TownNPCMood.NoHome` localization key will now be generated for town pets as well.
 * Town NPCs can now have specific happiness dialogue for other Town NPCs or biomes that work just like the previous `LikeNPC_Princess` and `Princess_LovesNPC`.
   * For Mod NPCs, the localization keys are scoped in `Mods.{ModName}.NPCs.{ModNPCName}.TownNPCMood`
     * `{AffectionLevel}NPC_{OtherNPCInternalName}` For specific dialogue for talking about other NPC. Other loved NPCs will use the generic `{AffectionLevel}NPC`.

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -184,6 +184,9 @@ public static class NPCLoader
 				Language.GetOrRegister(fullKey, () => Language.Exists(oldKey) ? $"{{${oldKey}}}" : Language.GetTextValue(defaultValueKey));
 			}
 		}
+		if (NPCID.Sets.IsTownPet[npc.NPC.type]) {
+			Language.GetOrRegister(npc.GetLocalizationKey("TownNPCMood.NoHome"), () => Language.GetTextValue("TownNPCMood.NoHome"));
+		}
 	}
 
 	internal static void Unload()


### PR DESCRIPTION
### What is the new feature?

Automatically registers the `TownNPCMood.NoHome` for modded town pets now that it is an expected key to have for the Housing button.

### Why should this be part of tModLoader?

To match automatically registering TownNPCMood keys for normal Town NPCs and so modders porting their mods to 1.4.5 are less likely to forget to add this key to their Town Pets.

### Are there alternative designs?

Right not it will auto fill with "I hate not having a home." It could be something else.

