### PR TITLE
Flail API

### DIFF
--- a/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
@@ -48,6 +48,7 @@ namespace ExampleMod.Content.Projectiles
 			return base.PreDrawExtras();
 		}
 
+		// These 2 hooks are specific to projectiles using ProjAIStyleID.Flail and allow customizing the behavior of that aiStyle to some degree.
 		public override void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance) {
 			spinVisualDistance += 30;
 		}

--- a/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
@@ -52,7 +52,7 @@ namespace ExampleMod.Content.Projectiles
 			spinVisualDistance += 30;
 		}
 
-		public override void FlailCollisionRange(ref float range) {
+		public override void FlailSpinCollisionRange(ref float range) {
 			range += 30;
 		}
 

--- a/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
@@ -47,6 +47,12 @@ namespace ExampleMod.Content.Projectiles
 			Projectile.type = ProjectileID.Sunfury;
 			return base.PreDrawExtras();
 		}
+		public override void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance) {
+			spinVisualDistance += 30;
+		}
+		public override void FlailCollisionRange(ref float range) {
+			range += 30;
+		}
 		public override bool PreDraw(ref Color lightColor) {
 			Projectile.type = ModContent.ProjectileType<ExampleFlailProjectile>();
 
@@ -88,7 +94,7 @@ namespace ExampleMod.Content.Projectiles
 			}
 		}
 
-		// Finally, you can slightly customize the AI if you read and understand the vanilla aiStyle source code. You can't customize the range, retract speeds, or anything else. If you need to customize those things, you'll need to follow ExampleAdvancedFlailProjectile. This example spawns a Grenade right when the flail starts to retract.
+		// Finally, you can customize the AI if you read and understand the vanilla aiStyle source code. This example spawns a Grenade right when the flail starts to retract.
 		public override void AI() {
 			// The only reason this code works is because the author read the vanilla code and comprehended it well enough to tack on additional logic.
 			if (Main.myPlayer == Projectile.owner && Projectile.ai[0] == 2f && Projectile.ai[1] == 0f) {

--- a/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
+++ b/ExampleMod/Content/Projectiles/ExampleFlailProjectile.cs
@@ -47,12 +47,15 @@ namespace ExampleMod.Content.Projectiles
 			Projectile.type = ProjectileID.Sunfury;
 			return base.PreDrawExtras();
 		}
+
 		public override void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance) {
 			spinVisualDistance += 30;
 		}
+
 		public override void FlailCollisionRange(ref float range) {
 			range += 30;
 		}
+
 		public override bool PreDraw(ref Color lightColor) {
 			Projectile.type = ModContent.ProjectileType<ExampleFlailProjectile>();
 

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -442,8 +442,8 @@ public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile
 	{
 	}
 
-	/// <inheritdoc cref="ModProjectile.FlailCollisionRange"/>
-	public virtual void FlailCollisionRange(Projectile projectile, ref float range)
+	/// <inheritdoc cref="ModProjectile.FlailSpinCollisionRange"/>
+	public virtual void FlailSpinCollisionRange(Projectile projectile, ref float range)
 	{
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -436,10 +436,12 @@ public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile
 	public virtual void EmitEnchantmentVisualsAt(Projectile projectile, Vector2 boxPosition, int boxWidth, int boxHeight)
 	{
 	}
+
 	/// <inheritdoc cref="ModProjectile.FlailStats"/>
 	public virtual void FlailStats(Projectile projectile, ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
 	{
 	}
+
 	/// <inheritdoc cref="ModProjectile.FlailCollisionRange"/>
 	public virtual void FlailCollisionRange(Projectile projectile, ref float range)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalProjectile.cs
@@ -436,4 +436,12 @@ public abstract class GlobalProjectile : GlobalType<Projectile, GlobalProjectile
 	public virtual void EmitEnchantmentVisualsAt(Projectile projectile, Vector2 boxPosition, int boxWidth, int boxHeight)
 	{
 	}
+	/// <inheritdoc cref="ModProjectile.FlailStats"/>
+	public virtual void FlailStats(Projectile projectile, ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
+	{
+	}
+	/// <inheritdoc cref="ModProjectile.FlailCollisionRange"/>
+	public virtual void FlailCollisionRange(Projectile projectile, ref float range)
+	{
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -477,8 +477,8 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	}
 
 	/// <summary>
-	/// Used to adjust flail properties
-	/// Called when aiStyle is <see cref="ProjAIStyleID.Flail"/>
+	/// Used to adjust flail properties.
+	/// <para/> Called when aiStyle is <see cref="ProjAIStyleID.Flail"/>.
 	/// </summary>
 	/// <param name="launchTimeLimit">How much time the projectile can go before retracting (speed and shootTimer will set the flail's range)</param>
 	/// <param name="launchSpeed">How fast the projectile can move</param>
@@ -494,8 +494,8 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	}
 
 	/// <summary>
-	/// Used to adjust flail spin collision range
-	/// Called during <see cref="Projectile.Colliding(Rectangle, Rectangle)"/> when aiStyle is <see cref="ProjAIStyleID.Flail"/>
+	/// Used to adjust flail spin collision range.
+	/// <para/> Called during <see cref="Projectile.Colliding(Rectangle, Rectangle)"/> when aiStyle is <see cref="ProjAIStyleID.Flail"/>.
 	/// </summary>
 	public virtual void FlailSpinCollisionRange(ref float range)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -478,6 +478,7 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 
 	/// <summary>
 	/// Used to adjust flail properties
+	/// Called when aiStyle is <see cref="ProjAIStyleID.Flail"/>
 	/// </summary>
 	/// <param name="launchTimeLimit">How much time the projectile can go before retracting (speed and shootTimer will set the flail's range)</param>
 	/// <param name="launchSpeed">How fast the projectile can move</param>
@@ -486,11 +487,17 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	/// <param name="maxRetractSpeed">The max speed the projectile will have while retracting</param>
 	/// <param name="forcedRetractAcceleration">How quickly the projectile will accelerate back towards the player while being forced to retract</param>
 	/// <param name="maxForcedRetractSpeed">The max speed the projectile will have while being forced to retract</param>
+	/// <param name="ricochetTimeLimit">How long the projectile will remain in the ricocheting state before switching to the dropping state</param>
+	/// <param name="spinVisualDistance">How far from the player the flail will be while spinning</param>
 	public virtual void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
 	{
 	}
 
-	public virtual void FlailCollisionRange(ref float range)
+	/// <summary>
+	/// Used to adjust flail spin collision range
+	/// Called during <see cref="Projectile.Colliding(Rectangle, Rectangle)"/> when aiStyle is <see cref="ProjAIStyleID.Flail"/>
+	/// </summary>
+	public virtual void FlailSpinCollisionRange(ref float range)
 	{
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -475,6 +475,7 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	public virtual void EmitEnchantmentVisualsAt(Vector2 boxPosition, int boxWidth, int boxHeight)
 	{
 	}
+
 	/// <summary>
 	/// Used to adjust flail properties
 	/// </summary>
@@ -488,6 +489,7 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	public virtual void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
 	{
 	}
+
 	public virtual void FlailCollisionRange(ref float range)
 	{
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModProjectile.cs
@@ -475,4 +475,20 @@ public abstract class ModProjectile : ModType<Projectile, ModProjectile>, ILocal
 	public virtual void EmitEnchantmentVisualsAt(Vector2 boxPosition, int boxWidth, int boxHeight)
 	{
 	}
+	/// <summary>
+	/// Used to adjust flail properties
+	/// </summary>
+	/// <param name="launchTimeLimit">How much time the projectile can go before retracting (speed and shootTimer will set the flail's range)</param>
+	/// <param name="launchSpeed">How fast the projectile can move</param>
+	/// <param name="maxLaunchLength">How far the projectile's chain can stretch before being forced to retract when in launched state</param>
+	/// <param name="retractAcceleration">How quickly the projectile will accelerate back towards the player while retracting</param>
+	/// <param name="maxRetractSpeed">The max speed the projectile will have while retracting</param>
+	/// <param name="forcedRetractAcceleration">How quickly the projectile will accelerate back towards the player while being forced to retract</param>
+	/// <param name="maxForcedRetractSpeed">The max speed the projectile will have while being forced to retract</param>
+	public virtual void FlailStats(ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
+	{
+	}
+	public virtual void FlailCollisionRange(ref float range)
+	{
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -804,4 +804,28 @@ public static class ProjectileLoader
 			g.EmitEnchantmentVisualsAt(projectile, boxPosition, boxWidth, boxHeight);
 		}
 	}
+
+	private delegate void DelegateFlailStats(Projectile projectile, ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance);
+	private static HookList HookFlailStats = AddHook<DelegateFlailStats>(g => g.FlailStats);
+
+	public static void FlailStats(Projectile projectile, ref int launchTimeLimit, ref float launchSpeed, ref float maxLaunchLength, ref float retractAcceleration, ref float maxRetractSpeed, ref float forcedRetractAcceleration, ref float maxForcedRetractSpeed, ref int ricochetTimeLimit, ref float spinVisualDistance)
+	{
+		projectile.ModProjectile?.FlailStats(ref launchTimeLimit, ref launchSpeed, ref maxLaunchLength, ref retractAcceleration, ref maxRetractSpeed, ref forcedRetractAcceleration, ref maxForcedRetractSpeed, ref ricochetTimeLimit, ref spinVisualDistance);
+
+		foreach (var g in HookFlailStats.Enumerate(projectile)) {
+			g.FlailStats(projectile, ref launchTimeLimit, ref launchSpeed, ref maxLaunchLength, ref retractAcceleration, ref maxRetractSpeed, ref forcedRetractAcceleration, ref maxForcedRetractSpeed, ref ricochetTimeLimit, ref spinVisualDistance);
+		}
+	}
+
+	private delegate void DelegateFlailCollisionRange(Projectile projectile, ref float range);
+	private static HookList HookFlailCollisionRange = AddHook<DelegateFlailCollisionRange>(g => g.FlailCollisionRange);
+
+	public static void FlailCollisionRange(Projectile projectile, ref float range)
+	{
+		projectile.ModProjectile?.FlailCollisionRange(ref range);
+
+		foreach (var g in HookFlailCollisionRange.Enumerate(projectile)) {
+			g.FlailCollisionRange(projectile, ref range);
+		}
+	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ProjectileLoader.cs
@@ -817,15 +817,15 @@ public static class ProjectileLoader
 		}
 	}
 
-	private delegate void DelegateFlailCollisionRange(Projectile projectile, ref float range);
-	private static HookList HookFlailCollisionRange = AddHook<DelegateFlailCollisionRange>(g => g.FlailCollisionRange);
+	private delegate void DelegateFlailSpinCollisionRange(Projectile projectile, ref float range);
+	private static HookList HookFlailSpinCollisionRange = AddHook<DelegateFlailSpinCollisionRange>(g => g.FlailSpinCollisionRange);
 
-	public static void FlailCollisionRange(Projectile projectile, ref float range)
+	public static void FlailSpinCollisionRange(Projectile projectile, ref float range)
 	{
-		projectile.ModProjectile?.FlailCollisionRange(ref range);
+		projectile.ModProjectile?.FlailSpinCollisionRange(ref range);
 
-		foreach (var g in HookFlailCollisionRange.Enumerate(projectile)) {
-			g.FlailCollisionRange(projectile, ref range);
+		foreach (var g in HookFlailSpinCollisionRange.Enumerate(projectile)) {
+			g.FlailSpinCollisionRange(projectile, ref range);
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1266,16 +1266,23 @@
  		if (aiStyle != 45 && aiStyle != 137 && aiStyle != 92 && aiStyle != 105 && aiStyle != 106 && !ProjectileID.Sets.IsAGolfBall[type] && type != 463 && type != 69 && type != 70 && type != 621 && type != 10 && type != 11 && type != 379 && type != 407 && type != 476 && type != 623 && (type < 625 || type > 628) && type != 833 && type != 834 && type != 835 && type != 818 && type != 831 && type != 820 && type != 864 && type != 970 && type != 995 && type != 908)
  			return type != 1020;
  
-@@ -11854,6 +_,9 @@
- 			}
- 		}
+@@ -11596,12 +_,16 @@
  
+ 	public bool Colliding(Rectangle myRect, Rectangle targetRect)
+ 	{
 +		if (ProjectileLoader.Colliding(this, myRect, targetRect) is bool modColliding)
 +			return modColliding;
 +
- 		if (myRect.Intersects(targetRect))
- 			return true;
- 
+ 		if (aiStyle == 15) {
+ 			if (ai[0] == 0f) {
+ 				Vector2 mountedCenter = Main.player[owner].MountedCenter;
+ 				Vector2 vector = targetRect.ClosestPointInRect(mountedCenter) - mountedCenter;
+ 				vector.Y /= 0.8f;
+ 				float num = 55f;
++				ProjectileLoader.FlailCollisionRange(this, ref num);
+ 				return vector.Length() <= num;
+ 			}
+ 		}
 @@ -12433,7 +_,7 @@
  		if (Main.netMode == 1 && (ProjectileID.Sets.IsAGolfBall[type] || type == 820)) {
  			int num = (int)(position.X + (float)(width / 2)) / 16;
@@ -1651,10 +1658,13 @@
  	{
  		for (int i = 0; i < 200; i++) {
  			localNPCImmunity[i] = 0;
-@@ -30413,8 +_,11 @@
+@@ -30413,8 +_,14 @@
  				break;
  		}
  
++		float spinVisualDistance = 30f;
++		ProjectileLoader.FlailStats(this, ref num, ref num2, ref num3, ref num4, ref num5, ref num6, ref num7, ref num14, ref spinVisualDistance);
++
 +		/*
  		float meleeSpeed = player.meleeSpeed;
  		float num15 = 1f / meleeSpeed;
@@ -1663,6 +1673,16 @@
  		num2 *= num15;
  		num8 *= num15;
  		num9 *= num15;
+@@ -30451,7 +_,8 @@
+ 				if (vector4.Y * player.gravDir > 0f)
+ 					vector4.Y *= 0.5f;
+ 
++				base.Center = mountedCenter + vector4 * spinVisualDistance;
+-				base.Center = mountedCenter + vector4 * 30f;
++				//base.Center = mountedCenter + vector4 * 30f;
+ 				velocity = Vector2.Zero;
+ 				localNPCHitCooldown = num12;
+ 				break;
 @@ -30730,7 +_,10 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1279,7 +1279,7 @@
  				Vector2 vector = targetRect.ClosestPointInRect(mountedCenter) - mountedCenter;
  				vector.Y /= 0.8f;
  				float num = 55f;
-+				ProjectileLoader.FlailCollisionRange(this, ref num);
++				ProjectileLoader.FlailSpinCollisionRange(this, ref num);
  				return vector.Length() <= num;
  			}
  		}

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1673,13 +1673,12 @@
  		num2 *= num15;
  		num8 *= num15;
  		num9 *= num15;
-@@ -30451,7 +_,8 @@
+@@ -30451,7 +_,7 @@
  				if (vector4.Y * player.gravDir > 0f)
  					vector4.Y *= 0.5f;
  
-+				base.Center = mountedCenter + vector4 * spinVisualDistance;
 -				base.Center = mountedCenter + vector4 * 30f;
-+				//base.Center = mountedCenter + vector4 * 30f;
++				base.Center = mountedCenter + vector4 * spinVisualDistance; // TML: 30->spinVisualDistance
  				velocity = Vector2.Zero;
  				localNPCHitCooldown = num12;
  				break;

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -8,7 +8,7 @@
  
  	<!-- General -->
  	<PropertyGroup>
-@@ -11,59 +_,99 @@
+@@ -11,59 +_,105 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -63,13 +63,19 @@
 -			<LogicalName>Terraria.Libraries.ReLogic.ReLogic.dll</LogicalName>
 -		</EmbeddedResource>
 +		<ProjectReference Include="../../../tModPorter/tModPorter/tModPorter.csproj" />
-+		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj"
-+			ReferenceOutputAssembly="false" />
-+		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist.CodeFixes/tModCodeAssist.CodeFixes.csproj"
-+			ReferenceOutputAssembly="false" />
++		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj" ReferenceOutputAssembly="false" />
++		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist.CodeFixes/tModCodeAssist.CodeFixes.csproj" ReferenceOutputAssembly="false" />
  
  		<Reference Include="CsvHelper" />
 -		<Reference Include="Ionic.Zip.CF" />
++
++		<Reference Include="Microsoft.CodeAnalysis.CSharp">
++		  <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\tModLoaderDev\Libraries\microsoft.codeanalysis.csharp\5.3.0\lib\net10.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
++		</Reference>
++
++		<Reference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild">
++		  <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\tModLoaderDev\Libraries\microsoft.codeanalysis.workspaces.msbuild\5.3.0\lib\net10.0\Microsoft.CodeAnalysis.Workspaces.MSBuild.dll</HintPath>
++		</Reference>
  		<Reference Include="MP3Sharp" />
  		<Reference Include="Newtonsoft.Json" />
  		<Reference Include="NVorbis" />

--- a/patches/tModLoader/Terraria/Terraria.csproj.patch
+++ b/patches/tModLoader/Terraria/Terraria.csproj.patch
@@ -8,7 +8,7 @@
  
  	<!-- General -->
  	<PropertyGroup>
-@@ -11,59 +_,105 @@
+@@ -11,59 +_,99 @@
  		<Company>Re-Logic</Company>
  		<Copyright>Copyright © 2022 Re-Logic</Copyright>
  		<RootNamespace>Terraria</RootNamespace>
@@ -63,19 +63,13 @@
 -			<LogicalName>Terraria.Libraries.ReLogic.ReLogic.dll</LogicalName>
 -		</EmbeddedResource>
 +		<ProjectReference Include="../../../tModPorter/tModPorter/tModPorter.csproj" />
-+		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj" ReferenceOutputAssembly="false" />
-+		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist.CodeFixes/tModCodeAssist.CodeFixes.csproj" ReferenceOutputAssembly="false" />
++		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist/tModCodeAssist.csproj"
++			ReferenceOutputAssembly="false" />
++		<ProjectReference Include="../../../tModCodeAssist/tModCodeAssist.CodeFixes/tModCodeAssist.CodeFixes.csproj"
++			ReferenceOutputAssembly="false" />
  
  		<Reference Include="CsvHelper" />
 -		<Reference Include="Ionic.Zip.CF" />
-+
-+		<Reference Include="Microsoft.CodeAnalysis.CSharp">
-+		  <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\tModLoaderDev\Libraries\microsoft.codeanalysis.csharp\5.3.0\lib\net10.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-+		</Reference>
-+
-+		<Reference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild">
-+		  <HintPath>..\..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\tModLoaderDev\Libraries\microsoft.codeanalysis.workspaces.msbuild\5.3.0\lib\net10.0\Microsoft.CodeAnalysis.Workspaces.MSBuild.dll</HintPath>
-+		</Reference>
  		<Reference Include="MP3Sharp" />
  		<Reference Include="Newtonsoft.Json" />
  		<Reference Include="NVorbis" />


### PR DESCRIPTION
### What is the new feature?
Flail API.

### Why should this be part of tModLoader?
An entire vanilla weapon category with its own ai style currently can't be implemented with slight changes without completely reimplementing the ai style.

### Are there alternative designs?
Sets could be used, but this approach more accurately predicts what modders might want to vary.

### Sample usage for the new feature
See Example Flail.

### ExampleMod updates
Example Flail now has doubled spinning range.

Also fixes #5240, because that mostly affects flails.

### Porting Notes
- `(Mod|Global)Projectile.Colliding` has been fixed to now be called for some projectile types and aiStyle values that were previously skipped. This has a slight chance of affecting some mods.