### PR TITLE
[1.4.5] Fix modded dressers being destroyed by explosions

### DIFF
--- a/patches/tModLoader/Terraria/Projectile.cs.patch
+++ b/patches/tModLoader/Terraria/Projectile.cs.patch
@@ -2067,6 +2067,14 @@
  		switch (Main.tile[x, y].type) {
  			case 26:
  			case 88:
+@@ -64035,6 +_,7 @@
+ 			case 504:
+ 			case 685:
+ 			case 686:
++			case var t when TileID.Sets.BasicDresser[t]:
+ 				return false;
+ 			case 107:
+ 			case 108:
 @@ -64069,6 +_,9 @@
  		return true;
  	}


### PR DESCRIPTION
### What is the bug?

Modded dressers are destroyed by explosions. Vanilla dressers are not.

The bug looks conditional at first: a modded dresser only blows up when it is empty. That is an unrelated check hiding it, since `WorldGen.KillTile` refuses to break any container that still holds items.

### How did you fix the bug?

`Projectile.CanExplodeTile` matches vanilla dressers by hardcoded id:

```cs
switch (Main.tile[x, y].type) {
    case 26:
    case 88:
    case 121:
    ...
        return false;
```

Modded dressers do not match `88`, so they fall through to the end of the method and `return true`.

Vanilla chests are already covered a few lines above through `TileID.Sets.BasicChest`, and `WorldGen.KillTile` already matches dressers with `TileID.Sets.BasicDresser`, so dressers were the only container left on a hardcoded id here. Matching the set puts modded dressers on the same path as vanilla.

### Are there alternatives to your fix?

No.