### PR TITLE
Arm64 architecture dedicated server support for docker

### DIFF
--- a/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
+++ b/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/Dockerfile
@@ -1,36 +1,14 @@
-FROM ubuntu:22.04 as builder
+FROM sonroyaalmerol/steamcmd-arm64:root-trixie AS arm64-base
+FROM cm2network/steamcmd:root-trixie AS amd64-base
 
-# Update and install the libc requirement that Alpine does not support
+FROM ${BUILDARCH}-base
 ARG DEBIAN_FRONTEND=noninteractive
-RUN dpkg --add-architecture i386 \
- && apt-get update -y \
- && apt-get install -y --no-install-recommends libc6:i386 \
- && rm -rf /var/lib/apt/lists/*
+# libicu is dotnet dependency
+# unzip is "./manage-tModLoaderServer.sh install-tml --github" dependency
+RUN apt-get update && \
+    libicu_pkgname=$(apt-cache show 'libicu[0-9]*' | awk -F: '/Package: /{print $2}') && \
+    apt-get install -y --no-install-recommends ${libicu_pkgname} unzip && rm -rf /var/lib/apt/lists/*
 
-FROM alpine:3.20
-
-# TODO try to get gcompat working
-RUN apk update \
-    && apk add --no-cache bash curl nano file libgcc libstdc++ icu-libs \
-    # && echo "x86" > /etc/apk/arch \
-    # && apk add --no-cache gcompat \
-    # && echo "x86_64" > /etc/apk/arch \
-    && rm -rf /var/cache/apk/*
-
-# Copy the required libc files since gcompat does not work with steamcmd
-COPY --from=builder \
-    /lib/i386-linux-gnu/ld-linux.so.2 \
-    /lib/i386-linux-gnu/libc.so.6 \
-    /lib/i386-linux-gnu/libdl.so.2 \
-    /lib/i386-linux-gnu/libm.so.6 \
-    /lib/i386-linux-gnu/libpthread.so.0 \
-    /lib/i386-linux-gnu/librt.so.1 \
-    /lib/
-
-# TODO: Currently it is too arduous to allow UID/GID to be set at runtime via ENV variables for a few reasons
-# 1) The entrypoint would need to run as root because of root requirements for usermod and groupmod
-# 2) Current tools for switching the running user (su-exec and gosu) mid-script have their own issues with TTY in a Docker container
-# See: https://github.com/ncopa/su-exec/issues/33 and https://github.com/tianon/gosu/pull/8   
 ARG UID=1000
 ARG GID=1000
 ENV UMASK=0002
@@ -38,33 +16,24 @@ ENV UMASK=0002
 # Set a specific tModLoader version, defaults to the latest Github release
 ARG TMLVERSION
 
-# Create tModLoader user and drop root permissions
-# BusyBox uses an old adduser without the --user-group option so create a group first
-RUN addgroup -g $GID tml \
-    && adduser -D --home /home/tml -u $UID -G tml tml
-
-USER tml
-ENV HOME /home/tml
-ENV USER tml
+RUN usermod -u $UID steam && groupmod -g $GID steam && usermod -g $GID steam && chown -R $UID:$GID /home/steam
+USER steam
+ENV HOME=/home/steam
 ENV PATH="$PATH:$HOME/.bin"
 WORKDIR $HOME
 
-# Setup the steam directory and steamcmd for the local user
-RUN mkdir -p ~/Steam ~/.bin \
-    && curl -sqL "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" | tar zxvf - -C ~/Steam
-
 # Create an easy to use steamcmd executable
-COPY --chown=tml:tml --chmod=0755 <<EOF ./.bin/steamcmd
+COPY --chown=steam:steam --chmod=0755 <<EOF ./.bin/steamcmd
 #\!/bin/bash
-
-exec ~/Steam/steamcmd.sh "\$@"
+exec ~/steamcmd/steamcmd.sh "\$@"
 EOF
 
 # Update SteamCMD and verify latest version
 RUN steamcmd +quit
 
 # To make local edits to the management script, change this URL to a local path for manage-tModLoaderServer.sh
-ADD --chown=tml:tml --chmod=0755 https://raw.githubusercontent.com/tModLoader/tModLoader/1.4.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh .
+ADD --chown=steam:steam --chmod=0755 https://raw.githubusercontent.com/tModLoader/tModLoader/1.4.4/patches/tModLoader/Terraria/release_extras/DedicatedServerUtils/manage-tModLoaderServer.sh .
+
 
 # Make management script executable and manually add the logs directory to fix the "Permission Denied" error on most systems.
 # Adding write permissions for the logs is necessary because when Docker mounts a volume that doesn't exist on the host it mounts both host and container as root


### PR DESCRIPTION
### What is the new feature?
Support `arm64` architecture for hosting a dedicated server using docker.

### Why should this be part of tModLoader?
This allows hosting dedicated server on various hardware. `Dockerfile` is also a little simpler now.

### Are there alternative designs?
Use `steamcmd` base image for `arm64` and `alpine` base image for `amd64` to save up on image size for more widely used `amd64` architecture. But it would require to support two ways of doing the same thing.

### Sample usage for the new feature
Either buy a Raspberry Pi or rent an `arm64` VPS (these are becoming increasingly popular lately) and host your own server.

-----------------

The problem: `Steamcmd` is made/built for `amd64` only.

There were several ways to go about running `steamcmd` on `arm64` hardware:

- Using https://github.com/FEX-Emu/FEX. I did not like this one because it requires to use `squashfs` image to run which is at least 2 Gb in size. They do claim it works faster than `box64` though. But we don't need speed for `steamcmd`
- Using https://github.com/ptitseb/box64. It's not too bad size-wise and works out of the box using the excellent images from https://github.com/sonroyaalmerol/steamcmd-arm64. For `amd64` achitecture https://hub.docker.com/r/cm2network/steamcmd is used.
- Using `qemu`. I haven't tried this one since `box64` developers removed `qemu` support in their images because `steamcmd` didn't work correctly with it: https://github.com/sonroyaalmerol/steamcmd-arm64/issues/7

So let's just use the images with `steamcmd` already preinstalled for both architectures.


#### Image size

Image size grew bigger as expected since there are `box64` utility files that are required and image itself uses `debian` as the base instead of `alpine` (`box64` cannot run on alpine: https://github.com/ptitSeb/box64/issues/2012):
```
IMAGE                        ID             DISK USAGE   CONTENT SIZE   EXTRA
1.4.4_amd64_orig:latest      f44c8543d709        711MB          212MB  
1.4.4_amd64_new:latest       c56167e93635       1.22GB          376MB        
```
```
IMAGE                                   ID             DISK USAGE   CONTENT SIZE   EXTRA
1.4.4_arm64:latest                      087b834d09ab       1.36GB             0B        
```