### PR TITLE
Port 1.4.5 IME preedit text and composition hotkey protection back to 1.4.4

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UITextBox.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UITextBox.cs.patch
@@ -1,6 +1,12 @@
 --- src/TerrariaNetCore/Terraria/GameContent/UI/Elements/UITextBox.cs
 +++ src/tModLoader/Terraria/GameContent/UI/Elements/UITextBox.cs
-@@ -5,7 +_,7 @@
+@@ -1,11 +_,13 @@
+ using System;
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Graphics;
++using ReLogic.Localization.IME;
++using ReLogic.OS;
+ using Terraria.UI;
  
  namespace Terraria.GameContent.UI.Elements;
  
@@ -9,3 +15,61 @@
  {
  	private int _cursor;
  	private int _frameCount;
+@@ -13,6 +_,19 @@
+ 	public bool ShowInputTicker = true;
+ 	public bool HideSelf;
+ 
++	protected override Vector2 TextDrawPosition {
++		get {
++			Vector2 textDrawPosition = base.TextDrawPosition;
++			if (ShowInputTicker) {
++				string compositionString = Platform.Get<IImeService>().CompositionString;
++				if (!string.IsNullOrEmpty(compositionString))
++					textDrawPosition.X -= (base.IsLarge ? FontAssets.DeathText.Value : FontAssets.MouseText.Value).MeasureString(compositionString).X * base.TextScale * TextHAlign;
++			}
++
++			return textDrawPosition;
++		}
++	}
++
+ 	public UITextBox(string text, float textScale = 1f, bool large = false)
+ 		: base(text, textScale, large)
+ 	{
+@@ -66,7 +_,19 @@
+ 
+ 		_cursor = base.Text.Length;
+ 		base.DrawSelf(spriteBatch);
++		if (!ShowInputTicker)
++			return;
++
++		Vector2 textDrawPosition = TextDrawPosition;
++		string compositionString = Platform.Get<IImeService>().CompositionString;
++		if (!string.IsNullOrEmpty(compositionString)) {
++			textDrawPosition.X += (base.IsLarge ? FontAssets.DeathText.Value : FontAssets.MouseText.Value).MeasureString(compositionString).X * base.TextScale;
++			DrawText(spriteBatch, compositionString, TextDrawPosition + new Vector2(base.TextSize.X, 0f), Main.imeCompositionStringColor);
++		}
++
+ 		_frameCount++;
++		// 1.4.5 Backport: Draw IME composition strings (#5293)
++		/*
+ 		if ((_frameCount %= 40) <= 20 && ShowInputTicker) {
+ 			CalculatedStyle innerDimensions = GetInnerDimensions();
+ 			Vector2 pos = innerDimensions.Position();
+@@ -81,6 +_,17 @@
+ 				Utils.DrawBorderStringBig(spriteBatch, "|", pos, base.TextColor, base.TextScale);
+ 			else
+ 				Utils.DrawBorderString(spriteBatch, "|", pos, base.TextColor, base.TextScale);
++		}
++		*/
++		if ((_frameCount %= 40) <= 20) {
++			textDrawPosition.X +=
++				(base.IsLarge ? FontAssets.DeathText.Value : FontAssets.MouseText.Value)
++				.MeasureString(base.Text.Substring(0, _cursor)).X * base.TextScale;
++			textDrawPosition.X += 6f - (base.IsLarge ? 8f : 4f) * base.TextScale;
++			if (base.IsLarge)
++				textDrawPosition.Y += 2f * base.TextScale;
++
++			DrawText(spriteBatch, "|", textDrawPosition, base.TextColor);
+ 		}
+ 	}
+ }

--- a/patches/tModLoader/Terraria/GameContent/UI/Elements/UITextPanel.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/Elements/UITextPanel.cs.patch
@@ -9,6 +9,27 @@
  
  namespace Terraria.GameContent.UI.Elements;
  
+@@ -56,6 +_,20 @@
+ 		}
+ 	}
+ 
++	protected virtual Vector2 TextDrawPosition {
++		get {
++			CalculatedStyle innerDimensions = GetInnerDimensions();
++			Vector2 result = innerDimensions.Position();
++			result.X += (innerDimensions.Width - _textSize.X) * TextHAlign;
++			if (_isLarge)
++				result.Y -= 10f * _textScale * _textScale;
++			else
++				result.Y -= 2f * _textScale;
++
++			return result;
++		}
++	}
++
+ 	public UITextPanel(T text, float textScale = 1f, bool large = false)
+ 	{
+ 		SetText(text, textScale, large);
 @@ -74,7 +_,14 @@
  
  	public virtual void SetText(T text, float textScale, bool large)
@@ -24,3 +45,41 @@
  		_text = text;
  		_textScale = textScale;
  		_textSize = textSize;
+@@ -93,6 +_,8 @@
+ 
+ 	protected void DrawText(SpriteBatch spriteBatch)
+ 	{
++		// 1.4.5 Backport: Draw IME composition strings (#5293)
++		/*
+ 		CalculatedStyle innerDimensions = GetInnerDimensions();
+ 		Vector2 pos = innerDimensions.Position();
+ 		if (_isLarge)
+@@ -101,6 +_,7 @@
+ 			pos.Y -= 2f * _textScale;
+ 
+ 		pos.X += (innerDimensions.Width - _textSize.X) * TextHAlign;
++		*/
+ 		string text = Text;
+ 		if (HideContents) {
+ 			if (_asterisks == null || _asterisks.Length != text.Length)
+@@ -109,9 +_,20 @@
+ 			text = _asterisks;
+ 		}
+ 
++		/*
+ 		if (_isLarge)
+ 			Utils.DrawBorderStringBig(spriteBatch, text, pos, _color, _textScale);
+ 		else
+ 			Utils.DrawBorderString(spriteBatch, text, pos, _color, _textScale);
++		*/
++		DrawText(spriteBatch, text, TextDrawPosition, _color);
++	}
++
++	protected void DrawText(SpriteBatch spriteBatch, string text, Vector2 position, Color color)
++	{
++		if (_isLarge)
++			Utils.DrawBorderStringBig(spriteBatch, text, position, color, _textScale);
++		else
++			Utils.DrawBorderString(spriteBatch, text, position, color, _textScale);
+ 	}
+ }

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -825,7 +825,7 @@
  	public static int[] anglerQuestItemNetIDs = new int[41] {
  		2450,
  		2451,
-@@ -1119,6 +_,9 @@
+@@ -1119,14 +_,22 @@
  	public static bool temporaryGUIScaleSliderUpdate = false;
  	public static bool InGuideCraftMenu;
  	public static bool InReforgeMenu;
@@ -835,7 +835,10 @@
  	public static Item HoverItem = new Item();
  	private static int backSpaceCount;
  	private static float backSpaceRate;
-@@ -1127,6 +_,9 @@
++	private static bool imeCompositionActive;
++	public static Microsoft.Xna.Framework.Color imeCompositionStringColor = new Microsoft.Xna.Framework.Color(255, 240, 20);
+ 	public static string motd = "";
+ 	public static bool toggleFullscreen;
  	public static int numDisplayModes;
  	public static int[] displayWidth = new int[99];
  	public static int[] displayHeight = new int[99];
@@ -2899,6 +2902,35 @@
  			if (chatRelease && !drawingPlayerChat && !editSign && !editChest && !gameMenu && !keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Escape)) {
  				SoundEngine.PlaySound(10);
  				OpenPlayerChat();
+@@ -14555,6 +_,8 @@
+ 			return;
+ 		}
+ 
++		// 1.4.5 Backport: Guard hotkeys while IME composition active (#5293)
++		/*
+ 		int linesOffset = 0;
+ 		if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Up))
+ 			linesOffset = 1;
+@@ -14564,6 +_,19 @@
+ 		chatMonitor.Offset(linesOffset);
+ 		if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Escape))
+ 			drawingPlayerChat = false;
++		*/
++		if (!imeCompositionActive) {
++			int linesOffset = 0;
++			if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Up))
++				linesOffset = 1;
++			else if (keyState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Down))
++				linesOffset = -1;
++
++			chatMonitor.Offset(linesOffset);
++		}
++
++		if (inputTextEscape && !imeCompositionActive)
++			drawingPlayerChat = false;
+ 
+ 		string text = chatText;
+ 		chatText = GetInputText(chatText);
 @@ -14582,7 +_,8 @@
  		if (!inputTextEnter || !chatRelease)
  			return;
@@ -2987,6 +3019,42 @@
  			for (int i = 0; i < keyCount; i++) {
  				int num = keyInt[i];
  				string text3 = keyString[i];
+@@ -15882,9 +_,11 @@
+ 		text += text2;
+ 		oldInputText = inputText;
+ 		inputText = Keyboard.GetState();
++		/*
+ 		Microsoft.Xna.Framework.Input.Keys[] pressedKeys = inputText.GetPressedKeys();
+ 		Microsoft.Xna.Framework.Input.Keys[] pressedKeys2 = oldInputText.GetPressedKeys();
++		*/
+-		if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back) && oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back)) {
++		if (inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back) && oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back) && !imeCompositionActive) {
+ 			backSpaceRate -= 0.05f;
+ 			if (backSpaceRate < 0f)
+ 				backSpaceRate = 0f;
+@@ -15901,6 +_,8 @@
+ 			backSpaceCount = 15;
+ 		}
+ 
++		// 1.4.5 Backport: Only delete commited text when no IME composition is active (#5293)
++		/*
+ 		for (int j = 0; j < pressedKeys.Length; j++) {
+ 			bool flag2 = true;
+ 			for (int k = 0; k < pressedKeys2.Length; k++) {
+@@ -15913,7 +_,13 @@
+ 				text = ((!array[array.Length - 1].DeleteWhole) ? text.Substring(0, text.Length - 1) : text.Substring(0, text.Length - array[array.Length - 1].TextOriginal.Length));
+ 			}
+ 		}
++		*/
++		if (((inputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back) && !oldInputText.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back) && !imeCompositionActive) || flag) && text.Length > 0) {
++			TextSnippet[] array = ChatManager.ParseMessage(text, Microsoft.Xna.Framework.Color.White).ToArray();
++			text = ((!array[array.Length - 1].DeleteWhole) ? text.Substring(0, text.Length - 1) : text.Substring(0, text.Length - array[array.Length - 1].TextOriginal.Length));
++		}
+ 
++		imeCompositionActive = !string.IsNullOrEmpty(Platform.Get<IImeService>().CompositionString);
+ 		return text;
+ 	}
+ 
 @@ -15938,11 +_,16 @@
  		MouseText(cursorText, null, rare, diff, hackedMouseX, hackedMouseY, hackedScreenWidth, hackedScreenHeight, pushWidthX, noOverride: true);
  	}
@@ -4613,11 +4681,11 @@
 -			if (textBlinkerState == 1)
 +			if (textBlinkerState == 1) {
  				flag3 = true;
-+
-+				textLines[amountOfLines - 1].Add(new TextSnippet("|", Microsoft.Xna.Framework.Color.White, 1f));
 +			}
  
++			/*
  			instance.DrawWindowsIMEPanel(new Vector2(screenWidth / 2, 90f), 0.5f);
++			*/
  		}
  
 +		/*
@@ -4633,7 +4701,7 @@
  			string text = textLines[i];
  			if (text != null) {
  				if (i == amountOfLines - 1 && flag3)
-@@ -31778,6 +_,23 @@
+@@ -31778,9 +_,43 @@
  				else
  					Utils.DrawBorderStringFourWay(spriteBatch, FontAssets.MouseText.Value, text, 170 + (screenWidth - 800) / 2, 120 + i * 30, color2, Microsoft.Xna.Framework.Color.Black, Vector2.Zero);
  			}
@@ -4645,9 +4713,6 @@
 +				hoveredSnippet = text[hoveredSnippetNum];
 +		}
 +
-+		if (flag3)
-+			textLines[amountOfLines - 1].RemoveAt(textLines[amountOfLines - 1].Count - 1);
-+
 +		// Added on-hover and on-click callbacks as well
 +		if (hoveredSnippet is not null) {
 +			hoveredSnippet.OnHover();
@@ -4657,6 +4722,29 @@
  		}
  
  		Microsoft.Xna.Framework.Rectangle rectangle = new Microsoft.Xna.Framework.Rectangle(screenWidth / 2 - TextureAssets.ChatBack.Width() / 2, 100, TextureAssets.ChatBack.Width(), (amountOfLines + 2) * 30);
++
++		// 1.4.5 Backport: Draw IME composition strings (#5293)
++		if (editSign && textLines[amountOfLines - 1] != null) {
++			Vector2 position = new Vector2(170 + (screenWidth - 800) / 2, 120 + (amountOfLines - 1) * 30);
++			position.X += ChatManager.GetStringSize(FontAssets.MouseText.Value, textLines[amountOfLines - 1].ToArray(), Vector2.One).X;
++			string compositionString = Platform.Get<IImeService>().CompositionString;
++			if (!string.IsNullOrEmpty(compositionString)) {
++				float compositionWidth = FontAssets.MouseText.Value.MeasureString(compositionString).X;
++				if (compositionWidth + position.X - (170 + (screenWidth - 800) / 2) > 460f)
++					position = new Vector2(170 + (screenWidth - 800) / 2, 120 + amountOfLines * 30);
++
++				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, compositionString, position, imeCompositionStringColor, 0f, Vector2.Zero, Vector2.One);
++				instance.DrawWindowsIMEPanel(position + new Vector2(0f, 54f), 0f);
++				position.X += compositionWidth;
++			}
++
++			if (flag3)
++				ChatManager.DrawColorCodedStringWithShadow(spriteBatch, FontAssets.MouseText.Value, "|", position, color2, 0f, Vector2.Zero, Vector2.One);
++		}
++
+ 		int num3 = 120 + amountOfLines * 30 + 30;
+ 		num3 -= 235;
+ 		UIVirtualKeyboard.ShouldHideText = !PlayerInput.SettingsForUI.ShowGamepadHints;
 @@ -31820,13 +_,20 @@
  		color2 = new Microsoft.Xna.Framework.Color(num, (int)((double)num / 1.1), num / 2, num);
  		string focusText = "";
@@ -4850,6 +4938,15 @@
  		UILinkPointNavigator.SetPosition(2503, vector2 + stringSize * 0.5f);
  		UILinkPointNavigator.Shortcuts.NPCCHAT_ButtonsRight2 = true;
  	}
+@@ -32797,7 +_,7 @@
+ 			List<TextSnippet> list = ChatManager.ParseMessage(text, Microsoft.Xna.Framework.Color.White);
+ 			string compositionString = Platform.Get<IImeService>().CompositionString;
+ 			if (compositionString != null && compositionString.Length > 0)
+-				list.Add(new TextSnippet(compositionString, new Microsoft.Xna.Framework.Color(255, 240, 20)));
++				list.Add(new TextSnippet(compositionString, imeCompositionStringColor));
+ 
+ 			if (textBlinkerState == 1)
+ 				list.Add(new TextSnippet("|", Microsoft.Xna.Framework.Color.White));
 @@ -32869,8 +_,12 @@
  			}
  		}

--- a/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
+++ b/patches/tModLoader/Terraria/UI/ChestUI.cs.patch
@@ -1,6 +1,14 @@
 --- src/TerrariaNetCore/Terraria/UI/ChestUI.cs
 +++ src/tModLoader/Terraria/UI/ChestUI.cs
-@@ -7,6 +_,8 @@
+@@ -2,11 +_,16 @@
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Graphics;
+ using Microsoft.Xna.Framework.Input;
++using ReLogic.Graphics;
++using ReLogic.Localization.IME;
++using ReLogic.OS;
+ using Terraria.Audio;
+ using Terraria.DataStructures;
  using Terraria.GameContent;
  using Terraria.GameInput;
  using Terraria.Localization;
@@ -9,6 +17,23 @@
  using Terraria.UI.Chat;
  using Terraria.UI.Gamepad;
  
+@@ -76,6 +_,8 @@
+ 		string text = string.Empty;
+ 		if (Main.editChest) {
+ 			text = Main.npcChatText;
++			// 1.4.5 Backport: Draw IME composition strings (#5293)
++			/*
+ 			Main.instance.textBlinkerCount++;
+ 			if (Main.instance.textBlinkerCount >= 20) {
+ 				if (Main.instance.textBlinkerState == 0)
+@@ -90,6 +_,7 @@
+ 				text += "|";
+ 
+ 			Main.instance.DrawWindowsIMEPanel(new Vector2(120f, 518f));
++			*/
+ 		}
+ 		else if (player.chest > -1) {
+ 			if (Main.chest[player.chest] == null)
 @@ -109,6 +_,8 @@
  					text = Lang.chestType2[tile.frameX / 36].Value;
  				else if (tile.type == 88)
@@ -18,6 +43,41 @@
  			}
  		}
  		else if (player.chest == -2) {
+@@ -127,11 +_,34 @@
+ 		Color color = new Color(Main.mouseTextColor, Main.mouseTextColor, Main.mouseTextColor, Main.mouseTextColor);
+ 		color = Color.White * (1f - (255f - (float)(int)Main.mouseTextColor) / 255f * 0.5f);
+ 		color.A = byte.MaxValue;
++		// 1.4.5 Backport: Draw IME composition strings (#5293)
++		/*
+ 		Utils.WordwrapString(text, FontAssets.MouseText.Value, 200, 1, out var lineAmount);
+ 		lineAmount++;
+ 		for (int i = 0; i < lineAmount; i++) {
+ 			ChatManager.DrawColorCodedStringWithShadow(spritebatch, FontAssets.MouseText.Value, text, new Vector2(504f, Main.instance.invBottom + i * 26), color, 0f, Vector2.Zero, Vector2.One, -1f, 1.5f);
+ 		}
++		*/
++		DynamicSpriteFont value = FontAssets.MouseText.Value;
++		Vector2 vector = new Vector2(504f, Main.instance.invBottom);
++		ChatManager.DrawColorCodedStringWithShadow(spritebatch, value, text, vector, color, 0f, Vector2.Zero, Vector2.One, -1f, 1.5f);
++		if (Main.editChest) {
++			vector.X += value.MeasureString(text).X;
++			Main.instance.DrawWindowsIMEPanel(vector + new Vector2(0f, 56f));
++			string compositionString = Platform.Get<IImeService>().CompositionString;
++			if (!string.IsNullOrEmpty(compositionString)) {
++				ChatManager.DrawColorCodedStringWithShadow(spritebatch, value, compositionString, vector, Main.imeCompositionStringColor, 0f, Vector2.Zero, Vector2.One, -1f, 1.5f);
++				vector.X += value.MeasureString(compositionString).X;
++			}
++
++			if (++Main.instance.textBlinkerCount >= 20) {
++				Main.instance.textBlinkerState = ((Main.instance.textBlinkerState == 0) ? 1 : 0);
++				Main.instance.textBlinkerCount = 0;
++			}
++
++			if (Main.instance.textBlinkerState == 1)
++				ChatManager.DrawColorCodedStringWithShadow(spritebatch, value, "|", vector, color, 0f, Vector2.Zero, Vector2.One, -1f, 1.5f);
++		}
+ 	}
+ 
+ 	private static void DrawButtons(SpriteBatch spritebatch)
 @@ -410,12 +_,18 @@
  							if (chest.item[i].stack >= chest.item[i].maxStack || !player.inventory[num].IsTheSameAs(chest.item[i]))
  								continue;


### PR DESCRIPTION
### What is the bug?
IME preedit text is not shown in tModLoader, and pressing some hotkeys will result in them both functioning on IME and the game. (e.g. Pressing backspace when IME is active will cause both the preedit text and submited text being deleted)
These bug are present in Terraria 1.4.4, and were fixed in 1.4.5.

### How did you fix the bug?
I backported the related code that fixed the bug in Terraria 1.4.5 back to tModLoader 1.4.4.

### Are there alternatives to your fix?
Not that I could think of.