### PR TITLE
Fix: Disable logging `OperationCanceledException`s in the FirstChanceException handler

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Logging.ExceptionHandling.cs
@@ -27,6 +27,7 @@ public static partial class Logging
 	private static readonly HashSet<string> ignoreTypes = new() {
 		"ReLogic.Peripherals.RGB.DeviceInitializationException",
 		"System.Threading.Tasks.TaskCanceledException",
+		"System.OperationCanceledException"
 	};
 	private static readonly HashSet<string> ignoreSources = new() {
 		"MP3Sharp",


### PR DESCRIPTION
In an effort to prevent redundant exception logging from cancellation token operations, tModLoader's first chance exception handler ignores logging `TaskCanceledException`s. This PR adds `OperationCanceledException` to the list of ignored types to expand on this intended behavior.