### PR TITLE
[1.4.5] Fixed ModTile.AdjTiles not being applied to crafting station lookups

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -43,8 +43,7 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - TileLoader.HasWalkDust and WalkDust never pass in the Tile or Frame values. New vanilla logic sometimes checks frameX/Y, so hook could be updated with more parameters to facilitate.
 - Collision.SwitchTiles `objType` parameter in Player.Update changed from 1 to 5. Why, isn't it still Player? Adjust docs accordingly after investigating.
   - Seems to control MessageID.PlayerControls being sent but I don't know why. 1 is unused.
-- Adjacent tiles are now contained in Recipe.TileCountsAs rather than hard-coded. Need to adjust TileLoader.AdjTiles hooks/docs/exampels to prioritize using Recipe.TileCountsAs
-  - Restore `TileLoader.AdjTiles(this, Main.tile[j, k].type);` patch to new Player.SetAdjTile method
+- Adjacent tiles are now contained in Recipe.TileCountsAs rather than hard-coded. ModTile.AdjTiles is registered into Recipe.TileCountsAs during Recipe.SetupRecipes, so Player.SetAdjTile applies it. The TileLoader.AdjTiles hook now only runs the dynamic GlobalTile hook.
 - Terraria added a CanConsumeConsumableItem stub method. Should it check item.consumable or only ItemLoader.ConsumeItem.
 - We'll need to check all bag drops and update the drop database.
 - A lot of the GetItemSettings presets have been renamed or removed. Might be something to document.

--- a/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/GlobalTile.cs
@@ -226,6 +226,9 @@ public abstract class GlobalTile : GlobalBlockType
 
 	/// <summary>
 	/// Allows you to determine which tiles the given tile type can be considered as when looking for crafting stations.
+	/// <br/><br/> Queried every time adjacent tiles are recalculated, so it can vary at runtime. For equivalences
+	/// that are fixed, prefer <see cref="ModTile.AdjTiles"/>, which is registered into
+	/// <see cref="Recipe.TileCountsAs"/> and also applies to the crafting station filter UI.
 	/// </summary>
 	/// <param name="type"></param>
 	/// <returns></returns>

--- a/patches/tModLoader/Terraria/ModLoader/ModTile.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ModTile.cs
@@ -36,7 +36,12 @@ public abstract class ModTile : ModBlockType
 	/// <para/> Use <see cref="MineResist"/> to adjust how long a tile takes to be mined.</summary>
 	public int MinPick { get; set; }
 
-	/// <summary> An array of the IDs of tiles that this tile can be considered as when looking for crafting stations. </summary>
+	/// <summary>
+	/// An array of the IDs of tiles that this tile can be considered as when looking for crafting stations.
+	/// <br/><br/> Registered into <see cref="Recipe.TileCountsAs"/> during recipe setup, so it must be assigned
+	/// in <see cref="ModBlockType.SetStaticDefaults"/>. Changing it afterwards has no effect. Use
+	/// <see cref="GlobalTile.AdjTiles(int)"/> for equivalences that need to change at runtime.
+	/// </summary>
 	public int[] AdjTiles { get; set; } = new int[0];
 
 	public override string LocalizationCategory => "Tiles";

--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -1172,12 +1172,8 @@ public static class TileLoader
 
 	public static void AdjTiles(Player player, int type)
 	{
-		ModTile modTile = GetTile(type);
-		if (modTile != null) {
-			foreach (int k in modTile.AdjTiles) {
-				player.adjTile[k] = true;
-			}
-		}
+		// ModTile.AdjTiles is registered into Recipe.TileCountsAs during Recipe.SetupRecipes,
+		// so Player.SetAdjTile already handles it. Only the dynamic GlobalTile hook runs here.
 		foreach (var hook in HookAdjTiles) {
 			int[] adjTiles = hook(type);
 			foreach (int k in adjTiles) {

--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5369,6 +5369,15 @@
  		List<Item[]> list = new List<Item[]>();
  		Dictionary<int, List<int>> dictionary = new Dictionary<int, List<int>>();
  		List<Point> list2 = new List<Point>();
+@@ -28824,6 +_,8 @@
+ 		if (tileType == 355 || tileType == 699)
+ 			alchemyTable = true;
+ 
++		TileLoader.AdjTiles(this, tileType);
++
+ 		List<int> list = Recipe.TileCountsAs[tileType];
+ 		if (list == null)
+ 			return;
 @@ -28842,6 +_,8 @@
  		adjHoney = false;
  		oldAdjLava = adjLava;
@@ -5378,7 +5387,7 @@
  		alchemyTable = false;
  		Rectangle tileRegion = TileReachCheckSettings.Simple.GetTileRegion(this, ateArtisanBread ? 4 : 0);
  		tileRegion = WorldUtils.ClampToWorld(tileRegion);
-@@ -28852,6 +_,14 @@
+@@ -28852,6 +_,12 @@
  					SetAdjTile(tile.type);
  					if (TileID.Sets.CountsAsWaterForCrafting[tile.type])
  						adjWaterSource = true;
@@ -5388,8 +5397,6 @@
 +						adjLava = true;
 +					if (TileID.Sets.CountsAsShimmerForCrafting[tile.type])
 +						adjShimmer = true;
-+
-+					// TODO: Move to SetAdjTile: TileLoader.AdjTiles(this, Main.tile[j, k].type);
  				}
  
  				if (tile.liquid > 200 && tile.liquidType() == 0)

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -288,14 +288,34 @@
  				array[j].Refresh();
  			}
  		}
-@@ -497,6 +_,7 @@
+@@ -471,6 +_,16 @@
+ 		AddTileCountsAs(304, 86);
+ 	}
+ 
++	// Added by TML. Must run after SetupTileInheritance, which clears the table.
++	private static void SetupModdedTileInheritance()
++	{
++		foreach (ModTile modTile in TileLoader.tiles) {
++			foreach (int adjTile in modTile.AdjTiles) {
++				AddTileCountsAs(modTile.Type, adjTile);
++			}
++		}
++	}
++
+ 	private static bool TileUsedInRecipeInherited(int tileType)
+ 	{
+ 		if (TileUsedInRecipes[tileType])
+@@ -497,8 +_,10 @@
  
  	public static void SetupRecipes()
  	{
 +		Recipe.SetupRecipeGroups(); // TML
  		Array.Clear(TileUsedInRecipes, 0, TileUsedInRecipes.Length);
  		SetupTileInheritance();
++		SetupModdedTileInheritance(); // TML
  		int num = 5;
+ 		int stack = 2;
+ 		currentRecipe.createItem.SetDefaults(8);
 @@ -15022,11 +_,19 @@
  		AddRecipe();
  		CreateReverseWallRecipes();


### PR DESCRIPTION

# PR Description

## What is the bug?

`ModTile.AdjTiles` has no effect. A modded crafting station declaring `AdjTiles = [TileID.WorkBenches]` is not treated as a workbench: standing next to it, recipes requiring a workbench stay unavailable.

1.4.5 moved tile equivalences into `Recipe.TileCountsAs`. Both `Player.SetAdjTile` and `NewCraftingUI.CraftStationRecipeFilter` resolve equivalences by recursing through that table. Nothing registers `ModTile.AdjTiles` into it, and the `TileLoader.AdjTiles(this, ...)` call in `Player.AdjTiles` was left commented out during the port:

```csharp
// TODO: Move to SetAdjTile: TileLoader.AdjTiles(this, Main.tile[j, k].type);
```

So `TileLoader.AdjTiles` had no call site at all.

## How did you fix the bug?

- Added `Recipe.SetupModdedTileInheritance()`, called right after `SetupTileInheritance()`, registering each `ModTile.AdjTiles` entry via `AddTileCountsAs`. Modded stations now use the same mechanism as vanilla equivalences such as `AddTileCountsAs(134, 16)` (Mythril Anvil counts as Anvil), so both `Player.SetAdjTile` and the crafting station filter UI pick them up.
- Restored the `TileLoader.AdjTiles(this, tileType)` call in `Player.SetAdjTile` and removed the TODO comment, as the porting note suggested.
- `TileLoader.AdjTiles` no longer iterates `ModTile.AdjTiles`, since `Recipe.TileCountsAs` now covers it. It still runs the `GlobalTile.AdjTiles` hook, which is queried per lookup and can vary at runtime.
- Documented the split on both members.

Removed the corresponding `PortingNotes_1.4.5.md` entry.

## Are there alternatives to your fix?

Restoring only the `TileLoader.AdjTiles` call, as the porting note's sub-item literally says, without touching `TileCountsAs`. That fixes `player.adjTile` so recipes become craftable, but `CraftStationRecipeFilter` reads `TileCountsAs` directly, so right clicking the station would still not list the equivalent station's recipes.

## Notes

Tested with ExampleWorkbench (`AdjTiles = [TileID.WorkBenches]`) placed away from any vanilla workbench. Before, workbench recipes were unavailable next to it; after, they are.
