### PR TITLE
[1.4.5] Enable screen shaders and render targets in legacy lighting modes

### DIFF
--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
@@ -1,0 +1,30 @@
+--- src/TerrariaNetCore/Terraria/Graphics/Capture/CaptureCamera.cs
++++ src/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs
+@@ -180,19 +_,27 @@
+ 
+ 	public void BeginDrawCapture()
+ 	{
++		/*
+ 		if (Lighting.NotRetro) {
+ 			Main.instance.GraphicsDevice.SetRenderTarget(Main.skyTarget);
+ 			Main.instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
+ 			Filters.Scene.BeginCapture(_filterFrameBuffer1);
+ 		}
++		*/
++		Main.instance.GraphicsDevice.SetRenderTarget(Main.skyTarget);
++		Main.instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
++		Filters.Scene.BeginCapture(_filterFrameBuffer1);
+ 
+ 		Main.waterTarget = _waterTarget;
+ 	}
+ 
+ 	public void EndDrawCapture(Vector2 screenSize, Vector2 sceneSize, Vector2 sceneOffset)
+ 	{
++		/*
+ 		if (Lighting.NotRetro)
+ 			Filters.Scene.EndCapture(_frameBuffer, _filterFrameBuffer1, _filterFrameBuffer2, screenSize, sceneSize, sceneOffset);
++		*/
++		Filters.Scene.EndCapture(_frameBuffer, _filterFrameBuffer1, _filterFrameBuffer2, screenSize, sceneSize, sceneOffset);
+ 	}
+ 
+ 	private unsafe void DrawBytesToBuffer(byte[] sourceBuffer, byte[] destinationBuffer, int sourceBufferWidth, int destinationBufferWidth, Microsoft.Xna.Framework.Rectangle area)

--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
@@ -1,30 +1,21 @@
 --- src/TerrariaNetCore/Terraria/Graphics/Capture/CaptureCamera.cs
 +++ src/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs
-@@ -180,19 +_,27 @@
+@@ -180,7 +_,8 @@
  
  	public void BeginDrawCapture()
  	{
-+		/*
- 		if (Lighting.NotRetro) {
+-		if (Lighting.NotRetro) {
++		// if (Lighting.NotRetro)
++		{
  			Main.instance.GraphicsDevice.SetRenderTarget(Main.skyTarget);
  			Main.instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
  			Filters.Scene.BeginCapture(_filterFrameBuffer1);
- 		}
-+		*/
-+		Main.instance.GraphicsDevice.SetRenderTarget(Main.skyTarget);
-+		Main.instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
-+		Filters.Scene.BeginCapture(_filterFrameBuffer1);
- 
- 		Main.waterTarget = _waterTarget;
- 	}
+@@ -191,7 +_,7 @@
  
  	public void EndDrawCapture(Vector2 screenSize, Vector2 sceneSize, Vector2 sceneOffset)
  	{
-+		/*
- 		if (Lighting.NotRetro)
+-		if (Lighting.NotRetro)
++		// (Lighting.NotRetro)
  			Filters.Scene.EndCapture(_frameBuffer, _filterFrameBuffer1, _filterFrameBuffer2, screenSize, sceneSize, sceneOffset);
-+		*/
-+		Filters.Scene.EndCapture(_frameBuffer, _filterFrameBuffer1, _filterFrameBuffer2, screenSize, sceneSize, sceneOffset);
  	}
  
- 	private unsafe void DrawBytesToBuffer(byte[] sourceBuffer, byte[] destinationBuffer, int sourceBufferWidth, int destinationBufferWidth, Microsoft.Xna.Framework.Rectangle area)

--- a/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
+++ b/patches/tModLoader/Terraria/Graphics/Capture/CaptureCamera.cs.patch
@@ -10,12 +10,15 @@
  			Main.instance.GraphicsDevice.SetRenderTarget(Main.skyTarget);
  			Main.instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
  			Filters.Scene.BeginCapture(_filterFrameBuffer1);
-@@ -191,7 +_,7 @@
+@@ -191,8 +_,10 @@
  
  	public void EndDrawCapture(Vector2 screenSize, Vector2 sceneSize, Vector2 sceneOffset)
  	{
 -		if (Lighting.NotRetro)
-+		// (Lighting.NotRetro)
++		// if (Lighting.NotRetro)
++		{
  			Filters.Scene.EndCapture(_frameBuffer, _filterFrameBuffer1, _filterFrameBuffer2, screenSize, sceneSize, sceneOffset);
++		}
  	}
  
+ 	private unsafe void DrawBytesToBuffer(byte[] sourceBuffer, byte[] destinationBuffer, int sourceBufferWidth, int destinationBufferWidth, Microsoft.Xna.Framework.Rectangle area)

--- a/patches/tModLoader/Terraria/Lighting.cs.patch
+++ b/patches/tModLoader/Terraria/Lighting.cs.patch
@@ -22,6 +22,14 @@
  	private static ILightingEngine _activeEngine;
  
  	public static float GlobalBrightness { get; set; }
+@@ -62,6 +_,7 @@
+ 
+ 	public static bool UsingNewLighting => Mode == LightMode.Color;
+ 
++	[Obsolete("Always false in TML")]
+ 	public static bool UpdateEveryFrame {
+ 		get {
+ 			if (!Main.RenderTargetsRequired)
 @@ -96,12 +_,19 @@
  			GlobalBrightness = 1f;
  	}

--- a/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/de-DE/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "Folgende Übersetzungsdateie hat sich verändert und wird neugeladen: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Terraria Content-Ordner nicht gefunden. Falls du tModLoader über Steam installiert hast, stelle sicher das Terraria installiert ist. Falls nicht, stelle sicher tModLoader in einem Ordner innerhalb des Terraria-Installationsverzeichnisses oder einem Ordner neben des Terraria-Installationsverzeichnisses zu installieren.",
 		"GraphicsEngineFailure": "Grafik-Engine-Ausfall",
 		"GraphicsEngineReportUnknown": "Unbekannt",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "The following localization files have changed and will be reloaded: {0}",
 
 		// MessageBox
+		"TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\r\n\r\nYour computer may not be performant enough to run tModLoader.",
 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
 		"GraphicsEngineFailure": "Graphics Engine Failure",
 		"GraphicsEngineReportUnknown": "Unknown",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -677,7 +677,7 @@
 		"WatchLocalizationFileMessage": "The following localization files have changed and will be reloaded: {0}",
 
 		// MessageBox
-		"TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\r\n\r\nYour computer may not be performant enough to run tModLoader.\r\n\r\nEnsure your graphics card is working/connected, and try restarting.",
+		"TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
 		"GraphicsEngineFailure": "Graphics Engine Failure",
 		"GraphicsEngineReportUnknown": "Unknown",

--- a/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/en-US/tModLoader.json
@@ -677,7 +677,7 @@
 		"WatchLocalizationFileMessage": "The following localization files have changed and will be reloaded: {0}",
 
 		// MessageBox
-		"TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\r\n\r\nYour computer may not be performant enough to run tModLoader.",
+		"TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\r\n\r\nYour computer may not be performant enough to run tModLoader.\r\n\r\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
 		"GraphicsEngineFailure": "Graphics Engine Failure",
 		"GraphicsEngineReportUnknown": "Unknown",

--- a/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/es-ES/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "Los siguientes archivos de localización han cambiado y se volverán a cargar: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "No se ha encontrado la carpeta de contenido de Terraria. Si instalaste tModLoader a través de Steam, asegúrate de que Terraria esté instalado. Si no, asegúrate de instalar el tModLoader en una carpeta ubicada dentro del directorio de instalación de Terraria o en una carpeta junto al directorio de instalación de Terraria.",
 		"GraphicsEngineFailure": "Fallo del motor de gráficos",
 		"GraphicsEngineReportUnknown": "Desconocido",

--- a/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/fr-FR/tModLoader.json
@@ -677,6 +677,7 @@
 		// "WatchLocalizationFileMessage": "The following localization files have changed and will be reloaded: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Dossier de contenu Terraria introuvable. Si vous avez installé tModLoader via Steam, assurez-vous que Terraria est installé. Sinon, assurez-vous d'installer tModLoader dans un dossier imbriqué dans le répertoire d'installation de Terraria ou un dossier à côté du répertoire d'installation de Terraria.",
 		"GraphicsEngineFailure": "Défaillance du Moteur Graphique",
 		"GraphicsEngineReportUnknown": "Inconnu",

--- a/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/it-IT/tModLoader.json
@@ -679,6 +679,7 @@
 		// "WatchLocalizationFileMessage": "The following localization files have changed and will be reloaded: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
 		// "GraphicsEngineFailure": "Graphics Engine Failure",
 		// "GraphicsEngineReportUnknown": "Unknown",

--- a/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pl-PL/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "Poniższe pliki lokalizacyjne zostały zmienione i zostaną ponownie załadowane: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Folder z zawartością Terrarii nie został znaleziony. Jeśli zainstalowałeś tModLoader przez Steam, upewnij się, że Terraria jest zainstalowana. Jeśli nie, upewnij się, że zainstalowałeś tModLoader w folderze wewnątrz katalogu instalacyjnego Terraria lub w folderze obok katalogu instalacyjnego Terraria.",
 		"GraphicsEngineFailure": "Błąd silnika graficznego",
 		"GraphicsEngineReportUnknown": "Nieznany",

--- a/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/pt-BR/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "Os seguintes arquivos de localização foram alterados e serão recarregados: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Pasta Content do Terraria não encontrada. Se você instalou o tModLoader através do Steam, certifique-se de que o Terraria está instalado. Caso contrário, certifique-se de instalar o tModLoader em uma pasta aninhada no diretório de instalação do Terraria ou em uma pasta próxima ao diretório de instalação do Terraria.",
 		"GraphicsEngineFailure": "Falha no Motor Gráfico",
 		"GraphicsEngineReportUnknown": "Desconhecido",

--- a/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/ru-RU/tModLoader.json
@@ -677,6 +677,7 @@
 		"WatchLocalizationFileMessage": "Следующие файлы локализации были изменены и перезагружены: {0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "Папка Content не найдена. Если tModLoader был установлен через Steam, убедитесь, что Terraria также установлена. Если нет, переместите папку tModLoader в папку с Terraria или рядом с ней.",
 		"GraphicsEngineFailure": "Ошибка графического движка.",
 		"GraphicsEngineReportUnknown": "Неизвестно.",

--- a/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
+++ b/patches/tModLoader/Terraria/Localization/Content/zh-Hans/tModLoader.json
@@ -679,6 +679,7 @@
 		"WatchLocalizationFileMessage": "下列本地化文件被修改并重新加载：\n{0}",
 
 		// MessageBox
+		// "TerrariaGraphicsResourcesInitFailed": "The game could not create the needed graphics resources.\n\nYour computer may not be performant enough to run tModLoader.\n\nEnsure your graphics card is working/connected, and try restarting.",
 		"ContentFolderNotFound": "无法检测到原版Terraria的Content资源文件夹\n如果你是通过Steam安装的tModLoader，请确保你也安装了Terraria\n否则，请确保你的tModLoader安装在原版Terraria的文件夹或与原版Terraria处于同级",
 		"GraphicsEngineFailure": "图形引擎崩溃",
 		"GraphicsEngineReportUnknown": "未知",

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1014,7 +1014,7 @@
  		}
  	}
  
-@@ -2209,11 +_,14 @@
+@@ -2209,10 +_,14 @@
  		}
  	}
  
@@ -1025,11 +1025,10 @@
 +			/*
  			if (!(GameZoomTarget > 1f))
  				return GameViewMatrix.TransformationMatrix.M11 > 1f;
--
 +			*/
+ 
  			return true;
  		}
- 	}
 @@ -2233,6 +_,11 @@
  
  	public static string SavePath => Program.SavePath;
@@ -6705,20 +6704,6 @@
  			_isDrawingOrUpdating = false;
  		}
  	}
-@@ -53441,10 +_,13 @@
- 			MapRenderer.DrawToMap(default(Microsoft.Xna.Framework.Rectangle));
- 		}
- 
-+		/*
- 		if (Lighting.UpdateEveryFrame)
- 			drawToScreen = true;
- 		else
- 			drawToScreen = false;
-+		*/
-+		drawToScreen = false;
- 
- 		if (drawToScreen && targetSet)
- 			ReleaseTargets();
 @@ -53568,9 +_,12 @@
  			}
  		}
@@ -6758,7 +6743,7 @@
  
  		bool flag2 = Terraria.Graphics.Effects.Filters.Scene.CanCapture() || ForegroundSunlightEffects;
 -		bool flag3 = !drawToScreen && !mapFullscreen && !onlyDrawFancyUI && Lighting.NotRetro && flag2;
-+		bool flag3 = /* !drawToScreen && */ !mapFullscreen && !onlyDrawFancyUI /* && Lighting.NotRetro */ && flag2;
++		bool flag3 = !drawToScreen && !mapFullscreen && !onlyDrawFancyUI /* && Lighting.NotRetro */ && flag2;
  		if (flag3) {
  			instance.GraphicsDevice.SetRenderTarget(skyTarget);
  			instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -92,6 +92,14 @@
  	public static UserInterface InGameUI = new UserInterface();
  	private static Action _pendingCharacterSelect;
  	public static bool drawBackGore;
+@@ -399,6 +_,7 @@
+ 	public static bool drawBetterDebug;
+ 	public static bool betterDebugRelease;
+ 	public static bool renderNow;
++	[Obsolete("Always false in TML")]
+ 	public static bool drawToScreen;
+ 	public static bool targetSet;
+ 	public static int mouseX;
 @@ -408,7 +_,15 @@
  	public static CraftingUI craftingUI = new CraftingUI();
  	public static BannerClaimingUI bannerUI = new BannerClaimingUI();
@@ -1006,8 +1014,12 @@
  		}
  	}
  
-@@ -2211,9 +_,10 @@
+@@ -2209,11 +_,14 @@
+ 		}
+ 	}
  
++
++	[Obsolete("Always true in TML")]
  	public static bool RenderTargetsRequired {
  		get {
 +			/*

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1006,6 +1006,18 @@
  		}
  	}
  
+@@ -2211,9 +_,10 @@
+ 
+ 	public static bool RenderTargetsRequired {
+ 		get {
++			/*
+ 			if (!(GameZoomTarget > 1f))
+ 				return GameViewMatrix.TransformationMatrix.M11 > 1f;
+-
++			*/
+ 			return true;
+ 		}
+ 	}
 @@ -2233,6 +_,11 @@
  
  	public static string SavePath => Program.SavePath;
@@ -6681,6 +6693,20 @@
  			_isDrawingOrUpdating = false;
  		}
  	}
+@@ -53441,10 +_,13 @@
+ 			MapRenderer.DrawToMap(default(Microsoft.Xna.Framework.Rectangle));
+ 		}
+ 
++		/*
+ 		if (Lighting.UpdateEveryFrame)
+ 			drawToScreen = true;
+ 		else
+ 			drawToScreen = false;
++		*/
++		drawToScreen = false;
+ 
+ 		if (drawToScreen && targetSet)
+ 			ReleaseTargets();
 @@ -53568,9 +_,12 @@
  			}
  		}
@@ -6715,6 +6741,15 @@
  		if (gameMenu || player[myPlayer].gravDir == 1f)
  			Rasterizer = RasterizerState.CullCounterClockwise;
  		else
+@@ -53663,7 +_,7 @@
+ 		}
+ 
+ 		bool flag2 = Terraria.Graphics.Effects.Filters.Scene.CanCapture() || ForegroundSunlightEffects;
+-		bool flag3 = !drawToScreen && !mapFullscreen && !onlyDrawFancyUI && Lighting.NotRetro && flag2;
++		bool flag3 = /* !drawToScreen && */ !mapFullscreen && !onlyDrawFancyUI /* && Lighting.NotRetro */ && flag2;
+ 		if (flag3) {
+ 			instance.GraphicsDevice.SetRenderTarget(skyTarget);
+ 			instance.GraphicsDevice.Clear(Microsoft.Xna.Framework.Color.Transparent);
 @@ -53748,7 +_,7 @@
  		spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, Rasterizer, null, GameViewMatrix.TransformationMatrix);
  		DrawBackgroundBlackFill();

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -6531,6 +6531,23 @@
  					byte b = tile.liquid;
  					bool num5 = num4 <= num2 && ((!flag2 && b < 250) || WorldGen.SolidTile(tile) || (b >= 200 && num4 == 0f));
  					bool flag3 = tile.active() && tileBlockLight[tile.type] && (!tile.invisibleBlock() || flag);
+@@ -50334,6 +_,8 @@
+ 			}
+ 		}
+ 		catch {
++			ErrorReporting.FatalExit(Language.GetTextValue("tModLoader.TerrariaGraphicsResourcesInitFailed"));
++			/*
+ 			Lighting.Mode = LightMode.Retro;
+ 			mapEnabled = false;
+ 			SaveSettings();
+@@ -50342,6 +_,7 @@
+ 			}
+ 			catch {
+ 			}
++			*/
+ 		}
+ 	}
+ 
 @@ -51071,18 +_,33 @@
  		}
  	}

--- a/patches/tModLoader/Terraria/SceneState.cs.patch
+++ b/patches/tModLoader/Terraria/SceneState.cs.patch
@@ -1,11 +1,14 @@
 --- src/TerrariaNetCore/Terraria/SceneState.cs
 +++ src/tModLoader/Terraria/SceneState.cs
-@@ -90,7 +_,7 @@
+@@ -90,7 +_,11 @@
  		ManageSpecialBiomeVisuals("Noir", metrics.NoirMonolith || perspectivePlayer.noirShader);
  		ManageSpecialBiomeVisuals("CRT", metrics.CRTMonolith || perspectivePlayer.CRTMonolithShader);
  		ManageSpecialBiomeVisuals("Test2", metrics.RetroMonolith || perspectivePlayer.retroMonolithShader);
--		ManageSpecialBiomeVisuals("WaterDistortion", Main.WaveQuality > 0);
++		/*
+ 		ManageSpecialBiomeVisuals("WaterDistortion", Main.WaveQuality > 0);
++		*/
 +		ManageSpecialBiomeVisuals("WaterDistortion", Main.WaveQuality > 0 && Lighting.NotRetro);
++
  		bool flag8 = metrics.TownNPCCount > 0 || metrics.PartyMonolithCount > 0;
  		MoveTowards(ref SkyManager.Instance["Party"].Opacity, flag8 ? 1 : 0, 0.01f);
  		if (Filters.Scene["Graveyard"].IsActive()) {

--- a/patches/tModLoader/Terraria/SceneState.cs.patch
+++ b/patches/tModLoader/Terraria/SceneState.cs.patch
@@ -1,5 +1,14 @@
 --- src/TerrariaNetCore/Terraria/SceneState.cs
 +++ src/tModLoader/Terraria/SceneState.cs
+@@ -90,7 +_,7 @@
+ 		ManageSpecialBiomeVisuals("Noir", metrics.NoirMonolith || perspectivePlayer.noirShader);
+ 		ManageSpecialBiomeVisuals("CRT", metrics.CRTMonolith || perspectivePlayer.CRTMonolithShader);
+ 		ManageSpecialBiomeVisuals("Test2", metrics.RetroMonolith || perspectivePlayer.retroMonolithShader);
+-		ManageSpecialBiomeVisuals("WaterDistortion", Main.WaveQuality > 0);
++		ManageSpecialBiomeVisuals("WaterDistortion", Main.WaveQuality > 0 && Lighting.NotRetro);
+ 		bool flag8 = metrics.TownNPCCount > 0 || metrics.PartyMonolithCount > 0;
+ 		MoveTowards(ref SkyManager.Instance["Party"].Opacity, flag8 ? 1 : 0, 0.01f);
+ 		if (Filters.Scene["Graveyard"].IsActive()) {
 @@ -292,7 +_,8 @@
  			MoveTowards(ref Main.shimmerAlpha, 0f, 0.05f);
  	}

--- a/solutions/TranslationsNeeded.txt
+++ b/solutions/TranslationsNeeded.txt
@@ -1,8 +1,8 @@
-zh-Hans 43
-ru-RU 44
-pt-BR 91
-pl-PL 88
-it-IT 1034
-fr-FR 499
-es-ES 460
-de-DE 462
+zh-Hans 44
+ru-RU 45
+pt-BR 92
+pl-PL 89
+it-IT 1035
+fr-FR 500
+es-ES 461
+de-DE 463


### PR DESCRIPTION
Based on my prior [WIP: Allow screen shaders when using Retro/Trippy lighting modes. (And additionally on the main menu.)](https://github.com/tModLoader/tModLoader/pull/4796)

### What is the new feature?
Legacy lighting modes will always use required targets (`WorldSceneLayerTarget`'s,`skyTarget`, `screenTarget`, and `screenTargetSwap`) when rendering, regardless of zoom.
`FilterManager::Begin`/`EndCapture` will now run regardless of lighting mode, should be noted that vanilla requirements (e.g. `Filters.Scene.CanCapture` and `Main.ForegroundSunlightEffects`) must still be `true`.
The `WaterDistortion` filter remains disabled in legacy modes.

### Why should this be part of tModLoader?
Some mods may rely on screen shaders for important visual information and thus break in legacy lighting modes.

### Are there alternative designs?
- Obsolete members could be removed, but would require extra patches and cause unnecessary porting friction.
- The new behaviour could be provided as a setting either for the user, or enabled by mods.
  - The old behaviour is done in vanilla to support older hardware, TML's system requirements already exceed this so a setting is likely not beneficial.

### Sample usage for the new feature
N/A

### ExampleMod updates
N/A

### Notes
- Vanilla's fallback case in `Main.InitTargets` has been replaced with a hard crash, this error needs localizing.

### Porting Notes
- Common modded logic pertaining to tile rendering similar to `var zero = Main.drawToScreen ? Vector2.Zero : new Vector2(Main.offScreenRange);` is legacy, and should be replaced with `var zero = new Vector2(Main.offScreenRange)` as `Main.drawToScreen` is always false. (Perhaps possible as a tModPorter task?)
