### PR TITLE
Allow setup-cli scripts to be aliased and called from elsewhere.

### DIFF
--- a/setup-cli.bat
+++ b/setup-cli.bat
@@ -1,6 +1,13 @@
 @echo off
 setlocal enabledelayedexpansion
 
+rem For the best development experience, alias this script in your shell config.
+rem For example:
+rem CMD/Batch  - doskey tml=C:\dev\terraria\tModLoader\setup-cli.bat
+rem PowerShell - Set-Alias -Name tml -Value C:\dev\terraria\tModLoader\setup-cli.bat
+
+cd /d "%~dp0"
+
 where git >NUL
 if !errorlevel! neq 0 (
 	echo git not found on PATH
@@ -26,5 +33,5 @@ if !errorlevel! neq 0 (
     exit /b %errorlevel%
 )
 
-endlocal
 dotnet run --project setup/CLI/Setup.CLI.csproj -c Release -p:WarningLevel=0 -v q -- %*
+

--- a/setup-cli.sh
+++ b/setup-cli.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# For the best development experience, alias this script in your shell config.
+# For example:
+# (ba)sh  - alias tml=~/dev/terraria/tModLoader/setup-cli.sh
+# Nushell - alias tml = ~/dev/terraria/tModLoader/setup-cli.sh
+
+# CD to the script's directory and allow execution from elsewhere.
+cd "$(dirname "$0")"
+
 if ! command -v git > /dev/null; 
 then
     echo "git not found in PATH"


### PR DESCRIPTION
> For the best development experience, alias this script in your shell config.
> For example:
> `(ba)sh     - alias tml=~/dev/terraria/tModLoader/setup-cli.sh`
> `Nushell    - alias tml = ~/dev/terraria/tModLoader/setup-cli.sh`
> `CMD/Batch  - doskey tml=C:\dev\terraria\tModLoader\setup-cli.bat`
> `PowerShell - Set-Alias -Name tml -Value C:\dev\terraria\tModLoader\setup-cli.bat`

This will allow using calls like `tml diff terraria` from anywhere.