### PR TITLE
fix: Fertilizer now grows modded saplings (resolves #3586)

### DIFF
--- a/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
+++ b/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
@@ -63,25 +63,28 @@ namespace ExampleMod.Content.Tiles.Plants
 				return;
 			}
 
-			Tile tile = Framing.GetTileSafely(i, j); // Safely get the tile at the given coordinates
-			bool growSuccess; // A bool to see if the tree growing was successful.
+			GrowSapling(i, j);
+		}
+
+		// Overridden to handle both ExampleTree (GrowTree) and ExamplePalmTree (GrowPalmTree) styles based on TileFrameX.
+		public override bool GrowSapling(int x, int y) {
+			Tile tile = Framing.GetTileSafely(x, y);
+			bool growSuccess;
 
 			// Style 0 is for the ExampleTree sapling, and style 1 is for ExamplePalmTree, so here we check frameX to call the correct method.
 			// Any pixels before 54 on the tilesheet are for ExampleTree while any pixels above it are for ExamplePalmTree
 			if (tile.TileFrameX < 54) {
-				growSuccess = WorldGen.GrowTree(i, j);
+				growSuccess = WorldGen.GrowTree(x, y);
 			}
 			else {
-				growSuccess = WorldGen.GrowPalmTree(i, j);
+				growSuccess = WorldGen.GrowPalmTree(x, y);
 			}
 
-			// A flag to check if a player is near the sapling
-			bool isPlayerNear = WorldGen.PlayerLOS(i, j);
-
-			// If growing the tree was a success and the player is near, show growing effects
-			if (growSuccess && isPlayerNear) {
-				WorldGen.TreeGrowFXCheck(i, j);
+			if (growSuccess && WorldGen.PlayerLOS(x, y)) {
+				WorldGen.TreeGrowFXCheck(x, y);
 			}
+
+			return growSuccess;
 		}
 
 		public override void SetSpriteEffects(int i, int j, ref SpriteEffects effects) {

--- a/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
+++ b/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
@@ -67,21 +67,21 @@ namespace ExampleMod.Content.Tiles.Plants
 		}
 
 		// Overridden to handle both ExampleTree (GrowTree) and ExamplePalmTree (GrowPalmTree) styles based on TileFrameX.
-		public override bool GrowSapling(int x, int y) {
-			Tile tile = Framing.GetTileSafely(x, y);
+		public override bool GrowSapling(int i, int j) {
+			Tile tile = Framing.GetTileSafely(i, j);
 			bool growSuccess;
 
 			// Style 0 is for the ExampleTree sapling, and style 1 is for ExamplePalmTree, so here we check frameX to call the correct method.
 			// Any pixels before 54 on the tilesheet are for ExampleTree while any pixels above it are for ExamplePalmTree
 			if (tile.TileFrameX < 54) {
-				growSuccess = WorldGen.GrowTree(x, y);
+				growSuccess = WorldGen.GrowTree(i, j);
 			}
 			else {
-				growSuccess = WorldGen.GrowPalmTree(x, y);
+				growSuccess = WorldGen.GrowPalmTree(i, j);
 			}
 
-			if (growSuccess && WorldGen.PlayerLOS(x, y)) {
-				WorldGen.TreeGrowFXCheck(x, y);
+			if (growSuccess && WorldGen.PlayerLOS(i, j)) {
+				WorldGen.TreeGrowFXCheck(i, j);
 			}
 
 			return growSuccess;

--- a/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
+++ b/ExampleMod/Content/Tiles/Plants/ExampleSapling.cs
@@ -58,26 +58,30 @@ namespace ExampleMod.Content.Tiles.Plants
 		}
 
 		public override void RandomUpdate(int i, int j) {
-			// A random chance to slow down growth
+			// Determine if the sapling is above ground or underground. We could use this to prevent above ground growth similar to gem trees, for example.
+			bool overground = Main.isThereAWorldSurface && j < (int)Main.worldSurface - 1;
+
+			// A random chance to slow down growth. 
 			if (!WorldGen.genRand.NextBool(20)) {
 				return;
 			}
 
-			GrowSapling(i, j);
+			// For natural spawns, we usually leave treeHeightAddon as 0 and ignoreWalls as false.
+			WorldGen.AttemptToGrowTreeFromSapling(i, j, underground: !overground, treeHeightAddon: 0, ignoreWalls: false);
 		}
 
 		// Overridden to handle both ExampleTree (GrowTree) and ExamplePalmTree (GrowPalmTree) styles based on TileFrameX.
-		public override bool GrowSapling(int i, int j) {
+		public override bool GrowSapling(int i, int j, bool underground, int treeHeightAddon, bool ignoreWalls) {
 			Tile tile = Framing.GetTileSafely(i, j);
 			bool growSuccess;
 
 			// Style 0 is for the ExampleTree sapling, and style 1 is for ExamplePalmTree, so here we check frameX to call the correct method.
 			// Any pixels before 54 on the tilesheet are for ExampleTree while any pixels above it are for ExamplePalmTree
 			if (tile.TileFrameX < 54) {
-				growSuccess = WorldGen.GrowTree(i, j);
+				growSuccess = WorldGen.GrowTree(i, j, treeHeightAddon, ignoreWalls);
 			}
 			else {
-				growSuccess = WorldGen.GrowPalmTree(i, j);
+				growSuccess = WorldGen.GrowPalmTree(i, j, treeHeightAddon, ignoreWalls);
 			}
 
 			if (growSuccess && WorldGen.PlayerLOS(i, j)) {

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -545,3 +545,4 @@ All classes are in the `Terraria.ModLoader` or `Terraria` namespaces unless othe
 * ⚙️: `ModNPC.OnChatButtonClicked` changed parameters. `(bool firstButton, ref string shop)` -> `(NPCInteraction interaction)`
 * ⚙️: `GlobalNPC.OnChatButtonClicked` and `GlobalNPC.PreChatButtonClicked` changed parameters. `(NPC npc, bool firstButton)` -> `(NPC npc, NPCInteraction interaction)`
 * ⚙️: `ModItem.IsQuestFish` has been removed. Use `ItemID.Sets.IsQuestFish` instead.
+* 🤖: Modded trees now support being grown directly with `Fertilizer` and `Infused Fertilizer`. This requires moving tree growing code in your sapling tiles. Move `WorldGen.GrowTree`/`WorldGen.GrowPalmTree` code from `ModTile.RandomUpdate` to the new `ModTile.GrowSapling` method and call `WorldGen.AttemptToGrowTreeFromSapling` in its place. See the [`ExampleSapling.cs` changes](https://github.com/tModLoader/tModLoader/pull/5229/changes) for an example.

--- a/patches/tModLoader/Terraria/ID/WallID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/WallID.cs.patch
@@ -21,7 +21,14 @@
  		public static bool[] DualDungeonsJungleBiomeWalls = Factory.CreateBoolSet(64, 204, 205, 206, 207, 15);
  		public static bool[] CanBeConvertedToGlowingMushroom = Factory.CreateBoolSet(64, 67, 15, 247);
  		public static bool[] AllowsUndergroundDesertEnemiesToSpawn = Factory.CreateBoolSet(187, 220, 222, 221, 216, 217, 219, 218, 223);
-@@ -36,9 +_,13 @@
+@@ -33,12 +_,20 @@
+ 		public static bool[] SpreadsHallow = Factory.CreateBoolSet(70, 219, 222, 28);
+ 		public static bool[] AllowsWind = Factory.CreateBoolSet(0, 150, 138, 145, 107, 152, 140, 139, 141, 106, 245, 315, 317);
+ 		public static bool[] Fences = Factory.CreateBoolSet(150, 138, 145, 107, 152, 140, 139, 141, 106, 245, 315, 317);
++		/// <summary>
++		/// If <see langword="true"/>, plants can grow naturally at a tile location occupied by this wall. Vanilla examples include various fences and various grass walls.
++		/// <para/> Defaults to <see langword="false"/>.
++		/// </summary>
  		public static bool[] AllowsPlantsToGrow = Factory.CreateBoolSet(0, 150, 138, 145, 107, 152, 140, 139, 141, 106, 245, 315, 317, 63, 64, 65, 66, 67, 68, 69, 81, 70, 264, 268, 265, 74, 80);
  		public static bool[] CannotBeReplacedByWallSpread = Factory.CreateBoolSet(4, 40, 3, 83, 87, 244, 34);
  		public static bool[] WallSpreadStopsAtAir = Factory.CreateBoolSet(63, 62);

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -154,15 +154,19 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
-	/// Called when fertilizer (<see cref="ItemID.Fertilizer"/>) is used on this tile, if <see cref="TileID.Sets.CommonSapling"/> is set for this tile type.
-	/// <br/> By default, attempts to grow a standard tree via <see cref="WorldGen.GrowTree"/>, matching vanilla fertilizer behavior. Override to use a different growth method (e.g. <see cref="WorldGen.GrowPalmTree"/>) or to add custom logic.
-	/// <br/> Return <see langword="true"/> if growth was attempted (even if it failed due to space constraints), <see langword="false"/> to do nothing.
+	/// Called when a tree is attempting to grow from a sapling tile (Assuming <see cref="TileID.Sets.CommonSapling"/> is set for this tile type) at this location. This can be either a natural growth from code calling <see cref="WorldGen.AttemptToGrowTreeFromSapling(int, int, bool, int, bool)"/> in <see cref="ModBlockType.RandomUpdate(int, int)"/> or unnaturally, such as when fertilizer (<see cref="ItemID.Fertilizer"/> or <see cref="ItemID.SuperFertilizer"/>) is used on this tile.
+	/// <para/> <paramref name="treeHeightAddon"/> and <paramref name="ignoreWalls"/> are set based on how the tree is being grown. For example, <see cref="ItemID.SuperFertilizer"/> will set <paramref name="treeHeightAddon"/> to 15 and <paramref name="ignoreWalls"/> to true, while natural growth will set <paramref name="treeHeightAddon"/> to 0 and <paramref name="ignoreWalls"/> to false.
+	/// <para/> By default, attempts to grow a standard tree via <see cref="WorldGen.GrowTree"/> and then potentially spawns leaves if a player is nearby, matching vanilla behavior. Override to use a different growth method (e.g. <see cref="WorldGen.GrowPalmTree"/>) or to add custom logic.
+	/// <para/> Return <see langword="true"/> if a tree was grown, <see langword="false"/> otherwise.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>
 	/// <param name="j">The y position in tile coordinates.</param>
-	public virtual bool GrowSapling(int i, int j)
+	/// <param name="underground">If the location should be considered underground or not.</param>
+	/// <param name="treeHeightAddon">The additional height for the tree. Will be 0 if <see cref="ItemID.Fertilizer"/> is used and 15 when <see cref="ItemID.SuperFertilizer"/> is used.</param>
+	/// <param name="ignoreWalls">If wall restrictions should be ignored.</param>
+	public virtual bool GrowSapling(int i, int j, bool underground, int treeHeightAddon, bool ignoreWalls)
 	{
-		bool success = WorldGen.GrowTree(i, j);
+		bool success = WorldGen.GrowTree(i, j, treeHeightAddon, ignoreWalls);
 		if (success && WorldGen.PlayerLOS(i, j))
 			WorldGen.TreeGrowFXCheck(i, j);
 		return success;

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -158,13 +158,13 @@ public abstract class ModTile : ModBlockType
 	/// <br/> By default, attempts to grow a standard tree via <see cref="WorldGen.GrowTree"/>, matching vanilla fertilizer behavior. Override to use a different growth method (e.g. <see cref="WorldGen.GrowPalmTree"/>) or to add custom logic.
 	/// <br/> Return <see langword="true"/> if growth was attempted (even if it failed due to space constraints), <see langword="false"/> to do nothing.
 	/// </summary>
-	/// <param name="x">The x position in tile coordinates.</param>
-	/// <param name="y">The y position in tile coordinates.</param>
-	public virtual bool GrowSapling(int x, int y)
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	public virtual bool GrowSapling(int i, int j)
 	{
-		bool success = WorldGen.GrowTree(x, y);
-		if (success && WorldGen.PlayerLOS(x, y))
-			WorldGen.TreeGrowFXCheck(x, y);
+		bool success = WorldGen.GrowTree(i, j);
+		if (success && WorldGen.PlayerLOS(i, j))
+			WorldGen.TreeGrowFXCheck(i, j);
 		return success;
 	}
 

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -154,6 +154,21 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Called when fertilizer (<see cref="ItemID.Fertilizer"/>) is used on this tile, if <see cref="TileID.Sets.CommonSapling"/> is set for this tile type.
+	/// <br/> By default, attempts to grow a standard tree via <see cref="WorldGen.GrowTree"/>, matching vanilla fertilizer behavior. Override to use a different growth method (e.g. <see cref="WorldGen.GrowPalmTree"/>) or to add custom logic.
+	/// <br/> Return <see langword="true"/> if growth was attempted (even if it failed due to space constraints), <see langword="false"/> to do nothing.
+	/// </summary>
+	/// <param name="x">The x position in tile coordinates.</param>
+	/// <param name="y">The y position in tile coordinates.</param>
+	public virtual bool GrowSapling(int x, int y)
+	{
+		bool success = WorldGen.GrowTree(x, y);
+		if (success && WorldGen.PlayerLOS(x, y))
+			WorldGen.TreeGrowFXCheck(x, y);
+		return success;
+	}
+
+	/// <summary>
 	/// Whether or not the smart interact function can select this tile. Useful for things like chests. Defaults to false.
 	/// </summary>
 	/// <param name="i">The x position in tile coordinates.</param>

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1094,12 +1094,12 @@ public static class TileLoader
 	/// Invokes <see cref="ModTile.GrowSapling"/> for the modded tile at the given coordinates.
 	/// Called by <see cref="WorldGen.AttemptToGrowTreeFromSapling"/> when fertilizer is used on a modded sapling tile.
 	/// </summary>
-	public static bool GrowModSapling(int x, int y, int type)
+	public static bool GrowModSapling(int i, int j, int type)
 	{
-		if (!Main.tile[x, y].active())
+		if (!Main.tile[i, j].active())
 			return false;
 
-		return GetTile(type)?.GrowSapling(x, y) ?? false;
+		return GetTile(type)?.GrowSapling(i, j) ?? false;
 	}
 
 	public static bool TileFrame(int i, int j, int type, ref bool resetFrame, ref bool noBreak)

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1094,12 +1094,12 @@ public static class TileLoader
 	/// Invokes <see cref="ModTile.GrowSapling"/> for the modded tile at the given coordinates.
 	/// Called by <see cref="WorldGen.AttemptToGrowTreeFromSapling"/> when fertilizer is used on a modded sapling tile.
 	/// </summary>
-	public static bool GrowModSapling(int i, int j, int type)
+	public static bool GrowModSapling(int i, int j, int type, bool underground, int treeHeightAddon, bool ignoreWalls)
 	{
 		if (!Main.tile[i, j].active())
 			return false;
 
-		return GetTile(type)?.GrowSapling(i, j) ?? false;
+		return GetTile(type)?.GrowSapling(i, j, underground, treeHeightAddon, ignoreWalls) ?? false;
 	}
 
 	public static bool TileFrame(int i, int j, int type, ref bool resetFrame, ref bool noBreak)

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1090,6 +1090,18 @@ public static class TileLoader
 		}
 	}
 
+	/// <summary>
+	/// Invokes <see cref="ModTile.GrowSapling"/> for the modded tile at the given coordinates.
+	/// Called by <see cref="WorldGen.AttemptToGrowTreeFromSapling"/> when fertilizer is used on a modded sapling tile.
+	/// </summary>
+	public static bool GrowModSapling(int x, int y, int type)
+	{
+		if (!Main.tile[x, y].active())
+			return false;
+
+		return GetTile(type)?.GrowSapling(x, y) ?? false;
+	}
+
 	public static bool TileFrame(int i, int j, int type, ref bool resetFrame, ref bool noBreak)
 	{
 		ModTile modTile = GetTile(type);

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1492,15 +1492,15 @@
  		if (aiStyle == 1) {
  			AI_001();
  		}
-@@ -19034,7 +_,7 @@
+@@ -19072,7 +_,7 @@
+ 							treeHeightAddon = 15;
+ 
  						Tile tile = Main.tile[num57, num58];
 -						if (tile.type >= 0 && tile.type < TileID.Count && TileID.Sets.CommonSapling[tile.type]) {
 +						if (tile.type >= 0 && TileID.Sets.CommonSapling[tile.type]) {
  							if (Main.remixWorld && num58 >= (int)Main.worldSurface - 1 && num58 < Main.maxTilesY - 20)
  								WorldGen.AttemptToGrowTreeFromSapling(num57, num58, underground: false, treeHeightAddon, ignoreWalls: true);
-
- 							WorldGen.AttemptToGrowTreeFromSapling(num57, num58, num58 > (int)Main.worldSurface - 1, treeHeightAddon, ignoreWalls: true);
- 						}
+ 
 @@ -26518,7 +_,7 @@
  					int num816 = (int)base.Center.Y / 16;
  					for (int num817 = num815 - num814; num817 <= num815 + num814; num817++) {

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1492,6 +1492,15 @@
  		if (aiStyle == 1) {
  			AI_001();
  		}
+@@ -19034,7 +_,7 @@
+ 						Tile tile = Main.tile[num57, num58];
+-						if (tile.type >= 0 && tile.type < TileID.Count && TileID.Sets.CommonSapling[tile.type]) {
++						if (tile.type >= 0 && TileID.Sets.CommonSapling[tile.type]) {
+ 							if (Main.remixWorld && num58 >= (int)Main.worldSurface - 1 && num58 < Main.maxTilesY - 20)
+ 								WorldGen.AttemptToGrowTreeFromSapling(num57, num58, underground: false, treeHeightAddon, ignoreWalls: true);
+
+ 							WorldGen.AttemptToGrowTreeFromSapling(num57, num58, num58 > (int)Main.worldSurface - 1, treeHeightAddon, ignoreWalls: true);
+ 						}
 @@ -26518,7 +_,7 @@
  					int num816 = (int)base.Center.Y / 16;
  					for (int num817 = num815 - num814; num817 <= num815 + num814; num817++) {

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -909,7 +909,15 @@
  		}
  	}
  
-@@ -24568,7 +_,7 @@
+@@ -24565,10 +_,15 @@
+ 		return false;
+ 	}
+ 
++	/// <summary>
++	/// Attempts to grow a tree at the specified tile coordinates. Returns true if the tree was successfully grown, false otherwise.
++	/// <para/> <paramref name="treeHeightAddon"/> adds additional height to the resulting tree, such as if grown by <see cref="ItemID.SuperFertilizer"/>. <paramref name="ignoreWalls"/> when true ignores wall restrictions that usually apply to natural tree growth. See also <see cref="WallID.Sets.AllowsPlantsToGrow"/>.
++	/// <para/> Note that this can be used to directly grow trees during world generation without placing a sapling first.
++	/// </summary>
  	public static bool GrowTree(int i, int y, int treeHeightAddon = 0, bool ignoreWalls = false)
  	{
  		int j;
@@ -2806,6 +2814,16 @@
  		return false;
  	}
  
+@@ -58333,6 +_,9 @@
+ 	public static IEntitySource GetItemSource_FromWallBreak(int x, int y) => new EntitySource_TileBreak(x, y);
+ 	public static IEntitySource GetItemSource_FromTreeShake(int x, int y) => new EntitySource_ShakeTree(x, y);
+ 
++	/// <summary>
++	/// Returns true if any player is "located on screen" of the tile coordinates provided. Technically it checks a little farther than the normal max gameplay dimensions. Used for things like spawning tree leaves when trees grow near players or preventing the cultists from spawning when players are nearby. 
++	/// </summary>
+ 	public static bool PlayerLOS(int x, int y)
+ 	{
+ 		Rectangle rectangle = new Rectangle(x * 16, y * 16, 16, 16);
 @@ -58347,6 +_,11 @@
  		return false;
  	}
@@ -3052,12 +3070,26 @@
  		int num = i - 1;
  		int num2 = i + 2;
  		int num3 = j - 1;
-@@ -61162,4 +_,4 @@
+@@ -61071,6 +_,10 @@
+ 			DontStarveTryWateringTile(i, j);
+ 	}
+ 
++	/// <summary>
++	/// Attempts to grow a tree from a sapling at the specified coordinates. Returns true if the tree was successfully grown, false otherwise.
++	/// <para/> <paramref name="treeHeightAddon"/> adds additional height to the resulting tree, such as if grown by <see cref="ItemID.SuperFertilizer"/>. <paramref name="ignoreWalls"/> when true ignores wall restrictions that usually apply to natural tree growth. <paramref name="underground"/> indicates if the location should be considered underground or not.
++	/// </summary>
+ 	public static bool AttemptToGrowTreeFromSapling(int x, int y, bool underground, int treeHeightAddon = 0, bool ignoreWalls = false)
+ 	{
+ 		if (Main.netMode == 1)
+@@ -61160,7 +_,7 @@
+ 					TreeGrowFXCheck(x, y);
+ 				return flag;
  			default:
 -				return false;
-+				return TileLoader.GrowModSapling(x, y, tile.type);
++				return TileLoader.GrowModSapling(x, y, tile.type, underground, treeHeightAddon, ignoreWalls);
  		}
  	}
+ 
 @@ -61201,6 +_,7 @@
  		return DelegateMethods.CheckResultOut;
  	}

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -3052,6 +3052,12 @@
  		int num = i - 1;
  		int num2 = i + 2;
  		int num3 = j - 1;
+@@ -61162,4 +_,4 @@
+ 			default:
+-				return false;
++				return TileLoader.GrowModSapling(x, y, tile.type);
+ 		}
+ 	}
 @@ -61201,6 +_,7 @@
  		return DelegateMethods.CheckResultOut;
  	}
@@ -3606,10 +3612,10 @@
  		return result;
 @@ -72683,7 +_,7 @@
  			return false;
- 
+
  		bool result = true;
 -		if (tileTopCache.active() && (TileID.Sets.BasicChest[tileTopCache.type] || TileID.Sets.BasicChestFake[tileTopCache.type] || tileTopCache.type == 323 || tileTopCache.type == 88 || tileTopCache.type == 80 || tileTopCache.type == 77 || tileTopCache.type == 26 || tileTopCache.type == 475 || tileTopCache.type == 470 || tileTopCache.type == 597))
 +		if (tileTopCache.active() && (TileID.Sets.BasicChest[tileTopCache.type] || TileID.Sets.BasicChestFake[tileTopCache.type] || TileID.Sets.BasicDresser[tileTopCache.type] || TileID.Sets.PreventsSandfall[tileTopCache.type]))
  			result = false;
- 
+
  		return result;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -3612,10 +3612,10 @@
  		return result;
 @@ -72683,7 +_,7 @@
  			return false;
-
+ 
  		bool result = true;
 -		if (tileTopCache.active() && (TileID.Sets.BasicChest[tileTopCache.type] || TileID.Sets.BasicChestFake[tileTopCache.type] || tileTopCache.type == 323 || tileTopCache.type == 88 || tileTopCache.type == 80 || tileTopCache.type == 77 || tileTopCache.type == 26 || tileTopCache.type == 475 || tileTopCache.type == 470 || tileTopCache.type == 597))
 +		if (tileTopCache.active() && (TileID.Sets.BasicChest[tileTopCache.type] || TileID.Sets.BasicChestFake[tileTopCache.type] || TileID.Sets.BasicDresser[tileTopCache.type] || TileID.Sets.PreventsSandfall[tileTopCache.type]))
  			result = false;
-
+ 
  		return result;


### PR DESCRIPTION
### What is the bug?

Fertilizer (ItemID.Fertilizer) has no effect on modded sapling tiles, even when the mod correctly sets `TileID.Sets.CommonSapling[Type] = true`.

Fixes #3586

There were two separate guards blocking modded tiles:

1. **`Projectile.cs`** (the fertilizer projectile AI): checked `tile.type < TileID.Count` before calling `AttemptToGrowTreeFromSapling`, which unconditionally excluded every modded tile ID regardless of `TileID.Sets.CommonSapling`.

2. **`WorldGen.AttemptToGrowTreeFromSapling`**: a switch over vanilla tile IDs (20 / 595 / 615 / 590) with `default: return false` — so even if a modded tile reached this function it was silently rejected.

### How did you fix the bug?

- **`Projectile.cs.patch`** — removed the `tile.type < TileID.Count` guard. `TileID.Sets.CommonSapling` is already sized to cover modded IDs so the check was unnecessary.
- **`WorldGen.cs.patch`** — replaced `default: return false` in `AttemptToGrowTreeFromSapling` with `return TileLoader.GrowModSapling(x, y, tile.type)`, delegating to the modded tile's own growth logic.
- **`TileLoader.cs`** — added `GrowModSapling(int x, int y, int type)` which invokes a new `ModTile.GrowSapling` hook.
- **`ModTile.cs`** — added virtual `GrowSapling(int x, int y)`. The default implementation calls `WorldGen.GrowTree` and shows the grow particle effect if successful, matching vanilla fertilizer behavior out of the box. Modders can override to use a different growth method (e.g. `WorldGen.GrowPalmTree`) or add custom logic.
- **`ExampleSapling.cs`** — overrides `GrowSapling` with direct `GrowTree`/`GrowPalmTree` logic; `RandomUpdate` now delegates to it so the growth code isn't duplicated and fertilizer correctly bypasses the 1-in-20 random delay.

### Are there alternatives to your fix?

Calling `TileLoader.RandomUpdate` directly instead of adding a new `GrowSapling` hook, but that would include the modder's random-chance delay in `RandomUpdate`, meaning fertilizer would only sometimes work — inconsistent with vanilla behavior.