### PR TITLE
Fix publish menu disclaimer and category title centering issues

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/AWorkshopPublishInfoState.cs.patch
@@ -113,6 +113,15 @@
  		if (info.tags != null) {
  			foreach (GroupOptionButton<WorkshopTagOption> tagOption in _tagOptions) {
  				bool flag = info.tags.Contains(tagOption.OptionValue.InternalNameForAPIs);
+@@ -209,7 +_,7 @@
+ 		UIText uIText = new UIText(Language.GetText("Workshop.SteamDisclaimer")) {
+ 			HAlign = 0f,
+ 			VAlign = 0f,
+-			Width = StyleDimension.FromPixelsAndPercent(-40f, 1f),
++			Width = StyleDimension.FromPixelsAndPercent(0f, 1f),
+ 			Height = StyleDimension.FromPixelsAndPercent(0f, 1f),
+ 			TextColor = Color.Cyan,
+ 			IgnoresMouseInteraction = true
 @@ -329,41 +_,46 @@
  	private UIElement CreatePublicSettingsRow(float accumulatedHeight, float height, string tagGroup)
  	{
@@ -203,7 +212,7 @@
 +				UIText uIText = new UIText(Language.GetText("tModLoader.TagsCategoryLanguage")) {
 +					HAlign = 0f,
 +					VAlign = 0f,
-+					Width = StyleDimension.FromPixelsAndPercent(-40f, 1f),
++					Width = StyleDimension.FromPixelsAndPercent(0f, 1f),
 +					Height = StyleDimension.FromPixelsAndPercent(44, 0f),
 +					Top = StyleDimension.FromPixelsAndPercent(5f + num5 * heightPerRow, 0f)
 +				};
@@ -224,7 +233,7 @@
 +				UIText uIText = new UIText(Language.GetText("tModLoader.TagsCategoryRating")) {
 +					HAlign = 0f,
 +					VAlign = 0f,
-+					Width = StyleDimension.FromPixelsAndPercent(-40f, 1f),
++					Width = StyleDimension.FromPixelsAndPercent(0f, 1f),
 +					Height = StyleDimension.FromPixelsAndPercent(44, 0f),
 +					Top = StyleDimension.FromPixelsAndPercent(5f + num5 * heightPerRow, 0f)
 +				};
@@ -248,6 +257,15 @@
  			groupOptionButton.OnLeftMouseDown += ClickTagOption;
  			groupOptionButton.OnMouseOver += ShowOptionDescription;
  			groupOptionButton.OnMouseOut += ClearOptionDescription;
+@@ -437,7 +_,7 @@
+ 		UIText uIText = new UIText(Language.GetText(titleTextKey)) {
+ 			HAlign = 0f,
+ 			VAlign = 0f,
+-			Width = StyleDimension.FromPixelsAndPercent(-40f, 1f),
++			Width = StyleDimension.FromPixelsAndPercent(0f, 1f),
+ 			Height = StyleDimension.FromPixelsAndPercent(num, 0f),
+ 			Top = StyleDimension.FromPixelsAndPercent(5f, 0f)
+ 		};
 @@ -594,7 +_,8 @@
  
  	private void AddPublishButton(int backButtonYLift, UIElement outerContainer)

--- a/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
+++ b/patches/tModLoader/Terraria/GameContent/UI/States/WorkshopPublishInfoStateForMods.TML.cs
@@ -111,7 +111,7 @@ public class WorkshopPublishInfoStateForMods : AWorkshopPublishInfoState<TmodFil
 		UIText uIText = new UIText(Language.GetText("tModLoader.WorkshopDisclaimer")) {
 			HAlign = 0f,
 			VAlign = 0f,
-			Width = StyleDimension.FromPixelsAndPercent(-40f, 1f),
+			Width = StyleDimension.FromPixelsAndPercent(0f, 1f),
 			Height = StyleDimension.FromPixelsAndPercent(0f, 1f),
 			TextColor = Color.Cyan,
 			IgnoresMouseInteraction = true


### PR DESCRIPTION
This PR fixes the centering issues on the publish menu. See how the disclaimer didn't use the full width and how the category titles are not centered properly.

<img width="662" height="551" alt="image" src="https://github.com/user-attachments/assets/9499668d-7a11-46fd-a21c-ae22c497ee5e" />

**Before:**
<img width="1920" height="1017" alt="dotnet_2026-08-06_17-59-11" src="https://github.com/user-attachments/assets/0d67c909-8540-485c-92f1-49962606e9bb" />

**After:**
<img width="1920" height="1017" alt="dotnet_2026-08-06_18-32-15" src="https://github.com/user-attachments/assets/376e06cb-f0cc-4f41-a191-76263d25d588" />
