### PR TITLE
fix: Prevent startup crash when Steam Workshop is offline

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -535,11 +535,11 @@ public partial class WorkshopHelper
 				try {
 					WaitForQueryResultAsync(query).GetAwaiter().GetResult();
 				}
-				catch (TimeoutException e) {
-					// Solxan: Most likely to occur during game startup if it occurs due to banned/malware startup check code
+				catch (Exception e) {
+					// Catch all workshop query failures (offline mode, timeout, k_EResultFail, etc.)
 					SteamedWraps.SteamAvailable = false;
 					SteamedWraps.SteamClient = false;
-					Utils.ShowFancyErrorMessage("Steam Workshop Timed Out. Steam Workshop related functionality has been disabled.\n" +
+					Utils.ShowFancyErrorMessage("Unable to access Steam Workshop. Steam Workshop related functionality has been disabled.\n" +
 						"Restart Steam and tModLoader to attempt to restore.", Interface.loadModsID);
 				}
 			}


### PR DESCRIPTION
### What is the bug?
When Steam is offline (or GOG without Steam), the workshop query during startup throws `System.Exception: Error: Unable to access Steam Workshop. ERROR CODE: k_EResultFail` from `WaitForQueryResultAsync`. The existing `catch (TimeoutException)` in `WaitForQueryResult` (added in abca3f4) doesn't catch this, so the exception propagates up through:

`DetectAbnormalSteamWorkshopDownloads` → `Initialize` → `OnLocalModsChanged` → `DirectQueryInstalledMDItems` → `QueryItemsSynchronously` → `WaitForQueryResult` → **uncaught crash**

### How did you fix the bug?
Broadened `catch (TimeoutException e)` to `catch (Exception e)` in `WorkshopHelper.TML.cs:WaitForQueryResult`. This applies the existing graceful degradation (set `SteamAvailable = false`, `SteamClient = false`, show message, continue) to **all** workshop query failures, not just timeouts.

### Are there alternatives to your fix?
Could add explicit offline checks before calling workshop APIs, but that would require touching multiple call sites. Catching the exception at the common `WaitForQueryResult` entry point is the minimal, safest fix that mirrors the existing timeout handling pattern.

### Issues fixed
- Fixes #5196
- Fixes #5126 