### PR TITLE
fix: Allow SteamAppId env var to be pre-set for Family Share launches

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Engine/Steam.cs
@@ -71,8 +71,12 @@ internal class Steam
 
 		//Solxan: While testing family share, noticed this inherently fails if game is not initiated from the 'start' button in Steam.
 		// Not normally a problem, as family share should be pathing to game server anyways
-		if (Environment.GetEnvironmentVariable("SteamAppId") != appId.ToString()) {
-			throw new Exception("Cannot overwrite steam env. SteamAppId=" + Environment.GetEnvironmentVariable("SteamAppId"));
+		var existingSteamAppId = Environment.GetEnvironmentVariable("SteamAppId");
+		if (existingSteamAppId == appId.ToString()) {
+			return;
+		}
+		if (existingSteamAppId != null) {
+			throw new Exception("Cannot overwrite steam env. SteamAppId=" + existingSteamAppId);
 		}
 	}
 }


### PR DESCRIPTION
Adds a guard clause in `Steam.SetAppId()` to skip setting the `SteamAppId` environment variable if it already matches the expected app ID. This fixes a crash when launching tModLoader via Steam Family Share .bat files, which pre-set `SteamAppId` before launch.

Fixes #5174.