### PR TITLE
fix: #5330 (Game limits itself to ~1 FPS on Linux).

### DIFF
--- a/patches/TerrariaNetCore/Terraria/Testing/DetailedFPS.cs.patch
+++ b/patches/TerrariaNetCore/Terraria/Testing/DetailedFPS.cs.patch
@@ -1,0 +1,14 @@
+--- src/Terraria/Terraria/Testing/DetailedFPS.cs
++++ src/TerrariaNetCore/Terraria/Testing/DetailedFPS.cs
+@@ -100,7 +_,11 @@
+ 	private const int BoxHeight = 100;
+ 	private static string[] _gcGenText;
+ 
++	// TML#5330:
++	/*
+ 	public static TimeSpan CurrentFrameTime {
++	*/
++	public static SWTimeSpan CurrentFrameTime {
+ 		get {
+ 			Frame frame = Frames[newest];
+ 			return Utils.SWTicksToTimeSpan(frame.events.Last().timestamp - frame.events[0].timestamp);

--- a/patches/TerrariaNetCore/Terraria/TimeLogger.cs.patch
+++ b/patches/TerrariaNetCore/Terraria/TimeLogger.cs.patch
@@ -1,0 +1,35 @@
+--- src/Terraria/Terraria/TimeLogger.cs
++++ src/TerrariaNetCore/Terraria/TimeLogger.cs
+@@ -10,6 +_,7 @@
+ using Terraria.GameContent.Drawing;
+ using Terraria.GameInput;
+ using Terraria.Testing;
++using Terraria.Utilities;
+ 
+ namespace Terraria;
+ 
+@@ -142,7 +_,11 @@
+ 
+ 		public int ElapsedTicks => (int)(Stopwatch.GetTimestamp() - ticks);
+ 
++		// TML#5330:
++		/*
+ 		public TimeSpan Elapsed => Utils.SWTicksToTimeSpan(ElapsedTicks);
++		*/
++		public SWTimeSpan Elapsed => Utils.SWTicksToTimeSpan(ElapsedTicks);
+ 	}
+ 
+ 	private class FormatPool
+@@ -699,7 +_,12 @@
+ 
+ 	private static string FormatTicks(int ticks)
+ 	{
++		// TML#5330:
++		/*
+ 		TimeSpan timeSpan = Utils.SWTicksToTimeSpan(ticks);
++		*/
++		var timeSpan = Utils.SWTicksToTimeSpan(ticks);
++
+ 		string text = _msFormat.Format((float)timeSpan.TotalMilliseconds);
+ 		if (text.Length > 5)
+ 			text = text.Substring(0, 5);

--- a/patches/TerrariaNetCore/Terraria/Utilities/SWTimeSpan.cs
+++ b/patches/TerrariaNetCore/Terraria/Utilities/SWTimeSpan.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace Terraria.Utilities;
+
+// TML#5330:
+/// <summary>
+/// A minimal TimeSpan that operates on the same level of precision as a <see cref="Stopwatch" />.
+/// <br/> Added by the <b>TerrariaNetCore</b> stage. See https://github.com/tModLoader/tModLoader/issues/5330 for details.
+/// </summary>
+public readonly struct SWTimeSpan(long swTicks)
+{
+    public readonly long Ticks = swTicks;
+
+    public readonly double TotalSeconds => Ticks / (double)Stopwatch.Frequency;
+    public readonly double TotalMilliseconds => Ticks / (double)(Stopwatch.Frequency * 1000);
+
+    public static SWTimeSpan operator -(SWTimeSpan a, SWTimeSpan b) => new(a.Ticks - b.Ticks);
+    public static SWTimeSpan operator +(SWTimeSpan a, SWTimeSpan b) => new(a.Ticks + b.Ticks);
+}

--- a/patches/TerrariaNetCore/Terraria/Utils.cs.patch
+++ b/patches/TerrariaNetCore/Terraria/Utils.cs.patch
@@ -1,6 +1,6 @@
 --- src/Terraria/Terraria/Utils.cs
 +++ src/TerrariaNetCore/Terraria/Utils.cs
-@@ -941,7 +_,11 @@
+@@ -941,13 +_,25 @@
  				});
  			}
  			else {
@@ -12,3 +12,17 @@
  			}
  		}
  	}
+ 
++	// TML#5330:
++	// Due to the potential of StopWatch having higher precision than TimeSpan is able to store,
++	// for convenience and minimal patching, the following method has been changed to use a new SWTimeSpan type instead.
++	/*
+ 	public static TimeSpan SWTicksToTimeSpan(long swTicks) => new TimeSpan((long)((double)swTicks * 10000000.0 / (double)Stopwatch.Frequency));
++	*/
++	public static SWTimeSpan SWTicksToTimeSpan(long swTicks) => new(swTicks);
+ 	public static long TimeSpanToSWTicks(TimeSpan timeSpan) => timeSpan.Ticks * Stopwatch.Frequency / 10000000;
++	// TML#5330: Additional overload.
++	public static long TimeSpanToSWTicks(SWTimeSpan timeSpan) => timeSpan.Ticks;
+ 
+ 	public static byte[] ToByteArray(this string str)
+ 	{

--- a/patches/tModLoader/Terraria/Utils.cs.patch
+++ b/patches/tModLoader/Terraria/Utils.cs.patch
@@ -201,7 +201,7 @@
  			}
  			else {
  #if NETCORE
-@@ -960,6 +_,11 @@
+@@ -968,6 +_,11 @@
  		return array;
  	}
  
@@ -213,7 +213,7 @@
  	public static float NextFloat(this UnifiedRandom r) => (float)r.NextDouble();
  	public static float NextFloatDirection(this UnifiedRandom r) => (float)r.NextDouble() * 2f - 1f;
  	public static float NextFloat(this UnifiedRandom random, FloatRange range) => random.NextFloat() * (range.Maximum - range.Minimum) + range.Minimum;
-@@ -1011,6 +_,7 @@
+@@ -1019,6 +_,7 @@
  		return asset.Value.Height;
  	}
  
@@ -221,7 +221,7 @@
  	public static Rectangle Frame(this Asset<Texture2D> tex, int horizontalFrames = 1, int verticalFrames = 1, int frameX = 0, int frameY = 0, int sizeOffsetX = 0, int sizeOffsetY = 0)
  	{
  		if (!tex.IsLoaded)
-@@ -1034,6 +_,10 @@
+@@ -1042,6 +_,10 @@
  		return tex.Value.Size();
  	}
  
@@ -232,7 +232,7 @@
  	public static Rectangle Frame(this Texture2D tex, int horizontalFrames = 1, int verticalFrames = 1, int frameX = 0, int frameY = 0, int sizeOffsetX = 0, int sizeOffsetY = 0)
  	{
  		int num = tex.Width / horizontalFrames;
-@@ -1310,7 +_,9 @@
+@@ -1318,7 +_,9 @@
  	public static Vector3 ToVector3(this Vector2 v) => new Vector3(v.X, v.Y, 0f);
  	public static Vector2D ToVector2D(this Point p) => new Vector2D(p.X, p.Y);
  	public static Vector2D ToVector2D(this Point16 p) => new Vector2D(p.X, p.Y);
@@ -242,7 +242,7 @@
  	public static Vector2 ToWorldCoordinates(this Point16 p, float autoAddX = 8f, float autoAddY = 8f) => p.ToVector2() * 16f + new Vector2(autoAddX, autoAddY);
  
  	public static Vector2 MoveTowards(this Vector2 currentPosition, Vector2 targetPosition, float maxAmountAllowedToMove)
-@@ -1335,8 +_,10 @@
+@@ -1343,8 +_,10 @@
  		return num2;
  	}
  
@@ -253,7 +253,7 @@
  	public static Point ToTileCoordinates(this Vector2 vec) => new Point((int)vec.X >> 4, (int)vec.Y >> 4);
  	public static Point ToTileCoordinates(this Vector2D vec) => new Point((int)vec.X >> 4, (int)vec.Y >> 4);
  	public static Point ToPoint(this Vector2 v) => new Point((int)v.X, (int)v.Y);
-@@ -1344,6 +_,11 @@
+@@ -1352,6 +_,11 @@
  	public static Vector2 ToVector2(this Vector2D v) => new Vector2((float)v.X, (float)v.Y);
  	public static Vector2D ToVector2D(this Vector2 v) => new Vector2D(v.X, v.Y);
  
@@ -265,7 +265,7 @@
  	public static Vector2 SafeNormalize(this Vector2 v, Vector2 defaultValue)
  	{
  		if (v == Vector2.Zero || v.HasNaNs())
-@@ -1362,6 +_,7 @@
+@@ -1370,6 +_,7 @@
  
  	public static Point ClampedInWorld(this Point p, int fluff = 0) => new Point(Clamp(p.X, fluff, Main.maxTilesX - fluff - 1), Clamp(p.Y, fluff, Main.maxTilesX - fluff - 1));
  
@@ -273,7 +273,7 @@
  	public static Vector2 ClosestPointOnLine(this Vector2 P, Vector2 A, Vector2 B)
  	{
  		Vector2 value = P - A;
-@@ -1430,16 +_,24 @@
+@@ -1438,16 +_,24 @@
  	public static float DistanceSQ(this Vector2 Origin, Vector2 Target) => Vector2.DistanceSquared(Origin, Target);
  	public static Vector2 DirectionTo(this Vector2 Origin, Vector2 Target) => Vector2.Normalize(Target - Origin);
  	public static Vector2 DirectionFrom(this Vector2 Origin, Vector2 Target) => Vector2.Normalize(Origin - Target);
@@ -298,7 +298,7 @@
  	public static int ToDirectionInt(this bool value)
  	{
  		if (!value)
-@@ -1448,6 +_,7 @@
+@@ -1456,6 +_,7 @@
  		return 1;
  	}
  
@@ -306,7 +306,7 @@
  	public static int ToInt(this bool value)
  	{
  		if (!value)
-@@ -1560,6 +_,7 @@
+@@ -1568,6 +_,7 @@
  		return false;
  	}
  
@@ -314,7 +314,7 @@
  	public static List<int> GetTrueIndexes(this bool[] array)
  	{
  		List<int> list = new List<int>();
-@@ -1853,14 +_,26 @@
+@@ -1861,14 +_,26 @@
  			text.Substring(0, maxCharactersDisplayed);
  
  		DynamicSpriteFont value = FontAssets.DeathText.Value;


### PR DESCRIPTION
### What is the bug?
Resolves #5330

### How did you fix the bug?
Avoided loss of StopWatch ticks' precision by skipping use of `System.TimeSpan` altogether.
Added `Terraria.Utilities.SWTimeSpan`, which is a tiny `long swTicks` wrapper that was made to minimize the amount of patches involved here.

### Are there alternatives to your fix?
Obsoleting `Terraria.Utils.SWTicksToTimeSpan` and `.TimeSpanToSWTicks`, adding `ToSeconds`/`ToMilliseconds` variants, rewriting all of its call site. Not pleasant.