### PR TITLE
[1.4.5] Update Achievement Identifiers on Wiki

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -24,7 +24,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - FileUtilities.Copy and Move no longer have an `overwrite` parameter.
 - LegacyAudioSystem now has TrackLoopCounts and PlayCallbacks. They seem to involve counting how many times a specific music has looped. Investigate. Modders might be interested. Used with RainbowBoulderMusicPlayCallback
 - SoundEngine.Initialize now returns the IAudioSystem. We should test if it is still necessary to show an error message for !IsAudioSupported. 1.4.5 change log claims "Terraria no longer fails to launch when it fails to detect an available audio device.", we should see if tModLoader can work without audio support too.
-- Update https://github.com/tModLoader/tModLoader/wiki/Vanilla-Content-IDs#achievement-identifiers with new achievements
 - https://github.com/tModLoader/tModLoader/pull/3500 seems to have changed ItemSourceID.PlayerDropItemCheck to ThrowItem. In 1.4.5 it was renamed to PlayerDrop and there is a new InventoryOverflow. Double check that the #3500 logic applies to the fixed 1.4.5 code. Maybe see if ThrowItem is a better name than PlayerDrop and can be fixed in Terraria, otherwise tModPorter it or double check that it is patched everywhere to use the new names.
 - Also, ItemSourceID.SortingWithNoSpace has been removed.
 - TileLoader.IsTileDangerous (and other methods?) now takes `Main.SceneMetrics.PerspectivePlayer` as input, not necessarily the LocalPlayer. I think this means dangersense should work when spectating. Need docs updates.


### PR DESCRIPTION
## Summary
This PR completes the porting note task to update the achievement identifiers on the [Vanilla Content IDs wiki page](https://github.com/tModLoader/tModLoader/wiki/Vanilla-Content-IDs#achievement-identifiers).

## Wiki Changes
Added 22 new achievement identifiers from the Terraria 1.4.5 source code to the main achievement list:
- BOOK_WORM
- BOULDER_LORD
- QUEEN_MACHINE
- ROLLIN_IN_YOUR_GRAVE
- FEAR_THE_SUN
- ITS_SHALING_OUTSIDE
- EXTRA_LIFE
- GRAVE_MISTAKE
- SPICY_LICKS
- ORGANIZED_CHAOS
- ON_FLEEK
- FORTUNE_FAVORS_THE_BOULD
- TRAINING_DAY
- MINI_ME
- TERRARIST
- NEW_DIGS
- MY_PEOPLE_NEED_ME
- GOING_OLDSCHOOL
- SEA_YOU_LATER
- TRASH_COMPACTOR
- CONSERVATIONIST
- INTERDIMENSIONAL_RECYCLING

These identifiers were extracted from `src/TerrariaNetCore/Terraria/Initializers/AchievementInitializer.cs` in the 1.4.5 branch.

## Removed Porting Note
Removed the completed line from `PortingNotes_1.4.5.md`:
> Update https://github.com/tModLoader/tModLoader/wiki/Vanilla-Content-IDs#achievement-identifiers with new achievements

## Verification
- All 137 vanilla achievements from the 1.4.5 source code are now listed in the wiki page.
- No made-up or guessed identifiers — all names trace directly back to the `new Achievement("...")` calls in the source.
- No source code files were modified (only the single line deletion in PortingNotes).

### AI Assistance
- Note: I used OpenCode with GLM 5.1 and Kimi K2.6 to help with this change.  