### PR TITLE
Fixes to hardmode world generation (1.4.5)

### DIFF
--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -960,11 +960,11 @@
 +		hardmodeTasks.Add(HardmodeEvilPass);
 +
 +		// Main.remixWorld and dualDungeonsSeed checks removed from Pass code, we want all passes present in the list no matter what and disable those that don't apply for consistency with other tModLoader approaches and modder expectations. #3606 discussion
-+		if (Main.remixWorld || flag) {
++		if (Main.remixWorld || !flag) {
 +			HardmodeGoodPass.Disable();
 +			HardmodeEvilPass.Disable();
 +		}
-+		else if (!Main.remixWorld || flag) {
++		if (!Main.remixWorld || !flag) {
 +			HardmodeGoodRemixPass.Disable();
 +		}
 +


### PR DESCRIPTION
### What is the bug?

Currently, hardmode world generation is bugged due to incorrect conditions being placed on when certain hardmode worldgen tasks are dis/enabled.

Currently, the game generates: 
* remix hardmode worldgen in normal worlds and remix worlds
* normal hardmode worldgen in normal dual dungeon seeds 
* no hardmode worldgen in remix dual dungeon seeds

This PR fixes this condition to better reflect how vanilla conditions it's hardmode worldgen.

Before the fix:
<img width="1641" height="453" alt="Screenshot 2026-06-13 195331" src="https://github.com/user-attachments/assets/0965283e-ac06-42c9-aa80-22f328cbb642" />

After the fix:
<img width="2274" height="610" alt="image" src="https://github.com/user-attachments/assets/2731f614-d48c-4993-a212-fc94687978f1" />


### How did you fix the bug?

Changing conditions within WorldGen.initializeHardMode() where the hardmode tasks are disabled.

### Are there alternatives to your fix?

This is currently the easiest fix for this bug.