### PR TITLE
[1.4.5] Fixed GetItemSource_InventoryOverflow method in Player.cs

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -2371,7 +2371,7 @@
 +	internal IEntitySource GetItemSource_Item(Item item) => GetSource_ItemUse(item);
 +	internal IEntitySource GetItemSource_OpenItem(int itemType) => GetSource_OpenItem(itemType);
 +	internal IEntitySource GetItemSource_Death() => GetSource_Death();
-+	internal IEntitySource GetItemSource_InventoryOverflow() => GetItemSource_Misc(ItemSourceID.InventoryOverflow);
++	internal IEntitySource GetItemSource_InventoryOverflow() => new EntitySource_OverfullInventory(this);
 +	internal IEntitySource GetItemSource_Misc(int itemSourceId) => GetSource_Misc(context: ItemSourceID.ToContextString(itemSourceId));
 +	internal IEntitySource GetProjectileSource_Item_WithPotentialAmmo(Item item, int ammoItemId) => GetSource_ItemUse_WithPotentialAmmo(item, ammoItemId);
 +	internal IEntitySource GetProjectileSource_OnHit(Entity victim, int projectileSourceId) => GetSource_OnHit(victim, context: ProjectileSourceID.ToContextString(projectileSourceId));


### PR DESCRIPTION
### What is the bug?
call GetItemSource_InventoryOverflow() method in Player.cs causes "ArgumentException: Unexpected or invalid value: '10'"

In Terraria.ID.ItemSourceID, there's a comment that ItemSourceID.InventoryOverflow causes an exception throw due to 'EntitySource_OverfullInventory being added.
But in Player.cs, the method still uses ItemSourceID.InventoryOverflow, causing this bug.

### How did you fix the bug?

Simply replace `GetItemSource_Misc(ItemSourceID.InventoryOverflow);` with `new EntitySource_OverfullInventory(this);`