### PR TITLE
[1.4.5] IsTileDangerous PerspectivePlayer Docs

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -27,9 +27,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Update https://github.com/tModLoader/tModLoader/wiki/Vanilla-Content-IDs#achievement-identifiers with new achievements
 - https://github.com/tModLoader/tModLoader/pull/3500 seems to have changed ItemSourceID.PlayerDropItemCheck to ThrowItem. In 1.4.5 it was renamed to PlayerDrop and there is a new InventoryOverflow. Double check that the #3500 logic applies to the fixed 1.4.5 code. Maybe see if ThrowItem is a better name than PlayerDrop and can be fixed in Terraria, otherwise tModPorter it or double check that it is patched everywhere to use the new names.
 - Also, ItemSourceID.SortingWithNoSpace has been removed.
-- TileLoader.IsTileDangerous (and other methods?) now takes `Main.SceneMetrics.PerspectivePlayer` as input, not necessarily the LocalPlayer. I think this means dangersense should work when spectating. Need docs updates.
-- TileLoader.IsTileSpelunkable also takes `Main.SceneMetrics.PerspectivePlayer`. These hooks now need a Player parameter, they don't currently have one.
-- TileLoader.IsTileBiomeSightable as well.
 - TileLoader.SpecialDraw (and other tile methods I assume) now takes a TileBatch instead of Main.spriteBatch. What does this affect? How will mods need to change? Why do some methods in TileDrawing still use Main.spriteBatch?
 - ShaderData classes now have `if (Main.dedServ)` checks. Are these overzealous, or do we need to adjust other places or inform modders that shader code might attempt to run on servers.
 - Player.voiceOverride. Currently an sbyte, might need to be an int like the other equipment slot IDs. Also an example would be nice.

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.TML.cs
@@ -14,7 +14,7 @@ public partial class TileDrawing
 
 	/// <summary>
 	/// Checks if a tile at the given coordinates counts towards tile coloring from the Dangersense buff.
-	/// <br/>Vanilla only uses Main.LocalPlayer for <paramref name="player"/>
+	/// <br/>Vanilla uses <c>Main.SceneMetrics.PerspectivePlayer</c> for <paramref name="player"/>
 	/// </summary>
 	public static bool IsTileDangerous(int tileX, int tileY, Player player)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -314,7 +314,7 @@ public abstract class ModTile : ModBlockType
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
-	/// <param name="player">Main.LocalPlayer</param>
+	/// <param name="player">The player viewing the area. <c>Main.SceneMetrics.PerspectivePlayer</c></param>
 	public virtual bool IsTileDangerous(int i, int j, Player player)
 	{
 		return false;


### PR DESCRIPTION
### What was changed?

Updated the docs for `ModTile.IsTileDangerous` and `GameContent.Drawing.TileDrawing.IsTileDangerous` to mention that they use `Main.SceneMetrics.PerspectivePlayer` now instead of `Main.LocalPlayer`.

The porting notes said to add a player parameter for `TileLoader.IsTileSpelunkable` and `TileLoader.IsTileBiomeSightable`, but I don't think that is necessary. Those hooks are in Main and not TileDrawing and don't need to use PerspectivePlayer?
I did extensive testing with local multiplayer using the Scrying Orb and they just worked out of the box without changes. I tested with Example Ore which has `ModTile.IsTileBiomeSightable`, Example Herb which has `ModTile.IsTileSpelunkable`, and Example Trap which has `ModTile.IsTileDangerous`. They all worked just they should without any changes.

Unless I missed something, I think that's all there is to it.