### PR TITLE
[1.4.5] tModPorter: remove plr parameter from Player.GetItem

### DIFF
--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -424,6 +424,7 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 * 🤖: `Main.ShouldShowInvisibleWalls` -> `Main.ShouldShowInvisibleBlocksAndWalls`
 * 🤖: `NPC.ShouldBestiaryGirlBeLycantrope` now static.
 * ⚙️: `NPC.SpawnWithHigherTime` removed. No longer used.
+* 🤖: `Player.GetItem` changed. The `plr` parameter has been removed.
 * 🤖: `Player.IsProjectileInteractibleAndInInteractionRange` -> `Player.IsProjectileInteractableAndInInteractionRange`
 * ⚙️: `Player.CheckForGoodTeleportationSpot` removed. Use `Utils.CheckForGoodTeleportationSpot` instead.
 * 💀: `Player.DropItems` now has a `gemsOnly` parameter indicating a softcore or creative player that should only drop large gems.

--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -206,7 +206,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 
 - TileID.Sets.WallsMergeWith usages in Framing.WallFrame changed to newly added TileID.Sets.TruncatesWalls (TODO: New set contains several new vanilla tiles, does that make sense? tModPorter?)
 - ItemVariants.EverythingWorld renamed to MechdusaWorld
-- Player.GetItem no longer has plr parameter
 - Main.GameModeInfo.IsJourneyMode -> Main.IsJourneyMode
 - Item.SetDefaults() -> Item.SetDefaults(0)
 - Item.SetDefaults(int, bool) -> Item.SetDefaults(int)

--- a/tModPorter/tModPorter.Tests/TestData/RemoveParameterTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RemoveParameterTest.Expected.cs
@@ -12,5 +12,10 @@ public class RemoveParameterTest
 		item.SetDefaults(5, variant: null);
 		item.SetDefaults(6);
 		item.SetDefaults(7, variant: null);
+
+		Player player = Main.LocalPlayer;
+		player.GetItem(item, GetItemSettings.PickupItemFromWorld);
+		player.GetItem(item, GetItemSettings.PickupItemFromWorld);
+		player.GetItem(newItem: item, settings: GetItemSettings.PickupItemFromWorld);
 	}
 }

--- a/tModPorter/tModPorter.Tests/TestData/RemoveParameterTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/RemoveParameterTest.cs
@@ -12,5 +12,10 @@ public class RemoveParameterTest
 		item.SetDefaults(5, variant: null, noMatCheck: false);
 		item.SetDefaults(6, Main.rand.NextBool() ? false : true);
 		item.SetDefaults(7, variant: null, noMatCheck: Main.rand.NextBool() ? false : true);
+
+		Player player = Main.LocalPlayer;
+		player.GetItem(0, item, GetItemSettings.PickupItemFromWorld);
+		player.GetItem(Main.myPlayer, item, GetItemSettings.PickupItemFromWorld);
+		player.GetItem(plr: 0, newItem: item, settings: GetItemSettings.PickupItemFromWorld);
 	}
 }

--- a/tModPorter/tModPorter/Config.Terraria.cs
+++ b/tModPorter/tModPorter/Config.Terraria.cs
@@ -369,6 +369,7 @@ public static partial class Config
 		RefactorStaticMethodCall("Terraria.RecipeGroup", "RegisterGroup", Removed("Replace this and \"new RecipeGroup()\" with RecipeGroup.Register"));
 
 		RefactorInstanceMethodCall("Terraria.Item", "SetDefaults", RemoveParameter(1, "noMatCheck", "bool"));
+		RefactorInstanceMethodCall("Terraria.Player", "GetItem", RemoveParameter(0, "plr", "int"));
 		RefactorInstanceMethodCall("Terraria.Tile", "water", GetterSetterToProperty("LiquidType", "Terraria.ID.LiquidID", "Water"));
 		RefactorInstanceMethodCall("Terraria.Tile", "anyWater", GetterToProperty("HasWater"));
 		RefactorInstanceMethodCall("Terraria.Tile", "anyLava", GetterToProperty("HasLava"));


### PR DESCRIPTION
### What is the bug?

`Player.GetItem` changed signature in the 1.4.5 port: the leading `int plr` parameter was removed. It went from

```cs
Item GetItem(int plr, Item newItem, GetItemSettings settings)   // 1.4.4
```

to

```cs
Item GetItem(Item newItem, GetItemSettings settings)            // 1.4.5
Item GetItem(WorldItem newItem, GetItemSettings settings)       // 1.4.5
```

Mod code calling the old 3-argument form doesn't compile against 1.4.5, and tModPorter didn't rewrite it automatically. This is the open `# tModPorter TODOs` item in `PortingNotes_1.4.5.md`: "Player.GetItem no longer has plr parameter".

### How did you fix the bug?

Added a tModPorter rule mirroring the existing `Item.SetDefaults(noMatCheck)` removal:

```cs
RefactorInstanceMethodCall("Terraria.Player", "GetItem", RemoveParameter(0, "plr", "int"));
```

This drops the first argument from `Player.GetItem(...)` calls when it's an `int` (or a named `plr:` argument), so `player.GetItem(plr, item, settings)` becomes `player.GetItem(item, settings)`. The rule is scoped to `Terraria.Player.GetItem` and only removes an `int`/`plr:` first argument, so already-updated calls (whose first argument is an `Item`/`WorldItem`) are left untouched, and it's idempotent.

Also:
- Added test coverage to `RemoveParameterTest.cs` / `.Expected.cs` (a positional literal `int`, a non-literal `int` `Main.myPlayer`, and a named `plr:` argument).
- Documented the change for modders in `MigrationGuide_1.4.5.md` (🤖).
- Checked the item off the `# tModPorter TODOs` list in `PortingNotes_1.4.5.md`.

Verified locally with `dotnet test tModPorter/tModPorter.Tests` — the `RemoveParameter` transform test and the `ExpectedModCompiles` test both pass (the expected output compiles against the 1.4.5 API).

### Are there alternatives to your fix?

- Match the parameter purely by name (`plr:`) rather than also by positional `int` index — but that would miss the common positional call style, so matching both (as the existing `SetDefaults` rule does) is better.
- Leave it to modders to fix manually — but tModPorter exists specifically to automate these mechanical signature changes.

#### Note
- I used Claude to help with this PR.
