### PR TITLE
setup: honor --patch-mode instead of always patching in EXACT mode

### DIFF
--- a/setup/CLI/Commands/SetupCommand.cs
+++ b/setup/CLI/Commands/SetupCommand.cs
@@ -29,11 +29,13 @@ public sealed class SetupCommand : CancellableAsyncCommand<SetupCommandSettings>
 {
 	private readonly IServiceProvider serviceProvider;
 	private readonly TaskRunner taskRunner;
+	private readonly ProgramSettings programSettings;
 
-	public SetupCommand(TaskRunner taskRunner, IServiceProvider serviceProvider)
+	public SetupCommand(TaskRunner taskRunner, IServiceProvider serviceProvider, ProgramSettings programSettings)
 	{
 		this.taskRunner = taskRunner;
 		this.serviceProvider = serviceProvider;
+		this.programSettings = programSettings;
 	}
 
 	protected override async Task<int> ExecuteAsync(
@@ -41,6 +43,7 @@ public sealed class SetupCommand : CancellableAsyncCommand<SetupCommandSettings>
 		SetupCommandSettings settings,
 		CancellationToken cancellationToken)
 	{
+		programSettings.PatchMode = settings.PatchMode;
 		var setupTask = new SetupTask(DecompileTaskParameters.CreateDefault(settings.TerrariaSteamDir, settings.TMLDevSteamDir), serviceProvider);
 
 		return await taskRunner.Run(setupTask, settings, settings.NoPrompts, cancellationToken: cancellationToken);


### PR DESCRIPTION
### The bug

`./setup-cli.sh setup -m FUZZY` silently patches in `EXACT` mode. The option is accepted, no warning is printed, and the run then dies on the first hunk that drifted:

```
Patch did not apply: ...
```

`SetupCommand` inherits `--patch-mode` from `PatchCommandSettings`, but never copies the parsed value into `ProgramSettings`, which is what `Patcher` actually reads. The two sibling commands do:

- `PatchSubCommands.cs:61` — `programSettings.PatchMode = settings.PatchMode;`
- `RegenSourceCommand.cs:27` — `programSettings.PatchMode = settings.PatchMode;`

`SetupCommand` is the only one that offers the option and drops it.

### The fix

- Inject `ProgramSettings` into `SetupCommand`
- Assign `programSettings.PatchMode = settings.PatchMode` before constructing the `SetupTask`, matching the other two commands

### Why it matters

This is the command you reach for when retargeting to a new vanilla version, which is exactly when `EXACT` cannot work — every hunk sitting on changed vanilla code fails. Without this you have to run `setup`, let it fail, then re-run `patch <layer> -m FUZZY` for each layer separately.

### Test plan

- `./setup-cli.sh setup -f -m FUZZY --terraria-steam-dir <dir>` against a vanilla version the patches were not cut for: before this change the run patches in EXACT and fails on the first drifted hunk; after it, hunks apply fuzzily and the run completes with the usual per-file failure report.
- `./setup-cli.sh setup -f` with no `-m` still uses `EXACT`, unchanged.
- Verified on Linux against Terraria 1.4.5.7 while retargeting the patch layers.