### PR TITLE
Added Mod.Index

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/Mod.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Mod.cs
@@ -130,6 +130,10 @@ public partial class Mod
 	public short NetID => netID;
 	/// <summary> If true, this mod has a <see cref="NetID"/> assigned. This is mainly useful for checking if a <see cref="ModSide.NoSync"/> mod is present on the server from a client to determine if a <see cref="ModPacket"/> can be sent to the server or not. </summary>
 	public bool IsNetSynced => netID >= 0;
+	/// <summary>
+	/// The index of this mod in <see cref="ModLoader.Mods"/>.
+	/// </summary>
+	public int Index { get; internal set; }
 
 	private IDisposable fileHandle;
 

--- a/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModLoader.cs
@@ -133,8 +133,11 @@ public static class ModLoader
 			var modInstances = AssemblyManager.InstantiateMods(modsToLoad, token);
 			modInstances.Insert(0, new ModLoaderMod());
 			Mods = modInstances.ToArray();
-			foreach (var mod in Mods)
+			for (int i = 0; i < Mods.Length; i++) {
+				Mod mod = Mods[i];
+				mod.Index = i;
 				modsByName[mod.Name] = mod;
+			}
 
 			ModContent.Load(token);
 


### PR DESCRIPTION
### What is the new feature?
``Mod.Index``, a property containing each mod's index.

### Why should this be part of tModLoader?
Allows more optimized access to data one mod associates with all mods.

### Are there alternative designs?
Could also add a ``SetFactory`` so mods can share sets.