### PR TITLE
[1.4.5] Fix item tooltip localization hot reload

### DIFF
--- a/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
+++ b/patches/tModLoader/Terraria/Localization/LanguageManager.cs.patch
@@ -29,7 +29,7 @@
  		if (ActiveCulture != culture) {
  			Thread.CurrentThread.CurrentCulture = culture.CultureInfo;
  			Thread.CurrentThread.CurrentUICulture = culture.CultureInfo;
-@@ -114,6 +_,25 @@
+@@ -114,6 +_,26 @@
  		ProcessCopyCommandsInTexts();
  	}
  
@@ -47,6 +47,7 @@
 +
 +		ProcessCopyCommandsInTexts();
 +		RecalculateBoundTextValues();
++		Terraria.UI.ItemTooltip.InvalidateTooltips();
 +		ChatInitializer.PrepareAliases();
 +
 +		SystemLoader.OnLocalizationsLoaded();


### PR DESCRIPTION
## What is the bug?

Item tooltips do not update when a mod localization file is hot reloaded.

The localization watcher reloads the updated text values correctly, but item tooltips cache their processed lines. Since those cached tooltip lines are not invalidated during a localization hot reload, existing items continue displaying the old text until the game or mod is reloaded.

## How did you fix the bug?

Invalidate item tooltips after localization has been reloaded and bound localization values have been recalculated.

This causes existing item tooltips to rebuild their processed lines from the updated localized text the next time they are accessed, restoring the hot reload behavior without recreating items or rebuilding the item content cache.

## Are there alternatives to your fix?

The modded item tooltip cache and content sample items could be rebuilt after every localization reload. However, this would perform unnecessary work because item tooltips already retain references to their localized text and have an existing invalidation mechanism.

Using the existing invalidation mechanism is smaller in scope and also updates tooltips attached to existing inventory and UI item instances.

## How was this tested?

- Edited a mod item tooltip in a localization file while the game was running.