### PR TITLE
[1.4.5] <right> and <left> Click Porting Notes

### DIFF
--- a/ExampleMod/Content/Items/Consumables/ExampleFishingCrate.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleFishingCrate.cs
@@ -14,6 +14,7 @@ namespace ExampleMod.Content.Items.Consumables
 			// Disclaimer for both of these sets (as per their docs): They are only checked for vanilla item IDs, but for cross-mod purposes it would be helpful to set them for modded crates too
 			ItemID.Sets.IsFishingCrate[Type] = true;
 			//ItemID.Sets.IsFishingCrateHardmode[Type] = true; // This is a crate that mimics a pre-hardmode biome crate, so this is commented out
+			ItemID.Sets.OpenableBag[Type] = true;
 
 			Item.ResearchUnlockCount = 10;
 		}

--- a/ExampleMod/Content/Items/HoldStyleShowcase.cs
+++ b/ExampleMod/Content/Items/HoldStyleShowcase.cs
@@ -19,6 +19,8 @@ namespace ExampleMod.Content.Items
 		public override void SetStaticDefaults() {
 			SwitchingText = this.GetLocalization("Switching");
 			ThisIsText = this.GetLocalization("ThisIs");
+
+			ItemID.Sets.HasRightFire[Type] = true;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Content/Items/UseStyleShowcase.cs
+++ b/ExampleMod/Content/Items/UseStyleShowcase.cs
@@ -19,6 +19,8 @@ namespace ExampleMod.Content.Items
 		public override void SetStaticDefaults() {
 			SwitchingText = this.GetLocalization("Switching");
 			ThisIsText = this.GetLocalization("ThisIs");
+
+			ItemID.Sets.HasRightFire[Type] = true;
 		}
 
 		public override void SetDefaults() {

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -196,7 +196,7 @@ Mods: {
 			ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				DefaultSignText: "{InputTrigger_InteractWithTile} me!"
+				DefaultSignText: Interact wih me!
 				MapEntry: Example Sign
 			}
 

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -196,7 +196,7 @@ Mods: {
 			ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				DefaultSignText: Right-click me!
+				DefaultSignText: "{InputTrigger_InteractWithTile} me!"
 				MapEntry: Example Sign
 			}
 
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				DisplayName: Use Style Showcase
-				# The special text "<right>" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				Tooltip:
 					'''
 					This item showcases each UseStyle.
-					<right> to cycle through UseStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
 					'''
 				Switching: Switching to ItemUseStyleID #{0}
 				ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					<right> to cycle through HoldStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
 					'''
 				Switching: Switching to ItemHoldStyleID #{0}
 				ThisIs: This is ItemHoldStyleID #{0}
@@ -1152,7 +1152,7 @@ Mods: {
 
 			CustomItemDrawingShowcase: {
 				DisplayName: Custom Item Drawing Showcase
-				Tooltip: <right> to cycle draw mode examples
+				Tooltip: "{InputTrigger_ToggleOrOpen} to cycle draw mode examples"
 				RightClick: Switching to drawMode #{0}: {1}
 				DrawMode_0: Draw an overlay/glowmask
 				DrawMode_1: Scale drawing to make a pulse effect similar to Soul items
@@ -1187,7 +1187,7 @@ Mods: {
 
 			BasicTileEntityItem: {
 				DisplayName: Basic Tile Entity Item
-				Tooltip: Collects rain water. Right Click when full to claim a water bucket.
+				Tooltip: Collects rain water. {InputTrigger_InteractWithTile} when full to claim a water bucket.
 			}
 
 			CorruptFossilTileItem: {

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -196,7 +196,7 @@ Mods: {
 			ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				DefaultSignText: Interact wih me!
+				DefaultSignText: Interact with me!
 				MapEntry: Example Sign
 			}
 

--- a/ExampleMod/Localization/en-US.hjson
+++ b/ExampleMod/Localization/en-US.hjson
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				DisplayName: Use Style Showcase
-				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_InteractWithTile}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				Tooltip:
 					'''
 					This item showcases each UseStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
+					{InputTrigger_InteractWithTile} to cycle through UseStyles.
 					'''
 				Switching: Switching to ItemUseStyleID #{0}
 				ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
+					{InputTrigger_InteractWithTile} to cycle through HoldStyles.
 					'''
 				Switching: Switching to ItemHoldStyleID #{0}
 				ThisIs: This is ItemHoldStyleID #{0}

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: Interact wih me!
+				// DefaultSignText: Interact with me!
 				// MapEntry: Example Sign
 			}
 

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				// DisplayName: Use Style Showcase
-				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_InteractWithTile}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				/* Tooltip:
 					'''
 					This item showcases each UseStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
+					{InputTrigger_InteractWithTile} to cycle through UseStyles.
 					''' */
 				// Switching: Switching to ItemUseStyleID #{0}
 				// ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				/* Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
+					{InputTrigger_InteractWithTile} to cycle through HoldStyles.
 					''' */
 				// Switching: Switching to ItemHoldStyleID #{0}
 				// ThisIs: This is ItemHoldStyleID #{0}

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: Right-click me!
+				// DefaultSignText: "{InputTrigger_InteractWithTile} me!"
 				// MapEntry: Example Sign
 			}
 
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				// DisplayName: Use Style Showcase
-				# The special text "<right>" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				/* Tooltip:
 					'''
 					This item showcases each UseStyle.
-					<right> to cycle through UseStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
 					''' */
 				// Switching: Switching to ItemUseStyleID #{0}
 				// ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				/* Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					<right> to cycle through HoldStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
 					''' */
 				// Switching: Switching to ItemHoldStyleID #{0}
 				// ThisIs: This is ItemHoldStyleID #{0}
@@ -1152,7 +1152,7 @@ Mods: {
 
 			CustomItemDrawingShowcase: {
 				// DisplayName: Custom Item Drawing Showcase
-				// Tooltip: <right> to cycle draw mode examples
+				// Tooltip: "{InputTrigger_ToggleOrOpen} to cycle draw mode examples"
 				// RightClick: Switching to drawMode #{0}: {1}
 				// DrawMode_0: Draw an overlay/glowmask
 				// DrawMode_1: Scale drawing to make a pulse effect similar to Soul items
@@ -1187,7 +1187,7 @@ Mods: {
 
 			BasicTileEntityItem: {
 				// DisplayName: Basic Tile Entity Item
-				// Tooltip: Collects rain water. Right Click when full to claim a water bucket.
+				// Tooltip: Collects rain water. {InputTrigger_InteractWithTile} when full to claim a water bucket.
 			}
 
 			CorruptFossilTileItem: {

--- a/ExampleMod/Localization/ru-RU.hjson
+++ b/ExampleMod/Localization/ru-RU.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: "{InputTrigger_InteractWithTile} me!"
+				// DefaultSignText: Interact wih me!
 				// MapEntry: Example Sign
 			}
 

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: Interact wih me!
+				// DefaultSignText: Interact with me!
 				// MapEntry: Example Sign
 			}
 

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				// DisplayName: Use Style Showcase
-				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_InteractWithTile}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				/* Tooltip:
 					'''
 					This item showcases each UseStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
+					{InputTrigger_InteractWithTile} to cycle through UseStyles.
 					''' */
 				// Switching: Switching to ItemUseStyleID #{0}
 				// ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				/* Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
+					{InputTrigger_InteractWithTile} to cycle through HoldStyles.
 					''' */
 				// Switching: Switching to ItemHoldStyleID #{0}
 				// ThisIs: This is ItemHoldStyleID #{0}

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: Right-click me!
+				// DefaultSignText: "{InputTrigger_InteractWithTile} me!"
 				// MapEntry: Example Sign
 			}
 
@@ -752,11 +752,11 @@ Mods: {
 
 			UseStyleShowcase: {
 				// DisplayName: Use Style Showcase
-				# The special text "<right>" will change depending on if the user is using keyboard or gamepad to show the alternate click button
+				# The special text "{InputTrigger_ToggleOrOpen}" will change depending on if the user is using keyboard or gamepad to show the alternate click button
 				/* Tooltip:
 					'''
 					This item showcases each UseStyle.
-					<right> to cycle through UseStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through UseStyles.
 					''' */
 				// Switching: Switching to ItemUseStyleID #{0}
 				// ThisIs: This is ItemUseStyleID #{0}
@@ -922,7 +922,7 @@ Mods: {
 				/* Tooltip:
 					'''
 					This item showcases each HoldStyle.
-					<right> to cycle through HoldStyles.
+					{InputTrigger_ToggleOrOpen} to cycle through HoldStyles.
 					''' */
 				// Switching: Switching to ItemHoldStyleID #{0}
 				// ThisIs: This is ItemHoldStyleID #{0}
@@ -1152,7 +1152,7 @@ Mods: {
 
 			CustomItemDrawingShowcase: {
 				// DisplayName: Custom Item Drawing Showcase
-				// Tooltip: <right> to cycle draw mode examples
+				// Tooltip: "{InputTrigger_ToggleOrOpen} to cycle draw mode examples"
 				// RightClick: Switching to drawMode #{0}: {1}
 				// DrawMode_0: Draw an overlay/glowmask
 				// DrawMode_1: Scale drawing to make a pulse effect similar to Soul items
@@ -1187,7 +1187,7 @@ Mods: {
 
 			BasicTileEntityItem: {
 				// DisplayName: Basic Tile Entity Item
-				// Tooltip: Collects rain water. Right Click when full to claim a water bucket.
+				// Tooltip: Collects rain water. {InputTrigger_InteractWithTile} when full to claim a water bucket.
 			}
 
 			CorruptFossilTileItem: {

--- a/ExampleMod/Localization/zh-Hans.hjson
+++ b/ExampleMod/Localization/zh-Hans.hjson
@@ -196,7 +196,7 @@ Mods: {
 			// ExampleDresser.MapEntry: Example Dresser
 
 			ExampleSign: {
-				// DefaultSignText: "{InputTrigger_InteractWithTile} me!"
+				// DefaultSignText: Interact wih me!
 				// MapEntry: Example Sign
 			}
 

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -518,9 +518,9 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 * ⚙️: `Player.RandomTeleportationAttemptSettings` is now `Utils.RandomTeleportationAttemptSettings`. Modder will need to populate all relevant new fields (`teleporteeSize,  `teleporteeVelocity`, `teleporteeGravityDirection`).
 
 ### Localization
-* 💀: `<left>` and `<right>` strings that automatically localized into "Left Click" and "Right Click" has been removed.
+* 💀: `<left>` and `<right>` strings that automatically localized into "Left Click" and "Right Click" have been removed.
   * Replace all `<left>` with `{InputTrigger_UseOrAttack}`.
-  * Replace `<right>` with one of the three options:
+  * Replace `<right>` with one of these three options:
     * `{InputTrigger_ToggleOrOpen}` Used by items that have right click functionality in the inventory. Example: Grab bags and items that transform into other items.
 	  * `{$CommonItemTooltip.RightClickToOpen}` can still be used for "Right Click to open".
 	* `{InputTrigger_InteractWithTile}` Used by things that have right click functionality with tiles or the world. Example: Placing items into a tile or right click alternate fire weapons.

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -528,6 +528,7 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 	  * `{$CommonItemTooltip.RightClickToOpen}` can still be used for "Right Click to open".
 	* `{InputTrigger_InteractWithTile}` Used by things that have right click functionality with tiles or the world. Example: Placing items into a tile or right click alternate fire weapons.
 	* `{InputTrigger_InteractWithTileUI}` Used by the crafting window to tell you can right click it to switch between the classic and modern styles.
+  * These changes are to better support gamepad hint text and interactions. Also consider testing all items in your mod with right click interactions with a gamepad. You may need to add `ItemID.Sets.OpenableBag` or `ItemID.Sets.HasRightFire` if the gamepad instructions are missing or incorrect.
 
 ## tModLoader changes
 

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -517,6 +517,15 @@ All classes are in the `Terraria` or `Terraria.ID` namespaces unless otherwise i
 ### Classes
 * ⚙️: `Player.RandomTeleportationAttemptSettings` is now `Utils.RandomTeleportationAttemptSettings`. Modder will need to populate all relevant new fields (`teleporteeSize,  `teleporteeVelocity`, `teleporteeGravityDirection`).
 
+### Localization
+* 💀: `<left>` and `<right>` strings that automatically localized into "Left Click" and "Right Click" has been removed.
+  * Replace all `<left>` with `{InputTrigger_UseOrAttack}`.
+  * Replace `<right>` with one of the three options:
+    * `{InputTrigger_ToggleOrOpen}` Used by items that have right click functionality in the inventory. Example: Grab bags and items that transform into other items.
+	  * `{$CommonItemTooltip.RightClickToOpen}` can still be used for "Right Click to open".
+	* `{InputTrigger_InteractWithTile}` Used by things that have right click functionality with tiles or the world. Example: Placing items into a tile or right click alternate fire weapons.
+	* `{InputTrigger_InteractWithTileUI}` Used by the crafting window to tell you can right click it to switch between the classic and modern styles.
+
 ## tModLoader changes
 
 All classes are in the `Terraria.ModLoader` or `Terraria` namespaces unless otherwise indicated.

--- a/patches/tModLoader/Terraria/ID/ItemID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/ItemID.cs.patch
@@ -765,11 +765,11 @@
  		public static bool[] BossBag = Factory.CreateBoolSet(3318, 3319, 3320, 3321, 3322, 3323, 3324, 3325, 3326, 3327, 3328, 3329, 3330, 3331, 3332, 3860, 3861, 3862, 4782, 4957, 5111);
 +
 +		/// <summary>
-+		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item can be right-clicked in the inventory.
++		/// If <see langword="true"/> for a given item type (<see cref="Item.type"/>), then that item can be right-clicked in the inventory. The gamepad hint text "Open" will also be displayed for the alternate click action while the item is highlighted in the inventory.
 +		/// <br/> Defaults to <see langword="false"/>.
 +		/// </summary>
 +		/// <remarks>
-+		/// For <see cref="ModItem"/>s, you can simply use <see cref="ModItem.CanRightClick"/> or <see cref="GlobalItem.CanRightClick(Item)"/> instead of this set.
++		/// You can use <see cref="ModItem.CanRightClick"/> or <see cref="GlobalItem.CanRightClick(Item)"/> instead of this set, but the gamepad hint text will show "Alt Action" instead of "Open".
 +		/// <br/> If you need to check if any item is right-clickable, use <see cref="ItemLoader.CanRightClick(Item)"/>.
 +		/// </remarks>
  		public static bool[] OpenableBag = Factory.CreateBoolSet(3318, 3319, 3320, 3321, 3322, 3323, 3324, 3325, 3326, 3327, 3328, 3329, 3330, 3331, 3332, 3860, 3861, 3862, 4782, 4957, 5111, 2334, 2335, 2336, 3203, 3204, 3205, 3206, 3207, 3208, 4405, 4407, 4877, 5002, 3979, 3980, 3981, 3982, 3983, 3984, 3985, 3986, 3987, 4406, 4408, 4878, 5003, 3093, 4345, 4410, 1774, 6142, 3085, 4879, 1869, 599, 600, 601);

--- a/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ItemSlot.cs.patch
@@ -696,3 +696,22 @@
  			return currentColor;
  
  		if (type == 662 || type == 663 || type == 5444 || type == 5450 || type == 5643) {
+@@ -3124,6 +_,18 @@
+ 					s += PlayerInput.BuildCommand(Language.GetTextValue("UI.ActionChangeType"), PlayerInput.ProfileGamepadUI.KeyStatus["Grapple"]);
+ 					if (CanExecuteCommand() && PlayerInput.Triggers.JustPressed.Grapple) {
+ 						TryItemSwap(inv[slot]);
++						PlayerInput.LockGamepadButtons("Grapple");
++						PlayerInput.SettingsForUI.TryRevertingToMouseMode();
++					}
++				}
++				// TML: Add a right click path for items that might not want "Open" as the gamepad hint text.
++				else if (ItemLoader.CanRightClick(inv[slot])) {
++					s += PlayerInput.BuildCommand(Language.GetTextValue("UI.ActionAltAction"), PlayerInput.ProfileGamepadUI.KeyStatus["Grapple"]);
++					if (CanExecuteCommand() && PlayerInput.Triggers.JustPressed.Grapple) {
++						if (Main.ItemDropsDB.GetRulesForItemID(inv[slot].type).Any())
++							TryOpenContainer(inv, context, slot, player);
++						else
++							ItemLoader.RightClick(inv[slot], player);
+ 						PlayerInput.LockGamepadButtons("Grapple");
+ 						PlayerInput.SettingsForUI.TryRevertingToMouseMode();
+ 					}


### PR DESCRIPTION
### What is the bug?

* `<right>` and `<left>` are no longer auto translated to "Right Click" and "Left Click".

### How did you fix the bug?

* Replaced with existing `{InputTrigger_UseOrAttack}` (left click) and `{InputTrigger_ToggleOrOpen}`, `{InputTrigger_InteractWithTile}`, or `{InputTrigger_InteractWithTileUI}` (right click)

### Are there alternatives to your fix?

* We could register `<right>` and `<left>` as global substitutes if wanted to bring those back. However, `{InputTrigger_XYZ}` has different buttons depending on the context for the controller.
  * Example: `{InputTrigger_ToggleOrOpen}` is right click on keyboard but is the Grapple button on controller.

### Porting Notes

* Replace all `<left>` with `{InputTrigger_UseOrAttack}`.
* Replace `<right>` with one of the three options:
  * `{InputTrigger_ToggleOrOpen}` Used by items that have right click functionality in the inventory. Example: Grab bags and items that transform into other items.
	* `{$CommonItemTooltip.RightClickToOpen}` can still be used for "Right Click to open".
  * `{InputTrigger_InteractWithTile}` Used by things that have right click functionality with tiles or the world. Example: Placing items into a tile or right click alternate fire weapons.
  * `{InputTrigger_InteractWithTileUI}` Used by the crafting window to tell you can right click it to switch between the classic and modern styles.

#### Other keys

Lang.InitGlobalSubstitutions() has many other substitutions that may be useful.
* `{InputTriggerUI_BuildFromInventory}` -> QuickMount button
* `{?InputTriggerUI_TrashEnabled}` -> true if enabled
  * Example: "{?InputTriggerUI_TrashEnabled}If your Inventory is full, you can press {InputTriggerUI_Trash} to send items to the Trash.",
* `{InputTriggerUI_Trash}` -> Control or Shift depending on the user's settings. Or SmartSelect button for controller.
* `{InputTriggerUI_FavoriteItem}` -> FavoriteKey button (left alt) or SmartCursor button for controller.
* `{InputTrigger_QuickEquip}` -> Grapple button
* `{InputTrigger_Grapple}` -> Grapple button
* `{InputTrigger_LockOn}` -> LockOn button
* `{InputTrigger_RadialQuickbar}` -> HotbarMinus button
* `{InputTrigger_RadialHotbar}` -> HotbarPlus button
* `{InputTrigger_SmartCursor}` -> SmartCursor button
* `{InputTrigger_SmartSelect}` -> SmartSelect button
* `{ToggleArmorSetBonusKey}` -> Up or Down depending on the user's settings.