### PR TITLE
fix: Fix Dockerfile to work with i386 and x64 glibc

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
@@ -1,23 +1,21 @@
 FROM ubuntu:22.04 as builder
 
-# Update and install the libc requirement that Alpine does not support
 ARG DEBIAN_FRONTEND=noninteractive
 RUN dpkg --add-architecture i386 \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends libc6:i386 \
  && rm -rf /var/lib/apt/lists/*
 
-FROM alpine:3.20
+FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        bash curl nano file libgcc-s1 libstdc++6 \
+        libicu70 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# TODO try to get gcompat working
-RUN apk update \
-    && apk add --no-cache bash curl nano file libgcc libstdc++ icu-libs \
-    # && echo "x86" > /etc/apk/arch \
-    # && apk add --no-cache gcompat \
-    # && echo "x86_64" > /etc/apk/arch \
-    && rm -rf /var/cache/apk/*
-
-# Copy the required libc files since gcompat does not work with steamcmd
+# Copy i386 libs from builder (for steamcmd)
 COPY --from=builder \
     /lib/i386-linux-gnu/ld-linux.so.2 \
     /lib/i386-linux-gnu/libc.so.6 \
@@ -25,7 +23,10 @@ COPY --from=builder \
     /lib/i386-linux-gnu/libm.so.6 \
     /lib/i386-linux-gnu/libpthread.so.0 \
     /lib/i386-linux-gnu/librt.so.1 \
-    /lib/
+    /lib/i386-linux-gnu/
+
+RUN mkdir -p /lib/i386-linux-gnu \
+    && ln -sf /lib/i386-linux-gnu/ld-linux.so.2 /lib/ld-linux.so.2
 
 # TODO: Currently it is too arduous to allow UID/GID to be set at runtime via ENV variables for a few reasons
 # 1) The entrypoint would need to run as root because of root requirements for usermod and groupmod
@@ -40,8 +41,8 @@ ARG TMLVERSION
 
 # Create tModLoader user and drop root permissions
 # BusyBox uses an old adduser without the --user-group option so create a group first
-RUN addgroup -g $GID tml \
-    && adduser -D --home /home/tml -u $UID -G tml tml
+RUN groupadd -g $GID tml \
+    && useradd -m -d /home/tml -u $UID -g tml tml
 
 USER tml
 ENV HOME /home/tml

--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh
@@ -368,8 +368,8 @@ case $cmd in
 			mkdir -p "$folder/Mods" "$folder/Worlds"
 			install_workshop_mods
 
-			cat "dotnet installed via management script... pending first server start..." >> "$HOME/server/tModLoader-Logs/server.log"
-			cd "$HOME/server" || exit
+			echo "dotnet installed via management script... pending first server start..." >> "$HOME/server/tModLoader-Logs/server.log"
+			cd "$folder/server" || exit
 		elif ! [[ -f "$folder/server/LaunchUtils/ScriptCaller.sh" ]]; then
 			echo "A tModLoader server is not installed yet, please run the install or install-tml command before starting a server"
 			exit 1


### PR DESCRIPTION
### What is the bug?
2 issues.
1. patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh had invalid syntax and an invalid path that was preventing it from properly changing directory before trying to run ./LaunchUtils/ScriptCaller.sh
2. The Dockerfile was not bringing in the correct libraries to allow dotnet to run. 

### How did you fix the bug?
1. Changed the cat to an echo so it saves the string properly and fixed the cd to use $folder instead of $HOME
2.
#### Switched final stage from Alpine to Ubuntu 22.04
Alpine uses musl libc instead of glibc. The dotnet runtime bundled with tModLoader is compiled against glibc, making it fundamentally incompatible with Alpine. Rather than manually copying glibc files in (which was the original approach for steamcmd), switching to Ubuntu gives both dotnet and steamcmd a native, fully compatible libc environment.
#### Added libc6:i386 and i386 lib copying for steamcmd
steamcmd is a 32-bit binary, so it needs 32-bit (i386) glibc libs alongside the 64-bit ones. The builder stage installs these and they get copied into the final image, along with a symlink at /lib/ld-linux.so.2 so the 32-bit dynamic linker is found at the path the binary expects.
#### Added libicu70, libstdc++6, libgcc-s1, ca-certificates
These are runtime dependencies of dotnet that aren't included in a minimal Ubuntu image.
#### Replaced addgroup/adduser with groupadd/useradd
The original commands used BusyBox/Alpine syntax. Ubuntu ships the full shadow-utils versions which use different flags (-D doesn't exist, -g is ambiguous, etc.).

This does make the final docker image larger, but it's not much different than copying all the needed library files manually and it prevents the glibc version incompatibility between ubuntu and alpine.

### Are there alternatives to your fix?
Yes quite a few.

#### Keep Alpine, use gcompat
The Dockerfile even has this commented out with a TODO. gcompat is an Alpine package that provides a glibc compatibility layer over musl. It was abandoned because it doesn't work with steamcmd, but it might have worked for dotnet alone. The problem is you need both to work, so you'd still need the manual i386 lib copying for steamcmd anyway.
#### Keep Alpine, copy all glibc libs manually
The original approach, extend it to also copy the 64-bit glibc libs from the builder. This is what I attempted first and got to exit code 139 (segfault). The root cause was linker/libc version mismatch when mixing Ubuntu's glibc with Alpine's linker. It's theoretically possible to get this working by also copying the linker itself and patching the ELF interpreter path with patchelf, but it's fragile and complex.
#### Use Debian slim as the final stage
A middle ground between Alpine (tiny, incompatible) and full Ubuntu (large, compatible). Debian slim is glibc-based like Ubuntu but smaller. Since the builder is already Ubuntu 22.04, using Debian bookworm could introduce subtle glibc version differences, so Ubuntu was the safer match.
#### Use the official steamcmd Docker image as the base
cm2network/steamcmd is a community image that already has steamcmd installed with all its 32-bit dependencies sorted. You could use it as the base and only worry about the dotnet/tModLoader layer on top. The downside is depending on a third-party base image you don't control.
#### Patch the dotnet binary with patchelf
patchelf can rewrite the ELF interpreter path and rpath in a binary, which would let you tell dotnet to use whatever linker path you have available. Very low-level and brittle, any tModLoader update would require repatching.