### PR TITLE
[1.4.5] Add perspective of player to tile sight hooks

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleHerb.cs
+++ b/ExampleMod/Content/Tiles/ExampleHerb.cs
@@ -153,7 +153,7 @@ namespace ExampleMod.Content.Tiles
 			}
 		}
 
-		public override bool IsTileSpelunkable(int i, int j) {
+		public override bool IsTileSpelunkable(int i, int j, Player player) {
 			PlantStage stage = GetStage(i, j);
 
 			// Only glow if the herb is grown

--- a/ExampleMod/Content/Tiles/ExampleOre.cs
+++ b/ExampleMod/Content/Tiles/ExampleOre.cs
@@ -35,7 +35,7 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		// Example of how to enable the Biome Sight buff to highlight this tile. Biome Sight is technically intended to show "infected" tiles, so this example is purely for demonstration purposes.
-		public override bool IsTileBiomeSightable(int i, int j, ref Color sightColor) {
+		public override bool IsTileBiomeSightable(int i, int j, Player player, ref Color sightColor) {
 			sightColor = Color.Blue;
 			return true;
 		}

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -527,6 +527,7 @@ All classes are in the `Terraria.ModLoader` or `Terraria` namespaces unless othe
 * ⚙️: `ModProjectile.DrawHeldProjInFrontOfHeldItemAndArms` has been removed. Set `Projectile.drawLayer` to `ProjectileDrawLayerID.HeldProjOverHand` instead. 
 * ⚙️: `(ModProjectile|GlobalProjectile).PreDraw/PreDrawExtras/PostDraw` now has a `Player` parameter. Use this instead of `Main.player[Projectile.owner]` to properly support rendering projectiles to custom `Player` instances, such as Mannequins.
 * ⚙️: `ModPylon.ValidTeleportCheck_AnyDanger` and `GlobalPylon.ValidTeleportCheck_PreAnyDanger` have been removed. Pylons no longer check for danger when teleporting.
+* ⚙️: `(ModTile|GlobalTile).IsTileBiomeSightable/IsTileSpelunkable` now have a `Player` parameter. Use this instead of `Main.LocalPlayer` so these hooks work correctly when rendering from a different player perspective.
 * 🤖: `ModTile.AddToArray` is no longer used for `TileID.Sets.RoomNeeds` entries since `TileID.Sets.RoomNeeds` fields have changed to typical ID sets.
 * `NPCLoader.blockLoot` can now affect all drops such as coins, hearts, etherian mana, and skyblock specific drops. Before it could only affect loot table drops.
 * ⚙️: `NPCSpawnInfo` is no longer used, it has been replaced by `NPC.Spawner` in functionality.

--- a/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Drawing/TileDrawing.cs.patch
@@ -258,7 +258,7 @@
  		}
  
 -		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY)) {
-+		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(tileX, tileY, tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY)) {
++		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(tileX, tileY, _perspectivePlayer, tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY)) {
  			if (tileDrawInfo.tileLight.R < 200)
  				tileDrawInfo.tileLight.R = 200;
  
@@ -267,7 +267,7 @@
  		if (_perspectivePlayer.biomeSight) {
  			Color sightColor = Color.White;
 -			if (Main.IsTileBiomeSightable(tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY, ref sightColor)) {
-+			if (Main.IsTileBiomeSightable(tileX, tileY, tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY, ref sightColor)) {
++			if (Main.IsTileBiomeSightable(tileX, tileY, _perspectivePlayer, tileDrawInfo.typeCache, tileDrawInfo.tileFrameX, tileDrawInfo.tileFrameY, ref sightColor)) {
  				if (tileDrawInfo.tileLight.R < sightColor.R)
  					tileDrawInfo.tileLight.R = sightColor.R;
  
@@ -824,7 +824,7 @@
  		}
  
 -		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(typeCache, tileFrameX, tileFrameY)) {
-+		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(i, j, typeCache, tileFrameX, tileFrameY)) {
++		if (_perspectivePlayer.findTreasure && Main.IsTileSpelunkable(i, j, _perspectivePlayer, typeCache, tileFrameX, tileFrameY)) {
  			if (tileLight.R < 200)
  				tileLight.R = 200;
  
@@ -833,7 +833,7 @@
  
  		Color sightColor = Color.White;
 -		if (Main.IsTileBiomeSightable(typeCache, tileFrameX, tileFrameY, ref sightColor)) {
-+		if (Main.IsTileBiomeSightable(i, j, typeCache, tileFrameX, tileFrameY, ref sightColor)) {
++		if (Main.IsTileBiomeSightable(i, j, _perspectivePlayer, typeCache, tileFrameX, tileFrameY, ref sightColor)) {
  			if (tileLight.R < sightColor.R)
  				tileLight.R = sightColor.R;
  
@@ -912,7 +912,7 @@
  			if (_perspectivePlayer.biomeSight) {
  				Color sightColor = Color.White;
 -				if (Main.IsTileBiomeSightable(type, tileFrameX, tileFrameY, ref sightColor)) {
-+				if (Main.IsTileBiomeSightable(x, i, type, tileFrameX, tileFrameY, ref sightColor)) {
++				if (Main.IsTileBiomeSightable(x, i, _perspectivePlayer, type, tileFrameX, tileFrameY, ref sightColor)) {
  					if (color.R < sightColor.R)
  						color.R = sightColor.R;
  

--- a/patches/tModLoader/Terraria/Main.TML.cs
+++ b/patches/tModLoader/Terraria/Main.TML.cs
@@ -167,18 +167,30 @@ public partial class Main
 	/// Checks if a tile at the given coordinates counts towards tile coloring from the Spelunker buff, and is detected by various pets.
 	/// </summary>
 	public static bool IsTileSpelunkable(int tileX, int tileY)
+		=> IsTileSpelunkable(tileX, tileY, LocalPlayer);
+
+	/// <summary>
+	/// Checks if a tile at the given coordinates counts towards tile coloring from the Spelunker buff for the given player, and is detected by various pets.
+	/// </summary>
+	public static bool IsTileSpelunkable(int tileX, int tileY, Player player)
 	{
 		Tile tile = Main.tile[tileX, tileY];
-		return IsTileSpelunkable(tileX, tileY, tile.type, tile.frameX, tile.frameY);
+		return IsTileSpelunkable(tileX, tileY, player, tile.type, tile.frameX, tile.frameY);
 	}
 
 	/// <summary>
 	/// Checks if a tile at the given coordinates counts towards tile coloring from the Biome Sight buff.
 	/// </summary>
 	public static bool IsTileBiomeSightable(int tileX, int tileY, ref Color sightColor)
+		=> IsTileBiomeSightable(tileX, tileY, LocalPlayer, ref sightColor);
+
+	/// <summary>
+	/// Checks if a tile at the given coordinates counts towards tile coloring from the Biome Sight buff for the given player.
+	/// </summary>
+	public static bool IsTileBiomeSightable(int tileX, int tileY, Player player, ref Color sightColor)
 	{
 		Tile tile = Main.tile[tileX, tileY];
-		return IsTileBiomeSightable(tileX, tileY, tile.type, tile.frameX, tile.frameY, ref sightColor);
+		return IsTileBiomeSightable(tileX, tileY, player, tile.type, tile.frameX, tile.frameY, ref sightColor);
 	}
 
 	public static void InfoDisplayPageHandler(int startX, ref string mouseText, out int startingDisplay, out int endingDisplay)

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -3951,36 +3951,47 @@
  
  			Vector2 stringSize = ChatManager.GetStringSize(FontAssets.MouseText.Value, text, new Vector2(1f));
  			float t = num2;
-@@ -18474,10 +_,15 @@
+@@ -18474,10 +_,20 @@
  		}
  	}
  
 -	public static bool IsTileSpelunkable(Tile t) => IsTileSpelunkable(t.type, t.frameX, t.frameY);
-+	//TML: Added x/y to IsTileSpelunkable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
-+	internal static bool IsTileSpelunkable(int tileX, int tileY, Tile t) => IsTileSpelunkable(tileX, tileY, t.type, t.frameX, t.frameY);
++	//TML: Added x/y/player to IsTileSpelunkable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
++	internal static bool IsTileSpelunkable(int tileX, int tileY, Tile t) => IsTileSpelunkable(tileX, tileY, LocalPlayer, t);
  
 -	public static bool IsTileSpelunkable(ushort typeCache, short tileFrameX, short tileFrameY)
++	internal static bool IsTileSpelunkable(int tileX, int tileY, Player player, Tile t) => IsTileSpelunkable(tileX, tileY, player, t.type, t.frameX, t.frameY);
++
 +	internal static bool IsTileSpelunkable(int tileX, int tileY, ushort typeCache, short tileFrameX, short tileFrameY)
++		=> IsTileSpelunkable(tileX, tileY, LocalPlayer, typeCache, tileFrameX, tileFrameY);
++
++	internal static bool IsTileSpelunkable(int tileX, int tileY, Player player, ushort typeCache, short tileFrameX, short tileFrameY)
  	{
-+		bool? modded = TileLoader.IsTileSpelunkable(tileX, tileY, typeCache);
++		bool? modded = TileLoader.IsTileSpelunkable(tileX, tileY, typeCache, player);
 +		if (modded.HasValue)
 +			return modded.Value;
 +
  		if (tileSpelunker[typeCache])
  			return true;
  
-@@ -18490,8 +_,16 @@
+@@ -18490,8 +_,22 @@
  		return false;
  	}
  
-+	// TML: Added x/y to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
++	// TML: Added x/y/player to IsTileBiomeSightable methods for hook compatibility, made internal. Public variant is in Main.TML.cs.
 +	internal static bool IsTileBiomeSightable(int tileX, int tileY, Tile t, ref Microsoft.Xna.Framework.Color sightColor) =>
-+		IsTileBiomeSightable(tileX, tileY, t.type, t.frameX, t.frameY, ref sightColor);
++		IsTileBiomeSightable(tileX, tileY, LocalPlayer, t, ref sightColor);
++
++	internal static bool IsTileBiomeSightable(int tileX, int tileY, Player player, Tile t, ref Microsoft.Xna.Framework.Color sightColor) =>
++		IsTileBiomeSightable(tileX, tileY, player, t.type, t.frameX, t.frameY, ref sightColor);
 +
 -	public static bool IsTileBiomeSightable(ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
 +	internal static bool IsTileBiomeSightable(int tileX, int tileY, ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
++		=> IsTileBiomeSightable(tileX, tileY, LocalPlayer, type, tileFrameX, tileFrameY, ref sightColor);
++
++	internal static bool IsTileBiomeSightable(int tileX, int tileY, Player player, ushort type, short tileFrameX, short tileFrameY, ref Microsoft.Xna.Framework.Color sightColor)
  	{
-+		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, type, ref sightColor);
++		bool? modded = TileLoader.IsTileBiomeSightable(tileX, tileY, type, player, ref sightColor);
 +		if (modded.HasValue)
 +			return modded.Value;
 +

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -101,34 +101,36 @@ public abstract class GlobalTile : GlobalBlockType
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
-	/// <param name="player">Main.LocalPlayer</param>
+	/// <param name="player">The player whose perspective is being rendered.</param>
 	public virtual bool? IsTileDangerous(int i, int j, int type, Player player)
 	{
 		return null;
 	}
 
 	/// <summary>
-	/// Allows you to customize whether this tile glows <paramref name="sightColor"/> while the local player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
+	/// Allows you to customize whether this tile glows <paramref name="sightColor"/> while the given player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
 	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions and colors. Returns null by default.
 	/// <br/>This is only called on the local client.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
+	/// <param name="player">The player whose perspective is being rendered.</param>
 	/// <param name="sightColor">The color this tile should glow with, which defaults to <see cref="Color.White"/>.</param>
-	public virtual bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
+	public virtual bool? IsTileBiomeSightable(int i, int j, int type, Player player, ref Color sightColor)
 	{
 		return null;
 	}
 
 	/// <summary>
-	/// Allows you to customize whether this tile can glow yellow while having the Spelunker buff, and is also detected by various pets.
+	/// Allows you to customize whether this tile can glow yellow while the given player has the Spelunker buff, and is also detected by various pets.
 	/// <br/>Return true to force this behavior, or false to prevent it, overriding vanilla conditions. Returns null by default.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
 	/// <param name="type">The tile type</param>
-	public virtual bool? IsTileSpelunkable(int i, int j, int type)
+	/// <param name="player">The player whose perspective is being rendered.</param>
+	public virtual bool? IsTileSpelunkable(int i, int j, int type, Player player)
 	{
 		return null;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -321,25 +321,27 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Allows you to determine whether this tile glows <paramref name="sightColor"/> while the local player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
+	/// Allows you to determine whether this tile glows <paramref name="sightColor"/> while the given player has the <see href="https://terraria.wiki.gg/wiki/Biome_Sight_Potion">Biome Sight buff</see>.
 	/// <br/>Return true and assign to <paramref name="sightColor"/> to allow this tile to glow.
 	/// <br/>This is only called on the local client.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
+	/// <param name="player">The player whose perspective is being rendered.</param>
 	/// <param name="sightColor">The color this tile should glow with, which defaults to <see cref="Color.White"/>.</param>
-	public virtual bool IsTileBiomeSightable(int i, int j, ref Color sightColor)
+	public virtual bool IsTileBiomeSightable(int i, int j, Player player, ref Color sightColor)
 	{
 		return false;
 	}
 
 	/// <summary>
-	/// Allows you to customize whether this tile can glow yellow while having the Spelunker buff, and is also detected by various pets.
+	/// Allows you to customize whether this tile can glow yellow while the given player has the Spelunker buff, and is also detected by various pets.
 	/// <br/>This is only called if Main.tileSpelunker[type] is false.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
-	public virtual bool IsTileSpelunkable(int i, int j)
+	/// <param name="player">The player whose perspective is being rendered.</param>
+	public virtual bool IsTileSpelunkable(int i, int j, Player player)
 	{
 		return false;
 	}

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -66,9 +66,9 @@ public static class TileLoader
 	private delegate void DelegateModifyLight(int i, int j, int type, ref float r, ref float g, ref float b);
 	private static DelegateModifyLight[] HookModifyLight;
 	private static Func<int, int, int, Player, bool?>[] HookIsTileDangerous;
-	private delegate bool? DelegateIsTileBiomeSightable(int i, int j, int type, ref Color sightColor);
+	private delegate bool? DelegateIsTileBiomeSightable(int i, int j, int type, Player player, ref Color sightColor);
 	private static DelegateIsTileBiomeSightable[] HookIsTileBiomeSightable;
-	private static Func<int, int, int, bool?>[] HookIsTileSpelunkable;
+	private static Func<int, int, int, Player, bool?>[] HookIsTileSpelunkable;
 	private delegate void DelegateSetSpriteEffects(int i, int j, int type, ref SpriteEffects spriteEffects);
 	private static DelegateSetSpriteEffects[] HookSetSpriteEffects;
 	private static Action[] HookAnimateTile;
@@ -904,18 +904,18 @@ public static class TileLoader
 		return retVal;
 	}
 
-	public static bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor)
+	public static bool? IsTileBiomeSightable(int i, int j, int type, Player player, ref Color sightColor)
 	{
 		bool? retVal = null;
 
 		ModTile modTile = GetTile(type);
 
-		if (modTile != null && modTile.IsTileBiomeSightable(i, j, ref sightColor)) {
+		if (modTile != null && modTile.IsTileBiomeSightable(i, j, player, ref sightColor)) {
 			retVal = true;
 		}
 
 		foreach (var hook in HookIsTileBiomeSightable) {
-			bool? globalRetVal = hook(i, j, type, ref sightColor);
+			bool? globalRetVal = hook(i, j, type, player, ref sightColor);
 			if (globalRetVal.HasValue) {
 				if (globalRetVal.Value) {
 					retVal = true;
@@ -929,18 +929,18 @@ public static class TileLoader
 		return retVal;
 	}
 
-	public static bool? IsTileSpelunkable(int i, int j, int type)
+	public static bool? IsTileSpelunkable(int i, int j, int type, Player player)
 	{
 		bool? retVal = null;
 
 		ModTile modTile = GetTile(type);
 
-		if (!Main.tileSpelunker[type] && modTile != null && modTile.IsTileSpelunkable(i, j)) {
+		if (!Main.tileSpelunker[type] && modTile != null && modTile.IsTileSpelunkable(i, j, player)) {
 			retVal = true;
 		}
 
 		foreach (var hook in HookIsTileSpelunkable) {
-			bool? globalRetVal = hook(i, j, type);
+			bool? globalRetVal = hook(i, j, type, player);
 			if (globalRetVal.HasValue) {
 				if (globalRetVal.Value) {
 					retVal = true;

--- a/tModPorter/tModPorter.Tests/TestData/GlobalTileTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalTileTest.Expected.cs
@@ -9,6 +9,14 @@ public class GlobalTileTest : GlobalTile {
 		return false;
 	}
 
+	public override bool? IsTileBiomeSightable(int i, int j, int type, Player player, ref Color sightColor)/* tModPorter Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer. */ {
+		return true;
+	}
+
+	public override bool? IsTileSpelunkable(int i, int j, int type, Player player)/* tModPorter Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer. */ {
+		return true;
+	}
+
 	public override void SetStaticDefaults() { /* Empty */ }
 
 	public override void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref TileDrawInfo drawData) {

--- a/tModPorter/tModPorter.Tests/TestData/GlobalTileTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/GlobalTileTest.cs
@@ -8,6 +8,14 @@ public class GlobalTileTest : GlobalTile {
 		return false;
 	}
 
+	public override bool? IsTileBiomeSightable(int i, int j, int type, ref Color sightColor) {
+		return true;
+	}
+
+	public override bool? IsTileSpelunkable(int i, int j, int type) {
+		return true;
+	}
+
 	public override void SetDefaults() { /* Empty */ }
 
 	public override void DrawEffects(int i, int j, int type, SpriteBatch spriteBatch, ref Color drawColor, ref int nextSpecialDrawIndex) {

--- a/tModPorter/tModPorter.Tests/TestData/ModTileTest.Expected.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModTileTest.Expected.cs
@@ -80,6 +80,14 @@ public class ModTileTest : ModTile
 		return false;
 	}
 
+	public override bool IsTileBiomeSightable(int i, int j, Player player, ref Color sightColor)/* tModPorter Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer. */ {
+		return true;
+	}
+
+	public override bool IsTileSpelunkable(int i, int j, Player player)/* tModPorter Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer. */ {
+		return true;
+	}
+
 	public override bool HasSmartInteract(int i, int j, SmartInteractScanSettings settings) { return true; /* comment */ }
 
 	public override bool RightClick(int i, int j) { return false; /* comment */ }

--- a/tModPorter/tModPorter.Tests/TestData/ModTileTest.cs
+++ b/tModPorter/tModPorter.Tests/TestData/ModTileTest.cs
@@ -62,6 +62,14 @@ public class ModTileTest : ModTile
 		return false;
 	}
 
+	public override bool IsTileBiomeSightable(int i, int j, ref Color sightColor) {
+		return true;
+	}
+
+	public override bool IsTileSpelunkable(int i, int j) {
+		return true;
+	}
+
 	public override bool HasSmartInteract() { return true; /* comment */ }
 
 	public override bool NewRightClick(int i, int j) { return false; /* comment */ }

--- a/tModPorter/tModPorter/Config.ModLoader.cs
+++ b/tModPorter/tModPorter/Config.ModLoader.cs
@@ -178,6 +178,10 @@ public static partial class Config
 		ChangeHookSignature("Terraria.ModLoader.ModTile",			"DrawEffects");
 		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"DrawEffects");
 		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"IsTileDangerous", comment: "Suggestion: Return null instead of false");
+		ChangeHookSignature("Terraria.ModLoader.ModTile",			"IsTileBiomeSightable", comment: "Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer.");
+		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"IsTileBiomeSightable", comment: "Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer.");
+		ChangeHookSignature("Terraria.ModLoader.ModTile",			"IsTileSpelunkable", comment: "Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer.");
+		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"IsTileSpelunkable", comment: "Suggestion: Add the new Player parameter to the hook signature and use it instead of Main.LocalPlayer.");
 		ChangeHookSignature("Terraria.ModLoader.GlobalTile",		"PlaceInWorld");
 		ChangeHookSignature("Terraria.ModLoader.ModNPC",			"SetNPCNameList", comment: "Suggestion: Return a list of names");
 		ChangeHookSignature("Terraria.ModLoader.ModNPC",			"CanTownNPCSpawn", comment: "Suggestion: Copy the implementation of NPC.SpawnAllowed_Merchant in vanilla if you to count money, and be sure to set a flag when unlocked, so you don't count every tick.");


### PR DESCRIPTION
### What is the bug?
`IsTileSpelunkable` and `IsTileBiomeSightable` do not receive the player whose perspective is being rendered. Mods must rely on `Main.LocalPlayer`, producing incorrect results when rendering another player's perspective, such as while spectating.

### How did you fix the bug?
Added a `Player` parameter to the corresponding `ModTile` and `GlobalTile` hooks and passed `_perspectivePlayer` through `TileDrawing`, `Main`, and `TileLoader`.
Existing public `Main` overloads remain available and default to `Main.LocalPlayer`. Hook documentation, migration guidance, and tModPorter rules were also updated.

### Are there alternatives to your fix?
Hooks could read `Main.SceneMetrics.PerspectivePlayer` directly, but an explicit parameter avoids hidden global state and matches the existing `IsTileDangerous` design.

### What are the changes to ExampleMod?
Updated `ExampleHerb.IsTileSpelunkable` and `ExampleOre.IsTileBiomeSightable` to use the new signatures.

### Do these changes need additional documentation?
The migration guide documents the signature changes and advises using the supplied player instead of `Main.LocalPlayer`. tModPorter updates existing overrides and emits a migration suggestion.