### PR TITLE
[1.4.5] EM Simple Minion Buff Text

### DIFF
--- a/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
+++ b/ExampleMod/Content/Projectiles/Minions/ExampleSimpleMinion.cs
@@ -23,6 +23,7 @@ namespace ExampleMod.Content.Projectiles.Minions
 		public override void SetStaticDefaults() {
 			Main.buffNoSave[Type] = true; // This buff won't save when you exit the world
 			Main.buffNoTimeDisplay[Type] = true; // The time remaining won't display on this buff
+			BuffID.Sets.BuffTextHandlers.Add(Type, new CachedProjectileCounterBuffTextHandler(ModContent.ProjectileType<ExampleSimpleMinion>())); // Adds the counter under the buff for how many active minions there are.
 		}
 
 		public override void Update(Player player, ref int buffIndex) {

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -390,7 +390,7 @@ See ExampleWhip, ExampleWhipAdvanced, ExampleWhipProjectile, and ExampleWhipProj
   * Assign `TECritterAnchor.CritterPrototypes[Type]` in `ModNPC.SetStaticDefaults` to dictate the animation and AI to use while leashed. 
   * Add `ItemID.Sets.PlaceTileOnAltUse[Type] = true;` to `ModItem.SetStaticDefaults` and set `Item.createTile = TileID.CritterAnchor;` in `ModItem.SetDefaults`.
 * Minion buffs can now have a counter for how many times the minion was summoned. Simply add `BuffID.Sets.BuffTextHandlers.Add(Type, new CachedProjectileCounterBuffTextHandler(ModContent.ProjectileType<YourMinionsProjectile>()));` to the buff's `SetStaticDefaults`.
-  * Custom buff text handlers can be made by creating a class that inherits `IBuffTextHandler` if the vanilla `CachedProjectileCounterBuffTextHandler` doesn't suit your minion.
+  * Custom buff text handlers can be made by creating a class that inherits `IBuffTextHandler` if the vanilla `CachedProjectileCounterBuffTextHandler` doesn't suit your minion or if you want to display custom text on a buff for any other purpose.
 
 ### Example Mod
 

--- a/MigrationGuide_1.4.5.md
+++ b/MigrationGuide_1.4.5.md
@@ -389,6 +389,8 @@ See ExampleWhip, ExampleWhipAdvanced, ExampleWhipProjectile, and ExampleWhipProj
 * Critters can now be leashed. While leashed, they are a new type of `Entity` called `LeashedCritter` rather than a `NPC`. This requires several changes to support.
   * Assign `TECritterAnchor.CritterPrototypes[Type]` in `ModNPC.SetStaticDefaults` to dictate the animation and AI to use while leashed. 
   * Add `ItemID.Sets.PlaceTileOnAltUse[Type] = true;` to `ModItem.SetStaticDefaults` and set `Item.createTile = TileID.CritterAnchor;` in `ModItem.SetDefaults`.
+* Minion buffs can now have a counter for how many times the minion was summoned. Simply add `BuffID.Sets.BuffTextHandlers.Add(Type, new CachedProjectileCounterBuffTextHandler(ModContent.ProjectileType<YourMinionsProjectile>()));` to the buff's `SetStaticDefaults`.
+  * Custom buff text handlers can be made by creating a class that inherits `IBuffTextHandler` if the vanilla `CachedProjectileCounterBuffTextHandler` doesn't suit your minion.
 
 ### Example Mod
 
@@ -418,6 +420,7 @@ Several Example Mod examples have been updated to adapt to 1.4.5 changes and to 
       * Previously, the draw code was specific for `ExampleWhipProjectileAdvanced`. Now it will work for any number of segments.
 	  * Even if your whips seem to draw fine, double check the code because it is likely that the third segment of your whip wasn't being drawn.
 	* See the *Whips and Tag Effects* section above for details on tag damage changes.
+* `ExampleSimpleMinionBuff` now tracks how many minions were summoned with `BuffID.Sets.BuffTextHandlers`.
 
 ## Renamed, Moved, or Removed Members
 

--- a/patches/tModLoader/Terraria/DataStructures/CachedProjectileCounterBuffTextHandler.cs.patch
+++ b/patches/tModLoader/Terraria/DataStructures/CachedProjectileCounterBuffTextHandler.cs.patch
@@ -1,0 +1,12 @@
+--- src/TerrariaNetCore/Terraria/DataStructures/CachedProjectileCounterBuffTextHandler.cs
++++ src/tModLoader/Terraria/DataStructures/CachedProjectileCounterBuffTextHandler.cs
+@@ -4,6 +_,9 @@
+ {
+ 	private int[] projectilesToLookFor;
+ 
++	/// <summary>
++	/// Displays the total number of projectiles owned by the local player for the specified projectile types. Displays "x" followed by the total count if greater than 0, otherwise returns null.
++	/// </summary>
+ 	public CachedProjectileCounterBuffTextHandler(params int[] projectileTypesToLookFor)
+ 	{
+ 		projectilesToLookFor = projectileTypesToLookFor;

--- a/patches/tModLoader/Terraria/ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/BuffID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/BuffID.cs
 +++ src/tModLoader/Terraria/ID/BuffID.cs
-@@ -2,25 +_,86 @@
+@@ -2,25 +_,87 @@
  using System.Collections.Generic;
  using ReLogic.Reflection;
  using Terraria.DataStructures;
@@ -86,7 +86,8 @@
  		public static bool[] NurseCannotRemoveDebuff = Factory.CreateBoolSet(28, 34, 87, 89, 21, 86, 199, 332, 333, 334, 165, 146, 48, 158, 157, 350, 215, 147, 321, 43);
  		public static int[] AddBuffTimeAdditivelyToCap = Factory.CreateIntSet(0, 94, 600, 383, 43200);
 +		/// <summary>
-+		/// Allows for assigning an IBuffTextHandler to this buff ID. Used in vanilla to add a counter to minion buffs for how many minions of that type are active.
++		///	Allows for assigning an IBuffTextHandler to this buff ID. Used to calculate the text below the buff icon, overriding the time remaining text if that would be shown.
++		/// <para/> All vanilla entries are <see cref="CachedProjectileCounterBuffTextHandler"/> and are used to show how many sets of minions have been summoned that correspond to the buff.
 +		/// </summary>
  		public static Dictionary<int, IBuffTextHandler> BuffTextHandlers = new Dictionary<int, IBuffTextHandler> {
  			{ 64, new CachedProjectileCounterBuffTextHandler(266) },

--- a/patches/tModLoader/Terraria/ID/BuffID.cs.patch
+++ b/patches/tModLoader/Terraria/ID/BuffID.cs.patch
@@ -1,6 +1,6 @@
 --- src/TerrariaNetCore/Terraria/ID/BuffID.cs
 +++ src/tModLoader/Terraria/ID/BuffID.cs
-@@ -2,23 +_,81 @@
+@@ -2,25 +_,86 @@
  using System.Collections.Generic;
  using ReLogic.Reflection;
  using Terraria.DataStructures;
@@ -85,7 +85,12 @@
 +		/// </summary>
  		public static bool[] NurseCannotRemoveDebuff = Factory.CreateBoolSet(28, 34, 87, 89, 21, 86, 199, 332, 333, 334, 165, 146, 48, 158, 157, 350, 215, 147, 321, 43);
  		public static int[] AddBuffTimeAdditivelyToCap = Factory.CreateIntSet(0, 94, 600, 383, 43200);
++		/// <summary>
++		/// Allows for assigning an IBuffTextHandler to this buff ID. Used in vanilla to add a counter to minion buffs for how many minions of that type are active.
++		/// </summary>
  		public static Dictionary<int, IBuffTextHandler> BuffTextHandlers = new Dictionary<int, IBuffTextHandler> {
+ 			{ 64, new CachedProjectileCounterBuffTextHandler(266) },
+ 			{ 125, new CachedProjectileCounterBuffTextHandler(373) },
 @@ -47,8 +_,15 @@
  			{ 385, new CachedProjectileCounterBuffTextHandler(1093) },
  			{ 386, new CachedProjectileCounterBuffTextHandler(1094) }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -153,19 +153,19 @@
  	public static bool[] pvpBuff = new bool[BuffID.Count];
 +
 +	/// <summary>
-+	/// Allows status effects for which this is set to true to persist after the afflicted player's death.<br/>
++	/// If <see langword="true"/> for a given <see cref="BuffID"/>, then that buff will persist after the afflicted player's death.<br/>
 +	/// Defaults to <see langword="false"/>; all vanilla flask effects have their entries here set to true.<br/>
 +	/// </summary>
  	public static bool[] persistentBuff = new bool[BuffID.Count];
 +
 +	/// <summary>
-+	/// Categorizes status effects for which this is set to true as being from vanity pets, preventing them from overlapping with other vanity pet status effects.<br/>
++	/// If <see langword="true"/> for a given <see cref="BuffID"/>, then that buff corresponds to a vanity pet buff, preventing them from overlapping with other vanity pet status effects.<br/>
 +	/// Defaults to <see langword="false"/>; all vanilla vanity pets have their entries here set to true.<br/>
 +	/// </summary>
  	public static bool[] vanityPet = new bool[BuffID.Count];
 +
 +	/// <summary>
-+	/// Categorizes status effects for which this is set to true as being tied to a light pet, preventing them from overlapping with other light pet status effects.<br/>
++	/// If <see langword="true"/> for a given <see cref="BuffID"/>, then that buff corresponds to a light pet buff, preventing them from overlapping with other light pet status effects.<br/>
 +	/// Defaults to <see langword="false"/>; all vanilla light pets have their entries here set to true.<br/>
 +	/// </summary>
  	public static bool[] lightPet = new bool[BuffID.Count];


### PR DESCRIPTION
### What are the changes to ExampleMod?

Added `BuffID.Sets.BuffTextHandlers` to `ExampleSimpleMinionBuff` to show a counter for how many minions are active.

### Do these changes need additional documentation?

A custom class that inherits `IBuffTextHandler` can be used to create custom logic/buff text. I put this in the migration guide.

I guess we could add docs to `IBuffTextHandler` and `IBuffTextHandler.HandleBuffText()`, but the interface is so simple that I figured it wasn't necessary.