### PR TITLE
[1.4.5] Fixed smart cursor not placing modded blocks

### DIFF
--- a/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
+++ b/patches/tModLoader/Terraria/GameContent/SmartCursorHelper.cs.patch
@@ -8,6 +8,15 @@
  
  namespace Terraria.GameContent;
  
+@@ -170,7 +_,7 @@
+ 
+ 	private static bool AllowNormalBlockPlacementBehaviourForItemType(int itemType)
+ 	{
+-		if (itemType < 0 || itemType >= ItemID.Count)
++		if (itemType < 0)
+ 			return false;
+ 
+ 		if (itemType == 213 || itemType == 5295 || ItemID.Sets.GrassSeeds[itemType] || ItemID.Sets.Moss[itemType])
 @@ -221,7 +_,7 @@
  			return;
  


### PR DESCRIPTION
### What is the bug?

Smart cursor block placement does nothing for any modded block. Vanilla blocks work.

### How did you fix the bug?

`SmartCursorHelper` drops the vanilla `ItemID.Count` and `TileID.Count` upper bounds in six places so modded content gets through, but the same bound was left in `AllowNormalBlockPlacementBehaviourForItemType`:

```cs
if (itemType < 0 || itemType >= ItemID.Count)
    return false;
```

`Step_BlocksLines` calls that method right after its own bound was removed, so every modded item was rejected one level down. Removed the bound there too.

### Are there alternatives to your fix?

No.
