### PR TITLE
[1.4.5] Auto generate localized metadata template files when creating new mods (relates #5226)

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Core/SourceManagement.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Core/SourceManagement.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using Stubble.Core;
+using Terraria.Localization;
 
 #nullable enable
 #pragma warning disable IDE0057
@@ -25,10 +26,24 @@ internal static class SourceManagement
 		public required string ModDisplayName { get; set; }
 		public required string ModAuthor { get; set; }
 		public required string ModVersion { get; set; }
+		public string ModDisplayNameCultureName { get; set; } = GetLocalizedModDisplayNameCultureName();
 		public string ItemName { get; set; } = string.Empty;
 		public string ItemDisplayName { get; set; } = string.Empty;
 
 		public bool IncludeItem => ItemName != string.Empty;
+		public bool IncludeLocalizedModDisplayName => ModDisplayNameCultureName != string.Empty;
+
+		private static string GetLocalizedModDisplayNameCultureName()
+		{
+			string cultureName = Language.ActiveCulture?.Name;
+			string defaultCultureName = GameCulture.DefaultCulture?.Name;
+
+			if (!string.IsNullOrEmpty(cultureName) && !string.Equals(cultureName, defaultCultureName, StringComparison.OrdinalIgnoreCase)) {
+				return cultureName;
+			}
+
+			return string.Empty;
+		}
 
 		public static TemplateParameters FromSourceFolder(string modSrcDirectory)
 		{

--- a/patches/tModLoader/Terraria/ModLoader/Templates/build.txt
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/build.txt
@@ -1,3 +1,4 @@
 displayName = {{ModDisplayName}}
-author = {{ModAuthor}}
+{{#IncludeLocalizedModDisplayName}}displayName.{{ModDisplayNameCultureName}} = {{ModDisplayName}}
+{{/IncludeLocalizedModDisplayName}}author = {{ModAuthor}}
 version = {{ModVersion}}

--- a/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop_{{ModDisplayNameCultureName}}.txt
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/description_workshop_{{ModDisplayNameCultureName}}.txt
@@ -1,0 +1,2 @@
+{{#IncludeLocalizedModDisplayName}}This description will show up on the steam page, check out https://steamcommunity.com/comment/Guide/formattinghelp.
+{{/IncludeLocalizedModDisplayName}}

--- a/patches/tModLoader/Terraria/ModLoader/Templates/description_{{ModDisplayNameCultureName}}.txt
+++ b/patches/tModLoader/Terraria/ModLoader/Templates/description_{{ModDisplayNameCultureName}}.txt
@@ -1,0 +1,2 @@
+{{#IncludeLocalizedModDisplayName}}Modify this file with a description of your mod.
+{{/IncludeLocalizedModDisplayName}}


### PR DESCRIPTION
### What is the new feature?

When creating a new mod from the in-game Create Mod menu while tModLoader is using a non-default game language, the generated mod source now includes localization-friendly metadata templates.

Specifically, the mod template now:
- Adds a localized display name entry in [build.txt](src/tModLoader/Terraria/ModLoader/Templates/build.txt:2) for the active game culture.
- Generates a localized mod description template file via [description_{{ModDisplayNameCultureName}}.txt](src/tModLoader/Terraria/ModLoader/Templates/description_{{ModDisplayNameCultureName}}.txt:1).
- Generates a localized Steam Workshop description template file via [description_workshop_{{ModDisplayNameCultureName}}.txt](src/tModLoader/Terraria/ModLoader/Templates/description_workshop_{{ModDisplayNameCultureName}}.txt:1).
- Uses the active game language culture detected in [SourceManagement.cs](src/tModLoader/Terraria/ModLoader/Core/SourceManagement.cs:29) to decide whether localized template files should be emitted.

### Why should this be part of tModLoader?

This improves the new mod creation flow for non-English users. If a user creates a mod while using another supported game language, the generated mod source will already contain the correct localized metadata and description files expected by tModLoader and Steam Workshop publishing.

This reduces friction for new modders and makes the template output better match the localization support already used when reading localized mod display names, mod descriptions, and Workshop descriptions.

### Are there alternative designs?

An alternative would be to always generate localized description files for all known cultures, but that would create many unused files for most new mods.

Another option would be to add extra UI fields to the Create Mod menu for localized descriptions, but that would make the initial mod creation UI more complicated. This PR keeps the behavior simple by generating only the files relevant to the currently active non-default game language.

### Sample usage for the new feature

Set tModLoader to a non-default language, then create a new mod from the in-game Create Mod menu.

The generated mod source will include:
- The default [description.txt](src/tModLoader/Terraria/ModLoader/Templates/description.txt:1).
- The default [description_workshop.txt](src/tModLoader/Terraria/ModLoader/Templates/description_workshop.txt:1).
- A localized description file for the current culture.
- A localized Workshop description file for the current culture.
- A localized display name entry in [build.txt](src/tModLoader/Terraria/ModLoader/Templates/build.txt:2).