### PR TITLE
Fix errors in journey item dupe menu search causing it to stop working

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/Creative/ItemFilters.cs.patch
@@ -8,7 +8,7 @@
  using Terraria.UI;
  
  namespace Terraria.GameContent.Creative;
-@@ -21,16 +_,32 @@
+@@ -21,16 +_,39 @@
  		private int _unusedResearchLine;
  		private string _search;
  
@@ -31,7 +31,14 @@
  			float knockBack = entry.knockBack;
 -			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines);
 +			Main.MouseText_DrawItemTooltip_GetLinesInfo(entry, ref _unusedYoyoLogo, ref _unusedResearchLine, knockBack, ref numLines, _toolTipLines, _unusedPrefixLine, _unusedBadPrefixLines, _toolTipNames, out _);
-+			var modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedPrefixLine, ref _unusedBadPrefixLines, ref _unusedYoyoLogo, out _, -1);
++			List<TooltipLine> modifiedTooltipLines;
++			try {
++				modifiedTooltipLines = ItemLoader.ModifyTooltips(entry, ref numLines, _toolTipNames, ref _toolTipLines, ref _unusedPrefixLine, ref _unusedBadPrefixLines, ref _unusedYoyoLogo, out _, -1);
++			}
++			catch {
++				// Fix erroneous tooltips preventing the filter from working entirely
++				return false;
++			}
 +
 +			/*
  			for (int i = 0; i < numLines; i++) {


### PR DESCRIPTION
### What is the bug?
If an item happens to throw an exception during `ModifyTooltips`, the journey mode item duplication menu search will stop working as the exception prevents the filter from applying.

### How did you fix the bug?
try/catch the `ModifyTooltips` line and return false.
I tested this in ExampleMod with an item returning a dummy exception.
The actual exception will still get logged automatically so this doesn't hide the problem, it just improves user friendliness.

### Are there alternatives to your fix?
The search ends up ignoring the item entirely even though its name would match, this is because `ModifyTooltips` also includes the `Name` line and the filter matches on the resulting lines only. Maybe an additional improvement would be to modify the filter to also check for the item's native display name, that way a bad tooltip would still show a "bad" item if the user searches for the item name.
