### PR TITLE
feat: shared lighting buffer acquisition api

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Light/ILightingEngine.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/ILightingEngine.TML.cs
@@ -1,0 +1,6 @@
+﻿namespace Terraria.Graphics.Light;
+
+partial interface ILightingEngine
+{
+	LightMapBuffer GetBufferTexture();
+}

--- a/patches/tModLoader/Terraria/Graphics/Light/ILightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/ILightingEngine.cs.patch
@@ -1,0 +1,11 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Light/ILightingEngine.cs
++++ src/tModLoader/Terraria/Graphics/Light/ILightingEngine.cs
+@@ -2,7 +_,7 @@
+ 
+ namespace Terraria.Graphics.Light;
+ 
+-public interface ILightingEngine
++public partial interface ILightingEngine
+ {
+ 	void Rebuild();
+ 

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
@@ -4,6 +4,6 @@ partial class LegacyLighting
 {
 	public LightMapBuffer GetBufferTexture()
 	{
-		return _lightMap.GetBufferTexture();
+		return exposedLightMap.GetBufferTexture();
 	}
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Graphics.Light;
+
+partial class LegacyLighting
+{
+	public LightMapBuffer GetBufferTexture()
+	{
+		return LightMapBuffer.FromLightMap(_lightMap);
+	}
+}

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.TML.cs
@@ -4,6 +4,6 @@ partial class LegacyLighting
 {
 	public LightMapBuffer GetBufferTexture()
 	{
-		return LightMapBuffer.FromLightMap(_lightMap);
+		return _lightMap.GetBufferTexture();
 	}
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -24,6 +24,16 @@
  		if (x < _expandedRectLeft || x >= _expandedRectRight || y < _expandedRectTop || y >= _expandedRectBottom)
  			return Vector3.Zero;
  
+@@ -276,6 +_,9 @@
+ 			PreRenderPhase();
+ 
+ 		_lastCameraPosition = Main.Camera.UnscaledPosition;
++
++		// TML: Mark light map as dirty to prompt buffer regenration.
++		_lightMap.MarkDirty();
+ 	}
+ 
+ 	private void TryUpdatingMapWithLight()
 @@ -581,6 +_,7 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -14,7 +14,7 @@
  {
  	public struct RectArea
  	{
-@@ -133,6 +_,21 @@
+@@ -133,6 +_,11 @@
  	private static FastRandom _swipeRandom = FastRandom.CreateWithRandomSeed();
  	private LightMap _lightMap = new LightMap();
  
@@ -22,16 +22,6 @@
 +	// lighting and mask data.  This new light map contains a copy of the data
 +	// in _states so it can be used with the LightMapBuffer API.
 +	private LightMap exposedLightMap = new();
-+	private int cachedExpandedLeft;
-+	private int cachedExpandedTop;
-+
-+	private void UpdateLightMap(int x, int y, Vector3 color)
-+	{
-+		// x += (_expandedRectLeft - cachedExpandedLeft);
-+		// y += (_expandedRectTop - cachedExpandedTop);
-+
-+		exposedLightMap[x, y] = color;
-+	}
 +
  	public int Mode { get; set; }
  
@@ -57,14 +47,13 @@
  		if (_states != null && _states.Length >= num && _states[0].Length >= num2)
  			return;
  
-@@ -276,6 +_,10 @@
+@@ -276,6 +_,9 @@
  			PreRenderPhase();
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty.
 +		exposedLightMap.MarkDirty();
-+		Main.NewText($"{_expandedRectLeft - cachedExpandedLeft} {_expandedRectTop - cachedExpandedTop}");
  	}
  
  	private void TryUpdatingMapWithLight()
@@ -74,7 +63,7 @@
  				}
 +
 +				// TML: LightMapBuffer state maintenance.
-+				UpdateLightMap(i - _expandedRectLeft, j - _expandedRectTop, lightingState.ToVector3());
++				exposedLightMap[i - _expandedRectLeft, j - _expandedRectTop] = lightingState.ToVector3();
  			}
  		}
  	}
@@ -84,7 +73,7 @@
  				obj.B = lightingState.B;
 +
 +				// TML: LightMapBuffer state maintenace.
-+				UpdateLightMap(i, j, obj.ToVector3());
++				exposedLightMap[i, j] = obj.ToVector3();
  			}
  		}
  	}
@@ -94,7 +83,7 @@
  					obj.B = lightingState.B2;
 +
 +					// TML: LightMapBuffer state maintenance.
-+					UpdateLightMap(i, j, obj.ToVector3());
++					exposedLightMap[i, j] = obj.ToVector3();
  				}
  			}
  
@@ -104,7 +93,7 @@
  				obj2.B = lightingState2.R2;
 +
 +				// TML: LightMapBuffer state maintenance.
-+				UpdateLightMap(k, l, obj2.ToVector3());
++				exposedLightMap[k, l] = obj2.ToVector3();
  			}
  		}
  	}
@@ -118,7 +107,7 @@
  	}
  
  	private void PreRenderPhase()
-@@ -581,13 +_,19 @@
+@@ -581,13 +_,17 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);
  		Main.UpdateSceneMetrics();
@@ -128,8 +117,6 @@
  			DrawInvisibleWalls = Main.ShouldShowInvisibleBlocksAndWalls()
  		});
 +		// TML: Mark light map as dirty and update area.
-+		cachedExpandedLeft = _expandedRectLeft;
-+		cachedExpandedTop = _expandedRectTop;
 +		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  
  		for (int m = num; m < num2; m++) {

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -30,7 +30,7 @@
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty and update area.
-+		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectBottom));
++		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  	}
  
  	private void TryUpdatingMapWithLight()

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -14,6 +14,18 @@
  {
  	public struct RectArea
  	{
+@@ -133,6 +_,11 @@
+ 	private static FastRandom _swipeRandom = FastRandom.CreateWithRandomSeed();
+ 	private LightMap _lightMap = new LightMap();
+ 
++	// TML: _lightMap is used by vanilla to get TileScanner data for basic
++	// lighting and mask data.  This new light map contains a copy of the data
++	// in _states so it can be used with the LightMapBuffer API.
++	private LightMap exposedLightMap = new();
++
+ 	public int Mode { get; set; }
+ 
+ 	public bool IsColorOrWhiteMode => Mode < 2;
 @@ -144,6 +_,9 @@
  
  	public Vector3 GetColor(int x, int y)
@@ -24,16 +36,77 @@
  		if (x < _expandedRectLeft || x >= _expandedRectRight || y < _expandedRectTop || y >= _expandedRectBottom)
  			return Vector3.Zero;
  
+@@ -165,6 +_,10 @@
+ 		int num = (int)_camera.UnscaledSize.X / 16 + 90 + 10;
+ 		int num2 = (int)_camera.UnscaledSize.Y / 16 + 90 + 10;
+ 		_lightMap.SetSize(num, num2);
++
++		// TML: LightMapBuffer state maintenance.
++		exposedLightMap.SetSize(num, num2);
++
+ 		if (_states != null && _states.Length >= num && _states[0].Length >= num2)
+ 			return;
+ 
 @@ -276,6 +_,9 @@
  			PreRenderPhase();
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty.
-+		_lightMap.MarkDirty();
++		exposedLightMap.MarkDirty();
  	}
  
  	private void TryUpdatingMapWithLight()
+@@ -362,6 +_,9 @@
+ 					if (lightingState.B < _skyColor)
+ 						lightingState.B = tileB;
+ 				}
++
++				// TML: LightMapBuffer state maintenance.
++				exposedLightMap[i - _expandedRectLeft, j - _expandedRectTop] = lightingState.ToVector3();
+ 			}
+ 		}
+ 	}
+@@ -420,6 +_,9 @@
+ 				obj.R = lightingState.R;
+ 				obj.G = lightingState.G;
+ 				obj.B = lightingState.B;
++
++				// TML: LightMapBuffer state maintenace.
++				exposedLightMap[i, j] = obj.ToVector3();
+ 			}
+ 		}
+ 	}
+@@ -467,6 +_,9 @@
+ 					obj.R = lightingState.R2;
+ 					obj.G = lightingState.G2;
+ 					obj.B = lightingState.B2;
++
++					// TML: LightMapBuffer state maintenance.
++					exposedLightMap[i, j] = obj.ToVector3();
+ 				}
+ 			}
+ 
+@@ -490,6 +_,9 @@
+ 				obj2.R = lightingState2.R2;
+ 				obj2.G = lightingState2.R2;
+ 				obj2.B = lightingState2.R2;
++
++				// TML: LightMapBuffer state maintenance.
++				exposedLightMap[k, l] = obj2.ToVector3();
+ 			}
+ 		}
+ 	}
+@@ -513,6 +_,9 @@
+ 				}
+ 			}
+ 		}
++
++		// TML: LightMapBuffer state maintenance.
++		exposedLightMap.Clear();
+ 	}
+ 
+ 	private void PreRenderPhase()
 @@ -581,13 +_,17 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);
@@ -44,7 +117,7 @@
  			DrawInvisibleWalls = Main.ShouldShowInvisibleBlocksAndWalls()
  		});
 +		// TML: Mark light map as dirty and update area.
-+		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
++		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  
  		for (int m = num; m < num2; m++) {
  			LightingState[] array3 = _states[m - _expandedRectLeft];

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -52,8 +52,8 @@
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
-+		// TML: Mark light map as dirty.
-+		exposedLightMap.MarkDirty();
++		// TML: Mark light map as dirty and update area.
++		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  	}
  
  	private void TryUpdatingMapWithLight()
@@ -107,7 +107,7 @@
  	}
  
  	private void PreRenderPhase()
-@@ -581,13 +_,17 @@
+@@ -581,6 +_,7 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);
  		Main.UpdateSceneMetrics();
@@ -115,9 +115,7 @@
  		_tileScanner.Update();
  		_tileScanner.ExportTo(new Rectangle(num, num3, num2 - num, num4 - num3), _lightMap, new TileLightScannerOptions {
  			DrawInvisibleWalls = Main.ShouldShowInvisibleBlocksAndWalls()
- 		});
-+		// TML: Mark light map as dirty and update area.
-+		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
+@@ -588,6 +_,7 @@
  
  		for (int m = num; m < num2; m++) {
  			LightingState[] array3 = _states[m - _expandedRectLeft];

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -14,7 +14,7 @@
  {
  	public struct RectArea
  	{
-@@ -133,6 +_,11 @@
+@@ -133,6 +_,21 @@
  	private static FastRandom _swipeRandom = FastRandom.CreateWithRandomSeed();
  	private LightMap _lightMap = new LightMap();
  
@@ -22,6 +22,16 @@
 +	// lighting and mask data.  This new light map contains a copy of the data
 +	// in _states so it can be used with the LightMapBuffer API.
 +	private LightMap exposedLightMap = new();
++	private int cachedExpandedLeft;
++	private int cachedExpandedTop;
++
++	private void UpdateLightMap(int x, int y, Vector3 color)
++	{
++		// x += (_expandedRectLeft - cachedExpandedLeft);
++		// y += (_expandedRectTop - cachedExpandedTop);
++
++		exposedLightMap[x, y] = color;
++	}
 +
  	public int Mode { get; set; }
  
@@ -47,13 +57,14 @@
  		if (_states != null && _states.Length >= num && _states[0].Length >= num2)
  			return;
  
-@@ -276,6 +_,9 @@
+@@ -276,6 +_,10 @@
  			PreRenderPhase();
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty.
 +		exposedLightMap.MarkDirty();
++		Main.NewText($"{_expandedRectLeft - cachedExpandedLeft} {_expandedRectTop - cachedExpandedTop}");
  	}
  
  	private void TryUpdatingMapWithLight()
@@ -63,7 +74,7 @@
  				}
 +
 +				// TML: LightMapBuffer state maintenance.
-+				exposedLightMap[i - _expandedRectLeft, j - _expandedRectTop] = lightingState.ToVector3();
++				UpdateLightMap(i - _expandedRectLeft, j - _expandedRectTop, lightingState.ToVector3());
  			}
  		}
  	}
@@ -73,7 +84,7 @@
  				obj.B = lightingState.B;
 +
 +				// TML: LightMapBuffer state maintenace.
-+				exposedLightMap[i, j] = obj.ToVector3();
++				UpdateLightMap(i, j, obj.ToVector3());
  			}
  		}
  	}
@@ -83,7 +94,7 @@
  					obj.B = lightingState.B2;
 +
 +					// TML: LightMapBuffer state maintenance.
-+					exposedLightMap[i, j] = obj.ToVector3();
++					UpdateLightMap(i, j, obj.ToVector3());
  				}
  			}
  
@@ -93,7 +104,7 @@
  				obj2.B = lightingState2.R2;
 +
 +				// TML: LightMapBuffer state maintenance.
-+				exposedLightMap[k, l] = obj2.ToVector3();
++				UpdateLightMap(k, l, obj2.ToVector3());
  			}
  		}
  	}
@@ -107,7 +118,7 @@
  	}
  
  	private void PreRenderPhase()
-@@ -581,13 +_,17 @@
+@@ -581,13 +_,19 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);
  		Main.UpdateSceneMetrics();
@@ -117,6 +128,8 @@
  			DrawInvisibleWalls = Main.ShouldShowInvisibleBlocksAndWalls()
  		});
 +		// TML: Mark light map as dirty and update area.
++		cachedExpandedLeft = _expandedRectLeft;
++		cachedExpandedTop = _expandedRectTop;
 +		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  
  		for (int m = num; m < num2; m++) {

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Light/LegacyLighting.cs
 +++ src/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs
-@@ -4,6 +_,7 @@
+@@ -4,11 +_,12 @@
  using ReLogic.Threading;
  using Terraria.DataStructures;
  using Terraria.Graphics.Capture;
@@ -8,6 +8,12 @@
  using Terraria.Utilities;
  
  namespace Terraria.Graphics.Light;
+ 
+-public class LegacyLighting : ILightingEngine
++public partial class LegacyLighting : ILightingEngine
+ {
+ 	public struct RectArea
+ 	{
 @@ -144,6 +_,9 @@
  
  	public Vector3 GetColor(int x, int y)

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -53,7 +53,7 @@
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty and update area.
-+		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
++		exposedLightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, maxLightArrayX, maxLightArrayY));
  	}
  
  	private void TryUpdatingMapWithLight()

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -30,7 +30,7 @@
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
 +		// TML: Mark light map as dirty and update area.
-+		_lightMap.UpdateArea(area);
++		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectBottom));
  	}
  
  	private void TryUpdatingMapWithLight()

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -29,8 +29,8 @@
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
-+		// TML: Mark light map as dirty to prompt buffer regenration.
-+		_lightMap.MarkDirty();
++		// TML: Mark light map as dirty and update area.
++		_lightMap.UpdateArea(area);
  	}
  
  	private void TryUpdatingMapWithLight()

--- a/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LegacyLighting.cs.patch
@@ -29,12 +29,12 @@
  
  		_lastCameraPosition = Main.Camera.UnscaledPosition;
 +
-+		// TML: Mark light map as dirty and update area.
-+		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
++		// TML: Mark light map as dirty.
++		_lightMap.MarkDirty();
  	}
  
  	private void TryUpdatingMapWithLight()
-@@ -581,6 +_,7 @@
+@@ -581,13 +_,17 @@
  		num3 = Utils.Clamp(_expandedRectTop, 5, Main.maxTilesY - 1);
  		num4 = Utils.Clamp(_expandedRectBottom, 5, Main.maxTilesY - 1);
  		Main.UpdateSceneMetrics();
@@ -42,7 +42,9 @@
  		_tileScanner.Update();
  		_tileScanner.ExportTo(new Rectangle(num, num3, num2 - num, num4 - num3), _lightMap, new TileLightScannerOptions {
  			DrawInvisibleWalls = Main.ShouldShowInvisibleBlocksAndWalls()
-@@ -588,6 +_,7 @@
+ 		});
++		// TML: Mark light map as dirty and update area.
++		_lightMap.UpdateArea(new Rectangle(_expandedRectLeft, _expandedRectTop, _expandedRectRight - _expandedRectLeft, _expandedRectBottom - _expandedRectTop));
  
  		for (int m = num; m < num2; m++) {
  			LightingState[] array3 = _states[m - _expandedRectLeft];

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -1,10 +1,54 @@
-﻿using System.Runtime.CompilerServices;
+﻿#nullable enable
+
+using System.Runtime.CompilerServices;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace Terraria.Graphics.Light;
 
 partial class LightMap
 {
+	private Texture2D? bufferTexture;
+	private bool dirtyBuffer;
+
+	public unsafe LightMapBuffer GetBufferTexture()
+	{
+		var width = Width + 1;
+		var height = Height + 1;
+
+		// TODO
+		var tileArea = new Rectangle(0, 0, width, height);
+
+		if (bufferTexture is null) {
+			bufferTexture = InitBufferTexture(width, height);
+			dirtyBuffer = true;
+		}
+		else if (bufferTexture.Width != width || bufferTexture.Height != height) {
+			bufferTexture?.Dispose();
+			bufferTexture = InitBufferTexture(width, height);
+			dirtyBuffer = true;
+		}
+
+		if (dirtyBuffer) {
+			fixed(Vector4* pColors = &_colors[0]) {
+				bufferTexture.SetDataPointerEXT(0, null, (nint)pColors, width * height * 4);
+			}
+
+			dirtyBuffer = false;
+		}
+
+		return new LightMapBuffer
+		{
+			Texture = bufferTexture,
+			ScreenTileArea = tileArea
+		};
+	}
+
+	private static Texture2D InitBufferTexture(int width, int height)
+	{
+		return new Texture2D(Main.instance.GraphicsDevice, width, height, mipMap: false, format: SurfaceFormat.Vector4);
+	}
+
 	// PERF: If we ever need these to be faster:
 	// private static Vector3 ToVector3(in Vector4 value)
 	//     return *(Vector3*)&value;

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -10,9 +10,18 @@ partial class LightMap
 {
 	private Texture2D? bufferTexture;
 	private bool dirtyBuffer;
+	private Rectangle tileArea;
+	private int tilePadding;
 
 	public void MarkDirty()
 	{
+		dirtyBuffer = true;
+	}
+
+	public void UpdateArea(Rectangle area, int padding)
+	{
+		tileArea = area;
+		tilePadding = padding;
 		dirtyBuffer = true;
 	}
 
@@ -20,9 +29,6 @@ partial class LightMap
 	{
 		var width = Width + 1;
 		var height = Height + 1;
-
-		// TODO
-		var tileArea = new Rectangle(0, 0, width, height);
 
 		if (bufferTexture is null) {
 			bufferTexture = InitBufferTexture(width, height);

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -11,17 +11,15 @@ partial class LightMap
 	private Texture2D? bufferTexture;
 	private bool dirtyBuffer;
 	private Rectangle tileArea;
-	private int tilePadding;
 
 	public void MarkDirty()
 	{
 		dirtyBuffer = true;
 	}
 
-	public void UpdateArea(Rectangle area, int padding)
+	public void UpdateArea(Rectangle area)
 	{
 		tileArea = area;
-		tilePadding = padding;
 		dirtyBuffer = true;
 	}
 
@@ -51,7 +49,7 @@ partial class LightMap
 		return new LightMapBuffer
 		{
 			Texture = bufferTexture,
-			ScreenTileArea = tileArea
+			TileArea = tileArea
 		};
 	}
 

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -11,6 +11,11 @@ partial class LightMap
 	private Texture2D? bufferTexture;
 	private bool dirtyBuffer;
 
+	public void MarkDirty()
+	{
+		dirtyBuffer = true;
+	}
+
 	public unsafe LightMapBuffer GetBufferTexture()
 	{
 		var width = Width + 1;

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -1,0 +1,6 @@
+﻿namespace Terraria.Graphics.Light;
+
+partial class LightMap
+{
+
+}

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -1,6 +1,33 @@
-﻿namespace Terraria.Graphics.Light;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.Xna.Framework;
+
+namespace Terraria.Graphics.Light;
 
 partial class LightMap
 {
+	// PERF: If we ever need these to be faster:
+	// private static Vector3 ToVector3(in Vector4 value)
+	//     return *(Vector3*)&value;
+	//
+	// private static void FromVector3(in Vector3 value, ref Vector4 dst)
+	//   *(Vector3*)&dst = value;
+	//
+	// The reason I don't currently do this is it relies on the memory layout
+	// of Vector3 and Vector4 to be Explicit or Sequential, which it currently
+	// isn't.  (In practice, this would probably work fine on 64-bit machines).
+	//
+	// As it currently stands, I don't notice a massive performance impact, so
+	// the JIT likely handles these cases quite well already.
 
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static Vector3 ToVector3(in Vector4 value)
+	{
+		return new Vector3(value.X, value.Y, value.Z);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static Vector4 FromVector3(in Vector3 value)
+	{
+		return new Vector4(value.X, value.Y, value.Z, 1f);
+	}
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.TML.cs
@@ -40,7 +40,7 @@ partial class LightMap
 
 		if (dirtyBuffer) {
 			fixed(Vector4* pColors = &_colors[0]) {
-				bufferTexture.SetDataPointerEXT(0, null, (nint)pColors, width * height * 4);
+				bufferTexture.SetDataPointerEXT(0, null, (nint)pColors, width * height * sizeof(Vector4));
 			}
 
 			dirtyBuffer = false;

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -9,7 +9,7 @@
 +// from column-major to row-major; see comments below for explanations.
 +public partial class LightMap
  {
-+	// TML: Colors are now stored as a Vector4 array instead of a Vector4 array
++	// TML: Colors are now stored as a Vector4 array instead of a Vector3 array
 +	// with the express purpose of making it easier to write their data to a
 +	// texture.  This may be reverted if FNA ever adds a Vector3 surface
 +	// format.  The alpha channel is always 1.

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -122,7 +122,7 @@
  		Width = width;
  		Height = height;
 +
-+		tileArea = new Rectangle(0, 0, width + 1, height + 1);
++		tileArea = new Rectangle(0, 0, width, height);
 +
 +		if (bufferTexture is not null && (bufferTexture.Width != width || bufferTexture.Height != height)) {
 +			bufferTexture?.Dispose();

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -86,7 +86,7 @@
  	}
  
  	private void BlurLine(int startIndex, int endIndex, int stride)
-@@ -189,13 +_,28 @@
+@@ -189,16 +_,38 @@
  		}
  	}
  
@@ -108,11 +108,21 @@
  		if (width * height > _colors.Length) {
  			_colors = new Vector3[width * height];
  			_mask = new LightMaskMode[width * height];
-+		}
+ 		}
 +		*/
 +		if (neededSize > _colors.Length) {
 +			_colors = new Vector4[neededSize];
 +			_mask = new LightMaskMode[neededSize];
- 		}
++		}
  
  		Width = width;
+ 		Height = height;
++
++		if (bufferTexture is not null && (bufferTexture.Width != width || bufferTexture.Height != height)) {
++			bufferTexture?.Dispose();
++			bufferTexture = null;
++		}
++
++		dirtyBuffer = true;
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -1,5 +1,14 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Light/LightMap.cs
 +++ src/tModLoader/Terraria/Graphics/Light/LightMap.cs
+@@ -4,7 +_,7 @@
+ 
+ namespace Terraria.Graphics.Light;
+ 
+-public class LightMap
++public partial class LightMap
+ {
+ 	private Vector3[] _colors;
+ 	private LightMaskMode[] _mask;
 @@ -193,9 +_,21 @@
  
  	public void SetSize(int width, int height)

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -31,7 +31,7 @@
  		}
  	}
  
-@@ -44,15 +_,18 @@
+@@ -44,15 +_,22 @@
  		LightDecayThroughCrackedBrick = 0.8f;
  		LightDecayThroughWater = new Vector3(0.88f, 0.96f, 1.015f) * 0.91f;
  		LightDecayThroughHoney = new Vector3(0.75f, 0.7f, 0.6f) * 0.91f;
@@ -41,6 +41,10 @@
  		_colors = new Vector3[41209];
  		_mask = new LightMaskMode[41209];
 +		*/
++
++		// Initialized in SetSize.
++		_colors = [];
++		_mask = [];
 +		SetSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
  	}
  

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -1,15 +1,100 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Light/LightMap.cs
 +++ src/tModLoader/Terraria/Graphics/Light/LightMap.cs
-@@ -4,7 +_,7 @@
+@@ -4,9 +_,15 @@
  
  namespace Terraria.Graphics.Light;
  
 -public class LightMap
++// TML: Switched backing color store from Vector3[] to Vector4[], changed store
++// from column-major to row-major; see comments below for explanations.
 +public partial class LightMap
  {
- 	private Vector3[] _colors;
++	// TML: Colors are now stored as a Vector4 array instead of a Vector4 array
++	// with the express purpose of making it easier to write their data to a
++	// texture.  This may be reverted if FNA ever adds a Vector3 surface
++	// format.  The alpha channel is always 1.
+-	private Vector3[] _colors;
++	private Vector4[] _colors;
  	private LightMaskMode[] _mask;
-@@ -193,9 +_,21 @@
+ 	private FastRandom _random = FastRandom.CreateWithRandomSeed();
+ 	private const int DEFAULT_WIDTH = 203;
+@@ -30,10 +_,10 @@
+ 
+ 	public Vector3 this[int x, int y] {
+ 		get {
+-			return _colors[IndexOf(x, y)];
++			return ToVector3(_colors[IndexOf(x, y)]);
+ 		}
+ 		set {
+-			_colors[IndexOf(x, y)] = value;
++			_colors[IndexOf(x, y)] = FromVector3(value);
+ 		}
+ 	}
+ 
+@@ -44,15 +_,18 @@
+ 		LightDecayThroughCrackedBrick = 0.8f;
+ 		LightDecayThroughWater = new Vector3(0.88f, 0.96f, 1.015f) * 0.91f;
+ 		LightDecayThroughHoney = new Vector3(0.75f, 0.7f, 0.6f) * 0.91f;
++		/*
+ 		Width = 203;
+ 		Height = 203;
+ 		_colors = new Vector3[41209];
+ 		_mask = new LightMaskMode[41209];
++		*/
++		SetSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+ 	}
+ 
+ 	public void GetLight(int x, int y, out Vector3 color)
+ 	{
+-		color = _colors[IndexOf(x, y)];
++		color = ToVector3(_colors[IndexOf(x, y)]);
+ 	}
+ 
+ 	public LightMaskMode GetMask(int x, int y) => _mask[IndexOf(x, y)];
+@@ -81,6 +_,7 @@
+ 
+ 	private void BlurPass()
+ 	{
++		/*
+ 		FastParallel.For(0, Width, delegate (int start, int end, object context) {
+ 			for (int j = start; j < end; j++) {
+ 				BlurLine(IndexOf(j, 0), IndexOf(j, Height - 1 - NonVisiblePadding), 1);
+@@ -94,6 +_,26 @@
+ 				BlurLine(IndexOf(Width - 1, i), IndexOf(NonVisiblePadding, i), -Height);
+ 			}
+ 		});
++		*/
++
++		// TML: Because we switch from column-major to row-major (see IndexOf
++		// comments), we also need to change the strides for these BlurLine
++		// operations.  Also increase Width by 1 because the array is
++		// consistently initialized with extra padding.
++		int rowStride = Width + 1;
++		FastParallel.For(0, Width, delegate (int start, int end, object context) {
++			for (int j = start; j < end; j++) {
++				BlurLine(IndexOf(j, 0), IndexOf(j, Height - 1 - NonVisiblePadding), rowStride);
++				BlurLine(IndexOf(j, Height - 1), IndexOf(j, NonVisiblePadding), -rowStride);
++			}
++		});
++
++		FastParallel.For(0, Height, delegate (int start, int end, object context) {
++			for (int i = start; i < end; i++) {
++				BlurLine(IndexOf(0, i), IndexOf(Width - 1 - NonVisiblePadding, i), 1);
++				BlurLine(IndexOf(Width - 1, i), IndexOf(NonVisiblePadding, i), -1);
++			}
++		});
+ 	}
+ 
+ 	private void BlurLine(int startIndex, int endIndex, int stride)
+@@ -189,13 +_,28 @@
+ 		}
+ 	}
+ 
++	// TML: Convert the color array from column-major to row-major to allow for
++	// direct texture uploads without it being rotated.
+-	private int IndexOf(int x, int y) => x * Height + y;
++	// private int IndexOf(int x, int y) => x * Height + y;
++	private int IndexOf(int x, int y) => y * (Width + 1) + x;
  
  	public void SetSize(int width, int height)
  	{
@@ -26,7 +111,7 @@
 +		}
 +		*/
 +		if (neededSize > _colors.Length) {
-+			_colors = new Vector3[neededSize];
++			_colors = new Vector4[neededSize];
 +			_mask = new LightMaskMode[neededSize];
  		}
  

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMap.cs.patch
@@ -86,7 +86,7 @@
  	}
  
  	private void BlurLine(int startIndex, int endIndex, int stride)
-@@ -189,16 +_,38 @@
+@@ -189,16 +_,40 @@
  		}
  	}
  
@@ -117,6 +117,8 @@
  
  		Width = width;
  		Height = height;
++
++		tileArea = new Rectangle(0, 0, width + 1, height + 1);
 +
 +		if (bufferTexture is not null && (bufferTexture.Width != width || bufferTexture.Height != height)) {
 +			bufferTexture?.Dispose();

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
@@ -11,11 +11,23 @@ public readonly struct LightMapBuffer
 	/// <summary>
 	///		The texture containing the light map data.  One pixel corresponds
 	///		to one tile.
+	///		<para />
+	///		This may contain padded data; see <see cref="TileArea"/> for more
+	///		information.
 	/// </summary>
 	public required Texture2D Texture { get; init; }
 
 	/// <summary>
-	///		The area of the texture that contains on-screen data.
+	///		The bounds of the texture with light data.  The X and Y coordinates
+	///		indicate the top-left position of the buffer in tile coordinates,
+	///		and the Width and Height indicate the full area being procesesed.
+	///		<para />
+	///		The light map buffer is subject to two possible kinds of padding:
+	///		1) padding in the allocated color/mask buffers, and 2) padding with
+	///		valid data, but is exempt from further processing (i.e. blurring in
+	///		<see cref="LightingEngine"/>).
+	///		<br />
+	///		Width and Height will exclude the former but, include the latter.
 	/// </summary>
-	public required Rectangle ScreenTileArea { get; init; }
+	public required Rectangle TileArea { get; init; }
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
@@ -1,9 +1,21 @@
-﻿namespace Terraria.Graphics.Light;
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
+namespace Terraria.Graphics.Light;
+
+/// <summary>
+///		Represents the texture buffer for a <see cref="LightMap"/>.
+/// </summary>
 public readonly struct LightMapBuffer
 {
-	public static LightMapBuffer FromLightMap(LightMap lightMap)
-	{
+	/// <summary>
+	///		The texture containing the light map data.  One pixel corresponds
+	///		to one tile.
+	/// </summary>
+	public required Texture2D Texture { get; init; }
 
-	}
+	/// <summary>
+	///		The area of the texture that contains on-screen data.
+	/// </summary>
+	public required Rectangle ScreenTileArea { get; init; }
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightMapBuffer.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Graphics.Light;
+
+public readonly struct LightMapBuffer
+{
+	public static LightMapBuffer FromLightMap(LightMap lightMap)
+	{
+
+	}
+}

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.TML.cs
@@ -4,6 +4,6 @@ partial class LightingEngine
 {
 	public LightMapBuffer GetBufferTexture()
 	{
-		return LightMapBuffer.FromLightMap(_activeLightMap);
+		return _activeLightMap.GetBufferTexture();
 	}
 }

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.TML.cs
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.TML.cs
@@ -1,0 +1,9 @@
+﻿namespace Terraria.Graphics.Light;
+
+partial class LightingEngine
+{
+	public LightMapBuffer GetBufferTexture()
+	{
+		return LightMapBuffer.FromLightMap(_activeLightMap);
+	}
+}

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -19,12 +19,22 @@
  		IncrementState();
 -	}
 +
-+        // TML: Mark light map as dirty to prompt buffer regenration.
++		// TML: Mark light map as dirty.
 +        _workingLightMap.MarkDirty();
 +    }
  
  	private void IncrementState()
  	{
+@@ -101,6 +_,9 @@
+ 
+ 	private void ProcessScan(Rectangle area)
+ 	{
++		// TML: Mark affected area.
++		_workingLightMap.UpdateArea(area, padding: 28);
++
+ 		area.Inflate(28, 28);
+ 		_workingProcessedArea = area;
+ 		_workingLightMap.SetSize(area.Width, area.Height);
 @@ -167,6 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -25,16 +25,14 @@
  
  	private void IncrementState()
  	{
-@@ -101,6 +_,9 @@
- 
- 	private void ProcessScan(Rectangle area)
- 	{
-+		// TML: Mark affected area.
-+		_workingLightMap.UpdateArea(area, padding: 28);
-+
+@@ -104,6 +_,7 @@
  		area.Inflate(28, 28);
  		_workingProcessedArea = area;
  		_workingLightMap.SetSize(area.Width, area.Height);
++		_workingLightMap.UpdateArea(area);
+ 		_workingLightMap.NonVisiblePadding = 18;
+ 		_tileScanner.Update();
+ 		_tileScanner.ExportTo(area, _workingLightMap, new TileLightScannerOptions {
 @@ -167,6 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -13,6 +13,18 @@
  {
  	private enum EngineState
  	{
+@@ -92,7 +_,10 @@
+ 
+ 		TimeLogger.LightingByPass[(int)_state].AddTime(fromTimestamp);
+ 		IncrementState();
+-	}
++
++        // TML: Mark light map as dirty to prompt buffer regenration.
++        _workingLightMap.MarkDirty();
++    }
+ 
+ 	private void IncrementState()
+ 	{
 @@ -167,6 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Light/LightingEngine.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Light/LightingEngine.cs
 +++ src/tModLoader/Terraria/Graphics/Light/LightingEngine.cs
-@@ -4,6 +_,7 @@
+@@ -4,10 +_,11 @@
  using ReLogic.Threading;
  using Terraria.Graphics.Capture;
  using Terraria.Map;
@@ -8,6 +8,11 @@
  
  namespace Terraria.Graphics.Light;
  
+-public class LightingEngine : ILightingEngine
++public partial class LightingEngine : ILightingEngine
+ {
+ 	private enum EngineState
+ 	{
 @@ -167,6 +_,13 @@
  		}
  

--- a/patches/tModLoader/Terraria/Lighting.TML.cs
+++ b/patches/tModLoader/Terraria/Lighting.TML.cs
@@ -20,7 +20,7 @@ partial class Lighting
 	///		reinitalized between frames in response to lighting updates and
 	///		light map resizes.
 	///		<para/>
-	///		<b>This method is not thread-safe; it many initialize and mutate
+	///		<b>This method is not thread-safe; it may initialize and mutate
 	///		graphics resources and must be called exclusively on the main
 	///		thread.</b>
 	/// </summary>

--- a/patches/tModLoader/Terraria/Lighting.TML.cs
+++ b/patches/tModLoader/Terraria/Lighting.TML.cs
@@ -1,9 +1,34 @@
-﻿using Terraria.Graphics.Light;
+﻿using Microsoft.Xna.Framework.Graphics;
+using Terraria.Graphics.Light;
 
 namespace Terraria;
 
 partial class Lighting
 {
+	/// <summary>
+	///		Requests the active <see cref="LightMap"/> as a
+	///		<see cref="Texture2D"/>, with each pixel corresponding to a tile.
+	///		<br />
+	///		For more information on how to use this buffer, see
+	///		<see cref="LightMapBuffer"/>.
+	///		<para />
+	///		<b>You should never store the returned buffer</b>; instead, this
+	///		method should be directly called every time you need to access the
+	///		buffer across multiple frames.
+	///		<br />
+	///		The buffer may be arbitrarily written to, or even disposed of and
+	///		reinitalized between frames in response to lighting updates and
+	///		light map resizes.
+	///		<para/>
+	///		<b>This method is not thread-safe; it many initialize and mutate
+	///		graphics resources and must be called exclusively on the main
+	///		thread.</b>
+	/// </summary>
+	/// <returns>
+	///		A <see cref="LightMapBuffer"/> with data corresponding to the
+	///		active <see cref="LightMap"/>.
+	/// </returns>
+	/// <seealso cref="LightMapBuffer"/>
 	public static LightMapBuffer GetBufferTexture()
 	{
 		return _activeEngine.GetBufferTexture();

--- a/patches/tModLoader/Terraria/Lighting.TML.cs
+++ b/patches/tModLoader/Terraria/Lighting.TML.cs
@@ -1,0 +1,11 @@
+﻿using Terraria.Graphics.Light;
+
+namespace Terraria;
+
+partial class Lighting
+{
+	public static LightMapBuffer GetBufferTexture()
+	{
+		return _activeEngine.GetBufferTexture();
+	}
+}

--- a/patches/tModLoader/Terraria/Lighting.cs.patch
+++ b/patches/tModLoader/Terraria/Lighting.cs.patch
@@ -1,17 +1,18 @@
 --- src/TerrariaNetCore/Terraria/Lighting.cs
 +++ src/tModLoader/Terraria/Lighting.cs
-@@ -7,6 +_,10 @@
+@@ -7,15 +_,19 @@
  
  namespace Terraria;
  
+-public class Lighting
 +/// <summary>
 +/// This class manages lighting in the game world. Lighting is calculated and tracked at tile coordinates within the users game view. The most common use of this class is to use <c>GetColor</c> methods to retrieve the light values at a location for drawing a specific entity. Another common usage is adding light to the game world using the <c>AddLight</c> methods.
 +/// <br/><br/> Lighting is not calculated on the server, as such it should not be used for anything gameplay related that needs to sync with the server.
 +/// </summary>
- public class Lighting
++public partial class Lighting
  {
  	private const float DEFAULT_GLOBAL_BRIGHTNESS = 1.2f;
-@@ -14,8 +_,8 @@
+ 	private const float BLIND_GLOBAL_BRIGHTNESS = 1f;
  	[Old]
  	public static int OffScreenTiles = 45;
  	private static LightMode _mode = LightMode.Color;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6803,6 +6803,46 @@
  	}
  
  	private static void UpdateAtmosphereTransparencyToSkyColor(float y)
+@@ -55298,6 +_,31 @@
+ 		ColorOfTheSkies = bgColorToSet;
+ 	}
+ 
++	// TML: Augment GetAreaToLight with additional information for light maps.
++	public static Rectangle GetAreaToLight()
++	{
++		return GetAreaToLight(out _, out _);
++	}
++
++	/// <summary>
++	///		Returns the area to light, as well as the scaled and unscaled
++	///		camera bounds.
++	/// </summary>
++	/// <param name="scaledBounds">The scaled bounds, in tiles.</param>
++	/// <param name="unscaledBounds">The unscaled bounds, in tiles.</param>
++	public static Rectangle GetAreaToLight(out Rectangle scaledBounds, out Rectangle unscaledBounds)
++	{
++		var unscaledPos = Camera.UnscaledPosition;
++		var unscaledSize = Camera.UnscaledSize;
++		var scaledPos = Camera.ScaledPosition;
++		var scaledSize = Camera.ScaledSize;
++
++		var useScaled = Lighting.UsingNewLighting;
++		var pos = useScaled ? scaledPos : unscaledPos;
++		var size = useScaled ? scaledSize : unscaledPos;
++	}
++
++	/*
+ 	public static Microsoft.Xna.Framework.Rectangle GetAreaToLight()
+ 	{
+ 		Vector2 vector = Camera.ScaledPosition;
+@@ -55313,6 +_,7 @@
+ 		int num4 = (int)Math.Floor((vector.Y + vector2.Y) / 16f) + 2;
+ 		return new Microsoft.Xna.Framework.Rectangle(num, num3, num2 - num, num4 - num3);
+ 	}
++	*/
+ 
+ 	public static void ClampScreenPositionToWorld()
+ 	{
 @@ -55390,6 +_,10 @@
  				else
  					bgStyle = 9;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6803,46 +6803,6 @@
  	}
  
  	private static void UpdateAtmosphereTransparencyToSkyColor(float y)
-@@ -55298,6 +_,31 @@
- 		ColorOfTheSkies = bgColorToSet;
- 	}
- 
-+	// TML: Augment GetAreaToLight with additional information for light maps.
-+	public static Rectangle GetAreaToLight()
-+	{
-+		return GetAreaToLight(out _, out _);
-+	}
-+
-+	/// <summary>
-+	///		Returns the area to light, as well as the scaled and unscaled
-+	///		camera bounds.
-+	/// </summary>
-+	/// <param name="scaledBounds">The scaled bounds, in tiles.</param>
-+	/// <param name="unscaledBounds">The unscaled bounds, in tiles.</param>
-+	public static Rectangle GetAreaToLight(out Rectangle scaledBounds, out Rectangle unscaledBounds)
-+	{
-+		var unscaledPos = Camera.UnscaledPosition;
-+		var unscaledSize = Camera.UnscaledSize;
-+		var scaledPos = Camera.ScaledPosition;
-+		var scaledSize = Camera.ScaledSize;
-+
-+		var useScaled = Lighting.UsingNewLighting;
-+		var pos = useScaled ? scaledPos : unscaledPos;
-+		var size = useScaled ? scaledSize : unscaledPos;
-+	}
-+
-+	/*
- 	public static Microsoft.Xna.Framework.Rectangle GetAreaToLight()
- 	{
- 		Vector2 vector = Camera.ScaledPosition;
-@@ -55313,6 +_,7 @@
- 		int num4 = (int)Math.Floor((vector.Y + vector2.Y) / 16f) + 2;
- 		return new Microsoft.Xna.Framework.Rectangle(num, num3, num2 - num, num4 - num3);
- 	}
-+	*/
- 
- 	public static void ClampScreenPositionToWorld()
- 	{
 @@ -55390,6 +_,10 @@
  				else
  					bgStyle = 9;


### PR DESCRIPTION
### What is the new feature?

Introduces a new API for acquiring the current lighting buffer as a texture.

You may request the lighting buffer with `Lighting.GetBufferTexture()`, which returns a `LightMapBuffer` object. This object has the buffer `Texture` as well as the tile bounds defined as `TileArea`. Read the documentation for specifics on what the properties mean. A buffer texture pixel corresponds to a single tile in the world.

Also tweaks LegacyLighting to copy its lighting state to a LightMap.

### Why should this be part of tModLoader?

Many mods that work with lighting need this same general data, but collecting it is expensive; this reduces redundancy across mods. It also implements it in a manner that is considerably more efficient than any mod could implement it, by making fundamental changes to LightMap that are not possible with MonoMod.

Nitrate uses a lighting buffer to apply lighting to entities. So does my 1.4.5 rendering mod. Starlight River uses it for lighting up backgrounds. This is generally useful for applying light to large meshes.

### Are there alternative designs?

Nothing substantial. The only other approach is manually copying data with GetColor calls. The advantage of this is it doesn't require modifying any of the lighting engines or LightMap, but it's also considerably slower.

### Sample usage for the new feature

This short mod draws the buffer both as a small image in the corner of the screen and as a full image overlayed on the corresponding tiles.

```cs
using Microsoft.Xna.Framework;
using Microsoft.Xna.Framework.Graphics;
using Microsoft.Xna.Framework.Input;
using System.Collections.Generic;
using Terraria;
using Terraria.ModLoader;
using Terraria.UI;

namespace LightBufferTest;

public class LightBufferTest : Mod;

internal sealed class System : ModSystem
{
    public enum Mode
    {
        Disabled,
        SmallWindow,
        Fullscreen,
        Count
    }

    private Mode mode;

    public void CycleMode()
    {
        mode = (Mode)(((int)mode + 1) % (int)Mode.Count);
    }

    public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
    {
        base.ModifyInterfaceLayers(layers);

        layers.Add(new LegacyGameInterfaceLayer("SmallWindow", () =>
        {
            if (mode != Mode.SmallWindow)
            {
                return true;
            }

            var buffer = Lighting.GetBufferTexture();
            Main.spriteBatch.Draw(buffer.Texture, new Vector2(256f), new Rectangle(0, 0, buffer.TileArea.Width, buffer.TileArea.Height), Color.White);
            return true;
        }, InterfaceScaleType.UI));

        layers.Add(new LegacyGameInterfaceLayer("Fullscreen", () =>
        {
            if (mode != Mode.Fullscreen)
            {
                return true;
            }

            Main.spriteBatch.End();
            Main.spriteBatch.Begin(SpriteSortMode.Deferred, null, SamplerState.PointClamp, null, null, null, Main.GameViewMatrix.ZoomMatrix);

            var buffer = Lighting.GetBufferTexture();

            var area = new Rectangle(0, 0, buffer.TileArea.Width, buffer.TileArea.Height);
            var rect = buffer.TileArea;
            rect.Width *= 16;
            rect.Height *= 16;
            rect.X *= 16;
            rect.Y *= 16;
            rect.X -= (int)Main.screenPosition.X;
            rect.Y -= (int)Main.screenPosition.Y;
            Main.spriteBatch.Draw(buffer.Texture, rect, area, Color.White * 0.5f);

            Main.spriteBatch.End();
            Main.spriteBatch.Begin(SpriteSortMode.Deferred, null, null, null, null, null, Main.GameViewMatrix.ZoomMatrix);
            return true;
        }, InterfaceScaleType.Game));
    }

    public override void PostUpdateInput()
    {
        base.PostUpdateInput();

        if (Main.keyState.IsKeyDown(Keys.F6) && !Main.oldKeyState.IsKeyDown(Keys.F6))
        {
            CycleMode();
            Main.NewText("Cycled to mode: " + mode.ToString());
        }
    }
}
```

### ExampleMod updates

Not really useful for anything in EM, but a sample mod is attached above.

### Porting Notes

Nothing is *necessary* to port, but if you already had a system like this, you should use this.

A screenspace version of the buffer is not provided.

If you implement `ILightingEngine` yourself, you will need to implement `GetBufferTexture`.