### PR TITLE
fix: resize claimable banners array

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/BannerSystem.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/BannerSystem.cs.patch
@@ -8,7 +8,7 @@
  using Terraria.Net;
  
  namespace Terraria.GameContent;
-@@ -99,7 +_,11 @@
+@@ -99,8 +_,12 @@
  	}
  
  	public static readonly int MaxBannerTypes = 293;
@@ -18,9 +18,11 @@
 +	/// </summary>
 -	private static int[] killCount = new int[MaxBannerTypes];
 +	public static int[] killCount = new int[MaxBannerTypes];
- 	private static ushort[] claimableBanners = new ushort[MaxBannerTypes];
+-	private static ushort[] claimableBanners = new ushort[MaxBannerTypes];
++	public static ushort[] claimableBanners = new ushort[MaxBannerTypes];
  	public static bool AnyNewClaimableBanners;
  
+ 	public static int GetKillCount(int banner) => killCount[banner];
 @@ -237,8 +_,20 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/NPCLoader.cs
@@ -90,6 +90,7 @@ public static class NPCLoader
 		Array.Resize(ref Main.SceneMetrics.NPCBannerBuff, NPCCount);
 		Array.Resize(ref Main.SceneMetrics.ClosestNPCPosition, NPCCount);
 		Array.Resize(ref BannerSystem.killCount, NPCCount);
+		Array.Resize(ref BannerSystem.claimableBanners, NPCCount);
 		Array.Resize(ref NPC.ShimmeredTownNPCs, NPCCount);
 		Array.Resize(ref NPC.npcsFoundForCheckActive, NPCCount);
 		Array.Resize(ref Lang._npcNameCache, NPCCount);


### PR DESCRIPTION
Resizes the claimable banners array to allow an upper limit of the total NPC count, like the kill count array.