### PR TITLE
Fix opening legacy presents

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.TML.cs
@@ -1189,6 +1189,18 @@ partial class ItemDropDatabase
 		RegisterToItem(ItemID.Present, new SequentialRulesNotScalingWithLuckRule(chanceDenominator: 1, rules));
 	}
 
+	private void RegisterLegacyPresent()
+	{
+		IItemDropRule[] rules = new IItemDropRule[]
+		{
+			ItemDropRule.ByConditionNotScalingWithLuck(new Conditions.IsHardmode(), ItemID.SnowGlobe, chanceDenominator: 14),
+			new CommonDropNotScalingWithLuck(ItemID.CandyCaneBlock, 14, 8, 20, 49),
+			ItemDropRule.Common(ItemID.GreenCandyCaneBlock, 1, 20, 49)
+		};
+
+		RegisterToMultipleItems(new SequentialRulesNotScalingWithLuckRule(chanceDenominator: 1, rules), ItemID.BluePresent, ItemID.GreenPresent, ItemID.YellowPresent);
+	}
+
 	private void RegisterCanOfWorms()
 	{
 		RegisterToItem(ItemID.CanOfWorms, ItemDropRule.NotScalingWithLuck(ItemID.Worm, 1, 5, 8));

--- a/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/ItemDropRules/ItemDropDatabase.cs.patch
@@ -46,7 +46,7 @@
  	{
  		if (_entriesByNpcNetId.ContainsKey(npcNetId))
  			_entriesByNpcNetId[npcNetId].Remove(entry);
-@@ -143,6 +_,31 @@
+@@ -143,6 +_,32 @@
  		RegisterMimic();
  		RegisterEclipse();
  		RegisterBloodMoonFishing();
@@ -59,6 +59,7 @@
 +		RegisterHerbBag();
 +		RegisterGoodieBag();
 +		RegisterPresent();
++		RegisterLegacyPresent();
 +		RegisterCanOfWorms();
 +		RegisterOyster();
 +		RegisterCapricorns();

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -432,7 +432,7 @@
  				return false;
 -
 +		*/
-+		else if (item.type == 599 && item.type == 600 && item.type == 601) {
++		else if (item.type == 599 || item.type == 600 || item.type == 601) {
  			player.OpenLegacyPresent(item.type);
  		}
 +		else { // Added by TML.


### PR DESCRIPTION
### What is the bug?
Original：
``` csharp
private static bool TryOpenContainer_GrantItems(Item item, Player player)
{
	if (ItemID.Sets.BossBag[item.type]) {
		player.OpenBossBag(item.type);
	}
	else if (ItemID.Sets.IsFishingCrate[item.type]) {
		player.OpenFishingCrate(item.type);
	}
	else if (item.type == 3093) {
		player.OpenHerbBag(3093);
	}
	else if (item.type == 4345) {
		player.OpenCanofWorms(item.type);
	}
	else if (item.type == 4410) {
		player.OpenOyster(item.type);
	}
	else if (item.type == 1774) {
		player.OpenGoodieBag(1774);
	}
	else if (item.type == 6142) {
		player.OpenChilletEgg(6142);
	}
	else if (item.type == 3085) {
		if (!player.ConsumeItem(327, reverseOrder: false, includeVoidBag: true))
			return false;

		player.OpenLockBox(3085);
	}
	else if (item.type == 4879) {
		if (!player.HasItemInInventoryOrOpenVoidBag(329))
			return false;

		player.OpenShadowLockbox(4879);
	}
	else if (item.type == 1869) {
		player.OpenPresent(1869);
	}
	/*
	else {
		if (item.type != 599 && item.type != 600 && item.type != 601)
			return false;
	*/
	else if (item.type == 599 && item.type == 600 && item.type == 601) { // this is always false
		player.OpenLegacyPresent(item.type);
	}
	else { // Added by TML.
		player.DropFromItem(item.type);
	}

	ItemLoader.RightClickCallHooks(item, player);
	return true;
}
```

### How did you fix the bug?
Change `&&` to `||`.

### Are there alternatives to your fix?
Leave it as is, because these three items are unobtainable now.