### PR TITLE
Use debian-based steamcmd docker image as the base for both arm64 and amd64 dedicated servers

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
@@ -1,70 +1,40 @@
-FROM ubuntu:22.04 as builder
+FROM sonroyaalmerol/steamcmd-arm64:root-trixie AS arm64-base
+FROM cm2network/steamcmd:root-trixie AS amd64-base
 
-# Update and install the libc requirement that Alpine does not support
+FROM ${BUILDARCH}-base
 ARG DEBIAN_FRONTEND=noninteractive
-RUN dpkg --add-architecture i386 \
- && apt-get update -y \
- && apt-get install -y --no-install-recommends libc6:i386 \
- && rm -rf /var/lib/apt/lists/*
+# libicu is dotnet dependency
+# unzip is "./manage-tModLoaderServer.sh install-tml --github" dependency
+RUN apt-get update && \
+    libicu_pkgname=$(apt-cache show 'libicu[0-9]*' | awk -F: '/Package: /{print $2}') && \
+    apt-get install -y --no-install-recommends ${libicu_pkgname} unzip && rm -rf /var/lib/apt/lists/*
 
-FROM alpine:3.20
-
-# TODO try to get gcompat working
-RUN apk update \
-    && apk add --no-cache bash curl nano file libgcc libstdc++ icu-libs \
-    # && echo "x86" > /etc/apk/arch \
-    # && apk add --no-cache gcompat \
-    # && echo "x86_64" > /etc/apk/arch \
-    && rm -rf /var/cache/apk/*
-
-# Copy the required libc files since gcompat does not work with steamcmd
-COPY --from=builder \
-    /lib/i386-linux-gnu/ld-linux.so.2 \
-    /lib/i386-linux-gnu/libc.so.6 \
-    /lib/i386-linux-gnu/libdl.so.2 \
-    /lib/i386-linux-gnu/libm.so.6 \
-    /lib/i386-linux-gnu/libpthread.so.0 \
-    /lib/i386-linux-gnu/librt.so.1 \
-    /lib/
-
-# TODO: Currently it is too arduous to allow UID/GID to be set at runtime via ENV variables for a few reasons
-# 1) The entrypoint would need to run as root because of root requirements for usermod and groupmod
-# 2) Current tools for switching the running user (su-exec and gosu) mid-script have their own issues with TTY in a Docker container
-# See: https://github.com/ncopa/su-exec/issues/33 and https://github.com/tianon/gosu/pull/8   
-ARG UID=1000
-ARG GID=1000
 ENV UMASK=0002
 
 # Set a specific tModLoader version, defaults to the latest Github release
 ARG TMLVERSION
+ARG UID=1000
+ARG GID=1000
 
-# Create tModLoader user and drop root permissions
-# BusyBox uses an old adduser without the --user-group option so create a group first
-RUN addgroup -g $GID tml \
-    && adduser -D --home /home/tml -u $UID -G tml tml
-
-USER tml
-ENV HOME /home/tml
-ENV USER tml
+RUN usermod -u $UID steam && groupmod -g $GID steam && usermod -g $GID steam && chown -R $UID:$GID /home/steam
+USER steam
+ENV HOME=/home/steam
 ENV PATH="$PATH:$HOME/.bin"
 WORKDIR $HOME
 
-# Setup the steam directory and steamcmd for the local user
-RUN mkdir -p ~/Steam ~/.bin \
-    && curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf - -C ~/Steam
-
 # Create an easy to use steamcmd executable
-COPY --chown=tml:tml --chmod=0755 <<EOF ./.bin/steamcmd
+COPY --chown=steam:steam --chmod=0755 <<EOF ./.bin/steamcmd
 #\!/bin/bash
-
-exec ~/Steam/steamcmd.sh "\$@"
+exec ~/steamcmd/steamcmd.sh "\$@"
 EOF
 
 # Update SteamCMD and verify latest version
 RUN steamcmd +quit
 
 # To make local edits to the management script, change this URL to a local path for manage-tModLoaderServer.sh
-ADD --chown=tml:tml --chmod=0755 https://raw.githubusercontent.com/tModLoader/tModLoader/1.4.5/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh .
+COPY --chown=steam:steam --chmod=0755 manage-tModLoaderServer.sh .
+#ADD --chown=steam:steam --chmod=0755 https://raw.githubusercontent.com/tModLoader/tModLoader/1.4.5/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh .
+
 
 # Make management script executable and manually add the logs directory to fix the "Permission Denied" error on most systems.
 # Adding write permissions for the logs is necessary because when Docker mounts a volume that doesn't exist on the host it mounts both host and container as root

--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/docker-compose.yml
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/docker-compose.yml
@@ -1,10 +1,7 @@
-version: "3.0"
-
 services:
   tml:
     container_name: tml
     restart: unless-stopped
-    #platform: linux/amd64 # Enable if you are running Docker on an ARM machine
     build:
       context: .
       # args:


### PR DESCRIPTION
### What is the new feature?
Support `arm64` architecture for hosting a dedicated server using docker.

### Why should this be part of tModLoader?
This allows hosting dedicated server on various hardware.

### Are there alternative designs?
\-

### Sample usage for the new feature
Either buy a Raspberry Pi or rent an `arm64` VPS (these are becoming increasingly popular lately) and host your own server.

--------------

TODO list:

- [ ] Format entrypoint back into json or find a reasonable way to tell `manage-tModLoaderServer.sh` to use `--linkworkshopmods` option
- [ ] Make sure docker attach works
-----------------

`Steamcmd` is built for `amd64` only.

There were several ways to go about running `steamcmd` on `arm64` hardware:

- Using https://github.com/FEX-Emu/FEX. I did not like this one because it requires to use `squashfs` image to run which is at least 2 Gb in size. They do claim it works faster than `box64` though. But we don't need speed for `steamcmd`
- Using https://github.com/ptitseb/box64. It's not too bad size-wise and works out of the box using the excellent images from https://github.com/sonroyaalmerol/steamcmd-arm64. For `amd64` https://hub.docker.com/r/cm2network/steamcmd is used.
- Using `qemu`. I haven't tried this one since `box64` developers removed `qemu` support in their images because `steamcmd` didn't work correctly with it: https://github.com/sonroyaalmerol/steamcmd-arm64/issues/7

So just use the images with `steamcmd` already preinstalled.


### Notes:

#### Image size

Image size grew bigger as expected since there is `box64` files required and image uses `debian` as the base instead of alpine (`box64` cannot run on alpine: https://github.com/ptitSeb/box64/issues/2012):
```
tmod_1.4.5_amd64:latest                440619c26a90        711MB          212MB        
tmod_1.4.5_amd64_new:latest       8657b4bca475       1.22GB          376MB
```
```
tmod_1.4.5_arm64_new:latest        351047ba1e92       1.36GB             0B  
```

#### arm64 workshop read
It seems like `arm64` version of `tModLoader` can't/won't start reading workshop mods from provided `-steamworkshopfolder` argument. Server logs from amd and arm64 images running from the same folder structure:
[arm64-server.log](https://github.com/user-attachments/files/29661181/arm64-server.log)
[amd64-server.log](https://github.com/user-attachments/files/29661182/amd64-server.log)

For now I have added generation of softlinks from latest version of every mod from workshop folder to `Mods` folder.

it's in its own commit so easy to revert if needed.
