### PR TITLE
[1.4.5] Restore ConsumeIngredient hooks during crafting

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -118,8 +118,7 @@ Once all patches are fixed, these items need to be fixed or double checked:
   - useX (useWood, ext) also removed. Same.
   - Need needTorchGodsFavor condition
   - needEverythingSeed seems to be replaced by needMechdusa. TODo: Rename Condition.ZenithWorld?
-  - Recipe item consumption seems to be in another class now, patches need to be moved. GetIngredientCraftingDiscount also needs to be tweaked to work again for modded RecipeLoader.ConsumeIngredient
-    - Hook needs rework to use `Recipe.RequiredItemEntry`
+  - Recipe item consumption is now in `CraftingRequests`. `RecipeLoader.ConsumeIngredient` is now called from `Recipe.GetIngredientsForOneCraft`, so consume ingredient callbacks work for crafting again.
   - CraftViaRequest complicates `RecipeItemCreationContext.DestinationStack` I think. Removed for compile, restore if possible. OnCraftHooks also not hooked up.
     - In theory it can be restored, since the `_pendingCrafts` queue remains on the client, and changes to `Main.mouseItem` are forbidden while a craft is pending. Documentation needs to note that the craft could be refunded though, so we likely need `OnCraft` hoook to be in `CraftItem_GrantItem`. We could amend the response packet from the server to send the consumed items, at the cost of quite some bandwidth when rapid crafting
 - ItemSlot flow changed a lot. AccCheck no longer exists, replaced by CanEquipAccessoryInSlot?

--- a/patches/tModLoader/Terraria/Recipe.cs.patch
+++ b/patches/tModLoader/Terraria/Recipe.cs.patch
@@ -148,7 +148,7 @@
  	public Recipe()
  	{
  		for (int i = 0; i < maxRequirements; i++) {
-@@ -154,10 +_,18 @@
+@@ -154,10 +_,22 @@
  			acceptedGroups[i] = -1;
  		}
  	}
@@ -168,6 +168,10 @@
  			RequiredItemEntry requiredItemEntry = requiredItemQuickLookup[i];
  			if (requiredItemEntry.itemIdOrRecipeGroup != 0) {
  				requiredItemEntry.stack -= GetIngredientCraftingDiscount(player, requiredItemEntry);
++
++				// TML: ConsumeIngredient hook allows adjusting the amount of each ingredient consumed. See IngredientQuantityRules.Alchemy.
++				int type = requiredItemEntry.IsRecipeGroup ? requiredItemEntry.RecipeGroup.GetPlaceholderItemType() : requiredItemEntry.itemIdOrRecipeGroup;
++				RecipeLoader.ConsumeIngredient(this, type, ref requiredItemEntry.stack, false);
 @@ -173,6 +_,7 @@
  
  	private int GetIngredientCraftingDiscount(Player player, RequiredItemEntry req)
@@ -176,13 +180,14 @@
  		int num = 0;
  		if (alchemy && player.alchemyTable) {
  			for (int i = 0; i < req.stack; i++) {
-@@ -182,6 +_,9 @@
+@@ -182,6 +_,10 @@
  		}
  
  		return num;
 +		*/
 +
-+		return 0; // TODO, reimplement crafting discounts in terms of RequiredItemEntry
++		// Crafting ingredient discounts (like the alchemy table) are handled by ConsumeIngredient callbacks, see GetIngredientsForOneCraft.
++		return 0;
  	}
  
  	public static void UpdateRecipeList()

--- a/test/RecipeConsumeIngredientTests.cs
+++ b/test/RecipeConsumeIngredientTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Terraria.ID;
+
+namespace Terraria.ModLoader;
+
+[TestClass]
+public class RecipeConsumeIngredientTests
+{
+	[ClassInitialize]
+	public static void ClassInitialize(TestContext context)
+	{
+		Program.SavePath = ".";
+	}
+
+	private static Recipe MakeRecipe(int ingredientType, int stack)
+	{
+		var recipe = new Recipe();
+		recipe.requiredItem.Add(new Item { type = ingredientType, stack = stack });
+		recipe.requiredItemQuickLookup = new[] { new Recipe.RequiredItemEntry(ingredientType, stack) };
+		return recipe;
+	}
+
+	[TestMethod]
+	public void ConsumeIngredientCallbackAdjustsAmountConsumed()
+	{
+		Recipe recipe = MakeRecipe(ItemID.Chain, 1);
+		recipe.AddConsumeIngredientCallback((Recipe r, int type, ref int amount, bool isDecrafting) => {
+			if (type == ItemID.Chain)
+				amount = 0;
+		});
+
+		var ingredients = new List<Recipe.RequiredItemEntry>();
+		recipe.GetIngredientsForOneCraft(new Player(), ingredients);
+
+		Assert.AreEqual(0, ingredients.Count);
+	}
+
+	[TestMethod]
+	public void IngredientsWithoutCallbacksAreUnchanged()
+	{
+		Recipe recipe = MakeRecipe(ItemID.IronBar, 3);
+
+		var ingredients = new List<Recipe.RequiredItemEntry>();
+		recipe.GetIngredientsForOneCraft(new Player(), ingredients);
+
+		Assert.AreEqual(1, ingredients.Count);
+		Assert.AreEqual(ItemID.IronBar, ingredients[0].itemIdOrRecipeGroup);
+		Assert.AreEqual(3, ingredients[0].stack);
+	}
+}


### PR DESCRIPTION
### Summary
Calls `RecipeLoader.ConsumeIngredient` from `Recipe.GetIngredientsForOneCraft` so consume-ingredient callbacks fire during crafting again.

### Why
In 1.4.5, ingredient consumption moved from `Recipe.Create()` to `CraftingRequests`. The ported code never calls the hook, so:
* modded `AddConsumeIngredientCallback`s (e.g. ExampleMod's `DontConsumeChain`) do nothing when crafting,
* the alchemy table 1/3 savings were lost for potion recipes (vanilla applied them via `GetIngredientCraftingDiscount`, which was stubbed to `return 0` with a TODO),
while shimmer decrafting *does* call the hook (via `WorldItem.GetShimmered`), making behavior inconsistent.

The hook is invoked per `RequiredItemEntry` after vanilla's discount step, so it covers both `CraftLocally` and `CraftViaRequest` paths (both build on the ingredients list). For recipe-group entries, the group's placeholder item type is passed, mirroring what the 1.4.4 hook received.

### Behavior
* Vanilla 1.4.5: alchemy discount was missing (tML regression vs 1.4.4 tML and vanilla intent).
* With this PR: `IngredientQuantityRules.Alchemy` (auto-added for placed-bottle recipes) restores the 1/3 chance savings; custom callbacks adjust consumption as in 1.4.4.
* Shimmer decrafting is unchanged.
* Server-side consumption amounts are consistent because `CraftViaRequest` derives its requested quantities from the same adjusted ingredient stacks.

### Testing
* New MSTests in `test/RecipeConsumeIngredientTests.cs`:
  * a callback zeroing an ingredient's amount excludes it from the craft ingredients,
  * recipes without callbacks pass ingredients through unchanged.
* Verified hunk counts/apply against reconstructed vanilla method text and validated the patched logic in a standalone compile+run harness (3/3 checks pass). Full CI build/test will validate integration; local full decompile wasn't possible here (Steam client updated to 1.4.5.7 while the branch targets 1.4.5.6).

### Migration
None — this restores documented behavior (`AddConsumeIngredientCallback`, wiki "custom item consumption").

### Related
PortingNotes_1.4.5.md → Recipe Changes: "GetIngredientCraftingDiscount also needs to be tweaked to work again for modded RecipeLoader.ConsumeIngredient" / "Hook needs rework to use Recipe.RequiredItemEntry" (updated in this PR).