### PR TITLE
[1.4.5] Fixed modded campfires not toggling on right click

### DIFF
--- a/patches/tModLoader/Terraria/Player.cs.patch
+++ b/patches/tModLoader/Terraria/Player.cs.patch
@@ -5058,7 +5058,7 @@
  				for (int i = 0; i < pylons.Count; i++) {
  					TeleportPylonInfo info = pylons[i];
  					if (TeleportPylonsMapLayer.IsRevealed(info))
-@@ -25892,7 +_,7 @@
+@@ -25892,12 +_,15 @@
  				Wiring.HitSwitch(myX, myY);
  				NetMessage.SendData(59, -1, -1, null, myX, myY);
  			}
@@ -5067,6 +5067,14 @@
  				flag2 = true;
  				SoundEngine.PlaySound(28, myX * 16, myY * 16, 0);
  				WorldGen.SwitchMB(myX, myY);
+ 			}
++			/*
+ 			else if (TileID.Sets.Campfires[tile.type]) {
++			*/
++			else if (TileID.Sets.Campfires[tile.type] && tile.type < TileID.Count) {
+ 				flag2 = true;
+ 				SoundEngine.PlaySound(28, myX * 16, myY * 16, 0);
+ 				int num17 = 3;
 @@ -26022,7 +_,10 @@
  				flag2 = true;
  				GamepadEnableGrappleCooldown();


### PR DESCRIPTION
### What is the bug?

Modded campfires do not toggle when right clicked. Toggling them with wire works, and vanilla campfires right click fine.

### How did you fix the bug?

`TileInteractionsUse` runs two separate statements. First the vanilla campfire branch in the else if chain:

```cs
else if (TileID.Sets.Campfires[tile.type]) {
    ...
    tile2.frameY += num23;
}
```

then, at the end of the method, outside that chain:

```cs
if (TileLoader.RightClick(myX, myY))
    flag2 = true;
```

`TileID.Sets.Campfires` is an open set, so a modded campfire enters the vanilla branch and gets its frameY flipped, then `ModTile.RightClick` flips it back. Wire toggling only goes through `HitWire`, so it flips once and works.

Excluded modded tiles from the vanilla branch with `&& tile.type < TileID.Count`, the same way the chest and torch branches in this chain already do.

### Are there alternatives to your fix?

No.
