### PR TITLE
fix: Resolve full solution builds failing on first runs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ solutions/**/*.tar.gz
 /artifacts
 solutions/tModLoader v*
 solutions/Release/
-**/msbuild.binlog
+**/*.binlog
 /steam_build

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -22,9 +22,9 @@
 
 	<PropertyGroup>
 		<!-- Legacy property name for tMLSteamPath -->
-		<TerrariaSteamPath>$(MSBuildThisFileDirectory)</TerrariaSteamPath>
-		<tMLSteamPath>$(MSBuildThisFileDirectory)</tMLSteamPath>
-		<tMLLibraryPath>$(tMLSteamPath)Libraries</tMLLibraryPath>
+		<TerrariaSteamPath Condition="'$(TerrariaSteamPath)' == ''">$(MSBuildThisFileDirectory)</TerrariaSteamPath>
+		<tMLSteamPath Condition="'$(tMLSteamPath)' == ''">$(MSBuildThisFileDirectory)</tMLSteamPath>
+		<tMLLibraryPath Condition="'$(tMLLibraryPath)' == ''">$(tMLSteamPath)Libraries</tMLLibraryPath>
 		<tMLName>tModLoader</tMLName>
 		<tMLPath>$(tMLName).dll</tMLPath>
 		<tMLServerPath>$(tMLPath) -server</tMLServerPath>

--- a/patches/tModLoader/Terraria/release_extras/tMLMod.targets
+++ b/patches/tModLoader/Terraria/release_extras/tMLMod.targets
@@ -21,10 +21,12 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<!-- Legacy property name for tMLSteamPath -->
-		<TerrariaSteamPath Condition="'$(TerrariaSteamPath)' == ''">$(MSBuildThisFileDirectory)</TerrariaSteamPath>
-		<tMLSteamPath Condition="'$(tMLSteamPath)' == ''">$(MSBuildThisFileDirectory)</tMLSteamPath>
-		<tMLLibraryPath Condition="'$(tMLLibraryPath)' == ''">$(tMLSteamPath)Libraries</tMLLibraryPath>
+		<!-- GetDirectoryName is used to get a path without a trailing slash. -->
+		<TerrariaSteamPath Condition="'$(TerrariaSteamPath)' == ''">$([System.IO.Path]::GetDirectoryName('$(MSBuildThisFileDirectory)'))</TerrariaSteamPath>
+		<tModLoaderSteamPath Condition="'$(tModLoaderSteamPath)' == ''">$([System.IO.Path]::GetDirectoryName('$(MSBuildThisFileDirectory)'))</tModLoaderSteamPath>
+		<tMLLibraryPath>$(tModLoaderSteamPath)/Libraries</tMLLibraryPath>
+		<!-- tMLSteamPath property is obsolete, switch to tModLoaderSteamPath. Note the lack of trailing slash. -->
+		<tMLSteamPath>$(tModLoaderSteamPath)/</tMLSteamPath>
 		<tMLName>tModLoader</tMLName>
 		<tMLPath>$(tMLName).dll</tMLPath>
 		<tMLServerPath>$(tMLPath) -server</tMLServerPath>
@@ -59,9 +61,9 @@
 		<BuildLaunch>$(DotNetName)</BuildLaunch>
 		<BuildArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</BuildArch>
 		<BuildEnvVars Condition="'$(OS)' == 'Windows_NT'"></BuildEnvVars>
-		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' != 'Arm64'">LD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/Linux</BuildEnvVars>
-		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' == 'Arm64'">LD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/Linux-arm64</BuildEnvVars>
-		<BuildEnvVars Condition="'$(OS)' == 'OSX'">DYLD_LIBRARY_PATH=$(tMLSteamPath)Libraries/Native/OSX</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' != 'Arm64'">LD_LIBRARY_PATH=$(tModLoaderSteamPath)/Libraries/Native/Linux</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'Unix' AND '$(BuildArch)' == 'Arm64'">LD_LIBRARY_PATH=$(tModLoaderSteamPath)/Libraries/Native/Linux-arm64</BuildEnvVars>
+		<BuildEnvVars Condition="'$(OS)' == 'OSX'">DYLD_LIBRARY_PATH=$(tModLoaderSteamPath)/Libraries/Native/OSX</BuildEnvVars>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(BuildMod)' == 'true'">
@@ -75,7 +77,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="$(tMLSteamPath)$(tMLPath)" Private="$(OutputTmlReferences)" />
+		<Reference Include="$(tModLoaderSteamPath)/$(tMLPath)" Private="$(OutputTmlReferences)" />
 		<Reference Include="$(tMLLibraryPath)/**/*.dll" Private="$(OutputTmlReferences)" />
 		<Reference Remove="$(tMLLibraryPath)/Native/**" />
 		<Reference Remove="$(tMLLibraryPath)/**/runtime*/**" />
@@ -98,7 +100,7 @@
 	<Target Name="BuildMod" AfterTargets="Build" Condition="'$(BuildMod)' == 'true'">
 		<Exec
 			Command="$(BuildLaunch) $(tMLServerPath) -build $(ProjectDir) -eac $(TargetPath) -define &quot;$(DefineConstants)&quot; -unsafe $(AllowUnsafeBlocks) $(ExtraBuildModFlags)"
-			WorkingDirectory="$(tMLSteamPath)"
+			WorkingDirectory="$(tModLoaderSteamPath)"
 			EnvironmentVariables="$(BuildEnvVars)"
 		/>
 	</Target>

--- a/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
+++ b/tModCodeAssist/tModCodeAssist.Tests/tModCodeAssist.Tests.csproj
@@ -4,8 +4,7 @@
     <OutputTmlReferences>true</OutputTmlReferences>
   </PropertyGroup>
 
-  <Import Project="../../src/WorkspaceInfo.targets" />
-  <Import Project="$(tModLoaderSteamPath)/tMLMod.targets" />
+  <Import Project="../../tModLoader.targets" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/tModLoader.sln
+++ b/tModLoader.sln
@@ -10,6 +10,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FNA.Core", "FNA\FNA.Core.csproj", "{1EED6B32-5FC7-41A8-91C3-08147C46DD4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleMod", "ExampleMod\ExampleMod.csproj", "{F646F0CE-2C51-4610-B097-F16FB58CECC5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4EFE2B31-D61A-4C07-BAD2-991D3633C237} = {4EFE2B31-D61A-4C07-BAD2-991D3633C237}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "tModPorter", "tModPorter\tModPorter\tModPorter.csproj", "{2667C978-80E3-4D97-9F64-E519BA578BC1}"
 EndProject

--- a/tModLoader.targets
+++ b/tModLoader.targets
@@ -1,19 +1,15 @@
 <!-- This is a special targets file that is only to be used by TML's own project files, such as ExampleMod. -->
+<!-- It replaces the one found in ModSources, avoiding reliance on the TML output folder and the problems that come with that. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Set game paths from WorkspaceInfo.targets and avoid having them overwritten by tMLMod.targets. -->
   <Import Project="src/WorkspaceInfo.targets" />
-  <PropertyGroup>
-		<tMLSteamPath>$(tModLoaderSteamPath)/</tMLSteamPath>
-		<tMLLibraryPath>$(tMLSteamPath)Libraries</tMLLibraryPath>
-  </PropertyGroup>  
-  <!-- Import targets from src, do not use the destination folder in order to not create an eval-build dependency cycle. -->
   <Import Project="src/tModLoader/Terraria/release_extras/tMLMod.targets" />  
 
   <ItemGroup>
-    <!-- unfortunately VS Goto Defintion doesn't work on pdb source paths, only direct project references -->
-    <Reference Remove="$(tMLSteamPath)**/FNA.dll"/>
-    <Reference Remove="$(tMLSteamPath)**/ReLogic.dll"/>
-    <Reference Remove="$(tMLSteamPath)**/tModLoader.dll"/>
+    <!-- Unfortunately VS Goto Definition doesn't work on PDB source paths, only direct project references. -->
+    <Reference Remove="$(tModLoaderSteamPath)/**/FNA.dll"/>
+    <Reference Remove="$(tModLoaderSteamPath)/**/ReLogic.dll"/>
+    <Reference Remove="$(tModLoaderSteamPath)/**/tModLoader.dll"/>
     <ProjectReference Include="$(MSBuildThisFileDirectory)FNA/FNA.Core.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)src/tModLoader/ReLogic/ReLogic.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)src/tModLoader/Terraria/Terraria.csproj" />

--- a/tModLoader.targets
+++ b/tModLoader.targets
@@ -1,8 +1,14 @@
+<!-- This is a special targets file that is only to be used by TML's own project files, such as ExampleMod. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- special targets file for ExampleMod. Fits in place of the one in /Mod Sources -->  
+  <!-- Set game paths from WorkspaceInfo.targets and avoid having them overwritten by tMLMod.targets. -->
   <Import Project="src/WorkspaceInfo.targets" />
-  <Import Project="$(tModLoaderSteamPath)/tMLMod.targets" />
-  
+  <PropertyGroup>
+		<tMLSteamPath>$(tModLoaderSteamPath)/</tMLSteamPath>
+		<tMLLibraryPath>$(tMLSteamPath)Libraries</tMLLibraryPath>
+  </PropertyGroup>  
+  <!-- Import targets from src, do not use the destination folder in order to not create an eval-build dependency cycle. -->
+  <Import Project="src/tModLoader/Terraria/release_extras/tMLMod.targets" />  
+
   <ItemGroup>
     <!-- unfortunately VS Goto Defintion doesn't work on pdb source paths, only direct project references -->
     <Reference Remove="$(tMLSteamPath)**/FNA.dll"/>


### PR DESCRIPTION
This slightly hacky patch fixes the following type of compilation error that can be encountered by simply wiping the destination folder and running `dotnet build tModLoader.sln`:
<img width="1552" height="251" alt="image" src="https://github.com/user-attachments/assets/53d7c23d-9681-4a1c-9811-373b204ce729" />
<img width="1916" height="184" alt="image" src="https://github.com/user-attachments/assets/8c30e694-92ce-4b8b-9460-bcd05c4c8569" />

### Changes
- The repo's `/tModLoader.targets` file is updated to evaluate `tMLMod.targets` directly from `src/.../release_targets`, removing the dependency cycle between evaluations and builds. Paths still point to the destination, but that should be fine as they are not fully acted upon before builds. In this process, `tMLMod.targets`'s paths are modified to only be set if they are missing.
- The solution is modified to explicitly build EM after TML. Adding references at a later stage via the means of targets did not work out.

### Alternative approaches
- Since `/tModLoader.targets` already adds project references for TML, ReLogic and FNA, that trend might be able to be continued with it changed to copy all of TML's original references to the child projects that use it. But that would be even more hacky. 