### PR TITLE
[1.4.5] Document NPC.defLifeMax

### DIFF
--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -151,7 +151,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - UserInterface.MouseCaptured -> could be useful
 - FlexibleTileWand is now used to place many other tiles that used to rely solely on RandomStyleRange. We should add an example of a custom FlexibleTileWand item/tile and document when to use it.
 - UIScrollbar.AutoHide and CanScroll
-- NPC.defLifeMax
 - NPC.DelBuff has new quiet parameter
 - TileID.Sets.DontDrawTileSlopes.
 - Player.selectedItem is not a getter property instead of a field. We might need to document selectedItemState and other related new fields.

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -534,7 +534,7 @@
  	public static bool downedDeerclops = false;
  	public static int ShieldStrengthTowerSolar = 0;
  	public static int ShieldStrengthTowerVortex = 0;
-@@ -4594,58 +_,227 @@
+@@ -4594,59 +_,227 @@
  	public static bool TowerActiveNebula = false;
  	public static bool TowerActiveStardust = false;
  	public static bool LunarApocalypseIsUp = false;
@@ -636,9 +636,9 @@
  	public int defDefense;
 +
 +	/// <summary>
-+	/// Stores the value of <see cref="lifeMax"/> at the end of SetDefaults. Useful for scaling max life in AI code, such as for expert or master mode scaling.
++	/// Stores the value of <see cref="lifeMax"/> at the end of SetDefaults. This value takes into account difficulty mode adjustments. Useful for calculating dynamically changing <see cref="lifeMax"/> in AI code, such as how <see cref="ItemID.CombatBook"/> affects Town NPC, or how some slimes have different health values if carrying specific items.
 +	/// </summary>
-+	public int defLifeMax;
+ 	public int defLifeMax;
 +
 +	/// <summary>
 +	/// Denotes whether or not this NPC counts as dealing cold damage for the purposes of the Warmth Potion.<br/>

--- a/patches/tModLoader/Terraria/NPC.cs.patch
+++ b/patches/tModLoader/Terraria/NPC.cs.patch
@@ -534,7 +534,7 @@
  	public static bool downedDeerclops = false;
  	public static int ShieldStrengthTowerSolar = 0;
  	public static int ShieldStrengthTowerVortex = 0;
-@@ -4594,59 +_,223 @@
+@@ -4594,58 +_,227 @@
  	public static bool TowerActiveNebula = false;
  	public static bool TowerActiveStardust = false;
  	public static bool LunarApocalypseIsUp = false;
@@ -634,7 +634,11 @@
 +	/// Stores the value of <see cref="defense"/> at the end of SetDefaults. Useful for scaling defense in AI code, like how King Slime changes defense as it gets smaller.
 +	/// </summary>
  	public int defDefense;
- 	public int defLifeMax;
++
++	/// <summary>
++	/// Stores the value of <see cref="lifeMax"/> at the end of SetDefaults. Useful for scaling max life in AI code, such as for expert or master mode scaling.
++	/// </summary>
++	public int defLifeMax;
 +
 +	/// <summary>
 +	/// Denotes whether or not this NPC counts as dealing cold damage for the purposes of the Warmth Potion.<br/>


### PR DESCRIPTION
### Summary
Documents the new 1.4.5 `NPC.defLifeMax` field, following the existing `defDamage`/`defDefense` doc pattern.

### Why
PortingNotes_1.4.5.md item under "New Fields that might need more documentation": "NPC.defLifeMax".

### Behavior
Docs-only change.

### Related
PortingNotes_1.4.5.md (item removed by this PR).