### PR TITLE
[1.4.5] Fixed thrown Mud Balls placing dirt instead of mud

### DIFF
--- a/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
+++ b/patches/tModLoader/Terraria/ID/ProjectileID.TML.cs
@@ -42,6 +42,7 @@ partial class ProjectileID
 			PearlSandBallGun, new FallingBlockTileItemInfo(TileID.Pearlsand),
 			CrimsandBallGun, new FallingBlockTileItemInfo(TileID.Crimsand),
 			MudBall, new FallingBlockTileItemInfo(TileID.Mud),
+			MudBallPlayer, new FallingBlockTileItemInfo(TileID.Mud, ItemID.MudBlock),
 			AshBallFalling, new FallingBlockTileItemInfo(TileID.Ash),
 			SnowBallHostile, new FallingBlockTileItemInfo(TileID.SnowBlock),
 			SandBallFalling, new FallingBlockTileItemInfo(TileID.Sand, ItemID.SandBlock),

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1987,17 +1987,14 @@
  					if (type == 109) {
  						num1107 = 147;
  						num1108 = 0;
-@@ -63743,8 +_,9 @@
+@@ -63743,6 +_,7 @@
  						num1107 = 495;
  						num1108 = 4090;
  					}
 +					*/
  
--					if (type == 1081 && !WorldGen.SolidTile3(num1105, num1106 + 1)) {
-+					if (type == ProjectileID.MudBallPlayer && !WorldGen.SolidTile3(num1105, num1106 + 1)) {
+ 					if (type == 1081 && !WorldGen.SolidTile3(num1105, num1106 + 1)) {
  						if (WorldGen.SolidTile3(num1105 - 1, num1106 + 1) && !Main.tile[num1105 - 1, num1106].active())
- 							num1105--;
- 						else if (WorldGen.SolidTile3(num1105 + 1, num1106 + 1) && !Main.tile[num1105 + 1, num1106].active())
 @@ -63886,9 +_,13 @@
  					x2 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					y8 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;

--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -1987,14 +1987,17 @@
  					if (type == 109) {
  						num1107 = 147;
  						num1108 = 0;
-@@ -63750,6 +_,7 @@
- 						else if (WorldGen.SolidTile3(num1105 + 1, num1106 + 1) && !Main.tile[num1105 + 1, num1106].active())
- 							num1105++;
+@@ -63743,8 +_,9 @@
+ 						num1107 = 495;
+ 						num1108 = 4090;
  					}
 +					*/
  
- 					if (type == 109) {
- 						int num1109 = Player.FindClosest(position, width, height);
+-					if (type == 1081 && !WorldGen.SolidTile3(num1105, num1106 + 1)) {
++					if (type == ProjectileID.MudBallPlayer && !WorldGen.SolidTile3(num1105, num1106 + 1)) {
+ 						if (WorldGen.SolidTile3(num1105 - 1, num1106 + 1) && !Main.tile[num1105 - 1, num1106].active())
+ 							num1105--;
+ 						else if (WorldGen.SolidTile3(num1105 + 1, num1106 + 1) && !Main.tile[num1105 + 1, num1106].active())
 @@ -63886,9 +_,13 @@
  					x2 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;
  					y8 *= 1f + (float)Main.rand.Next(-20, 21) * 0.01f;


### PR DESCRIPTION
### What is the bug?

Thrown Mud Balls place a Dirt Block instead of Mud when they land, and drop a Dirt Block if they cannot place.

### How did you fix the bug?

`ProjectileID.MudBallPlayer` was missing from `ProjectileID.Sets.FallingBlockTileItem`, so the falling tile code fell back to dirt. Vanilla maps it to `TileID.Mud` and `ItemID.MudBlock`. The entry was lost when the vanilla if chain was rewritten into the set.

Also restored the vanilla behavior where a Mud Ball landing on a spot with no solid tile below slides one tile left or right before placing. That code was left inside the commented out vanilla block.

### Are there alternatives to your fix?

No.
