### PR TITLE
[1.4.5] Restore NPC Dialogue Fixes

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/NPCChatPanel.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/NPCChatPanel.cs.patch
@@ -1,6 +1,32 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/NPCChatPanel.cs
 +++ src/tModLoader/Terraria/GameContent/UI/NPCChatPanel.cs
-@@ -55,7 +_,7 @@
+@@ -1,6 +_,8 @@
+ using System;
++using System.Collections;
+ using System.Collections.Generic;
+ using Microsoft.Xna.Framework;
++using Microsoft.Xna.Framework.Graphics;
+ using ReLogic.Graphics;
+ using ReLogic.Localization.IME;
+ using ReLogic.OS;
+@@ -46,16 +_,24 @@
+ 			return;
+ 		}
+ 
++		// TML: Moved color definition up.
++		int num = (mouseTextColor * 2 + 255) / 3;
++		Color color = new Color(num, num, num, num);
++		PrepareText(color);
++		/*
+ 		PrepareText();
++		*/
+ 		PrepareInteractions();
+ 		PrepareVirtualKeyboard();
+ 		Color chatBack = new Color(200, 200, 200, 200);
++		/*
+ 		int num = (mouseTextColor * 2 + 255) / 3;
+ 		Color color = new Color(num, num, num, num);
++		*/
  		Point point = new Point(500, 500);
  		Rectangle rectangle = new Rectangle(Main.screenWidth / 2 - point.X / 2, 100, point.X, 30);
  		rectangle.Height += 30 * _textDisplayCache.AmountOfLines;
@@ -73,3 +99,69 @@
  
  		int count = _interactions.Count;
  		_neededInteractionLines = (int)Math.Ceiling((float)count / 4f);
+@@ -159,11 +_,11 @@
+ 		UIVirtualKeyboard.OffsetDown = num;
+ 	}
+ 
+-	private void PrepareText()
++	private void PrepareText(Color baseColor) // Added baseColor parameter
+ 	{
+ 		string chatTextToShow = Main.npcChatText;
+ 		OverrideChatTextWithShenanigans(ref chatTextToShow);
+-		_textDisplayCache.PrepareCache(chatTextToShow);
++		_textDisplayCache.PrepareCache(chatTextToShow, baseColor);
+ 	}
+ 
+ 	private void OverrideChatTextWithShenanigans(ref string chatTextToShow)
+@@ -187,9 +_,15 @@
+ 	{
+ 		Vector2 vector = textArea.TopLeft() + new Vector2(20f, 20f);
+ 		DynamicSpriteFont value = FontAssets.MouseText.Value;
++		/*
+ 		string[] textLines = _textDisplayCache.TextLines;
++		*/
++		List<List<TextSnippet>> textLines = _textDisplayCache.TextLines;
+ 		int amountOfLines = _textDisplayCache.AmountOfLines;
++		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
++		TextSnippet hoveredSnippet = null;
+ 		for (int i = 0; i < amountOfLines; i++) {
++			/*
+ 			string text = textLines[i];
+ 			if (text != null) {
+ 				if (allowRichText)
+@@ -197,13 +_,35 @@
+ 				else
+ 					Utils.DrawBorderStringFourWay(Main.spriteBatch, value, text, vector.X, vector.Y + (float)(i * 30), textColor, Color.Black, Vector2.Zero);
+ 			}
++			*/
++			List<TextSnippet> text = textLines[i];
++			ChatManager.DrawColorCodedStringWithShadow(Main.spriteBatch, FontAssets.MouseText.Value, text.ToArray(), new Vector2(170 + (Main.screenWidth - 800) / 2, 120 + i * 30), textColor, Color.Black, 0f, Vector2.Zero, Vector2.One, out int hoveredSnippetNum);
++
++			if (hoveredSnippetNum > -1)
++				hoveredSnippet = text[hoveredSnippetNum];
++		}
++
++		/*
++		if (textBlinkerState == 1)
++			textLines[amountOfLines - 1].RemoveAt(textLines[amountOfLines - 1].Count - 1);
++		*/
++
++		// Added on-hover and on-click callbacks as well
++		if (hoveredSnippet is not null) {
++			hoveredSnippet.OnHover();
++
++			if (Main.mouseLeft && Main.mouseLeftRelease)
++				hoveredSnippet.OnClick();
+ 		}
+ 
+ 		if (!Main.editSign || textLines[amountOfLines - 1] == null)
+ 			return;
+ 
+ 		Vector2 vector2 = vector + new Vector2(0f, (amountOfLines - 1) * 30);
++		/*
+ 		vector2.X += value.MeasureString(textLines[amountOfLines - 1]).X;
++		*/
++		vector2.X += ChatManager.GetStringSize(FontAssets.MouseText.Value, textLines[amountOfLines - 1].ToArray(), Vector2.One).X;
+ 		string compositionString = Platform.Get<IImeService>().CompositionString;
+ 		if (compositionString != null && compositionString.Length > 0) {
+ 			float x = value.MeasureString(compositionString).X;

--- a/patches/tModLoader/Terraria/GameContent/UI/NPCChatPanel.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/NPCChatPanel.cs.patch
@@ -129,7 +129,7 @@
  			string text = textLines[i];
  			if (text != null) {
  				if (allowRichText)
-@@ -197,13 +_,35 @@
+@@ -197,13 +_,30 @@
  				else
  					Utils.DrawBorderStringFourWay(Main.spriteBatch, value, text, vector.X, vector.Y + (float)(i * 30), textColor, Color.Black, Vector2.Zero);
  			}
@@ -140,11 +140,6 @@
 +			if (hoveredSnippetNum > -1)
 +				hoveredSnippet = text[hoveredSnippetNum];
 +		}
-+
-+		/*
-+		if (textBlinkerState == 1)
-+			textLines[amountOfLines - 1].RemoveAt(textLines[amountOfLines - 1].Count - 1);
-+		*/
 +
 +		// Added on-hover and on-click callbacks as well
 +		if (hoveredSnippet is not null) {

--- a/patches/tModLoader/Terraria/GameContent/UI/TextDisplayCache.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/TextDisplayCache.cs.patch
@@ -1,0 +1,46 @@
+--- src/TerrariaNetCore/Terraria/GameContent/UI/TextDisplayCache.cs
++++ src/tModLoader/Terraria/GameContent/UI/TextDisplayCache.cs
+@@ -1,4 +_,7 @@
++using System.Collections.Generic;
++using Microsoft.Xna.Framework;
+ using Terraria.GameInput;
++using Terraria.UI.Chat;
+ 
+ namespace Terraria.GameContent.UI;
+ 
+@@ -9,19 +_,33 @@
+ 	private int _lastScreenHeight;
+ 	private InputMode _lastInputMode;
+ 
+-	public string[] TextLines { get; private set; }
++	// Added by TML.
++	private Color originalColor;
++
++	public List<List<TextSnippet>> TextLines { get; private set; } // Changed from string[]
+ 
+ 	public int AmountOfLines { get; private set; }
+ 
+-	public void PrepareCache(string text)
++	// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
++	// Added baseColor parameter
++	public void PrepareCache(string text, Color baseColor)
+ 	{
++		/*
+ 		if (false | (Main.screenWidth != _lastScreenWidth) | (Main.screenHeight != _lastScreenHeight) | (_originalText != text) | (PlayerInput.CurrentInputMode != _lastInputMode)) {
++		*/
++		if (false | (Main.screenWidth != _lastScreenWidth) | (Main.screenHeight != _lastScreenHeight) | (_originalText != text) | (PlayerInput.CurrentInputMode != _lastInputMode) | (originalColor != baseColor)) {
+ 			_lastScreenWidth = Main.screenWidth;
+ 			_lastScreenHeight = Main.screenHeight;
+ 			_originalText = text;
+ 			_lastInputMode = PlayerInput.CurrentInputMode;
++			originalColor = baseColor;
++
++			/*
+ 			TextLines = Utils.WordwrapString(text, FontAssets.MouseText.Value, 460, 10, out var lineAmount);
+ 			AmountOfLines = lineAmount;
++			*/
++			TextLines = Utils.WordwrapStringSmart(text, baseColor, FontAssets.MouseText.Value, 460, 10);
++			AmountOfLines = TextLines.Count;
+ 		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Main.cs.rej
+++ b/patches/tModLoader/Terraria/Main.cs.rej
@@ -1,38 +1,3 @@
-@@ -143,20 +_,31 @@
- 		private int _lastScreenHeight;
- 		private InputMode _lastInputMode;
- 
--		public string[] TextLines { get; private set; }
-+		// Added by TML.
-+		private Color originalColor;
-+
-+		public List<List<TextSnippet>> TextLines { get; private set; } // Changed from string[]
- 
- 		public int AmountOfLines { get; private set; }
- 
--		public void PrepareCache(string text)
-+		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
-+		// Added baseColor parameter
-+		public void PrepareCache(string text, Color baseColor)
- 		{
--			if (false | (screenWidth != _lastScreenWidth) | (screenHeight != _lastScreenHeight) | (_originalText != text) | (PlayerInput.CurrentInputMode != _lastInputMode)) {
-+			if (false | (screenWidth != _lastScreenWidth) | (screenHeight != _lastScreenHeight) | (_originalText != text) | (PlayerInput.CurrentInputMode != _lastInputMode) | (originalColor != baseColor)) {
- 				_lastScreenWidth = screenWidth;
- 				_lastScreenHeight = screenHeight;
- 				_originalText = text;
- 				_lastInputMode = PlayerInput.CurrentInputMode;
- 				text = Lang.SupportGlyphs(text);
-+				originalColor = baseColor;
-+
-+				/*
- 				TextLines = Utils.WordwrapString(text, FontAssets.MouseText.Value, 460, 10, out var lineAmount);
- 				AmountOfLines = lineAmount;
-+				*/
-+				TextLines = Utils.WordwrapStringSmart(text, baseColor, FontAssets.MouseText.Value, 460, 10);
-+				AmountOfLines = TextLines.Count;
- 			}
- 		}
- 	}
 @@ -3933,8 +_,10 @@
  						new FileInfo(text2);
  						autoGenFileLocation = text2;
@@ -84,70 +49,6 @@
  			if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z) && !oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Z)) {
  				text = "";
  			}
-@@ -31743,8 +_,12 @@
- 			textValue = Language.GetTextValue("StardewTalk.PlayerHasColaAndIsHoldingIt");
- 
- 		bool flag2 = player[myPlayer].talkNPC != -1;
-+		/*
- 		_textDisplayCache.PrepareCache(textValue);
- 		string[] textLines = _textDisplayCache.TextLines;
-+		*/
-+		_textDisplayCache.PrepareCache(textValue, color2);
-+		List<List<TextSnippet>> textLines = _textDisplayCache.TextLines;
- 		int amountOfLines = _textDisplayCache.AmountOfLines;
- 		bool flag3 = false;
- 		if (editSign) {
-@@ -31758,16 +_,25 @@
- 				textBlinkerCount = 0;
- 			}
- 
--			if (textBlinkerState == 1)
-+			if (textBlinkerState == 1) {
- 				flag3 = true;
-+
-+				textLines[amountOfLines - 1].Add(new TextSnippet("|", Microsoft.Xna.Framework.Color.White, 1f));
-+			}
- 
- 			instance.DrawWindowsIMEPanel(new Vector2(screenWidth / 2, 90f), 0.5f);
- 		}
- 
-+		/*
- 		amountOfLines++;
-+		*/
- 		spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100f), new Microsoft.Xna.Framework.Rectangle(0, 0, TextureAssets.ChatBack.Width(), (amountOfLines + 1) * 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
- 		spriteBatch.Draw(TextureAssets.ChatBack.Value, new Vector2(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100 + (amountOfLines + 1) * 30), new Microsoft.Xna.Framework.Rectangle(0, TextureAssets.ChatBack.Height() - 30, TextureAssets.ChatBack.Width(), 30), color, 0f, default(Vector2), 1f, SpriteEffects.None, 0f);
-+
-+		// Fix all instances of drawing text to use TextSnippets instead of strings (#FixNPCChat)
-+		TextSnippet hoveredSnippet = null;
- 		for (int i = 0; i < amountOfLines; i++) {
-+			/*
- 			string text = textLines[i];
- 			if (text != null) {
- 				if (i == amountOfLines - 1 && flag3)
-@@ -31778,6 +_,23 @@
- 				else
- 					Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.MouseText.Value, text, 170 + (screenWidth - 800) / 2, 120 + i * 30, color2, Microsoft.Xna.Framework.Color.Black, Vector2.Zero);
- 			}
-+			*/
-+			List<TextSnippet> text = textLines[i];
-+			ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, text.ToArray(), new Vector2(170 + (screenWidth - 800) / 2, 120 + i * 30), 0f, color2, Color.Black, Vector2.Zero, Vector2.One, out int hoveredSnippetNum);
-+
-+			if (hoveredSnippetNum > -1)
-+				hoveredSnippet = text[hoveredSnippetNum];
-+		}
-+
-+		if (flag3)
-+			textLines[amountOfLines - 1].RemoveAt(textLines[amountOfLines - 1].Count - 1);
-+
-+		// Added on-hover and on-click callbacks as well
-+		if (hoveredSnippet is not null) {
-+			hoveredSnippet.OnHover();
-+
-+			if (mouseLeft && mouseLeftRelease)
-+				hoveredSnippet.OnClick();
- 		}
- 
- 		Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100, TextureAssets.ChatBack.Width(), (amountOfLines + 2) * 30);
 @@ -33572,7 +_,7 @@
  			if (numAvailableRecipes > 0) {
  				UILinkPointNavigator.Shortcuts.CRAFT_CurrentRecipeBig = -1;

--- a/patches/tModLoader/Terraria/UI/Chat/ChatManager.TML.cs
+++ b/patches/tModLoader/Terraria/UI/Chat/ChatManager.TML.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Graphics;
@@ -15,7 +12,7 @@ public static partial class ChatManager
 	public static void DrawColorCodedStringWithShadow(SpriteBatch spriteBatch, DynamicSpriteFont font, TextSnippet[] snippets, Vector2 position, Color color, Color shadowColor, float rotation, Vector2 origin, Vector2 baseScale, out int hoveredSnippet, float maxWidth = -1f, float spread = 2f)
 	{
 		DrawColorCodedStringShadow(spriteBatch, font, snippets, position, shadowColor, rotation, origin, baseScale, maxWidth, spread);
-		DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth, ignoreColors: true);
+		DrawColorCodedString(spriteBatch, font, snippets, position, color, rotation, origin, baseScale, out hoveredSnippet, maxWidth);
 	}
 
 	// Overload with shadowColor param


### PR DESCRIPTION
### What is the bug?

#2629 Make several fixes to allow NPC dialogue to properly use chat tags and proper text wrapping (that doesn't break color chat tags).

1.4.5 moved several of the methods into their own class or other class. `Main.TextDisplayCache` was moved to its own class (`Terraria.GameContent.UI.TextDisplayCache`) and `Main.GUIChatDrawInner` was migrated to `NPCChatPanel` (`Terraria.GameContent.UI.NPCChatPanel.DrawText`). The patches for them weren't applied to the new locations.

### How did you fix the bug?

Reapplied the patches in their new locations.

### Are there alternatives to your fix?

* You might notice `text = Lang.SupportGlyphs(text);` was not re-added to `TextDisplayCache.PrepareCache`. That's because `Lang.SupportGlyphs` was removed in 1.4.5. What it did was replace `<right>` and `<left>` with translated right and left click strings. This was replaced with `{InputTrigger_InteractWithTile}` and `{InputTrigger_UseOrAttack}` in 1.4.5 and works almost globally I believe. I'll make a separate PR updating Example Mod with the new substitutions.

* The original PR added this line 
```cs
if (flag3)
	textLines[amountOfLines - 1].RemoveAt(textLines[amountOfLines - 1].Count - 1);
```
with `flag3` being true if `textBlinkerState == 1`

I believe this was to remove the vertical bar for the cursor while typing in a sign from the calculations. If so, I'm not sure if it is necessary anymore because the vertical bar gets added at the end of the method whereas with 1.4.4 it was added at the beginning.