### PR TITLE
OnTileKilled hooks for ModTile and GlobalTile

### DIFF
--- a/ExampleMod/Content/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Content/Tiles/ExampleBlock.cs
@@ -30,9 +30,9 @@ namespace ExampleMod.Content.Tiles
 		}
 
 		public override void OnTileKilled(int i, int j) {
-			// 10% chance to spawn a mouse when broken.
-			if (Main.netMode != NetmodeID.MultiplayerClient && Main.rand.NextBool(10)) {
-				NPC.NewNPC(new EntitySource_TileBreak(i, j), i * 16, j * 16, NPCID.Mouse);
+			// 1% chance to release a firework when broken.
+			if (Main.netMode != NetmodeID.MultiplayerClient && Main.rand.NextBool(100)) {
+				Projectile.NewProjectile(new EntitySource_TileBreak(i, j), i * 16f, j * 16f, 0f, -4f, ProjectileID.RocketFireworksBoxRed + Main.rand.Next(4), 0, 0, Main.myPlayer);
 			}
 		}
 	}

--- a/ExampleMod/Content/Tiles/ExampleBlock.cs
+++ b/ExampleMod/Content/Tiles/ExampleBlock.cs
@@ -2,6 +2,7 @@ using ExampleMod.Content.Biomes;
 using ExampleMod.Content.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -26,6 +27,13 @@ namespace ExampleMod.Content.Tiles
 
 		public override void ChangeWaterfallStyle(ref int style) {
 			style = ModContent.GetInstance<ExampleWaterfallStyle>().Slot;
+		}
+
+		public override void OnTileKilled(int i, int j) {
+			// 10% chance to spawn a mouse when broken.
+			if (Main.netMode != NetmodeID.MultiplayerClient && Main.rand.NextBool(10)) {
+				NPC.NewNPC(new EntitySource_TileBreak(i, j), i * 16, j * 16, NPCID.Mouse);
+			}
 		}
 	}
 }

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -88,6 +88,17 @@ public abstract class GlobalTile : GlobalBlockType
 	{
 	}
 
+	/// <summary>
+	/// Called when the tile at the given coordinates is destroyed by regular means (<see cref="WorldGen.KillTile(int, int, bool, bool, bool)"/>).
+	/// <para/>This will be called for all tiles, including each tile of a multi-tile.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	/// <param name="type">The tile type</param>
+	public virtual void OnTileKilled(int i, int j, int type)
+	{
+	}
+
 	/// <inheritdoc cref="ModTile.NearbyEffects(int, int, bool)"/>
 	public virtual void NearbyEffects(int i, int j, int type, bool closer)
 	{

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -306,6 +306,17 @@ public abstract class ModTile : ModBlockType
 	}
 
 	/// <summary>
+	/// Called when the tile at the given coordinates is destroyed by regular means (<see cref="WorldGen.KillTile(int, int, bool, bool, bool)"/>).
+	/// <para/>This will be called for all tiles, including each tile of a multi-tile.
+	/// <br/> For multi-tiles, <see cref="KillMultiTile(int, int, int, int)"/> may be more appropriate depending on your use case.
+	/// </summary>
+	/// <param name="i">The x position in tile coordinates.</param>
+	/// <param name="j">The y position in tile coordinates.</param>
+	public virtual void OnTileKilled(int i, int j)
+	{
+	}
+
+	/// <summary>
 	/// Allows you to make things happen when this tile is within a certain range of the player, such as how banners, campfire, and monoliths work.
 	/// <para/> This method will be called on tiles within 2 specific ranges, once for calculating visual effects and another time for calculating gameplay effects:
 	/// <para/> When calculating <b>visual effects</b>, the <paramref name="closer"/> parameter will be <see langword="true"/>. The visual effect range depend on the game window resolution, zoom level, and lighting mode, so it will not be reliable for gameplay effects but rather it adjusts to the players view of the game world. This is suitable for monoliths, water fountains, and music boxes.

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -61,6 +61,7 @@ public static class TileLoader
 	private static DelegateCanKillTile[] HookCanKillTile;
 	private delegate void DelegateKillTile(int i, int j, int type, ref bool fail, ref bool effectOnly, ref bool noItem);
 	private static DelegateKillTile[] HookKillTile;
+	private static Action<int, int, int>[] HookOnTileKilled;
 	private static Func<int, int, int, bool>[] HookCanExplode;
 	private static Action<int, int, int, bool>[] HookNearbyEffects;
 	private delegate void DelegateModifyLight(int i, int j, int type, ref float r, ref float g, ref float b);
@@ -231,6 +232,7 @@ public static class TileLoader
 		ModLoader.BuildGlobalHook(ref HookDrop, globalTiles, g => g.Drop);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateCanKillTile>(ref HookCanKillTile, globalTiles, g => g.CanKillTile);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateKillTile>(ref HookKillTile, globalTiles, g => g.KillTile);
+		ModLoader.BuildGlobalHook(ref HookOnTileKilled, globalTiles, g => g.OnTileKilled);
 		ModLoader.BuildGlobalHook(ref HookCanExplode, globalTiles, g => g.CanExplode);
 		ModLoader.BuildGlobalHook(ref HookNearbyEffects, globalTiles, g => g.NearbyEffects);
 		ModLoader.BuildGlobalHook<GlobalTile, DelegateModifyLight>(ref HookModifyLight, globalTiles, g => g.ModifyLight);
@@ -656,6 +658,14 @@ public static class TileLoader
 	public static void KillMultiTile(int i, int j, int frameX, int frameY, int type)
 	{
 		GetTile(type)?.KillMultiTile(i, j, frameX, frameY);
+	}
+
+	public static void OnTileKilled(int i, int j, int type)
+	{
+		GetTile(type)?.OnTileKilled(i, j);
+		foreach (var hook in HookOnTileKilled) {
+			hook(i, j, type);
+		}
 	}
 
 	public static bool CanExplode(int i, int j)

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2619,6 +2619,15 @@
  		for (int k = 0; k < num13; k++) {
  			KillTile_MakeTileDust(i, j, tile);
  		}
+@@ -53477,6 +_,8 @@
+ 		if (Main.netMode != 2)
+ 			AchievementsHelper.NotifyTileDestroyed(Main.player[Main.myPlayer], tile.type);
+ 
++		TileLoader.OnTileKilled(i, j, tile.type);
++
+ 		tile.active(active: false);
+ 		tile.halfBrick(halfBrick: false);
+ 		tile.frameX = -1;
 @@ -53524,11 +_,23 @@
  		}
  	}


### PR DESCRIPTION
### What is the new feature?
Hook that runs when a tile is destroyed.

### Why should this be part of tModLoader?
There is currently no way to guarantee an event is carried out when a terrain tile or vanilla multi-tile is destroyed without an IL edit. `KillTile` hooks in `ModTile` and `GlobalTile` may be used along with checking `if (!fail)`, however, there is the chance that a subsequent `GlobalTile` might override `fail`, making the condition not true anymore.

### Are there alternative designs?
The placement for the new call to `TileLoader.OnTileKilled` could be moved further back, as the functionality isn't affected and may provide additional context to modders. It is currently placed immediately before tile data is cleared to allow modders to access this data inside the hook.
The hooks could also be split into `PreTileKilled` and `PostTileKilled`, where the latter runs after tile data is cleared, however I don't see an immediate use case.

### Sample usage for the new feature
Modders can use `OnTileKilled` to do things when a tile is destroyed by regular means, such as a player mining it.

Consider the following code. It makes a tile break neighboring tiles of the same type when broken, and has a 10% chance to release a firework.

```cs
public override void OnTileKilled(int i, int j) {
	Tile thisTile = Main.tile[i, j];
	thisTile.HasTile = false; // Prevents stack overflow
	for (int x = i - 1; x <= i + 1; x++) {
		for (int y = j - 1; y <= j + 1; y++) {
			if (y == i && x == j)
				continue;
			Tile t = Main.tile[x, y];
			if (t.HasTile && t.TileType == Type)
				WorldGen.KillTile(x, y);
		}
	}
	if (Main.netMode != NetmodeID.MultiplayerClient && Main.rand.NextBool(10)) {
		Projectile.NewProjectile(new EntitySource_TileBreak(i, j), i * 16f, j * 16f, 0f, -4f, ProjectileID.RocketFireworksBoxRed + Main.rand.Next(4), 0, 0, Main.myPlayer);
	}
}
```

Video showcase of the above:

https://github.com/user-attachments/assets/e42d8f42-865d-43d0-ac37-5ac498453018

### ExampleMod updates
Usage example including the firework effect from the above code is included in ExampleBlock.cs, though the effect could be changed or the example could be moved to another tile.

