### PR TITLE
[1.4.5] Fix crafted and dropped items never rolling prefixes

### DIFF
--- a/patches/tModLoader/Terraria/Item.cs.patch
+++ b/patches/tModLoader/Terraria/Item.cs.patch
@@ -845,7 +845,7 @@
  	public static void DropCache(IEntitySource reason, Vector2 pos, Vector2 spread, int t, bool stopCaching = true)
  	{
  		if (cachedItemSpawnsByType[t] == -1)
-@@ -282,17 +_,63 @@
+@@ -282,17 +_,62 @@
  		}
  	}
  
@@ -901,7 +901,6 @@
 +	/// <item><paramref name="prefixWeWant"/> is <c>0</c></item>
 +	/// <item><see cref="CanHavePrefixes"/> returns <see langword="false"/></item>
 +	/// <item><see cref="CanApplyPrefix(int)"/> returns <see langword="false"/></item>
-+	/// <item><c><paramref name="prefixWeWant"/> == -1</c> and <c><see cref="maxStack"/> &gt; 1</c></item>
 +	/// <item><see cref="ItemLoader.PrefixChance(Item, int, UnifiedRandom)"/> returns <see langword="false"/></item>
 +	/// <item><c><paramref name="prefixWeWant"/> == -1 or -2 or -3</c> and <see cref="PrefixLoader.Roll(Item, UnifiedRandom, out int, bool)"/> returns <see langword="false"/>.</item>
 +	/// </list>
@@ -910,7 +909,7 @@
  	public bool Prefix(int prefixWeWant, out bool rolledPrefixIsTopTier)
  	{
  		if (!WorldGen.isGeneratingOrLoadingWorld && Main.rand == null)
-@@ -312,7 +_,21 @@
+@@ -312,7 +_,17 @@
  		if (prefixWeWant == -2 || prefixWeWant == -1)
  			num = BestPrefixValue();
  
@@ -918,10 +917,6 @@
 +		if (prefixWeWant > 0 && !CanApplyPrefix(prefixWeWant))
 +			return false;
 +		*/
-+
-+		//#StackablePrefixWeapons: Stackable items will not spawn with a prefix on craft/generate. Only when deliberately reforged.
-+		if (prefixWeWant == -1 && maxStack > 1)
-+			return false;
 +
  		UnifiedRandom unifiedRandom = (WorldGen.isGeneratingOrLoadingWorld ? WorldGen.genRand : Main.rand);
 +

--- a/test/PrefixRollTests.cs
+++ b/test/PrefixRollTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Terraria.ID;
+
+namespace Terraria.ModLoader;
+
+[TestClass]
+public class PrefixRollTests
+{
+	[ClassInitialize]
+	public static void ClassInitialize(TestContext context)
+	{
+		Program.SavePath = ".";
+	}
+
+	// Regression test for #5301: 1.4.5 defaults Item.maxStack to CommonMaxStack (9999), so the
+	// removed "#StackablePrefixWeapons" guard (maxStack > 1) blocked random prefix rolls for every
+	// crafted or dropped weapon. A vanilla weapon must remain prefixable.
+	[TestMethod]
+	public void VanillaWeaponCanRollPrefixes()
+	{
+		Item item = new() {
+			type = ItemID.IronBroadsword,
+			maxStack = Item.CommonMaxStack
+		};
+
+		Assert.IsTrue(item.CanHavePrefixes());
+		Assert.IsTrue(item.Prefix(-3));
+	}
+}


### PR DESCRIPTION
### Summary
Removes the `maxStack > 1` early-return from `Item.Prefix` for random prefix rolls (`prefixWeWant == -1`).

### Why
The guard was ported from 1.4.4's `#StackablePrefixWeapons` feature, where `maxStack > 1` reliably identified stackable items (1.4.4 defaulted `Item.maxStack` to 1). Terraria 1.4.5 changed the default to `Item.CommonMaxStack` (9999), so the guard now matches **every** item and rejects random prefix rolls for all crafted and dropped weapons. This is the root cause of #5301.

### Behavior
* 1.4.4 tML: weapons rolled prefixes; genuinely stackable items did not spawn with one.
* 1.4.5 before this PR: nothing that goes through a random roll gets a prefix.
* With this PR: vanilla 1.4.5 behavior is restored - prefix rolls are gated by `CanHavePrefixes()` as vanilla intends.

The stacking-safety concern behind the original feature remains covered by `ItemLoader.CanStack`, which refuses to stack items with differing prefixes, and mods can still control rolls through `GlobalItem/ModItem.PrefixChance`. The remaining opt-in `AllowReforgeForStackableItem` check in the crafting path (`Main.cs`) is unaffected since it requires an explicit mod flag.

### Testing
* New test `PrefixRollTests.VanillaWeaponCanRollPrefixes`: an `IronBroadsword`-typed item at the new 9999 default `maxStack` passes `CanHavePrefixes()` and the `Prefix(-3)` roll check. Fails on current `1.4.5` (guard returns false), passes with this change.
* Hunk counts in the patch file revalidated after removal; full build/CI validation happens on GitHub (local full-source setup was not possible here).

### Related
Fixes #5301