### PR TITLE
[1.4.5] New 1.4.5 Use & Hold Styles

### DIFF
--- a/ExampleMod/Content/Items/HoldStyleShowcase.cs
+++ b/ExampleMod/Content/Items/HoldStyleShowcase.cs
@@ -53,7 +53,7 @@ namespace ExampleMod.Content.Items
 
 			if (player.altFunctionUse == 2) {
 				Item.holdStyle++;
-				if (Item.holdStyle > ItemHoldStyleID.HoldRadio) {
+				if (Item.holdStyle > ItemHoldStyleID.HoldOrb) {
 					Item.holdStyle = ItemHoldStyleID.None;
 				}
 				Main.NewText(SwitchingText.Format(Item.holdStyle));

--- a/ExampleMod/Content/Items/UseStyleShowcase.cs
+++ b/ExampleMod/Content/Items/UseStyleShowcase.cs
@@ -52,7 +52,7 @@ namespace ExampleMod.Content.Items
 
 			if (player.altFunctionUse == 2) {
 				Item.useStyle++;
-				if (Item.useStyle > ItemUseStyleID.RaiseLamp) {
+				if (Item.useStyle > ItemUseStyleID.PlaySound) {
 					Item.useStyle = ItemUseStyleID.Swing;
 				}
 				Main.NewText(SwitchingText.Format(Item.useStyle));

--- a/patches/tModLoader/Terraria/ID/ItemHoldStyleID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemHoldStyleID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/ItemHoldStyleID.cs
 +++ src/tModLoader/Terraria/ID/ItemHoldStyleID.cs
-@@ -1,14 +_,50 @@
+@@ -1,14 +_,54 @@
  namespace Terraria.ID;
  
 +/// <summary>
@@ -30,13 +30,13 @@
 +	/// </summary>
  	public const int HoldHeavy = 3;
 +	/// <summary>
-+	/// Item held by both hands low.
++	/// Item held by both hands low with the item pointing down.
 +	/// <br/> Used by Golf Clubs.
 +	/// </summary>
  	public const int HoldGolfClub = 4;
 +	/// <summary>
-+	/// Item held very low.
-+	/// <br/> Used by guitar-shaped instruments
++	/// Item held very low with the item pointing up.
++	/// <br/> Used by Stellar Tune, Ivy, and Rain Song.
 +	/// </summary>
  	public const int HoldGuitar = 5;
 +	/// <summary>
@@ -49,5 +49,9 @@
 +	/// <br/> Used by Kwad Racer Drone
 +	/// </summary>
  	public const int HoldRadio = 7;
++	/// <summary>
++	/// Similar to <see cref="HoldFront"/>, but using the composite arm instead.
++	/// <br/> Used by Scrying Orb
++	/// </summary>
  	public const int HoldOrb = 8;
  }

--- a/patches/tModLoader/Terraria/ID/ItemUseStyleID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemUseStyleID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/ItemUseStyleID.cs
 +++ src/tModLoader/Terraria/ID/ItemUseStyleID.cs
-@@ -1,22 +_,67 @@
+@@ -1,22 +_,86 @@
 +using ReLogic.Reflection;
 +
  namespace Terraria.ID;
@@ -11,11 +11,16 @@
 +/// </summary>
  public class ItemUseStyleID
  {
++	/// <summary>
++	/// Default. No specific animation will happen while this item is used.
++	/// <br/>Used by any item by default.
++	/// </summary>
  	public const int None = 0;
 +	/// <summary>Item is swung in an overhead arch.<br/>Used for many sword weapons, block placement, etc.</summary>
  	public const int Swing = 1;
 +	/// <summary>
-+	/// Unused
++	/// Item is brought in front of player and rotated towards player.
++	/// <br/> Unused. Replaced with <see cref="DrinkLiquid"/>
 +	/// </summary>
  	public const int DrinkOld = 7;
 +	/// <summary>Item is thrust horizontally.<br/>Use by <see cref="ItemID.Umbrella"/> and <see cref="ItemID.TragicUmbrella"/></summary>
@@ -44,18 +49,24 @@
 +	/// <br/> Used by potions, drinks, flasks, and hair dyes.
 +	/// </summary>
  	public const int DrinkLiquid = 9;
++	/// <summary>
++	/// No animation.
++	/// <br/> Used by Whoopie Cushion
++	/// </summary>
  	public const int HiddenAnimation = 10;
 +	/// <summary>
-+	/// Used by Lawn Mower
++	/// The item is pushed back and forth close to the ground.
++	/// <br/> Used by Lawn Mower
 +	/// </summary>
  	public const int MowTheLawn = 11;
 +	/// <summary>
-+	/// Used by guitar-shaped instruments
++	/// The item is strummed like a guitar
++	/// <br/> Used by Stellar Tune, Ivy, and Rain Song.
 +	/// </summary>
  	public const int Guitar = 12;
 +	/// <summary>
 +	/// Item is thrust in any direction towards the mouse.
-+	/// Used by Shortswords
++	/// <br/> Used by Shortswords
 +	/// </summary>
  	public const int Rapier = 13;
 +	/// <summary>
@@ -63,7 +74,15 @@
 +	/// <br/> Used by Nightglow.
 +	/// </summary>
  	public const int RaiseLamp = 14;
++	/// <summary>
++	/// Item is held in front of the player.
++	/// <br/> Used by Scrying Orb
++	/// </summary>
  	public const int HoldOrb = 15;
++	/// <summary>
++	/// This use style applies the hold style of the item if the item has a hold style. 
++	/// <br/> Used by Unicorn on a Stick.
++	/// </summary>
  	public const int PlaySound = 16;
 +	public const int Count = 17;
 +	public static readonly IdDictionary Search = IdDictionary.Create<ItemUseStyleID, int>(); // Added by TML

--- a/patches/tModLoader/Terraria/ID/ItemUseStyleID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemUseStyleID.cs.patch
@@ -13,7 +13,7 @@
  {
 +	/// <summary>
 +	/// Default. No specific animation will happen while this item is used.
-+	/// <br/>Used by any item by default.
++	/// <br/> Used by any item by default.
 +	/// </summary>
  	public const int None = 0;
 +	/// <summary>Item is swung in an overhead arch.<br/>Used for many sword weapons, block placement, etc.</summary>

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -450,7 +450,7 @@
  	public readonly Chest bank4 = Chest.CreateBank(-5);
  	public BitsByte voidVaultInfo;
  	public float headRotation;
-@@ -1006,31 +_,58 @@
+@@ -1006,31 +_,59 @@
  	public Vector2 fullRotationOrigin = Vector2.Zero;
  	public int fartKartCloudDelay;
  	public const int fartKartCloudDelayMax = 20;
@@ -469,6 +469,7 @@
 +	/// <summary> Indicates if this player is dead </summary>
  	public bool dead;
  	public int deadTime;
++	/// <summary> The index in <see cref="Main.player"/> of the player this player is spectating. Will be -1 if not spectating. </summary>
  	public int spectating = -1;
 +	/// <summary> The amount of time in ticks before this player respawns after death. Most suitably modified in <see cref="ModPlayer.Kill(double, int, bool, PlayerDeathReason)"/> </summary>
  	public int respawnTimer;

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -7529,6 +7529,17 @@
  
  		if ((sItem.type == 105 || sItem.type == 713) && !wet && !pulley) {
  			int maxValue2 = 20;
+@@ -40826,7 +_,10 @@
+ 		if (item.holdStyle == 5 && petting.isPetting)
+ 			return false;
+ 
++		/*
+ 		if (item.holdStyle == 8 && spectating < 0)
++		*/
++		if (item.holdStyle == 8 && spectating < 0 && item.type == ItemID.ScryingOrb) // Allow other items to use this holdStyle.
+ 			return false;
+ 
+ 		return true;
 @@ -40834,6 +_,12 @@
  
  	private void ItemCheck_ApplyHoldStyle(float mountOffset, Item sItem, Rectangle heldItemFrame)


### PR DESCRIPTION
### What was changed?

* Added docs for `ItemHoldStyleID.HoldOrb` as well as updated the docs of a couple of other hold styles.
* Added docs for `ItemUseStyleID.HoldOrb` and `ItemUseStyleID.PlaySound` as well as updated the docs for other use styles.
* Edited `Player.CanVisuallyHoldItem` to allow any item to use `ItemHoldStyle.HoldOrb`.
  * The HoldOrb hold style wouldn't render unless you were spectating a player. I added a check for the Scrying Orb (the only item in vanilla that uses this hold style) so that mods can use this hold style without needing for the player to spectate somebody.
  * (BTW, this hold style doesn't show up on the Scrying Orb in vanilla. It only shows if you are spectating a player. If you are using the Scrying Orb to spectate somebody, then the use style will play. If you are dead and spectating a player, you can't hold an item to see the hold style.)

### Are there alternative designs?

* `ItemUseStyleID.PlaySound` is pretty broken, visually. It applies the hold style of the item when used. If the item doesn't have a hold style, the item kind of just floats in place even if the player moves around. If the item does have a hold style, it works mostly. The animation of the player's body kind of freezes while the item is being used. Like for example, if the item uses HoldLamp hold style, which doesn't affect the front arm, jumping will raise the front arm and using the item will cause the raised arm to be frozen until the item time ends. You can also disconnect the player's legs from their torso.

### ExampleMod updates

* Updated HoldStylShowcase and UseStyleShowcase 