### PR TITLE
[1.4.5] Fix stale ModifyWorldGenTasks cref in ModSystem.cs docs

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModSystem.cs
@@ -417,7 +417,7 @@ public abstract partial class ModSystem : ModType
 	public virtual void ResetNearbyTileEffects() { }
 
 	/// <summary>
-	/// Similar to <see cref="ModifyWorldGenTasks(List{GenPass}, ref double)"/>, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. <para/>
+	/// Similar to <see cref="ModifyWorldGenTasks(List{GenPass})"/>, but occurs in-game when Hardmode starts. Can be used to modify which tasks should be done and/or add custom tasks. <para/>
 	/// By default the list will only contain 5 items, the vanilla hardmode tasks called "Hardmode Good Remix", "Hardmode Good", "Hardmode Evil", "Hardmode Walls", and "Hardmode Announcement". "Hardmode Good Remix" will only be enabled on <see href="https://terraria.wiki.gg/wiki/Don%27t_dig_up">Don't dig up</see> worlds (<see cref="Main.remixWorld"/>) while "Hardmode Good" and "Hardmode Evil" will be enabled otherwise.<para/>
 	/// To disable or hide tasks, please use <see cref="GenPass.Disable"/> and defensive coding.
 	/// </summary>


### PR DESCRIPTION
### What is the bug?

The XML doc comment on `ModSystem.ModifyHardmodeTasks` contains a `<see cref>` that references `ModifyWorldGenTasks(List{GenPass}, ref double)`. During the 1.4.5 port, `ModifyWorldGenTasks` lost its `ref double` progress parameter, so that overload no longer exists. The result is a CS1574 build warning ("XML comment has cref attribute that could not be resolved"), and the doc link doesn't resolve in IDEs.

### How did you fix the bug?

Updated the `cref` to match the current signature — it now reads `cref="ModifyWorldGenTasks(List{GenPass})"`. One-line change in the patch (`patches/tModLoader/Terraria/ModLoader/ModSystem.cs`); no behavior change.

### Are there alternatives to your fix?

The only alternative would be dropping the `<see cref>` for a plain-text reference, but pointing the cref at the real signature is strictly better — it keeps the IDE navigation link and the compiler-checked cross-reference intact.

A couple of notes for your first one here:
- The diff is purely a doc-comment fix in a committed patch file, so there's nothing to build or test for reviewers — that's part of why it's a safe first PR.
- If you'd rather the branch name didn't have the 4- ordinal, say the word and I'll rename it and re-push (it only exists on your fork right now, so that's clean to do before the PR is open).

#### Note 
- I used Claude to help me with this PR. 