### PR TITLE
[1.4.5] Fixed NullReferenceException when breaking a modded multitile

### DIFF
--- a/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
+++ b/patches/tModLoader/Terraria/ModLoader/TileLoader.cs
@@ -337,6 +337,10 @@ public static class TileLoader
 		}
 		*/
 		tileData = TileObjectData.GetTileData(Main.tile[i, j]);
+		// The tile can already be inactive here, since CheckModTile runs while the object is being destroyed.
+		if (tileData == null)
+			return;
+
 		int partFrameX = frameX % tileData.CoordinateFullWidth;
 		int partFrameY = frameY % tileData.CoordinateFullHeight;
 		int partX = partFrameX / (tileData.CoordinateWidth + tileData.CoordinatePadding);


### PR DESCRIPTION
### What is the bug?

Breaking a modded multitile can throw a `NullReferenceException`. Reproduced by placing and breaking ExamplePylon.

```
at Terraria.ModLoader.TileLoader.CheckModTile(Int32 i, Int32 j, Int32 type)
at Terraria.WorldGen.TileFrameImportant(...)
at Terraria.WorldGen.KillTile(...)
```

### How did you fix the bug?

`CheckModTile` fetches the tile data twice. The first call uses `GetTileData(type, 0, 0)` and is null checked. The second uses the `Tile` overload, which also returns null when the tile is no longer active, and was not checked. `CheckModTile` runs from `KillTile` while the object is being destroyed, so the tile can already be inactive there.

Added the missing null check.

### Are there alternatives to your fix?

No. Just a small fix.
