### PR TITLE
Resolve GameModeData porting note

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -2,7 +2,6 @@
 
 Once all patches are fixed, these items need to be fixed or double checked:
 
-- GameModeData.cs no longer exists, patches need to be redistributed
 - NPCSpawnParams.gameModeData no longer exists. This was potentially used in IBestiaryInfoElement.
 - NPCSpawnParams.strengthMultiplierOverride renamed to difficultyOverride. Investigate if behavior changed.
 - NPCHitCount = 58 --> (and others) needs comment explaining what the value should be. Why is it 1 more when no sound 0?

--- a/patches/tModLoader/Terraria/ID/NPCID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/NPCID.cs.patch
@@ -483,7 +483,7 @@
 +		/// If <see langword="true"/> for a given NPC type (<see cref="NPC.type"/>), then that NPC will receive stat scaling in Expert Mode, even if its normal stats would prevent that.
 +		/// <br/> Defaults to <see langword="false"/>.
 +		/// </summary>
-+		/// <remarks>NPCs with less than 5 health are most prone to needing this set. The full scaling conditions can be found at the start of <see cref="NPC.ScaleStats(int?, GameModeData, float?)"/>.</remarks>
++		/// <remarks>NPCs with less than 5 health are most prone to needing this set. The full scaling conditions can be found at the start of <see cref="NPC.ScaleStats(int?, float?)"/>.</remarks>
  		public static bool[] NeedsExpertScaling = Factory.CreateBoolSet(25, 30, 665, 33, 112, 666, 261, 265, 371, 516, 519, 397, 396, 398, 491);
 +
 +		/// <summary>

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1006,6 +1006,26 @@
  		}
  	}
  
+@@ -2233,6 +_,11 @@
+ 
+ 	public static string SavePath => Program.SavePath;
+ 
++	/// <summary>
++	/// The world mode of the active world. A <see cref="GameModeID"/> value. (<see href="https://terraria.wiki.gg/wiki/Difficulty#World_modes">World modes wiki page</see>)
++	/// <para/> For the actual active difficulty, see <see cref="Difficulty"/>.
++	/// <para/> For gameplay logic based on world difficulty it is usually best to check <see cref="Main.expertMode"/>, <see cref="masterMode"/>, and <see cref="IsJourneyMode"/> directly.
++	/// </summary>
+ 	public static int GameMode {
+ 		get {
+ 			if (ActiveWorldFileData == null)
+@@ -2246,6 +_,7 @@
+ 		}
+ 	}
+ 
++	/// <summary> The active world is a Journey mode world. Note that the world <see cref="Difficulty"/> is separate. </summary>
+ 	public static bool IsJourneyMode => GameMode == 3;
+ 
+ 	public static bool NoFunctionalSurface => worldSurface <= 30.0;
 @@ -2259,6 +_,7 @@
  		}
  	}
@@ -1014,17 +1034,25 @@
  	public static bool specialSeedWorld {
  		get {
  			if (!drunkWorld && !getGoodWorld && !tenthAnniversaryWorld && !notTheBeesWorld && !dontStarveWorld && !remixWorld && !noTrapsWorld && !zenithWorld)
-@@ -2295,8 +_,10 @@
+@@ -2295,10 +_,18 @@
  		}
  	}
  
-+	/// <summary> Returns true if the world is a Master Mode world. Note that the <see cref="expertMode"/> will also be true. </summary>
++	/// <summary> Returns true if the world is in Master Mode difficulty. Note that the <see cref="expertMode"/> will also be true. </summary>
  	public static bool masterMode => Difficulty >= GameDifficultyLevel.Master;
  
-+	/// <summary> Returns true if the world is an Expert Mode world. Will be true even in Master Mode worlds. </summary>
++	/// <summary> Returns true if the world is in Expert Mode difficulty. Will be true even in Master Mode or higher difficulties. </summary>
  	public static bool expertMode => Difficulty >= GameDifficultyLevel.Expert;
  
++	/// <summary>
++	/// The difficulty of the active world. Takes into account the Journey Mode difficulty slider if in use. Can be used to scale various stats to account for desired difficulty. (The <see href="https://terraria.wiki.gg/wiki/Difficulty">Difficulty wiki page</see> lists how difficulty affects some stats.)
++	/// <para/> Journey mode is 0.5, Class is 1, Expert is 2, Master is 3. The journey mode difficulty slider overrides these values and the For the Worthy seed will add 1.
++	/// <para/> For the actual world mode, see <see cref="GameMode"/>.
++	/// <para/> For gameplay logic based on world difficulty it is usually best to check <see cref="Main.expertMode"/>, <see cref="masterMode"/>, and <see cref="IsJourneyMode"/> directly.
++	/// </summary>
  	public static float Difficulty {
+ 		get {
+ 			float num = GameDifficultyLevel.Classic;
 @@ -2333,8 +_,16 @@
  	[Old("Transform is deprecated. Please use GameViewMatrix & GUIViewMatrix")]
  	public static Matrix Transform => GameViewMatrix.TransformationMatrix;


### PR DESCRIPTION
### What is changed

This addresses the first `PortingNotes_1.4.5.md` TODO:

> GameModeData.cs no longer exists, patches need to be redistributed

I checked for remaining `GameModeData` references and found the stale reference was in the XML docs for `NPCID.Sets.NeedsExpertScaling`.

The patch now updates the cref from:

```csharp
NPC.ScaleStats(int?, GameModeData, float?)
```

to the current 1.4.5 signature:

```csharp
NPC.ScaleStats(int?, float?)
```

The completed TODO was removed from `PortingNotes_1.4.5.md`.

### Verification

- `rg GameModeData .` finds no remaining references.
- `dotnet build` succeeds with 0 errors.
- existing warnings remain unrelated.

### Feedback wanted

This is my first small 1.4.5 porting contribution, so I would appreciate feedback on whether this is the expected way to resolve this TODO and whether removing the note from `PortingNotes_1.4.5.md` is appropriate.