### PR TITLE
[ExampleMod] ExampleInstancedItem expansion + comments

### DIFF
--- a/ExampleMod/Common/GlobalItems/WeaponWithGrowingDamage.cs
+++ b/ExampleMod/Common/GlobalItems/WeaponWithGrowingDamage.cs
@@ -13,6 +13,9 @@ using Terraria.ModLoader.IO;
 // Related to GlobalProjectile: ProjectileWithGrowingDamage
 namespace ExampleMod.Common.GlobalItems
 {
+	// This class features an implementation of instance fields stored on any item.
+	// As the hooks and approach is mostly the same except an additional InstancePerEntity override,
+	// it is sufficient to refer to ExampleInstancedItem for the understanding of the concept
 	public class WeaponWithGrowingDamage : GlobalItem
 	{
 		public int experience;

--- a/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleCanStackItem.cs
@@ -11,7 +11,7 @@ using Terraria.ModLoader.IO;
 namespace ExampleMod.Content.Items.Consumables
 {
 	// This showcases how the CanStack hook can be used in conjunction with custom data
-	// Custom data is also shown in ExampleDataItem, but here we need to use more hooks
+	// Custom data is also shown in more detail in ExampleInstancedItem
 
 	// This item, when crafted, stores the players name, and only lets other players open it. Bags with the same stored name aren't stackable
 	public class ExampleCanStackItem : ModItem

--- a/ExampleMod/Content/Items/Consumables/ExampleMultiUseItem.cs
+++ b/ExampleMod/Content/Items/Consumables/ExampleMultiUseItem.cs
@@ -10,6 +10,7 @@ using Terraria.ModLoader.IO;
 
 namespace ExampleMod.Content.Items.Consumables
 {
+	// Custom data is also shown in more detail in ExampleInstancedItem
 	public class ExampleMultiUseItem : ModItem
 	{
 		public static readonly int MaxUses = 4;

--- a/ExampleMod/Content/Items/ExampleDataItem.cs
+++ b/ExampleMod/Content/Items/ExampleDataItem.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Terraria;
 using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace ExampleMod.Content.Items
 {
+	// This item implements instanced fields, for more details see ExampleInstancedItem.cs
 	public class ExampleDataItem : ModItem
 	{
 		public override string Texture => "ExampleMod/Content/Items/ExampleItem";
@@ -33,6 +35,17 @@ namespace ExampleMod.Content.Items
 				Item.TurnToAir();
 			}
 		}
+
+		// To make the timer persistent when the item is dropped/moved around in multiplayer, NetSend + NetReceive are necessary
+		public override void NetSend(BinaryWriter writer) {
+			writer.Write(timer);
+		}
+
+		public override void NetReceive(BinaryReader reader) {
+			timer = reader.ReadInt32();
+		}
+
+		// LoadData + SaveData are not necessary here in the spirit of the "hot potato" example
 
 		public override void AddRecipes() {
 			Recipe recipe = CreateRecipe();

--- a/ExampleMod/Content/Items/ExampleInstancedItem.cs
+++ b/ExampleMod/Content/Items/ExampleInstancedItem.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Terraria;
 using Terraria.DataStructures;
@@ -10,6 +11,9 @@ using Terraria.ModLoader.IO;
 
 namespace ExampleMod.Content.Items
 {
+	// An instanced item (a ModItem that contains instanced fields) needs to make sure that the data inside is persistent across
+	// a wide range of situations, for example: Inventory movement, reforging, dropping, and loading/saving
+	// The main hooks to override for this are: Clone, SaveData, LoadData, NetSend, NetReceive
 	public class ExampleInstancedItem : ModItem
 	{
 		public Color[] colors;
@@ -27,10 +31,66 @@ namespace ExampleMod.Content.Items
 			Item.useStyle = ItemUseStyleID.Swing;
 		}
 
+		// Clone is only needed if you store reference types. In this example, Color[] is a reference type (Array),
+		// but a value type (int, Vector2, etc.) wouldn't need this
+		// Reference types only:
+		// In some rare cases, [CloneByReference] attribute on a field (or [field: CloneByReference] on a property) can be used
+		// if sharing the same data across all instances of the item is intended, then the hook does not need to be overridden
 		public override ModItem Clone(Item item) {
-			ExampleInstancedItem clone = (ExampleInstancedItem)base.Clone(item);
+			ExampleInstancedItem clone = (ExampleInstancedItem)base.Clone(item); // If we had any value types, they would be automatically cloned here
 			clone.colors = (Color[])colors?.Clone(); // note the ? here is important, colors may be null if spawned from other mods which don't call OnCreate
 			return clone;
+		}
+
+		// The LoadData + SaveData hooks are responsible for making the data persistent between world/player saving
+		// NOTE: The tag instance provided here is always empty by default.
+		// Read https://github.com/tModLoader/tModLoader/wiki/Saving-and-loading-using-TagCompound to better understand Saving and Loading data.
+		public override void SaveData(TagCompound tag) {
+			tag["Colors"] = colors;
+		}
+
+		public override void LoadData(TagCompound tag) {
+			colors = tag.Get<Color[]>("Colors");
+		}
+
+		// The NetSend + NetReceive hooks are responsible for making the data persistent between client and server, and during reforging
+		public override void NetSend(BinaryWriter writer) {
+			// For most data like int, float, etc., a simple writer.Write(value) + corresponding reader method is sufficient.
+			// For arrays, lists, and other sequences, the general approach is to send the length, and then send the elements one by one.
+			// And on receive, read length, initialize the data structure, and read into it in the same order.
+			// For more advanced data, the send/receive code varies greatly. Here, in order to send a Color, we send its bit-packed RGBA values as a uint
+			// Because colors can also be null, we utilize flags and send them efficiently using BitsByte. This allows for simple control flow on both sides
+
+			bool isNull = colors == null;
+			writer.Write(new BitsByte(isNull));
+
+			if (isNull) {
+				return;
+			}
+
+			int length = colors.Length;
+			writer.Write(length);
+			for (int i = 0; i < length; i++) {
+				writer.Write(colors[i].PackedValue);
+			}
+		}
+
+		public override void NetReceive(BinaryReader reader) {
+			BitsByte bits = reader.ReadByte();
+			bool isNull = bits[0];
+
+			if (isNull) {
+				colors = null;
+				return;
+			}
+
+			int length = reader.ReadInt32();
+			colors = new Color[length];
+			for (int i = 0; i < length; i++) {
+				colors[i] = new Color {
+					PackedValue = reader.ReadUInt32()
+				};
+			}
 		}
 
 		public override void OnCreated(ItemCreationContext context) {
@@ -62,16 +122,6 @@ namespace ExampleMod.Content.Items
 				// cycle through the colors
 				colors = colors.Skip(1).Concat(colors.Take(1)).ToArray();
 			}
-		}
-
-		// NOTE: The tag instance provided here is always empty by default.
-		// Read https://github.com/tModLoader/tModLoader/wiki/Saving-and-loading-using-TagCompound to better understand Saving and Loading data.
-		public override void SaveData(TagCompound tag) {
-			tag["Colors"] = colors;
-		}
-
-		public override void LoadData(TagCompound tag) {
-			colors = tag.Get<Color[]>("Colors");
 		}
 
 		public override void AddRecipes() => CreateRecipe().AddIngredient<ExampleItem>(10).Register();

--- a/ExampleMod/Content/Items/ExampleStackableDurabilityItem.cs
+++ b/ExampleMod/Content/Items/ExampleStackableDurabilityItem.cs
@@ -11,6 +11,7 @@ using Terraria.ModLoader.IO;
 
 namespace ExampleMod.Content.Items
 {
+	// Custom data is also shown in more detail in ExampleInstancedItem
 	public class ExampleStackableDurabilityItem : ModItem
 	{
 		// 0 to 1

--- a/ExampleMod/Content/Items/Weapons/HitModifiersShowcase.cs
+++ b/ExampleMod/Content/Items/Weapons/HitModifiersShowcase.cs
@@ -16,7 +16,7 @@ namespace ExampleMod.Content.Items.Weapons
 	/// When testing this weapon the first time, it is recommended to disable other mods and to remove all damage boosting accessories, as they will complicate the math being taught. <br/>
 	/// Testing against <see cref="NPCID.BlueArmoredBonesNoPants"/> is recommended as it has high defense (50), good knockback resistance, and enough health for a few hits. Having 50 defense makes the math for defense and armor penetration easy to follow.
 	/// <br/>
-	/// The math taught in this example also assumes the player is in a normal world. <br/> 
+	/// The math taught in this example also assumes the player is in a normal world. <br/>
 	/// Use right click to switch modes.<br/>
 	/// This example is purely for demonstration purposes only, it will not work in multiplayer. This should also not be considered correct code for a working dual-use weapon. <br/>
 	/// </summary>
@@ -80,7 +80,7 @@ namespace ExampleMod.Content.Items.Weapons
 					mode = 0;
 				}
 				Main.NewText(SwitchingText.Format(mode, GetMessageForMode()));
-				// This line will trigger NetSend to be called at the end of this game update, allowing the changes to useStyle to be in sync. 
+				// This line will trigger NetSend to be called at the end of this game update, allowing the changes to useStyle to be in sync.
 				Item.NetStateChanged();
 			}
 			else {


### PR DESCRIPTION
### What are the changes to ExampleMod?
When trying to help modders understand how instanced items work (items that track instanced data), I noticed there is no definitive example that goes in detail and explains which hooks are necessary. There are actually many applications of this concept in the mod, but with some inconsistencies, missing hooks (some intended, some not), or undocumented.

This PR expands the ExampleInstancedItem example to include most of the information modders would need, all in one file.

Common things modders wanted to know is how to handle control flow and lists/arrays for netcode, the example lent itself to showcase and explain it.

It also edits many of the partial examples of instanced items to refer to the ExampleInstancedItem one.

It also edits the "Hot Potato" example to include NetSend/NetReceive as I believe they are necessary for multiplayer to be more faithful to that specific example, otherwise dropped items will instantly reset. Load/SaveData are omitted as the timer is so low it doesn't really matter, it is not designed to be persistent.

I tested all the code in this PR in multiplayer and with saving/loading.

### Do these changes need additional documentation?
The other examples could be expanded to feature the full set of hooks to bring consistency, but I didn't deem it as necessary.

### 1.4.5
I believe this can be forwarded to 1.4.5 directly, at a glance I didn't see any differences in the code or comments used.

I created this PR on 1.4.4 because the current mod development still happens on that branch.

