### PR TITLE
[1.4.5][ExampleMod] Fixed ExampleZombieThief not removing the items it steals

### DIFF
--- a/ExampleMod/Content/NPCs/ExampleZombieThief.cs
+++ b/ExampleMod/Content/NPCs/ExampleZombieThief.cs
@@ -70,6 +70,7 @@ namespace ExampleMod.Content.NPCs
 				// Pickup the items only if the NPC touches them and they aren't already being grabbed by a player
 				if (item.active && !item.beingGrabbed && item.type == ModContent.ItemType<ExampleItem>() && hitbox.Intersects(item.Hitbox)) {
 					StolenItems += item.stack;
+					item.TurnToAir(fullReset: true);
 
 					NetMessage.SendData(MessageID.SyncItem, number: item.whoAmI);
 

--- a/PortingNotes_1.4.5.md
+++ b/PortingNotes_1.4.5.md
@@ -199,7 +199,6 @@ Once all patches are fixed, these items need to be fixed or double checked:
 - Item.SetDefaults(int, bool) -> Item.SetDefaults(int)
 
 # ExampleMod TODOs
-- Verify that ExampleZombieThief still works with changes
 
 # Terraria update requests
 


### PR DESCRIPTION
### What is the bug?

ExampleZombieThief never removes the items it picks up, so it keeps stealing the same item every frame. Dropping one Example Item next to it and killing it a few seconds later gave 204 items, and the original item was still lying on the ground.

`PortingNotes_1.4.5.md` asks for this to be verified.

### How did you fix the bug?

`6893d00dc8` renamed the loop variable from `worldItem` back to `item` and dropped the `TurnToAir` call along with it:

```diff
-			if (worldItem.active && ...) {
-				StolenItems += worldItem.stack;
-				worldItem.TurnToAir(fullReset: true);
+			if (item.active && ...) {
+				StolenItems += item.stack;
```

Put the call back. This is the 1.4.4 `item.active = false` that had already been ported to `WorldItem.TurnToAir`.

Also removed the entry from `PortingNotes_1.4.5.md` now that it is verified.

### Are there alternatives to your fix?

No.

### Testing

Dropped 4 Example Items next to the NPC. Before: items stayed on the ground, the emote repeated every frame, killing it dropped hundreds. After: items are picked up once and killing it drops 5 (4 stolen plus its own drop).
